### PR TITLE
Fix the validate script: missing uuid module

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -14,4 +14,8 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
+# grab e2e-test only related packages to avoid linting
+# errors for packages we didn't vendor.
+go get -t ./test/e2e/...
+
 golangci-lint run -D megacheck -E unused,gosimple,staticcheck


### PR DESCRIPTION
In this patch we grab all dependencies from ./test/e2e/...
golangci-lint fails otherwise because it's unable to find
the k8s uuid module which we don't vendor.

An alternative would be to start vendoring such module.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>