### PR TITLE
Enable validation in CI, test before build

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -2,9 +2,9 @@
 set -e
 
 cd $(dirname $0)
+./validate
+./test
 ./build
 ./build-routeagent
-./test
-#./validate
 ./download
 ./package


### PR DESCRIPTION
Now that validation works reliably, let's ensure it's enabled in CI
builds. Run validation first, then tests, before the builds
themselves.

Signed-off-by: Stephen Kitt <skitt@redhat.com>