### PR TITLE
Remove golangci-lint command flags in validate script

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -14,4 +14,4 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run -D megacheck -E unused,gosimple,staticcheck
+golangci-lint run


### PR DESCRIPTION
The script was running:
    
`golangci-lint run -D megacheck -E unused,gosimple,staticcheck`
    
With these flags, the `unused` linter does not actually run (I assume `gosimple` and `staticcheck` don't run either) as there is unused code submariner (`datastoresyncer`). Running just `golangci-lint run` yields errors emitted by `unused`.
    
I'm not clear as to the purpose of these flags. It isn't necessary to explicitly enable `unused`, `gosimple` and `staticcheck` as they are enabled by default. FWICT, `megacheck` runs `staticcheck`, `gosimple` and `unused` at once for efficiency - I don't know the reason for disabling it but doing so seems to also disable the other 3 even though they are explicitly enabled.