### PR TITLE
Fix goimports error in util.go

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/rdegges/go-ipify"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/rdegges/go-ipify"
 	"github.com/vishvananda/netlink"
 )
 


### PR DESCRIPTION
https://github.com/submariner-io/submariner/pull/95 modified the
imports so they're no longer sorted which fails goimports.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>