### PR TITLE
 Support Libreswan "cable" creation

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,10 +16,13 @@ jobs:
       matrix:
         globalnet: ['', '--globalnet']
         deploytool: ['operator', 'helm']
-        cable_driver: ['', 'wireguard']
+        cable_driver: ['', 'wireguard', 'libreswan']
         exclude:
+# Our Helm setup doesn’t know how to deploy other cable drivers
           - deploytool: 'helm'
             cable_driver: 'wireguard'
+          - deploytool: 'helm'
+            cable_driver: 'libreswan'
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,9 +2,12 @@ FROM fedora:31
 
 WORKDIR /var/submariner
 
+# iproute and iptables are used internally
+# libreswan or strongswan provide IKE
+# procps-ng is needed for sysctl
 RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   iproute iptables strongswan procps-ng && \
+                   iproute iptables libreswan strongswan procps-ng && \
     dnf -y clean all && \
     rpm -e gnupg2 rpm-sign-libs gpgme dnf libdnf yum python3-rpm \
            python3-dnf python3-gpg librepo python3-libdnf python3-hawkey \
@@ -14,6 +17,6 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
            libksba libreport-filesystem libsemanage libstdc++ openssl \
            python3-libcomps rpm-build-libs sssd-client
 
-COPY submariner.sh submariner-engine /usr/local/bin/
+COPY submariner.sh pluto submariner-engine /usr/local/bin/
 
 ENTRYPOINT submariner.sh

--- a/package/pluto
+++ b/package/pluto
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Checks pre-requisites and starts the Pluto daemon, without forking
+
+set -e
+
+# These are the ExecStartPre lines from the systemd service definition
+/usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
+/usr/libexec/ipsec/_stackmanager start
+/usr/sbin/ipsec --checknss
+/usr/sbin/ipsec --checknflog
+
+# Start the daemon itself with any additional arguments passed in
+/usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork  "$@"

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -1,11 +1,20 @@
 package libreswan
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
 
-	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/kelseyhightower/envconfig"
+	"k8s.io/klog"
+
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 const (
@@ -13,45 +22,347 @@ const (
 )
 
 func init() {
-	cable.AddDriver(cableDriverName, NewLibreSwan)
+	cable.AddDriver(cableDriverName, NewLibreswan)
 }
 
-type libreSwan struct {
+type libreswan struct {
+	secretKey string
+
+	debug   bool
+	logFile string
+
+	localEndpoint types.SubmarinerEndpoint
+
+	ipSecIKEPort  string
+	ipSecNATTPort string
+
+	// This tracks the requested connections
+	connections []subv1.Connection
 }
 
-// NewLibreSwan starts an IKE daemon using LibreSwan and configures it to manage Submariner's endpoints
-func NewLibreSwan(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
-	return &libreSwan{}, nil
+type specification struct {
+	PSK      string
+	Debug    bool
+	LogFile  string
+	IKEPort  string `default:"500"`
+	NATTPort string `default:"4500"`
+}
+
+const defaultIKEPort = "500"
+const defaultNATTPort = "4500"
+const ipsecSpecEnvVarPrefix = "ce_ipsec"
+
+// NewLibreswan starts an IKE daemon using Libreswan and configures it to manage Submariner's endpoints
+func NewLibreswan(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
+	ipSecSpec := specification{}
+
+	err := envconfig.Process(ipsecSpecEnvVarPrefix, &ipSecSpec)
+	if err != nil {
+		return nil, fmt.Errorf("error processing environment config for %s: %v", ipsecSpecEnvVarPrefix, err)
+	}
+
+	return &libreswan{
+		secretKey:     ipSecSpec.PSK,
+		debug:         ipSecSpec.Debug,
+		logFile:       ipSecSpec.LogFile,
+		ipSecIKEPort:  ipSecSpec.IKEPort,
+		ipSecNATTPort: ipSecSpec.NATTPort,
+		localEndpoint: localEndpoint,
+		connections:   []subv1.Connection{},
+	}, nil
 }
 
 // GetName returns driver's name
-func (i *libreSwan) GetName() string {
+func (i *libreswan) GetName() string {
 	return cableDriverName
 }
 
 // Init initializes the driver with any state it needs.
-func (i *libreSwan) Init() error {
+func (i *libreswan) Init() error {
+	// Write the secrets file:
+	// %any %any : PSK "secret"
+	// TODO Check whether the file already exists
+	file, err := os.Create("/etc/ipsec.d/submariner.secrets")
+	if err != nil {
+		return fmt.Errorf("error creating the secrets file: %v", err)
+	}
+	defer file.Close()
+
+	fmt.Fprintf(file, "%%any %%any : PSK \"%s\"\n", i.secretKey)
+
+	// Ensure Pluto is started
+	if err := i.runPluto(); err != nil {
+		return fmt.Errorf("error starting Pluto: %v", err)
+	}
+	return nil
+}
+
+func (i *libreswan) refreshConnectionStatus() error {
+	// Retrieve active tunnels from the daemon
+	cmd := exec.Command("/usr/libexec/ipsec/whack", "--trafficstatus")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		klog.Errorf("error retrieving whack's stdout: %v", err)
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		klog.Errorf("error starting whack: %v", err)
+		return err
+	}
+	scanner := bufio.NewScanner(stdout)
+	activeConnections := util.NewStringSet()
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Line format: 006 #3: "submariner-cable-cluster3-172-17-0-8-0-0", type=ESP, add_time=1590508783, inBytes=0, outBytes=0, id='172.17.0.8'
+		components := strings.Split(line, "\"")
+		if len(components) == 3 {
+			activeConnections.Add(components[1])
+		}
+	}
+	if err := cmd.Wait(); err != nil {
+		klog.Errorf("error waiting for whack: %v", err)
+		return err
+	}
+
+	localSubnets := extractSubnets(i.localEndpoint.Spec)
+	for j := range i.connections {
+		allConnected := true
+		remoteSubnets := extractSubnets(i.connections[j].Endpoint)
+		for lsi := range localSubnets {
+			for rsi := range remoteSubnets {
+				connectionName := fmt.Sprintf("%s-%d-%d", i.connections[j].Endpoint.CableName, lsi, rsi)
+				if !activeConnections.Contains(connectionName) {
+					allConnected = false
+				}
+			}
+		}
+		if allConnected {
+			i.connections[j].Status = subv1.Connected
+		} else {
+			// Pluto should be connecting for us
+			i.connections[j].Status = subv1.Connecting
+		}
+	}
+
 	return nil
 }
 
 // GetActiveConnections returns an array of all the active connections for the given cluster.
-func (i *libreSwan) GetActiveConnections(clusterID string) ([]string, error) {
-	return make([]string, 0), nil
+func (i *libreswan) GetActiveConnections(clusterID string) ([]string, error) {
+	if err := i.refreshConnectionStatus(); err != nil {
+		return []string{}, err
+	}
+
+	connections := []string{}
+	for j := range i.connections {
+		if i.connections[j].Status == subv1.Connected {
+			connections = append(connections, i.connections[j].Endpoint.CableName)
+		}
+	}
+	klog.Infof("Active connections: %v", connections)
+	return connections, nil
 }
 
 // GetConnections() returns an array of the existing connections, including status and endpoint info
-func (i *libreSwan) GetConnections() (*[]v1.Connection, error) {
-	connections := make([]v1.Connection, 0)
-	return &connections, nil
+func (i *libreswan) GetConnections() (*[]subv1.Connection, error) {
+	if err := i.refreshConnectionStatus(); err != nil {
+		return &[]subv1.Connection{}, err
+	}
+	return &i.connections, nil
+}
+
+func extractEndpointIP(endpoint subv1.EndpointSpec) string {
+	if endpoint.NATEnabled {
+		return endpoint.PublicIP
+	} else {
+		return endpoint.PrivateIP
+	}
+}
+
+func extractSubnets(endpoint subv1.EndpointSpec) []string {
+	endpointIP := extractEndpointIP(endpoint)
+
+	// Subnets
+	subnets := []string{endpointIP + "/32"}
+	for _, subnet := range endpoint.Subnets {
+		if !strings.HasPrefix(subnet, endpointIP) {
+			subnets = append(subnets, subnet)
+		}
+	}
+
+	return subnets
 }
 
 // ConnectToEndpoint establishes a connection to the given endpoint and returns a string
 // representation of the IP address of the target endpoint.
-func (i *libreSwan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (string, error) {
-	return "", fmt.Errorf("Not implemented")
+func (i *libreswan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (string, error) {
+	localEndpointIP := extractEndpointIP(i.localEndpoint.Spec)
+	remoteEndpointIP := extractEndpointIP(endpoint.Spec)
+	leftSubnets := extractSubnets(i.localEndpoint.Spec)
+	rightSubnets := extractSubnets(endpoint.Spec)
+
+	// Ensure we’re listening
+	cmd := exec.Command("/usr/libexec/ipsec/whack", "--listen")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("error listening: %v", err)
+	}
+
+	if len(leftSubnets) > 0 && len(rightSubnets) > 0 {
+		for lsi := range leftSubnets {
+			for rsi := range rightSubnets {
+				connectionName := fmt.Sprintf("%s-%d-%d", endpoint.Spec.CableName, lsi, rsi)
+
+				args := []string{}
+
+				args = append(args, "--psk", "--encrypt")
+				args = append(args, "--name", connectionName)
+
+				// Left-hand side
+				args = append(args, "--host", localEndpointIP)
+				args = append(args, "--client", leftSubnets[lsi])
+
+				args = append(args, "--to")
+
+				// Right-hand side
+				args = append(args, "--host", remoteEndpointIP)
+				args = append(args, "--client", rightSubnets[rsi])
+
+				klog.Infof("Creating connection to %v", endpoint)
+				klog.Infof("Whacking with %v", args)
+
+				cmd = exec.Command("/usr/libexec/ipsec/whack", args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				if err := cmd.Run(); err != nil {
+					switch err := err.(type) {
+					case *exec.ExitError:
+						klog.Errorf("error adding a connection with args %v; got exit code %d: %v", args, err.ExitCode(), err)
+					default:
+						return "", fmt.Errorf("error adding a connection with args %v: %v", args, err)
+					}
+				}
+
+				cmd = exec.Command("/usr/libexec/ipsec/whack", "--route", "--name", connectionName)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				if err := cmd.Run(); err != nil {
+					klog.Errorf("error routing connection %s: %v", connectionName, err)
+				}
+
+				cmd = exec.Command("/usr/libexec/ipsec/whack", "--initiate", "--name", connectionName)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				if err := cmd.Run(); err != nil {
+					klog.Errorf("error initiating a connection with args %v: %v", args, err)
+				}
+			}
+		}
+	}
+
+	i.connections = append(i.connections, subv1.Connection{Endpoint: endpoint.Spec, Status: subv1.Connected})
+
+	return remoteEndpointIP, nil
 }
 
 // DisconnectFromEndpoint disconnects from the connection to the given endpoint.
-func (i *libreSwan) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error {
-	return fmt.Errorf("Not implemented")
+func (i *libreswan) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error {
+	leftSubnets := extractSubnets(i.localEndpoint.Spec)
+	rightSubnets := extractSubnets(endpoint.Spec)
+
+	klog.Infof("Deleting connection to %v", endpoint)
+
+	if len(leftSubnets) > 0 && len(rightSubnets) > 0 {
+		for lsi := range leftSubnets {
+			for rsi := range rightSubnets {
+				connectionName := fmt.Sprintf("%s-%d-%d", endpoint.Spec.CableName, lsi, rsi)
+
+				args := []string{}
+
+				args = append(args, "--delete")
+				args = append(args, "--name", connectionName)
+
+				klog.Infof("Whacking with %v", args)
+
+				cmd := exec.Command("/usr/libexec/ipsec/whack", args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				if err := cmd.Run(); err != nil {
+					switch err := err.(type) {
+					case *exec.ExitError:
+						klog.Errorf("error deleting a connection with args %v; got exit code %d: %v", args, err.ExitCode(), err)
+					default:
+						return fmt.Errorf("error deleting a connection with args %v: %v", args, err)
+					}
+				}
+			}
+		}
+	}
+
+	i.connections = removeConnectionForEndpoint(i.connections, endpoint)
+
+	return nil
+}
+
+func removeConnectionForEndpoint(connections []subv1.Connection, endpoint types.SubmarinerEndpoint) []subv1.Connection {
+	for j := range connections {
+		if connections[j].Endpoint.CableName == endpoint.Spec.CableName {
+			if j == 0 && j == len(connections)-1 {
+				return []subv1.Connection{}
+			} else if j == 0 {
+				return connections[j+1:]
+			} else if j == len(connections)-1 {
+				return connections[:j]
+			}
+			return append(connections[:j], connections[j+1:]...)
+		}
+	}
+	return connections
+}
+
+func (i *libreswan) runPluto() error {
+	klog.Info("Starting Pluto")
+
+	args := []string{}
+	args = append(args, "--ikeport", i.ipSecIKEPort)
+	args = append(args, "--natikeport", i.ipSecNATTPort)
+
+	cmd := exec.Command("/usr/local/bin/pluto", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	var outputFile *os.File
+	if i.logFile != "" {
+		out, err := os.OpenFile(i.logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			return fmt.Errorf("Failed to open log file %s: %v", i.logFile, err)
+		}
+
+		cmd.Stdout = out
+		cmd.Stderr = out
+		outputFile = out
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+
+	if err := cmd.Start(); err != nil {
+		// Note - Close handles nil receiver
+		outputFile.Close()
+		return fmt.Errorf("error starting the Pluto process wih args %v: %v", args, err)
+	}
+
+	go func() {
+		defer outputFile.Close()
+		klog.Fatalf("Pluto exited: %v", cmd.Wait())
+	}()
+
+	return nil
 }

--- a/pkg/cable/libreswan/libreswan_suite_test.go
+++ b/pkg/cable/libreswan/libreswan_suite_test.go
@@ -1,0 +1,13 @@
+package libreswan_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLibreswan(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Libreswan Suite")
+}

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -1,0 +1,57 @@
+package libreswan
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+var _ = Describe("Libreswan", func() {
+	Describe("IPsec port configuration", testIPsecPortConfiguration)
+})
+
+func testIPsecPortConfiguration() {
+	When("NewLibreswan is called with no port environment variables set", func() {
+		It("should set the port fields from the defaults in the specification definition", func() {
+			checkLibreswanPorts(defaultIKEPort, defaultNATTPort)
+		})
+	})
+
+	When("NewLibreswan is called with port environment variables set", func() {
+		const (
+			ikePort        = "555"
+			nattPort       = "4555"
+			ikePortEnvVar  = "CE_IPSEC_IKEPORT"
+			nattPortEnvVar = "CE_IPSEC_NATTPORT"
+		)
+
+		BeforeEach(func() {
+			os.Setenv(ikePortEnvVar, ikePort)
+			os.Setenv(nattPortEnvVar, nattPort)
+		})
+
+		AfterEach(func() {
+			os.Unsetenv(ikePortEnvVar)
+			os.Unsetenv(nattPortEnvVar)
+		})
+
+		It("should set the port fields from the environment variables", func() {
+			checkLibreswanPorts(ikePort, nattPort)
+		})
+	})
+}
+
+func createLibreswan() *libreswan {
+	ls, err := NewLibreswan(types.SubmarinerEndpoint{}, types.SubmarinerCluster{})
+	Expect(err).NotTo(HaveOccurred())
+	return ls.(*libreswan)
+}
+
+func checkLibreswanPorts(ikePort string, nattPort string) {
+	ls := createLibreswan()
+	Expect(ls.ipSecIKEPort).To(Equal(ikePort))
+	Expect(ls.ipSecNATTPort).To(Equal(nattPort))
+}


### PR DESCRIPTION
This relies on the whack command-line tool for now. Because the
full-blown status is very hard to parse, the connection-tracking code
uses the simpler trafficstatus output, which doesn’t give all the
information we’d really need but is sufficient to determine whether a
connection is active or not.

We set up one tunnel per subnet pair, one tunnel between the hosts,
and one tunnel between each host and each opposing subnet.

Fixes: #592
Fixes: #385
Fixes: #564
Signed-off-by: Stephen Kitt <skitt@redhat.com>