### PR TITLE
Revert "Update Readme (running e2e tests without changing directory)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ cluster1 is our broker cluster, **to execute the E2E tests** we would do:
 
   ```bash
   export GO111MODULE=on
-  go test ./test/e2e -args -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
+  cd test/e2e
+  go test -args -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
                 -dp-context cluster2 \
                 -dp-context cluster3 \
                 -ginkgo.randomizeAllSpecs
@@ -272,7 +273,8 @@ specify the ginkgo.focus argument
 
   ```bash
   export GO111MODULE=on
-  go test ./test/e2e -args -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
+  cd test/e2e
+  go test -args -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
                 -dp-context cluster2 \
                 -dp-context cluster3 \
                 -ginkgo.focus=dataplane \
@@ -282,7 +284,8 @@ specify the ginkgo.focus argument
 It's possible to generate jUnit XML report files
   ```bash
   export GO111MODULE=on
-  go test ./test/e2e -args -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
+  cd test/e2e
+  go test -args  -kubeconfig=creds/cluster1:creds/cluster2:creds/cluster3 \
                  -dp-context cluster2 \
                  -dp-context cluster3 \
                  -ginkgo.v -report-dir ./junit -ginkgo.randomizeAllSpecs


### PR DESCRIPTION
If you don't cd into the directory, all the ginkgo output is hidden at commandline:

[ajo@rhvirt-casa submariner]$ go test ./test/e2e/ -args -ginkgo.v -ginkgo.randomizeAllSpecs -dp-context cluster2 -dp-context cluster3 -report-dir output/junit/
ok  	github.com/submariner-io/submariner/test/e2e	32.277s


Reverts submariner-io/submariner#105