### PR TITLE
Fix codegen script

### DIFF
--- a/scripts/codegen
+++ b/scripts/codegen
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-CODEGEN_SCRIPT_DIR="${GOPATH:-~/go}/src/k8s.io/code-generator"
+K8S_IO_DIR="${GOPATH:-~/go}/src/k8s.io"
+CODEGEN_SCRIPT_DIR="${K8S_IO_DIR}/code-generator"
 CODEGEN_SCRIPT="${CODEGEN_SCRIPT_DIR}/generate-groups.sh"
 CODEGEN_RELEASE_TAG=kubernetes-1.14.1
 
 if [ ! -f "$CODEGEN_SCRIPT" ]; then
     echo "$CODEGEN_SCRIPT does not exist - downloading..."
-    go get -d k8s.io/code-generator
-    cd $CODEGEN_SCRIPT_DIR
-    git checkout tags/$CODEGEN_RELEASE_TAG
+    cd $K8S_IO_DIR
+    git clone --branch $CODEGEN_RELEASE_TAG https://github.com/kubernetes/code-generator
+    cd -
     echo "Successsfully checked out release tag $CODEGEN_RELEASE_TAG"
 fi
 


### PR DESCRIPTION
The switch to using go mod broke the codegen script as 'go get' now
places the downloaded k8s.io/code-generator repo in the go mod cache which
is not intended to be accessed directly. So I changed it to use git
clone.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>