### PR TITLE
Fix e2e recurring runs

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -45,7 +45,6 @@ function kind_clusters() {
             fi
         done
     fi
-    export KUBECONFIG=$(kind get kubeconfig-path --name=cluster1):$(kind get kubeconfig-path --name=cluster2):$(kind get kubeconfig-path --name=cluster3)
 }
 
 function install_helm() {


### PR DESCRIPTION
The issue is that the removed line overrides the main KUBECONFIG exported after the initial run and recurring runs with status=keep fail.