### PR TITLE
Genericize some scripts

### DIFF
--- a/scripts/entry
+++ b/scripts/entry
@@ -7,13 +7,13 @@ mkdir -p bin dist output
 
 # download all go mod modules to the vendor directory 
 if [[ ! -d vendor ]]; then
-	./scripts/vendor
+	./$(dirname $0)/vendor
 else
 	echo "Skipping go modules download as your vendor directory is already populated"
 fi
 
-if [ -e ./scripts/$1 ]; then
-    ./scripts/"$@"
+if [ -e ./$(dirname $0)/$1 ]; then
+    ./$(dirname $0)/"$@"
 else
     "$@"
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+source $(dirname $0)/lib/find_functions
 
-source scripts/lib/find_functions
+cd $(git rev-parse --show-toplevel)
 
 echo Looking for packages to test
 
 PACKAGES=$(find_go_pkg_dirs)
 
-echo Running tests in ${PACKAGES}
+echo Running tests in \"${PACKAGES}\" under $(pwd) 
 [ "${ARCH}" == "amd64" ] && RACE=-race
 ginkgo ${RACE} -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+source $(dirname $0)/lib/find_functions
 
-source scripts/lib/find_functions
+cd $(git rev-parse --show-toplevel)
 
 EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
 
 PACKAGES=$(find_go_pkg_dirs --no-trailing-dots "*.go")
+
+echo Validating \"$PACKAGES\" under $(pwd)
 
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     echo Incorrect formatting, please run goimports


### PR DESCRIPTION
Modified the 'entry', 'test' and 'validate' scripts so as not too assume the
parent dir is named 'scripts'. Also 'test' and 'validate' now use the top-level
dir of the current git project. This prepares them in case we want to move them
to a common project. It also allows one to manually run them from another
project.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/121)
<!-- Reviewable:end -->
