### PR TITLE
[E2E] Use weave as default cni for all k8s and kind versions. 

### DIFF
--- a/scripts/kind-e2e/cluster2-config.yaml
+++ b/scripts/kind-e2e/cluster2-config.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  disableDefaultCNI: true
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta1

--- a/scripts/kind-e2e/cluster3-config.yaml
+++ b/scripts/kind-e2e/cluster3-config.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  disableDefaultCNI: true
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta1


### PR DESCRIPTION
This PR uses [Cluster.networking.disableDefaultCNI](https://github.com/kubernetes-sigs/kind/issues/278) option for clusters 2 and 3. After the container nodes are up we are installing weave manually. In previous setup with k8s version 1.14.1, weave was ignoring podCidr provided in kind config file and used its default 10.32.0.0/12 cidr as podCidr. This PR fixes this issue.The result is a cluster with weave and podCidr that is taken from kind config file. This removes the need to be constrained to specific k8s version or kind version. After this is merged kind can be safely upgraded. Other types of cni plugins can be tested more easily.