### PR TITLE
Reduce git rev parse

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -2,8 +2,7 @@
 set -e
 
 source $(dirname $0)/lib/debug_functions
-
-source $(dirname $0)/version
+source $(dirname $0)/lib/version
 
 cd $(dirname $0)/..
 mkdir -p bin

--- a/scripts/build
+++ b/scripts/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 source $(dirname $0)/version
 

--- a/scripts/build-routeagent
+++ b/scripts/build-routeagent
@@ -2,8 +2,7 @@
 set -e
 
 source $(dirname $0)/lib/debug_functions
-
-source $(dirname $0)/version
+source $(dirname $0)/lib/version
 
 cd $(dirname $0)/..
 mkdir -p bin

--- a/scripts/build-routeagent
+++ b/scripts/build-routeagent
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 source $(dirname $0)/version
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)
 ./validate

--- a/scripts/codegen
+++ b/scripts/codegen
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 K8S_IO_DIR="${GOPATH:-~/go}/src/k8s.io"
 CODEGEN_SCRIPT_DIR="${K8S_IO_DIR}/code-generator"

--- a/scripts/download
+++ b/scripts/download
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)/..
 

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)
 

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 trap "chown -R $DAPPER_UID:$DAPPER_GID ." exit
 

--- a/scripts/lib/version
+++ b/scripts/lib/version
@@ -1,6 +1,8 @@
-#!/bin/bash
-
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+# This should only be sourced
+if [ "${0##*/}" = "version" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
 
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"

--- a/scripts/package
+++ b/scripts/package
@@ -2,8 +2,7 @@
 set -e
 
 source $(dirname $0)/lib/debug_functions
-
-source $(dirname $0)/version
+source $(dirname $0)/lib/version
 
 ARCH=${ARCH:-"amd64"}
 SUFFIX=""

--- a/scripts/package
+++ b/scripts/package
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 source $(dirname $0)/version
 

--- a/scripts/release
+++ b/scripts/release
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)/..
 

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)/..
 

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -2,8 +2,7 @@
 set -e
 
 source $(dirname $0)/lib/debug_functions
-
-source $(dirname $0)/version
+source $(dirname $0)/lib/version
 
 cd $(dirname $0)/..
 echo "Downloading go modules to cache ----"

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
+source $(dirname $0)/lib/debug_functions
 
 source $(dirname $0)/version
 


### PR DESCRIPTION
Using "git rev-parse" to find debug_functions means that our build only works in _our_ git repository. This makes a number of scenarios difficult: building from a release archive, building within another git repository, etc. The result is that Submariner becomes harder to package...

The version script only makes sense when sourced; enforce that and move the script to lib.