### PR TITLE
Generate Junit reports for all Packages and E2E tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20181109181836-c59034cc13d5 // indirect
 	sigs.k8s.io/yaml v0.0.0-20181102190223-fd68e9863619 // indirect
 )
+
+replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v0.0.0-20191002161935-034fd2551d22

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -319,9 +319,10 @@ function test_with_e2e_tests {
     # Setup the KUBECONFIG env
     export KUBECONFIG=$(echo ${PRJ_ROOT}/output/kind-config/dapper/kind-config-cluster{1..3} | sed 's/ /:/g')
 
-    go test -args -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.reportPassed \
+    go test -v -args -ginkgo.v -ginkgo.randomizeAllSpecs \
         -dp-context cluster2 -dp-context cluster3  \
-        -report-dir ${DAPPER_SOURCE}/${DAPPER_OUTPUT}/junit 2>&1 | \
+	-ginkgo.noColor -ginkgo.reportPassed \
+        -ginkgo.reportFile ${DAPPER_SOURCE}/${DAPPER_OUTPUT}/e2e-junit.xml 2>&1 | \
         tee ${DAPPER_SOURCE}/${DAPPER_OUTPUT}/e2e-tests.log
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -13,4 +13,4 @@ PACKAGES=$(find_go_pkg_dirs)
 
 echo Running tests in ${PACKAGES}
 [ "${ARCH}" == "amd64" ] && RACE=-race
-ginkgo ${RACE} -cover ${PACKAGES}
+go test -v ${RACE} -cover ${PACKAGES} -ginkgo.reportPassed -ginkgo.reportFile junit.xml


### PR DESCRIPTION
- Adding the usage of Ginkgo PR onsi#601: `-ginkgo.reportFile <file path>`

- Fix (remove) ansi colors around test steps in E2E Junit report