### PR TITLE
Install the operator lifecycle manager

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -31,8 +31,9 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # kind           | e2e tests
 # ginkgo         | tests
 # goimports      | code formatting
+# make           | OLM installation
 RUN apt-get -q update && \
-    apt-get install -y gcc git curl docker.io && \
+    apt-get install -y gcc git curl docker.io make && \
     curl https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
     chmod a+x /usr/bin/kubectl && \

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -316,6 +316,16 @@ function install_olm() {
     fi
 }
 
+function install_marketplace {
+    pushd $(mktemp -d)
+    git clone https://github.com/operator-framework/operator-marketplace.git
+    cd operator-marketplace
+    for i in 1 2 3; do
+        KUBECONFIG="$(kind --name=cluster${i} get kubeconfig-path)" kubectl apply -f deploy/upstream/
+    done
+    popd
+}
+
 function test_with_e2e_tests {
     set -o pipefail 
 
@@ -380,6 +390,7 @@ if [[ $3 = true ]]; then
     enable_logging
 fi
 install_olm
+install_marketplace
 install_helm
 if [[ $4 = true ]]; then
     enable_kubefed


### PR DESCRIPTION
This installs OLM in the end-to-end tests. Unlike other components, it
doesn’t rely on binaries available on the system, so the version is
defined in the e2e.sh script itself rather than the container
definition.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/134)
<!-- Reviewable:end -->
