### PR TITLE
Exec iptables from the host filesystem

### DIFF
--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /var/submariner
 
 # These are all available in the UBI8 base OS repository
-RUN microdnf -y install --nodocs iproute iptables && \
+RUN microdnf -y install --nodocs iproute && \
     microdnf clean all
 
 COPY submariner-route-agent.sh /usr/local/bin
@@ -11,6 +11,9 @@ COPY submariner-route-agent.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/submariner-route-agent.sh
 
 COPY submariner-route-agent /usr/local/bin
+# We use iptables from the host
+COPY ./iptables /usr/sbin/
+COPY ./iptables-save /usr/sbin/
 
 # temporary sleep infinity so that we can do our debugging
 ENTRYPOINT submariner-route-agent.sh

--- a/package/iptables
+++ b/package/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/package/iptables-save
+++ b/package/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
Depends-On: https://github.com/submariner-io/submariner-charts/pull/3

Both iptables and nftables use netfilter framework in the kernel for
packet filtering. Many distributions are moving in the direction of
using nftables over iptables. Although, nftables uses a new command
line utility (named nft), starting from iptables >=1.8, it uses
nftables under the hood while continuing to support the same iptables
syntax from the user.

Quoting from Dan's comment [#]

"In iptables 1.8, the maintainers have "deprecated" the classic ip_tables:
the iptables tool now does userspace translation from the legacy UI/UX,
and uses nf_tables under the hood. So, the commands look and feel the
same, but they're now programming a different kernel subsystem.

The problem arises when you mix and match invocations of iptables 1.6
(the previous stable) and 1.8 on the same machine, because although they
look identical, they're programming different kernel subsystems.

Empirically, this causes weird and wonderful things to happen - things
like if you trace a packet coming from a pod, you see it flowing through
both ip_tables and nf_tables, but even if both accept the packet, it then
vanishes entirely and never gets forwarded"

So, as long as we are programming either nf_tables or iptables, we would
not have any issues. Currently, there is no easy way to identify what type
of rules are programmed on the host. This patch follows the same approach
(as described here [*]) that is taken in OpenShift where the host file
system is mounted inside the docker container and iptables utility on the
host is exec'ed for programming any firewall rules.

[#] https://github.com/kubernetes/kubernetes/issues/71305#issuecomment-448052889
[*] https://github.com/kubernetes/kubernetes/issues/71305#issuecomment-521978797