### PR TITLE
Some changes related to pods and namespaces

### DIFF
--- a/test/e2e/dataplane/tcp_pod_to_service.go
+++ b/test/e2e/dataplane/tcp_pod_to_service.go
@@ -22,14 +22,14 @@ func testPod2ServiceTCP(f *framework.Framework) {
 	connectorUUID := string(uuid.NewUUID())
 
 	By("Creating a listener pod in cluster B, which will wait for a handshake over TCP")
-	listenerPod := f.CreateTCPCheckListenerPod(framework.ClusterB, listenerUUID)
+	listenerPod := f.CreateTCPCheckListenerPod(framework.ClusterB, listenerUUID, f.Namespace)
 
 	By("Pointing a service ClusterIP to the listener pod in cluster B")
 	service := f.CreateTCPService(framework.ClusterB, listenerPod.Labels[framework.TestAppLabel], framework.TestPort)
 	framework.Logf("Service for listener pod has ClusterIP: %v", service.Spec.ClusterIP)
 
 	By("Creating a connector pod in cluster A, which will attempt the specific UUID handshake over TCP")
-	connectorPod := f.CreateTCPCheckConnectorPod(framework.ClusterA, listenerPod, service.Spec.ClusterIP, connectorUUID)
+	connectorPod := f.CreateTCPCheckConnectorPod(framework.ClusterA, listenerPod, service.Spec.ClusterIP, connectorUUID, f.Namespace)
 
 	By("Waiting for the listener pod to exit with code 0, returning what listener sent")
 	exitStatusL, exitMessageL := f.WaitForPodFinishStatus(listenerPod, framework.ClusterB)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -105,17 +105,7 @@ func (f *Framework) BeforeEach() {
 		namespaceLabels := map[string]string{
 			"e2e-framework": f.BaseName,
 		}
-
-		for idx, clientSet := range f.ClusterClients {
-			switch idx {
-			case ClusterA: // On the first cluster we let k8s generate a name for the namespace
-				namespace := generateNamespace(clientSet, f.BaseName, namespaceLabels)
-				f.Namespace = namespace.GetName()
-				f.UniqueName = namespace.GetName()
-			default: // On the other clusters we use the same name to make tracing easier
-				f.CreateNamespace(clientSet, f.Namespace, namespaceLabels)
-			}
-		}
+		f.GenerateNamespace(f.BaseName, namespaceLabels)
 	} else {
 		f.UniqueName = string(uuid.NewUUID())
 	}
@@ -272,4 +262,18 @@ func createNamespace(client kubeclientset.Interface, name string, labels map[str
 	namespace, err := client.CoreV1().Namespaces().Create(namespaceObj)
 	Expect(err).NotTo(HaveOccurred(), "Error creating namespace %v", namespaceObj)
 	return namespace
+}
+
+func (f *Framework) GenerateNamespace(name string, namespacelables map[string]string) string {
+	for idx, clientSet := range f.ClusterClients {
+		switch idx {
+		case ClusterA: // On the first cluster we let k8s generate a name for the namespace
+			namespace := generateNamespace(clientSet, f.BaseName, namespacelables)
+			f.Namespace = namespace.GetName()
+			f.UniqueName = namespace.GetName()
+		default: // On the other clusters we use the same name to make tracing easier
+			f.CreateNamespace(clientSet, f.Namespace, namespacelables)
+		}
+	}
+	return f.Namespace
 }

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -16,7 +16,7 @@ const (
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will listen on TestPort over TCP, send sendString over the connection,
 // and write the network response in the pod  termination log, then exit with 0 status
-func (f *Framework) CreateTCPCheckListenerPod(cluster int, sendString string) *v1.Pod {
+func (f *Framework) CreateTCPCheckListenerPod(cluster int, sendString string, namespace string) *v1.Pod {
 
 	tcpCheckListenerPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -24,6 +24,7 @@ func (f *Framework) CreateTCPCheckListenerPod(cluster int, sendString string) *v
 			Labels: map[string]string{
 				TestAppLabel: "tcp-check-listener",
 			},
+			Namespace : namespace,
 		},
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
@@ -53,7 +54,7 @@ func (f *Framework) CreateTCPCheckListenerPod(cluster int, sendString string) *v
 // The pod will connect to remoteIP:TestPort over TCP, send sendString over the
 // connection, and write the network response in the pod termination log, then
 // exit with 0 status
-func (f *Framework) CreateTCPCheckConnectorPod(cluster int, remoteCheckPod *v1.Pod, remoteIP string, sendString string) *v1.Pod {
+func (f *Framework) CreateTCPCheckConnectorPod(cluster int, remoteCheckPod *v1.Pod, remoteIP string, sendString string, namespace string) *v1.Pod {
 
 	tcpCheckConnectorPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,6 +62,7 @@ func (f *Framework) CreateTCPCheckConnectorPod(cluster int, remoteCheckPod *v1.P
 			Labels: map[string]string{
 				TestAppLabel: "tcp-check-pod",
 			},
+			Namespace : namespace,
 		},
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
This pathc does following:

1. Provides a provision to create multiple namespaces
   in a cluster
2. Provision to be able to create a pod in specified
   namespace

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/141)
<!-- Reviewable:end -->
