### PR TITLE
Point the helm chart configuration to submariner-io/submariner-charts

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -56,7 +56,7 @@ function kind_clusters() {
 function install_helm() {
     trap_commands
     helm init --client-only
-    helm repo add submariner-latest https://releases.rancher.com/submariner-charts/latest
+    helm repo add submariner-latest https://submariner-io.github.io/submariner-charts/charts
     pids=(-1 -1 -1)
     logs=()
     for i in 1 2 3; do


### PR DESCRIPTION
submariner-io/submariner-charts helm repository is hosting the latest charts from gh-pages branch.
The charts info is available at https://submariner-io.github.io/submariner-charts/charts/index.yaml.