### PR TITLE
Allow IPSec on non-standard ports via environment variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,6 @@ require (
 	sigs.k8s.io/yaml v0.0.0-20181102190223-fd68e9863619 // indirect
 )
 
-replace github.com/bronze1man/goStrongswanVici => github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda
+replace github.com/bronze1man/goStrongswanVici => github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff
 
 replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/submariner-io/submariner
 go 1.12
 
 require (
-	github.com/bronze1man/goStrongswanVici v0.0.0-20181105005556-92d3927c899e
+	github.com/bronze1man/goStrongswanVici v0.0.0-20190921045355-4c81bd8d0bd5
 	github.com/coreos/go-iptables v0.4.0
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
@@ -41,7 +41,5 @@ require (
 	k8s.io/kube-openapi v0.0.0-20181109181836-c59034cc13d5 // indirect
 	sigs.k8s.io/yaml v0.0.0-20181102190223-fd68e9863619 // indirect
 )
-
-replace github.com/bronze1man/goStrongswanVici => github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff
 
 replace github.com/onsi/ginkgo => github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/mangelajo/goStrongswanVici v0.0.0-20190223031456-9a5ae4453bd h1:hOq4ymLKjuNeXCJrTbPG/DAPK4DIroOaQUGu60Q7BXI=
 github.com/mangelajo/goStrongswanVici v0.0.0-20190223031456-9a5ae4453bd/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
+github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff h1:uPocK1/7heSIWzEANFvCLVcSHrVWROiRCp01aXT+yB0=
+github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
 github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda h1:/+TyeDEvC0xdyiIQg17E5wrWxTxO+oTcnOCjvM/V34U=
 github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -47,6 +49,7 @@ github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288 h1:IrDHY8COHGFX/oYjUAS
 github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bronze1man/goStrongswanVici v0.0.0-20190921045355-4c81bd8d0bd5 h1:Vf6H6edn93L8a9veAAWAJO+puYBr2MjYNgGNZ60s2aw=
+github.com/bronze1man/goStrongswanVici v0.0.0-20190921045355-4c81bd8d0bd5/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/coreos/go-iptables v0.4.0 h1:wh4UbVs8DhLUbpyq97GLJDKrQMjEDD63T1xE4CrsKzQ=
 github.com/coreos/go-iptables v0.4.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -35,20 +37,12 @@ github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be h1:AHimNtVIpiBjPU
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190223031456-9a5ae4453bd h1:hOq4ymLKjuNeXCJrTbPG/DAPK4DIroOaQUGu60Q7BXI=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190223031456-9a5ae4453bd/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff h1:uPocK1/7heSIWzEANFvCLVcSHrVWROiRCp01aXT+yB0=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-73b0716138ff/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda h1:/+TyeDEvC0xdyiIQg17E5wrWxTxO+oTcnOCjvM/V34U=
-github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda/go.mod h1:jBWUR9RyXtXsgAghFahi+vhaF5sup3XXAST2nvBkjug=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288 h1:IrDHY8COHGFX/oYjUAS2vB0qfHfQ09YzChm5RikI9Z8=
 github.com/onsi/ginkgo v0.0.0-20190716150225-054541502288/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
-github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf -y distrosync && \
     dnf -y install iproute iptables strongswan procps-ng && \
     dnf -y clean all
 
-COPY charon.conf /etc/strongswan.d/charon.conf
 COPY submariner.sh submariner-engine /usr/local/bin/
 
 ENTRYPOINT submariner.sh

--- a/package/charon.conf
+++ b/package/charon.conf
@@ -1,4 +1,0 @@
-charon {
-    make_before_break = yes
-    ignore_acquire_ts = yes
-}

--- a/pkg/cableengine/ipsec/strongswan_test.go
+++ b/pkg/cableengine/ipsec/strongswan_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Util", func() {
+var _ = Describe("Strongswan", func() {
 	Describe("Charon port configuration", testCharonConfigPortsGen)
 })
 
@@ -21,7 +21,9 @@ func testCharonConfigPortsGen() {
 			ss := strongSwan{ipSecIKEPort: "500", ipSecNATTPort: "4500"}
 			buf := new(bytes.Buffer)
 
-			ss.renderCharonConfigTemplate(buf)
+			err := ss.renderCharonConfigTemplate(buf)
+
+			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(buf.String()).To(ContainSubstring("port = 500"))
 			Expect(buf.String()).To(ContainSubstring("port_nat_t = 4500"))
@@ -36,7 +38,7 @@ func testCharonConfigPortsGen() {
 			checkEnvVarParsingPorts("500", "4500")
 		})
 
-		It("should get the rigth environment variable names", func() {
+		It("should get the right environment variable names", func() {
 			const (
 				ikePort        = "555"
 				nattPort       = "4555"
@@ -62,7 +64,7 @@ func checkEnvVarParsingPorts(ikePort string, nattPort string) {
 	Expect(ipSecSpec.NATTPort).To(Equal(nattPort))
 }
 
-func TestUtil(t *testing.T) {
+func TestStrongswan(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Strongswan Suite")
 }

--- a/pkg/cableengine/ipsec/strongswan_test.go
+++ b/pkg/cableengine/ipsec/strongswan_test.go
@@ -1,0 +1,66 @@
+package ipsec
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/kelseyhightower/envconfig"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Util", func() {
+	Describe("Charon port configuration", testCharonConfigPortsGen)
+})
+
+func testCharonConfigPortsGen() {
+	Context("config rendering", func() {
+		It("should render config correctly out of strongSwan parameters", func() {
+			ss := strongSwan{ipSecIKEPort: "500", ipSecNATTPort: "4500"}
+			buf := new(bytes.Buffer)
+
+			ss.renderCharonConfigTemplate(buf)
+
+			Expect(buf.String()).To(ContainSubstring("port = 500"))
+			Expect(buf.String()).To(ContainSubstring("port_nat_t = 4500"))
+
+		})
+	})
+
+	Context("environment variable processing", func() {
+		It("should get the defaults from the specification definition", func() {
+			checkEnvVarParsingPorts("500", "4500")
+		})
+
+		It("should get the rigth environment variable names", func() {
+			const (
+				ikePort        = "555"
+				nattPort       = "4555"
+				ikePortEnvVar  = "CE_IPSEC_IKEPORT"
+				nattPortEnvVar = "CE_IPSEC_NATTPORT"
+			)
+			os.Setenv(ikePortEnvVar, ikePort)
+			os.Setenv(nattPortEnvVar, nattPort)
+
+			checkEnvVarParsingPorts(ikePort, nattPort)
+
+			os.Unsetenv(ikePortEnvVar)
+			os.Unsetenv(nattPortEnvVar)
+		})
+	})
+}
+
+func checkEnvVarParsingPorts(ikePort string, nattPort string) {
+	ipSecSpec := specification{}
+	err := envconfig.Process(ipsecSpecEnvVarPrefix, &ipSecSpec)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ipSecSpec.IKEPort).To(Equal(ikePort))
+	Expect(ipSecSpec.NATTPort).To(Equal(nattPort))
+}
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Strongswan Suite")
+}

--- a/pkg/cableengine/ipsec/strongswan_test.go
+++ b/pkg/cableengine/ipsec/strongswan_test.go
@@ -25,6 +25,8 @@ func testCharonConfigPortsGen() {
 
 			Expect(buf.String()).To(ContainSubstring("port = 500"))
 			Expect(buf.String()).To(ContainSubstring("port_nat_t = 4500"))
+			Expect(buf.String()).To(ContainSubstring("make_before_break = yes"))
+			Expect(buf.String()).To(ContainSubstring("ignore_acquire_ts = yes"))
 
 		})
 	})


### PR DESCRIPTION
Some corporate networks block outgoing IPSEC traffic ports,
in such cases the option to specify no standard IPSEC ports
becomes necessary.

This patch allows control over the IPSEC UDP ports. All clusters
must use the same ports. In the future we should implement
the ability to declare which ports a cluster uses, and announce
those through the exchanged endpoint information.

The environment variables are:

  - CE_IPSEC_IKEPORT   defaults to 500
  - CE_IPSEC_NATTPORT  defaults to 4500