### PR TITLE
Use set -T instead of shopt -s extdebug

### DIFF
--- a/scripts/lib/debug_functions
+++ b/scripts/lib/debug_functions
@@ -14,6 +14,5 @@ function trap_commands() {
 
 ### Main ###
 
-export -f trap_commands
-shopt -s extdebug
+set -T
 trap_commands


### PR DESCRIPTION
This avoids issues caused by the extdebug bug in Bash < 4.4.

Closes: https://jira.coreos.com/browse/HYCLD-263
Signed-off-by: Stephen Kitt <skitt@redhat.com>