### PR TITLE
Fix entrypoints to support debug correctly

### DIFF
--- a/package/submariner-route-agent.sh
+++ b/package/submariner-route-agent.sh
@@ -4,7 +4,7 @@ set -e -x
 trap "exit 1" SIGTERM SIGINT
 
 if [ "${SUBMARINER_DEBUG}" == "true" ]; then
-    DEBUG="--debug -v=9"
+    DEBUG="-v=9"
 else
     DEBUG="-v=4"
 fi

--- a/package/submariner.sh
+++ b/package/submariner.sh
@@ -7,7 +7,7 @@ export CHARON_PID_FILE=/var/run/charon.pid
 rm -f ${CHARON_PID_FILE}
 
 if [ "${SUBMARINER_DEBUG}" == "true" ]; then
-    DEBUG="--debug -v=9"
+    DEBUG="-v=9"
 else
     DEBUG="-v=4"
 fi


### PR DESCRIPTION
The current entrypoints were using a flag `--debug` that is not
processed by the executables they run. Therefore, when setting
`SUBMARINER_DEBUG` environmental variable the container crashed
and entered a crash loop. Moreover, the debug env var was not taking
care of putting `charon` in debug mode.

This patch fixes this issues by removing the flag `--debug`.