### PR TITLE
Edit tests for mismatched DaemonSet name Op/Helm

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -252,8 +252,14 @@ function verify_subm_routeagent_daemonset() {
         exit 1
      else
 
-        desiredNumberScheduled=$(kubectl get DaemonSet routeagent -n $subm_ns -o jsonpath='{.status.desiredNumberScheduled}')
-        numberReady=$(kubectl get DaemonSet routeagent -n $subm_ns -o jsonpath='{.status.numberReady}')
+        # Operator uses preferred DaemonSet name routeagent, Helm uses old submariner-routeagent
+        if [ "$deploy_operator" = true ]; then
+          daemonset_name=routeagent
+        else
+          daemonset_name=submariner-routeagent
+        fi
+        desiredNumberScheduled=$(kubectl get DaemonSet $daemonset_name -n $subm_ns -o jsonpath='{.status.desiredNumberScheduled}')
+        numberReady=$(kubectl get DaemonSet $daemonset_name -n $subm_ns -o jsonpath='{.status.numberReady}')
 
         ((SECONDS+=2))
         sleep 2


### PR DESCRIPTION
The Operator uses preferred DaemonSet name routeagent, Helm uses old
submariner-routeagent. Modify tests to account for difference, pass.

The CI overrides deploytool to be "operator" and passes. But with the
default value of deploytool ("helm"), verifications fail without this.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>