### PR TITLE
Bump Operator version 0.0.1->0.0.2

### DIFF
--- a/operators/go/gen_subm_operator.sh
+++ b/operators/go/gen_subm_operator.sh
@@ -11,7 +11,7 @@ GOPATH=$HOME/go
 # disappearing repositories
 export GOPROXY=https://proxy.golang.org
 
-version=0.0.1
+version=0.0.2
 op_dir=$GOPATH/src/github.com/submariner-operator/submariner-operator
 op_gen_dir=$(pwd)
 op_out_dir=$op_gen_dir/submariner-operator

--- a/operators/go/submariner-operator/deploy/operator.yaml
+++ b/operators/go/submariner-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: submariner-operator
           # Replace this with the built image name
-          image: quay.io/submariner/submariner-operator:0.0.1
+          image: quay.io/submariner/submariner-operator:0.0.2
           command:
           - submariner-operator
           imagePullPolicy: Always

--- a/operators/go/submariner-operator/version/version.go
+++ b/operators/go/submariner-operator/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "0.0.2"
 )


### PR DESCRIPTION
After initial SubM Operator merge, bump version to "release" 0.0.1 and
make 0.0.2 the under-dev version.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>