### PR TITLE
Uncouple ci building from e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ To build `submariner-engine` and `submariner-route-agent` you can trigger `make`
 
 To run basic e2e tests you can trigger `make e2e` command.
 
+If you want to avoid part of the ci validation with make while testing your changes
+you can speedup the process by running: `make build package e2e`
+
 We welcome issues/PR's to Submariner, if you encounter issues that you'd like to fix while working on it or find new features that you'd like.
 
 # TODO

--- a/scripts/build
+++ b/scripts/build
@@ -4,7 +4,12 @@ set -e
 source $(dirname $0)/lib/debug_functions
 source $(dirname $0)/lib/version
 
-cd $(dirname $0)/..
-mkdir -p bin
-echo Building submariner-engine version $VERSION
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION" -o bin/submariner-engine main.go
+cd $(dirname $0)/
+
+./build-engine
+./build-routeagent
+
+if [[ $5 = operator ]]; then
+   test -d ../operators/go/submariner-operator || ./codegen-operator
+   ./build-operator
+fi

--- a/scripts/build-engine
+++ b/scripts/build-engine
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/lib/debug_functions
+source $(dirname $0)/lib/version
+
+cd $(dirname $0)/..
+mkdir -p bin
+echo Building submariner-engine version $VERSION
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION" -o bin/submariner-engine main.go

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,13 +5,7 @@ source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)
 
-if [[ $5 = operator ]]; then
-   test -d ../operators/go/submariner-operator || ./codegen-operator
-   ./build-operator
-fi
-
 ./validate
 ./test
-./build
-./build-routeagent
+./build $*
 ./package

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -5,16 +5,8 @@ source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)
 
-if [[ $5 = operator ]]; then
-   test -d ../operators/go/submariner-operator || ./codegen-operator
-   ./build-operator
-fi
-
 if [[ $1 = clean ]]; then
     ./../scripts/kind-e2e/e2e.sh clean
 else
-    ./build
-    ./build-routeagent
-    ./package
     ./../scripts/kind-e2e/e2e.sh "$@"
 fi

--- a/scripts/kind-e2e/README.md
+++ b/scripts/kind-e2e/README.md
@@ -32,13 +32,19 @@ This mode will create e2e environment on a local workstation, run unit tests, E2
 This mode is very convenient for CI purposes.
     
 ```bash
-make e2e
+make ci e2e
+```
+
+If you want to minimize runtime another option is to skip unit tests and source
+code validation:
+```bash
+make build package e2e
 ```
 
 To test specific k8s version, additional **version** parameter can be passed to **make e2e** command.
 
 ```bash
-make e2e version=1.14.1
+make ci e2e version=1.14.1
 ```
 
 Full list of supported k8s versions can found on [kind release page] page. We are using kind vesion 0.3.0.
@@ -51,7 +57,7 @@ This mode will **keep** the e2e environment running on a local workstation for f
 This mode can be triggered by adding **status=keep** parameter to **make e2e** command.
 
 ```bash
-make e2e status=keep
+make ci e2e status=keep
 ```
 
 After a permanent run completes, the configuration for the running clusters can be found inside **output/kind-config/local-dev** folder.
@@ -81,7 +87,7 @@ The logs from three clusters will be shipped to an elasticsearch deployment on c
 Logging should be used only in addition to **status=keep** command. The default value for **logging** is **false**.
 
 ```bash
-make e2e status=keep logging=true
+make ci e2e status=keep logging=true
 ```
 
 To access Kibana, run the following from new terminal tab/window:
@@ -107,7 +113,7 @@ Providing **kubefed=true** parameter to **make e2e** command will setup federati
 Federation control plane will be created on cluster1 and clusters 2/3 will be added as members. 
 
 ```bash
-make e2e status=keep kubefed=true
+make ci e2e status=keep kubefed=true
 ```
 
 To get the status of federated clusters:
@@ -123,7 +129,7 @@ To federate resources across the clusters [kubefedctl] tool must be installed on
 At any time you can run a cleanup command that will remove kind resources.
 
 ```bash
-make e2e status=clean
+make ci e2e status=clean
 ```
 
 You can do full docker cleanup, but it will force all the docker images to be removed and invalidate the local docker cache. 
@@ -136,7 +142,7 @@ docker system prune --all
 #### Full example
 
 ```bash
-make e2e status=keep version=1.14.1 logging=true kubefed=true
+make ci e2e status=keep version=1.14.1 logging=true kubefed=true
 ```
 
 <!--links-->


### PR DESCRIPTION
This will avoid the double-build of engine, routeagent and operator,
because they are built once for ci, and once again for e2e which
was not expected.

We start doing what documentation says, make compiles/builds, and e2e
just runs e2e with an existing build, README.md says:

```
To build `submariner-engine` and `submariner-route-agent` you can
trigger `make`, which will perform a Dapperized build of the components.

To run basic e2e tests you can trigger `make e2e` command.
```