### PR TITLE
Fix operator deployment to use submariner-routeagent DaemonSet

### DIFF
--- a/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
+++ b/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
@@ -321,7 +321,7 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Submariner) *appsv1.DaemonSet
 	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
-			Name:      "routeagent",
+			Name:      "submariner-routeagent",
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/operators/go/submariner_controller.go.nolint
+++ b/operators/go/submariner_controller.go.nolint
@@ -321,7 +321,7 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Submariner) *appsv1.DaemonSet
 	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
-			Name:      "routeagent",
+			Name:      "submariner-routeagent",
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -252,8 +252,8 @@ function verify_subm_routeagent_daemonset() {
         exit 1
      else
 
-        desiredNumberScheduled=$(kubectl get DaemonSet routeagent -n $subm_ns -o jsonpath='{.status.desiredNumberScheduled}')
-        numberReady=$(kubectl get DaemonSet routeagent -n $subm_ns -o jsonpath='{.status.numberReady}')
+        desiredNumberScheduled=$(kubectl get DaemonSet submariner-routeagent -n $subm_ns -o jsonpath='{.status.desiredNumberScheduled}')
+        numberReady=$(kubectl get DaemonSet submariner-routeagent -n $subm_ns -o jsonpath='{.status.numberReady}')
 
         ((SECONDS+=2))
         sleep 2


### PR DESCRIPTION
The helm charts and the operator differ on the DaemonSet name,
this patch makes that uniform so the verification logic works for
both equally.

This also fix deploying with helm.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>