### PR TITLE
Make operator use released version 0.0.2 of submariner

### DIFF
--- a/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
+++ b/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
@@ -376,7 +376,7 @@ func setSubmarinerDefaults(submariner *submarinerv1alpha1.Submariner) {
 	}
 
 	if spec.Version == "" {
-		spec.Version = "latest"
+		spec.Version = "0.0.2"
 	}
 }
 


### PR DESCRIPTION
By the default the operator will use version 0.0.2 of the submariner
components from quay.io/submariner.