### PR TITLE
Tag the operator images

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -8,4 +8,6 @@ docker tag rancher/submariner:dev quay.io/submariner/submariner:latest
 docker tag rancher/submariner:dev quay.io/submariner/submariner:"${TRAVIS_COMMIT:0:7}"
 docker tag rancher/submariner-route-agent:dev quay.io/submariner/submariner-route-agent:latest
 docker tag rancher/submariner-route-agent:dev quay.io/submariner/submariner-route-agent:"${TRAVIS_COMMIT:0:7}"
+docker tag quay.io/submariner/submariner-operator:dev quay.io/submariner/submariner-operator:latest
+docker tag quay.io/submariner/submariner-operator:dev quay.io/submariner/submariner-operator:"${TRAVIS_COMMIT:0:7}"
 for i in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "quay.io/submariner"); do docker push $i; done


### PR DESCRIPTION
This follows the model used for engine and routeagent images: CI tags
successful builds with :latest and the git SHA, and pushes them to
Quay.

Signed-off-by: Stephen Kitt <skitt@redhat.com>