### PR TITLE
Ensure we set the default values

### DIFF
--- a/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
+++ b/operators/go/submariner-operator/pkg/controller/submariner/submariner_controller.go
@@ -100,6 +100,8 @@ func (r *ReconcileSubmariner) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	setSubmarinerDefaults(instance)
+
 	// Create submariner-engine SA
 	//subm_engine_sa := corev1.ServiceAccount{}
 	//subm_engine_sa.Name = "submariner-engine"


### PR DESCRIPTION
We allow the Submariner CR to omit certain values (currently, the
repository and version used for the container images), but we never
set the default values. This calls setSubmarinerDefaults() to ensure
the values are populated.

Signed-off-by: Stephen Kitt <skitt@redhat.com>