### PR TITLE
Stop pushing the operator

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -10,6 +10,4 @@ docker tag rancher/submariner-route-agent:dev quay.io/submariner/submariner-rout
 docker tag rancher/submariner-route-agent:dev quay.io/submariner/submariner-route-agent:"${TRAVIS_COMMIT:0:7}"
 docker tag rancher/dapper-base:dev quay.io/submariner/dapper-base:latest
 docker tag rancher/dapper-base:dev quay.io/submariner/dapper-base:"${TRAVIS_COMMIT:0:7}"
-docker tag quay.io/submariner/submariner-operator:dev quay.io/submariner/submariner-operator:latest
-docker tag quay.io/submariner/submariner-operator:dev quay.io/submariner/submariner-operator:"${TRAVIS_COMMIT:0:7}"
 for i in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "quay.io/submariner"); do docker push $i; done


### PR DESCRIPTION
Now that the separate operator project pushes images, we should stop
pushing them from Submariner (even before we delete the operator
source code).

Signed-off-by: Stephen Kitt <skitt@redhat.com>