### PR TITLE
Install SubM on broker cluster

### DIFF
--- a/scripts/kind-e2e/cluster1-config.yaml
+++ b/scripts/kind-e2e/cluster1-config.yaml
@@ -12,3 +12,5 @@ kubeadmConfigPatches:
     dnsDomain: cluster1.local
 nodes:
 - role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
One of the test scenarios requires dynamically
adding/removing third cluster to the setup.
The idea is to use broker cluster as the third
cluster.

This patch just installs SubM on broker cluster
but does not tag any gateway nodes. Node is tagged
later in the test case to mimic adding third cluster.

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>