### PR TITLE
[Urgent] Fix for microdnf issue with the latest ubi image

### DIFF
--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 
 WORKDIR /var/submariner
 

--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 
+# Pinned to image 8.0 because of this bug
+#    https://github.com/rpm-software-management/microdnf/issues/50
+# TODO(dimaunx,majopela):  we should remove the :8.0 pin when the
+#                          bug has been solved for the UBI image.
+
 WORKDIR /var/submariner
 
 # These are all available in the UBI8 base OS repository


### PR DESCRIPTION
The routeagent build is based on registry.access.redhat.com/ubi8/ubi-minimal:latest/8.1 image that has an issue with microdnf. 

process:6): libdnf-WARNING **: 06:10:10.893: Loading "/etc/dnf/dnf.conf": IniParser: Can't open file
The command '/bin/sh -c microdnf -y install --nodocs iproute iptables && microdnf clean all' returned a non-zero code: 141

This issue also affects fedora:30 container images when microdnf is used instead of dnf.
https://github.com/rpm-software-management/microdnf/issues/50

The issue is not present in the registry.access.redhat.com/ubi8/ubi-minimal:8.0.





