### PR TITLE
Enhance E2E test debugging

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -81,16 +81,16 @@ func (np *NetworkPod) AwaitReady() {
 
 	np.Pod = AwaitUntil("get pod", func() (interface{}, error) {
 		return pods.Get(np.Pod.Name, metav1.GetOptions{})
-	}, func(result interface{}) (bool, error) {
+	}, func(result interface{}) (bool, string, error) {
 		pod := result.(*v1.Pod)
 		if pod.Status.Phase != v1.PodRunning {
 			if pod.Status.Phase != v1.PodPending {
-				return false, fmt.Errorf("expected pod to be in phase \"Pending\" or \"Running\"")
+				return false, "", fmt.Errorf("expected pod to be in phase \"Pending\" or \"Running\"")
 			}
-			return false, nil // pod is still pending
+			return false, "Pod is still pending", nil
 		}
 
-		return true, nil // pod is running
+		return true, "", nil // pod is running
 	}).(*v1.Pod)
 }
 
@@ -99,16 +99,16 @@ func (np *NetworkPod) AwaitSuccessfulFinish() {
 
 	np.Pod = AwaitUntil("get pod", func() (interface{}, error) {
 		return pods.Get(np.Pod.Name, metav1.GetOptions{})
-	}, func(result interface{}) (bool, error) {
+	}, func(result interface{}) (bool, string, error) {
 		np.Pod = result.(*v1.Pod)
 
 		switch np.Pod.Status.Phase {
 		case v1.PodSucceeded:
-			return true, nil
+			return true, "", nil
 		case v1.PodFailed:
-			return true, nil
+			return true, "", nil
 		default:
-			return false, nil
+			return false, fmt.Sprintf("Pod status is %v", np.Pod.Status.Phase), nil
 		}
 	}).(*v1.Pod)
 

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,14 +14,13 @@ func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, na
 		return f.ClusterClients[cluster].CoreV1().Pods(namespace).List(metav1.ListOptions{
 			LabelSelector: "app=" + appName,
 		})
-	}, func(result interface{}) (bool, error) {
+	}, func(result interface{}) (bool, string, error) {
 		pods := result.(*v1.PodList)
 		if expectedCount < 0 || len(pods.Items) == expectedCount {
-			return true, nil
+			return true, "", nil
 		}
 
-		Logf("Actual pod count %d does not match the expected pod count %d - retrying...", len(pods.Items), expectedCount)
-		return false, nil
+		return false, fmt.Sprintf("Actual pod count %d does not match the expected pod count %d", len(pods.Items), expectedCount), nil
 	}).(*v1.PodList)
 }
 


### PR DESCRIPTION
**First commit:**

`CheckResultFunc` now returns an optional string which is used by `AwaitUntil`
to provide additional context when an error is returned from `PollImmediate`.

**Second commit:**

Factored out a `AwaitResultOrError` function that returns error info and lets the caller assert failures. Added `NetworkPod.AwaitFinish` which sets the pod termination results and a separate `CheckSuccessfulFinish` method to assert success. `AwaitFinish` also outputs the pod's termination log. This allows `runAndVerifyNetworkPod2ServicePair` to await both Network pods prior to checking success so we can view both logs on failure.
    
Also added the -w flag to the listener pod's 'nc' command to wait a max of 45 s for a connection - this allows the pod to eventually terminate so we can output the log.
    
Similarly, on the connector pod, added retries with a connection timeout of 2 s up to 45 s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/208)
<!-- Reviewable:end -->
