### PR TITLE
Fix E2E setup script failure

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -148,9 +148,6 @@ function install_subm_in_cluster1() {
             --set engine.image.tag="local" \
             --set engine.image.pullPolicy="IfNotPresent" \
             --set crd.create="false"
-            echo Waiting for submariner pods to be Ready on cluster1...
-            kubectl --context=cluster1 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
-            kubectl --context=cluster1 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
     fi
 }
 


### PR DESCRIPTION
Recent changes to install subm on the brooker cluster caused a
failure when waiting for the subm pods to be ready b/c no
gateway node is configured so the engine isn't deployed. Removed
the code to wait for the pods.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>