### PR TITLE
Add Global CIDR to Cluster CRD

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -19,6 +19,7 @@ type ClusterSpec struct {
 	ColorCodes  []string `json:"color_codes"`
 	ServiceCIDR []string `json:"service_cidr"`
 	ClusterCIDR []string `json:"cluster_cidr"`
+	GlobalCIDR  []string `json:"global_cidr"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.GlobalCIDR != nil {
+		in, out := &in.GlobalCIDR, &out.GlobalCIDR
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
There is a growing need to be able to support multi cluster networking
across brownfield deployments that have limited abilities to create non
overlapping CIDRs for their Pod(s) and Service(s) networks. As discussed
during some meetings this can be addressed by having a Global multi
cluster network that is non-overlapping and can do NATting while still
be able to leverage the advantages that Submariner brings.

This patch adds the ability to define a Global CIDR segment associated
with a specific cluster and store the information as part of the
cluster's Cluster CRD. The autogenerated part was added by executing
`./scripts/codegen`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/213)
<!-- Reviewable:end -->
