### PR TITLE
kind-e2e: updated cluster yaml kubeadm api to v1beta2

### DIFF
--- a/scripts/kind-e2e/cluster1-config.yaml
+++ b/scripts/kind-e2e/cluster1-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config

--- a/scripts/kind-e2e/cluster2-config.yaml
+++ b/scripts/kind-e2e/cluster2-config.yaml
@@ -4,7 +4,7 @@ networking:
   disableDefaultCNI: true
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config

--- a/scripts/kind-e2e/cluster3-config.yaml
+++ b/scripts/kind-e2e/cluster3-config.yaml
@@ -4,7 +4,7 @@ networking:
   disableDefaultCNI: true
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config


### PR DESCRIPTION
addressing: https://github.com/kubernetes-sigs/kind/issues/666 