### PR TITLE
Fix for Flannel CNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,13 +289,6 @@ When running in Openshift, we need to grant the appropriate security context for
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
    ```
 
-### Flannel Notes
-
-When using flannel CNI, configure reverse path filtering to loose mode on the non-gateway nodes (i.e., worker nodes).
-Also, to preserve the setting, you can add it to /etc/sysctl.conf file
-
-sysctl -w net.ipv4.conf.flannel.1.rp_filter=2
-
 # Building
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ When running in Openshift, we need to grant the appropriate security context for
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
    ```
+
 # Building
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ When running in Openshift, we need to grant the appropriate security context for
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
    ```
-
 # Building
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ When running in Openshift, we need to grant the appropriate security context for
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
    ```
-
+   
 # Building
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,14 @@ When running in Openshift, we need to grant the appropriate security context for
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
    ```
-   
+
+### Flannel Notes
+
+When using flannel CNI, configure reverse path filtering to loose mode on the non-gateway nodes (i.e., worker nodes).
+Also, to preserve the setting, you can add it to /etc/sysctl.conf file
+
+sysctl -w net.ipv4.conf.flannel.1.rp_filter=2
+
 # Building
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/pkg/routeagent/controllers/route/driver.go
+++ b/pkg/routeagent/controllers/route/driver.go
@@ -1,0 +1,34 @@
+package route
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
+)
+
+const FlannelInterface = "flannel.1"
+
+func isFlannelCNI() error {
+	_, err := netlink.LinkByName(FlannelInterface)
+	if err != nil {
+		return fmt.Errorf("error retrieving link by name %s: %v", FlannelInterface, err)
+	}
+
+	// FlannelInterface exists, return nil
+	return nil
+}
+
+func toggleCNISpecificConfiguration() error {
+	// When using Flannel CNI, reverse path filtering has to be configured with loose mode on the FlannelInterface
+	if isFlannelCNI() == nil {
+		err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+FlannelInterface+"/rp_filter", []byte("2"), 0644)
+		if err != nil {
+			return fmt.Errorf("unable to update rp_filter for "+FlannelInterface+", err: %s", err)
+		} else {
+			klog.Info("Successfully configured rp_filter to loose mode(2) on " + FlannelInterface)
+		}
+	}
+	return nil
+}

--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -155,8 +155,14 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
+	// Configure CNI Specific changes
+	err := toggleCNISpecificConfiguration()
+	if err != nil {
+		return fmt.Errorf("toggleCNISpecificConfiguration returned error. %v", err)
+	}
+
 	// Create the necessary IPTable chains in the filter and nat tables.
-	err := r.createIPTableChains()
+	err = r.createIPTableChains()
 	if err != nil {
 		return fmt.Errorf("createIPTableChains returned error. %v", err)
 	}


### PR DESCRIPTION
Reverse path filtering is a mechanism used by networking devices to check whether a receiving packet
source address is routable. When reverse path filtering is enabled, the host will first check whether
the source of the received packet is reachable through the interface it came in. If it is routable
through the interface in which it came, then the packet is accepted otherwise its dropped.

When using flannel CNI, we have to configure loose mode for reverse path filtering and this patch
automates this change.

rp_filter - INTEGER
    0 - No source validation.
    1 - Strict mode as defined in RFC3704 Strict Reverse Path
        Each incoming packet is tested against the FIB and if the interface
        is not the best reverse path the packet check will fail.
        By default failed packets are discarded.
    2 - Loose mode as defined in RFC3704 Loose Reverse Path
        Each incoming packet's source address is also tested against the FIB
        and if the source address is not reachable via any interface
        the packet check will fail.

Current recommended practice in RFC3704 is to enable strict mode
to prevent IP spoofing from DDos attacks. If using asymmetric routing
or other complicated routing, then loose mode is recommended.

Source: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/217)
<!-- Reviewable:end -->
