### PR TITLE
Fix recurring runs if helm is used as an installation tool

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -150,33 +150,32 @@ function helm_install_subm() {
 
 # Only install Submariner on broker cluster with 2 worker nodes but do not tag any worker nodes with gateway label
 function install_subm_in_cluster1() {
-    if kubectl --context=cluster1 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
-            echo Submariner already installed, skipping submariner helm installation...
-            update_subm_pods cluster1
-        else
-            echo Installing submariner on cluster1...
-	    helm_install_subm cluster1 10.244.0.0/16 100.94.0.0/16 false
+    if kubectl --context=cluster1 get crd clusters.submariner.io > /dev/null 2>&1; then
+        echo Submariner CRDs already present, skipping submariner helm installation...
+    else
+        echo Installing submariner engine on cluster1...
+        helm_install_subm cluster1 10.244.0.0/16 100.94.0.0/16 false
     fi
 }
 
 function setup_cluster2_gateway() {
     if kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
-            echo Submariner already installed, skipping submariner helm installation...
-            update_subm_pods cluster2
-        else
-            echo Installing submariner on cluster2...
-            worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster2-worker | head -n 1)
-            kubectl --context=cluster2 label node cluster2-worker "submariner.io/gateway=true" --overwrite
-	    helm_install_subm cluster2 10.245.0.0/16 100.95.0.0/16 true
+        echo Submariner already installed, skipping submariner helm installation...
+        update_subm_pods cluster2
+    else
+        echo Installing submariner on cluster2...
+        worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster2-worker | head -n 1)
+        kubectl --context=cluster2 label node cluster2-worker "submariner.io/gateway=true" --overwrite
+        helm_install_subm cluster2 10.245.0.0/16 100.95.0.0/16 true
 
-            echo Waiting for submariner pods to be Ready on cluster2...
-            kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
-            kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
+        echo Waiting for submariner pods to be Ready on cluster2...
+        kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
+        kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
 
-            echo Deploying netshoot on cluster2 worker: ${worker_ip}
-            kubectl --context=cluster2 apply -f ${PRJ_ROOT}/scripts/kind-e2e/netshoot.yaml
-            echo Waiting for netshoot pods to be Ready on cluster2.
-            kubectl --context=cluster2 rollout status deploy/netshoot --timeout=120s
+        echo Deploying netshoot on cluster2 worker: ${worker_ip}
+        kubectl --context=cluster2 apply -f ${PRJ_ROOT}/scripts/kind-e2e/netshoot.yaml
+        echo Waiting for netshoot pods to be Ready on cluster2.
+        kubectl --context=cluster2 rollout status deploy/netshoot --timeout=120s
     fi
 }
 
@@ -184,20 +183,20 @@ function setup_cluster3_gateway() {
     if kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
             echo Submariner already installed, skipping submariner helm installation...
             update_subm_pods cluster3
-        else
-            echo Installing submariner on cluster3...
-            worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster3-worker | head -n 1)
-            kubectl --context=cluster3 label node cluster3-worker "submariner.io/gateway=true" --overwrite
-	    helm_install_subm cluster3 10.246.0.0/16 100.96.0.0/16 true
+    else
+        echo Installing submariner on cluster3...
+        worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster3-worker | head -n 1)
+        kubectl --context=cluster3 label node cluster3-worker "submariner.io/gateway=true" --overwrite
+        helm_install_subm cluster3 10.246.0.0/16 100.96.0.0/16 true
 
-            echo Waiting for submariner pods to be Ready on cluster3...
-            kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
-            kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
+        echo Waiting for submariner pods to be Ready on cluster3...
+        kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
+        kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
 
-            echo Deploying nginx on cluster3 worker: ${worker_ip}
-            kubectl --context=cluster3 apply -f ${PRJ_ROOT}/scripts/kind-e2e/nginx-demo.yaml
-            echo Waiting for nginx-demo deployment to be Ready on cluster3.
-            kubectl --context=cluster3 rollout status deploy/nginx-demo --timeout=120s
+        echo Deploying nginx on cluster3 worker: ${worker_ip}
+        kubectl --context=cluster3 apply -f ${PRJ_ROOT}/scripts/kind-e2e/nginx-demo.yaml
+        echo Waiting for nginx-demo deployment to be Ready on cluster3.
+        kubectl --context=cluster3 rollout status deploy/nginx-demo --timeout=120s
     fi
 }
 


### PR DESCRIPTION
Currently submariner engine is installed to cluster1 in additional to broker. The pods are not in running state. The check if to install engine again always fails and an error is returned that submariner release already exists on cluster1. This PR uses CRD presence instead of pods as a condition whether to install submariner engine again on cluster1. This fixes recurring runs if helm is used as an installer tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/222)
<!-- Reviewable:end -->
