### PR TITLE
Fix for make ci e2e recurring runs with helm

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -115,6 +115,7 @@ function setup_broker() {
     else
         echo Installing broker on cluster1.
         helm --kube-context cluster1 install submariner-latest/submariner-k8s-broker --name ${SUBMARINER_BROKER_NS} --namespace ${SUBMARINER_BROKER_NS}
+        helm_install_subm cluster1 10.244.0.0/16 100.94.0.0/16 false
     fi
 
     SUBMARINER_BROKER_URL=$(kubectl --context=cluster1 -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
@@ -148,56 +149,45 @@ function helm_install_subm() {
 	--set crd.create="${crd_create}"
 }
 
-# Only install Submariner on broker cluster with 2 worker nodes but do not tag any worker nodes with gateway label
-function install_subm_in_cluster1() {
-    if kubectl --context=cluster1 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
-            echo Submariner already installed, skipping submariner helm installation...
-            update_subm_pods cluster1
-        else
-            echo Installing submariner on cluster1...
-	    helm_install_subm cluster1 10.244.0.0/16 100.94.0.0/16 false
-    fi
-}
-
 function setup_cluster2_gateway() {
     if kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
-            echo Submariner already installed, skipping submariner helm installation...
-            update_subm_pods cluster2
-        else
-            echo Installing submariner on cluster2...
-            worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster2-worker | head -n 1)
-            kubectl --context=cluster2 label node cluster2-worker "submariner.io/gateway=true" --overwrite
-	    helm_install_subm cluster2 10.245.0.0/16 100.95.0.0/16 true
+        echo Submariner already installed, skipping submariner helm installation...
+        update_subm_pods cluster2
+    else
+        echo Installing submariner on cluster2...
+        worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster2-worker | head -n 1)
+        kubectl --context=cluster2 label node cluster2-worker "submariner.io/gateway=true" --overwrite
+        helm_install_subm cluster2 10.245.0.0/16 100.95.0.0/16 true
 
-            echo Waiting for submariner pods to be Ready on cluster2...
-            kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
-            kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
+        echo Waiting for submariner pods to be Ready on cluster2...
+        kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
+        kubectl --context=cluster2 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
 
-            echo Deploying netshoot on cluster2 worker: ${worker_ip}
-            kubectl --context=cluster2 apply -f ${PRJ_ROOT}/scripts/kind-e2e/netshoot.yaml
-            echo Waiting for netshoot pods to be Ready on cluster2.
-            kubectl --context=cluster2 rollout status deploy/netshoot --timeout=120s
+        echo Deploying netshoot on cluster2 worker: ${worker_ip}
+        kubectl --context=cluster2 apply -f ${PRJ_ROOT}/scripts/kind-e2e/netshoot.yaml
+        echo Waiting for netshoot pods to be Ready on cluster2.
+        kubectl --context=cluster2 rollout status deploy/netshoot --timeout=120s
     fi
 }
 
 function setup_cluster3_gateway() {
     if kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s > /dev/null 2>&1; then
-            echo Submariner already installed, skipping submariner helm installation...
-            update_subm_pods cluster3
-        else
-            echo Installing submariner on cluster3...
-            worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster3-worker | head -n 1)
-            kubectl --context=cluster3 label node cluster3-worker "submariner.io/gateway=true" --overwrite
-	    helm_install_subm cluster3 10.246.0.0/16 100.96.0.0/16 true
+        echo Submariner already installed, skipping submariner helm installation...
+        update_subm_pods cluster3
+    else
+        echo Installing submariner on cluster3...
+        worker_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster3-worker | head -n 1)
+        kubectl --context=cluster3 label node cluster3-worker "submariner.io/gateway=true" --overwrite
+        helm_install_subm cluster3 10.246.0.0/16 100.96.0.0/16 true
 
-            echo Waiting for submariner pods to be Ready on cluster3...
-            kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
-            kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
+        echo Waiting for submariner pods to be Ready on cluster3...
+        kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-engine -n submariner --timeout=60s
+        kubectl --context=cluster3 wait --for=condition=Ready pods -l app=submariner-routeagent -n submariner --timeout=60s
 
-            echo Deploying nginx on cluster3 worker: ${worker_ip}
-            kubectl --context=cluster3 apply -f ${PRJ_ROOT}/scripts/kind-e2e/nginx-demo.yaml
-            echo Waiting for nginx-demo deployment to be Ready on cluster3.
-            kubectl --context=cluster3 rollout status deploy/nginx-demo --timeout=120s
+        echo Deploying nginx on cluster3 worker: ${worker_ip}
+        kubectl --context=cluster3 apply -f ${PRJ_ROOT}/scripts/kind-e2e/nginx-demo.yaml
+        echo Waiting for nginx-demo deployment to be Ready on cluster3.
+        kubectl --context=cluster3 rollout status deploy/nginx-demo --timeout=120s
     fi
 }
 
@@ -215,7 +205,7 @@ function kind_import_images() {
        docker tag $OPERATOR_IMAGE submariner-operator:local
     fi
 
-    for i in 2 3; do
+    for i in 1 2 3; do
         echo "Loading submariner images in to cluster${i}..."
         kind --name cluster${i} load docker-image submariner:local
         kind --name cluster${i} load docker-image submariner-route-agent:local
@@ -466,7 +456,6 @@ if [ "$deploy_operator" = true ]; then
     deploy_nginx_cluster3
 elif [[ $5 = helm ]]; then
     helm=true
-    install_subm_in_cluster1
     setup_cluster2_gateway
     setup_cluster3_gateway
     for i in 2 3; do


### PR DESCRIPTION
Issue:
Running make ci e2e status=keep multiple times locally.

Currently after the first initial run, the broker cluster has submariner engine installed with helm. The pods are not healthy as we don't tag gateway nodes for broker cluster and not loading the images to cluster1. This results in a check for submariner pods always to be false and forces a recurring installation of the engine with helm. The engine on the broker cluster is needed only for testing purposes so this PR makes the installation occur only once during the broker installation phase on cluster1. 

Error:
Error: a release named submariner already exists.
Run: helm ls --all submariner; to check the status of the release
Or run: helm del --purge submariner; to delete it


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/225)
<!-- Reviewable:end -->
