### PR TITLE
Use chroot to verify iptables on the host

### DIFF
--- a/package/submariner-route-agent.sh
+++ b/package/submariner-route-agent.sh
@@ -9,10 +9,10 @@ else
     DEBUG="-v=4"
 fi
 
-function verify_iptables_on_host() {
-    chroot /host test -x /usr/sbin/$1 && { echo "0"; return; }
-    chroot /host test -x /sbin/$1 && { echo "1"; return; }
-    echo "-1"
+function find_iptables_on_host() {
+    chroot /host test -x /usr/sbin/$1 && { echo "/usr/sbin"; return; }
+    chroot /host test -x /sbin/$1 && { echo "/sbin"; return; }
+    echo "unknown"
 }
 
 
@@ -23,11 +23,11 @@ function verify_iptables_on_host() {
 # and iptables-save which program nftables under the hood. 
 
 for f in iptables-save iptables; do
-  iptablesExists=$(verify_iptables_on_host $f)
-  if [ $iptablesExists == "0" ]; then
+  iptablesLocation=$(find_iptables_on_host $f)
+  if [ $iptablesLocation == "/usr/sbin" ]; then
     echo "$f is present on the host at /usr/sbin/$f"
     cp /usr/sbin/${f}.wrapper /usr/sbin/$f
-  elif [ $iptablesExists == "1" ]; then
+  elif [ $iptablesLocation == "/sbin" ]; then
     echo "$f is present on the host at /sbin/$f"
     cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
   else

--- a/package/submariner-route-agent.sh
+++ b/package/submariner-route-agent.sh
@@ -9,6 +9,13 @@ else
     DEBUG="-v=4"
 fi
 
+function verify_iptables_on_host() {
+    chroot /host test -x /usr/sbin/$1 && { echo "0"; return; }
+    chroot /host test -x /sbin/$1 && { echo "1"; return; }
+    echo "-1"
+}
+
+
 # if host is mounted on /host and host has it's own iptables version
 # use that one instead via the shipped iptables wrapper, we do this
 # to avoid configuring iptables and nftables on the host which
@@ -16,16 +23,19 @@ fi
 # and iptables-save which program nftables under the hood. 
 
 for f in iptables-save iptables; do
-	if [[ -x /host/usr/sbin/$f ]]; then
-		cp /usr/sbin/${f}.wrapper /usr/sbin/$f
-	elif [[ -x /host/sbin/$f ]]; then
-		cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
-	else
-		echo "WARNING: not using iptables wrapper because iptables was not detected on the"
-	        echo "host at the following paths [/usr/sbin, /sbin]."
-		echo "Either the host file system isn't mounted or the host does not have iptables"
-		echo "installed. The pod will use the image installed iptables version."
-	fi
+  iptablesExists=$(verify_iptables_on_host $f)
+  if [ $iptablesExists == "0" ]; then
+    echo "$f is present on the host at /usr/sbin/$f"
+    cp /usr/sbin/${f}.wrapper /usr/sbin/$f
+  elif [ $iptablesExists == "1" ]; then
+    echo "$f is present on the host at /sbin/$f"
+    cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
+  else
+    echo "WARNING: not using iptables wrapper because iptables was not detected on the"
+    echo "host at the following paths [/usr/sbin, /sbin]."
+    echo "Either the host file system isn't mounted or the host does not have iptables"
+    echo "installed. The pod will use the image installed iptables version."
+  fi
 done
 
 exec submariner-route-agent ${DEBUG} -alsologtostderr


### PR DESCRIPTION
On some platforms, its seen that iptables on the host is a symlink to a file
(f.e, /etc/alternatives/iptables) which again is a symlink to another file
(f.e., /usr/sbin/iptables-legacy). On such platforms, with the current code,
when we validate the presence of iptables using "[[ -x /host/usr/sbin/iptables ]]",
it fails since "-x" dereferences the symbolic links and the symlink would point to
a file on the container file system (instead of checking the host filesystem).

This patch uses chroot with the host-filesystem for validating the presence of iptables.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/227)
<!-- Reviewable:end -->
