### PR TITLE
Allow to create a test env. without running e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect

--- a/scripts/kind-e2e/README.md
+++ b/scripts/kind-e2e/README.md
@@ -80,12 +80,18 @@ as with any normal k8s cluster.
 as docker images, submariner will be redeployed on the clusters from pushed images and E2E tests will be executed.
 This mode allows the developers to test their local code fast on a very close to real world scenario setup.
 
-**NOTE**: If you only want to create the test  environment without running the e2e tests, you can do it by executing 
+**NOTE**: If you only want to create the test environment without running the e2e tests, you can do it by executing 
 the following command: 
 
 ```bash
-make ci e2e status=create
+make build package e2e status=create
 ```
+or, if you don't want to rebuild your Submariner images, by:
+
+```bash
+make e2e status=create
+```
+
 #### Logging
 
 Providing **logging=true** parameter to **make e2e** command will setup ELK stack on the kind clusters.

--- a/scripts/kind-e2e/README.md
+++ b/scripts/kind-e2e/README.md
@@ -80,6 +80,12 @@ as with any normal k8s cluster.
 as docker images, submariner will be redeployed on the clusters from pushed images and E2E tests will be executed.
 This mode allows the developers to test their local code fast on a very close to real world scenario setup.
 
+**NOTE**: If you only want to create the test  environment without running the e2e tests, you can do it by executing 
+the following command: 
+
+```bash
+make ci e2e status=create
+```
 #### Logging
 
 Providing **logging=true** parameter to **make e2e** command will setup ELK stack on the kind clusters.
@@ -127,6 +133,12 @@ To federate resources across the clusters [kubefedctl] tool must be installed on
 
 #### Cleanup
 At any time you can run a cleanup command that will remove kind resources.
+
+```bash
+make e2e status=clean
+```
+
+or just
 
 ```bash
 make e2e status=clean

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -353,8 +353,7 @@ if [[ $1 = clean ]]; then
     cleanup
     exit 0
 fi
-
-if [[ $1 != keep ]]; then
+if [[ $1 != keep && $1 != create ]]; then
     trap cleanup EXIT
 fi
 
@@ -477,9 +476,12 @@ elif [[ $5 = helm ]]; then
 fi
 
 test_connection
-test_with_e2e_tests
 
-if [[ $1 = keep ]]; then
+if [[ $1 != create ]]; then
+    test_with_e2e_tests
+fi
+
+if [[ $1 = keep || $1 = create ]]; then
     echo "your 3 virtual clusters are deployed and working properly with your local"
     echo "submariner source code, and can be accessed with:"
     echo ""

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -477,7 +477,7 @@ fi
 
 test_connection
 
-if [[ $1 != create ]]; then
+if [[ $1 = keep ]]; then
     test_with_e2e_tests
 fi
 


### PR DESCRIPTION
Execution of the e2e tests takes around 2 minutes, if only the local
testing environment is required, the tests can be skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/submariner-io/submariner/228)
<!-- Reviewable:end -->
