### PR TITLE
Use a common iptables wrapper

### DIFF
--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -17,6 +17,6 @@ RUN chmod +x /usr/local/bin/submariner-route-agent.sh
 COPY submariner-route-agent /usr/local/bin
 
 # Wrapper scripts to use iptables from the host when that's available
-COPY ./iptables*.wrapper /usr/sbin/
+COPY ./iptables-wrapper.in /usr/sbin/
 
 ENTRYPOINT submariner-route-agent.sh

--- a/package/iptables-save.sbin.wrapper
+++ b/package/iptables-save.sbin.wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /sbin/iptables-save "$@"

--- a/package/iptables-save.wrapper
+++ b/package/iptables-save.wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-save "$@"

--- a/package/iptables-wrapper.in
+++ b/package/iptables-wrapper.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host @@PATH@@/${0##*/} "$@"

--- a/package/iptables.sbin.wrapper
+++ b/package/iptables.sbin.wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /sbin/iptables "$@"

--- a/package/iptables.wrapper
+++ b/package/iptables.wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables "$@"

--- a/package/submariner-route-agent.sh
+++ b/package/submariner-route-agent.sh
@@ -16,20 +16,21 @@ function find_iptables_on_host() {
 }
 
 
-# if host is mounted on /host and host has it's own iptables version
+# If host is mounted on /host and host has its own iptables version
 # use that one instead via the shipped iptables wrapper, we do this
 # to avoid configuring iptables and nftables on the host which
 # could lead to functional failures because some hosts use an iptables
-# and iptables-save which program nftables under the hood. 
+# and iptables-save which program nftables under the hood.
+# Since we're using UBI8, we only have nftables in the container so we
+# can't use the Kubernetes approach (see
+# https://github.com/kubernetes/kubernetes/pull/82966 and
+# https://github.com/kubernetes/website/pull/16271 for details).
 
 for f in iptables-save iptables; do
-  iptablesLocation=$(find_iptables_on_host $f)
-  if [ $iptablesLocation == "/usr/sbin" ]; then
-    echo "$f is present on the host at /usr/sbin/$f"
-    cp /usr/sbin/${f}.wrapper /usr/sbin/$f
-  elif [ $iptablesLocation == "/sbin" ]; then
-    echo "$f is present on the host at /sbin/$f"
-    cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
+  location=$(find_iptables_on_host $f)
+  if [ "${location}" != "unknown" ]; then
+    echo "$f is present on the host at ${location}/$f"
+	sed "s!@@PATH@@!${location}!" /usr/sbin/iptables-wrapper.in > /usr/sbin/$f
   else
     echo "WARNING: not using iptables wrapper because iptables was not detected on the"
     echo "host at the following paths [/usr/sbin, /sbin]."


### PR DESCRIPTION
This avoids having path-specific wrappers. The patch also documents
why we can’t use the Kubernetes approach.

Signed-off-by: Stephen Kitt <skitt@redhat.com>