### PR TITLE
Implement globalnet ingress and egress features

### DIFF
--- a/package/Dockerfile.globalnet
+++ b/package/Dockerfile.globalnet
@@ -7,10 +7,17 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
 
 WORKDIR /var/submariner
 
+# These are all available in the UBI8 base OS repository
+RUN microdnf -y install --nodocs iproute iptables && \
+    microdnf clean all
+
 COPY submariner-globalnet.sh /usr/local/bin
 
 RUN chmod +x /usr/local/bin/submariner-globalnet.sh
 
 COPY submariner-globalnet /usr/local/bin
+
+# Wrapper scripts to use iptables from the host when that's available
+COPY ./iptables*.wrapper /usr/sbin/
 
 ENTRYPOINT submariner-globalnet.sh

--- a/package/submariner-globalnet.sh
+++ b/package/submariner-globalnet.sh
@@ -9,4 +9,33 @@ else
     DEBUG="-v=4"
 fi
 
+function find_iptables_on_host() {
+    chroot /host test -x /usr/sbin/$1 && { echo "/usr/sbin"; return; }
+    chroot /host test -x /sbin/$1 && { echo "/sbin"; return; }
+    echo "unknown"
+}
+
+
+# if host is mounted on /host and host has it's own iptables version
+# use that one instead via the shipped iptables wrapper, we do this
+# to avoid configuring iptables and nftables on the host which
+# could lead to functional failures because some hosts use an iptables
+# and iptables-save which program nftables under the hood.
+
+for f in iptables-save iptables; do
+  iptablesLocation=$(find_iptables_on_host $f)
+  if [ $iptablesLocation == "/usr/sbin" ]; then
+    echo "$f is present on the host at /usr/sbin/$f"
+    cp /usr/sbin/${f}.wrapper /usr/sbin/$f
+  elif [ $iptablesLocation == "/sbin" ]; then
+    echo "$f is present on the host at /sbin/$f"
+    cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
+  else
+    echo "WARNING: not using iptables wrapper because iptables was not detected on the"
+    echo "host at the following paths [/usr/sbin, /sbin]."
+    echo "Either the host file system isn't mounted or the host does not have iptables"
+    echo "installed. The pod will use the image installed iptables version."
+  fi
+done
+
 exec submariner-globalnet ${DEBUG} -alsologtostderr

--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -2,5 +2,25 @@ package ipam
 
 import "time"
 
-const handlerResync = time.Hour * 24
-const submarinerIpamGlobalIp = "submariner.io/globalIp"
+type Operation string
+
+const (
+	handlerResync          = time.Hour * 24
+	submarinerIpamGlobalIp = "submariner.io/globalIp"
+	submarinerGlobalNet    = "SUBMARINER-GLOBALNET"
+
+	// Currently Submariner Globalnet implementation (for services) works with kube-proxy
+	// and uses iptable chain-names programmed by kube-proxy. If the internal implementation
+	// of kube-proxy changes, globalnet needs to be modified accordingly.
+	// Reference: https://bit.ly/2OPhlwk
+	kubeProxyServiceChainPrefix = "KUBE-SVC-"
+	kubeProxyNameSpace          = "kube-system"
+	kubeProxyLabelSelector      = "k8s-app=kube-proxy"
+
+	AddRules    = true
+	DeleteRules = false
+
+	Process = "Process"
+	Ignore  = "Ignore"
+	Requeue = "Requeue"
+)

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -1,0 +1,47 @@
+package ipam
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+func (i *Controller) syncPodRules(podIP, globalIP string, addRules bool) {
+	err := i.updateEgressRulesForPod(podIP, globalIP, addRules)
+	if err != nil {
+		klog.Errorf("Error updating egress rules for pod %s: %v", podIP, err)
+		return
+	}
+}
+
+func (i *Controller) syncServiceRules(service *k8sv1.Service, globalIP string, addRules bool) {
+	chainName := i.kubeProxyClusterIpServiceChainName(service)
+	err := i.updateIngressRulesForService(globalIP, chainName, addRules)
+	if err != nil {
+		klog.Errorf("Error updating ingress rules for service %#v: %v", service, err)
+		return
+	}
+}
+
+func (i *Controller) evaluateService(service *k8sv1.Service) Operation {
+	if service.Spec.Type != v1.ServiceTypeClusterIP {
+		// Normally ClusterIPServices can be accessed only within the local cluster.
+		// When multiple K8s clusters are connected via Submariner, it enables access
+		// to ClusterIPService even from remote clusters. So, as part of Submariner
+		// Globalnet implementation, we are only interested in ClusterIP Services and
+		// not the other types of Services like LoadBalancer Services, NodePort Services
+		// etc which are externally accessible.
+		return Ignore
+	}
+
+	if len(service.Spec.Selector) != 0 {
+		chainName := i.kubeProxyClusterIpServiceChainName(service)
+		if chainExists, _ := i.doesIPTablesChainExist("nat", chainName); !chainExists {
+			return Requeue
+		}
+	} else {
+		// Ignore services that do not have selectors
+		return Ignore
+	}
+	return Process
+}

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -1,0 +1,26 @@
+package ipam
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
+)
+
+func (i *Controller) updateEgressRulesForPod(podIP, globalIP string, addRules bool) error {
+	ruleSpec := []string{"-p", "all", "-s", podIP, "-j", "SNAT", "--to", globalIP}
+	if addRules {
+		klog.V(4).Infof("Installing iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
+		if err := i.ipt.AppendUnique("nat", route.SmPostRoutingChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	} else {
+		klog.V(4).Infof("Deleting iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
+		if err := i.ipt.Delete("nat", route.SmPostRoutingChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	}
+	return nil
+}

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -1,0 +1,69 @@
+package ipam
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/util"
+)
+
+func (i *Controller) initIPTableChains() error {
+	klog.V(4).Infof("Install/ensure %s chain exists", submarinerGlobalNet)
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", submarinerGlobalNet); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", submarinerGlobalNet, err)
+	}
+
+	forwardToSubGlobalNetRuleSpec := []string{"-j", submarinerGlobalNet}
+	if err := util.PrependUnique(i.ipt, "nat", "PREROUTING", forwardToSubGlobalNetRuleSpec); err != nil {
+		klog.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(forwardToSubGlobalNetRuleSpec, " "), err)
+	}
+	return nil
+}
+
+func (i *Controller) updateIngressRulesForService(globalIP, chainName string, addRules bool) error {
+	ruleSpec := []string{"-d", globalIP, "-j", chainName}
+	if addRules {
+		klog.V(4).Infof("Installing iptables rule for Service %s", strings.Join(ruleSpec, " "))
+		if err := i.ipt.AppendUnique("nat", submarinerGlobalNet, ruleSpec...); err != nil {
+			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	} else {
+		klog.V(4).Infof("Deleting iptable ingress rule for Service: %s", strings.Join(ruleSpec, " "))
+		if err := i.ipt.Delete("nat", submarinerGlobalNet, ruleSpec...); err != nil {
+			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	}
+	return nil
+}
+
+func (i *Controller) kubeProxyClusterIpServiceChainName(service *k8sv1.Service) string {
+	// CNIs that use kube-proxy with iptables for loadbalancing create an iptables chain for each service
+	// and incoming traffic to the clusterIP Service is directed into the respective chain.
+	// Reference: https://bit.ly/2OPhlwk
+	serviceName := service.GetNamespace() + "/" + service.GetName() + ":"
+	protocol := strings.ToLower(string(service.Spec.Ports[0].Protocol))
+	hash := sha256.Sum256([]byte(serviceName + protocol))
+	encoded := base32.StdEncoding.EncodeToString(hash[:])
+	return kubeProxyServiceChainPrefix + encoded[:16]
+}
+
+func (i *Controller) doesIPTablesChainExist(table, chain string) (bool, error) {
+	existingChains, err := i.ipt.ListChains(table)
+	if err != nil {
+		klog.V(4).Infof("Error listing iptables chains in %s table: %s", table, err)
+		return false, err
+	}
+
+	for _, val := range existingChains {
+		if val == chain {
+			klog.V(4).Infof("%s chain exists in %s table", chain, table)
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-iptables/iptables"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,11 @@ func NewController(spec *SubmarinerIpamControllerSpecification, config *Informer
 		return nil, err
 	}
 
+	iptableHandler, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+
 	ipamController := &Controller{
 		kubeClientSet:    config.KubeClientSet,
 		serviceWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Services"),
@@ -36,6 +42,7 @@ func NewController(spec *SubmarinerIpamControllerSpecification, config *Informer
 
 		excludeNamespaces: exclusionMap,
 		pool:              pool,
+		ipt:               iptableHandler,
 	}
 	klog.Info("Setting up event handlers")
 	config.ServiceInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
@@ -72,6 +79,22 @@ func (i *Controller) Run(stopCh <-chan struct{}) error {
 	klog.Info("Waiting for informer caches to sync")
 	if ok := cache.WaitForCacheSync(stopCh, i.servicesSynced, i.podsSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	// Query kube-proxy pods in the cluster
+	kubeProxyPodList, err := i.kubeClientSet.CoreV1().Pods(kubeProxyNameSpace).List(metav1.ListOptions{LabelSelector: kubeProxyLabelSelector})
+	if err != nil {
+		return fmt.Errorf("error while retrieving kube-proxy pods: %v", err)
+	}
+
+	// Currently submariner global-net implementation works only with kube-proxy.
+	if len(kubeProxyPodList.Items) == 0 {
+		return fmt.Errorf("cluster does not seem to use kube-proxy")
+	}
+
+	err = i.initIPTableChains()
+	if err != nil {
+		return fmt.Errorf("initIPTableChains returned error. %v", err)
 	}
 
 	klog.Info("Starting workers")
@@ -124,6 +147,34 @@ func (i *Controller) processNextObject(objWorkqueue workqueue.RateLimitingInterf
 				}
 				return fmt.Errorf("error retrieving submariner-ipam-controller object %s: %v", name, err)
 			}
+
+			switch runtimeObj.(type) {
+			case *k8sv1.Service:
+				service := runtimeObj.(*k8sv1.Service)
+				switch i.evaluateService(service) {
+				case Ignore:
+					objWorkqueue.Forget(obj)
+					return nil
+				case Requeue:
+					objWorkqueue.AddRateLimited(obj)
+					return fmt.Errorf("service %s requeued %d times", key, objWorkqueue.NumRequeues(obj))
+				}
+			case *k8sv1.Pod:
+				pod := runtimeObj.(*k8sv1.Pod)
+				// Process pod event only when it has an ipaddress. Pods skipped here will be handled subsequently
+				// during podUpdate event when an ipaddress is assigned to it.
+				if pod.Status.PodIP == "" {
+					objWorkqueue.Forget(obj)
+					return nil
+				}
+
+				// Privileged pods that use hostNetwork will be ignored.
+				if pod.Status.PodIP == pod.Status.HostIP {
+					klog.V(4).Infof("Ignoring pod %s on host %s as it uses hostNetworking", pod.Name, pod.Status.PodIP)
+					return nil
+				}
+			}
+
 			return objUpdater(runtimeObj, key)
 		})
 		if retryErr != nil {
@@ -190,6 +241,29 @@ func (i *Controller) handleUpdatePod(old interface{}, newObj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
+
+	oldPodIp := old.(*k8sv1.Pod).Status.PodIP
+	updatedPodIp := newObj.(*k8sv1.Pod).Status.PodIP
+	podHostIP := newObj.(*k8sv1.Pod).Status.HostIP
+	// Pod events that are skipped during addEvent are handled here when they are assigned an ipaddress.
+	if updatedPodIp != "" && oldPodIp != updatedPodIp {
+		klog.V(4).Infof("In handleUpdatePod, pod %s is now assigned %s address, enqueing", old.(*k8sv1.Pod).Name, updatedPodIp)
+		i.enqueueObject(newObj, i.podWorkqueue)
+		return
+	}
+
+	// When the POD is getting terminated, sometimes we get pod update event with podIp removed.
+	if oldPodIp != "" && updatedPodIp == "" {
+		klog.V(4).Infof("Pod %s with ip %s is being terminated", old.(*k8sv1.Pod).Name, oldPodIp)
+		i.handleRemovedPod(old)
+	}
+
+	// Ignore privileged pods that use hostNetwork
+	if updatedPodIp != "" && updatedPodIp == podHostIP {
+		klog.V(4).Infof("Pod %s on host %s uses hostNetwork, ignoring", old.(*k8sv1.Pod).Name, podHostIP)
+		return
+	}
+
 	oldGlobalIp := old.(*k8sv1.Pod).GetAnnotations()[submarinerIpamGlobalIp]
 	newGlobalIp := newObj.(*k8sv1.Pod).GetAnnotations()[submarinerIpamGlobalIp]
 	if oldGlobalIp != newGlobalIp && newGlobalIp != i.pool.GetAllocatedIp(key) {
@@ -224,6 +298,7 @@ func (i *Controller) handleRemovedService(obj interface{}) {
 				return
 			}
 			i.pool.Release(key)
+			i.syncServiceRules(service, globalIp, DeleteRules)
 			klog.V(4).Infof("Released ip %s for service %s", globalIp, key)
 		}
 	}
@@ -248,13 +323,14 @@ func (i *Controller) handleRemovedPod(obj interface{}) {
 	}
 	if !i.excludeNamespaces[pod.Namespace] {
 		globalIp := pod.Annotations[submarinerIpamGlobalIp]
-		if globalIp != "" {
+		if globalIp != "" && pod.Status.PodIP != "" {
 			if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
 				utilruntime.HandleError(err)
 				return
 			}
 			i.pool.Release(key)
-			klog.V(4).Infof("Released ip %s for pod %s", globalIp, key)
+			i.syncPodRules(pod.Status.PodIP, globalIp, DeleteRules)
+			klog.V(4).Infof("Released GlobalIp %s for pod %s", globalIp, key)
 		}
 	}
 }
@@ -305,6 +381,7 @@ func (i *Controller) serviceUpdater(obj runtime.Object, key string) error {
 	}
 	if annotations != nil {
 		service.SetAnnotations(annotations)
+		i.syncServiceRules(service, annotations[submarinerIpamGlobalIp], AddRules)
 		_, updateErr := i.kubeClientSet.CoreV1().Services(service.Namespace).Update(service)
 		return updateErr
 	}
@@ -321,6 +398,7 @@ func (i *Controller) podUpdater(obj runtime.Object, key string) error {
 	}
 	if annotations != nil {
 		pod.SetAnnotations(annotations)
+		i.syncPodRules(pod.Status.PodIP, annotations[submarinerIpamGlobalIp], AddRules)
 		_, updateErr := i.kubeClientSet.CoreV1().Pods(pod.Namespace).Update(pod)
 		return updateErr
 	}

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -1,6 +1,7 @@
 package ipam
 
 import (
+	"github.com/coreos/go-iptables/iptables"
 	kubeInformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -28,4 +29,6 @@ type Controller struct {
 
 	excludeNamespaces map[string]bool
 	pool              *IpPool
+
+	ipt *iptables.IPTables
 }

--- a/pkg/routeagent/controllers/route/iptables.go
+++ b/pkg/routeagent/controllers/route/iptables.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
+	"github.com/submariner-io/submariner/pkg/util"
 	"k8s.io/klog"
 )
 
@@ -16,18 +17,18 @@ func (r *Controller) createIPTableChains() error {
 	}
 
 	klog.V(4).Infof("Install/ensure %s chain exists", SmPostRoutingChain)
-	if err = r.createChainIfNotExists(ipt, "nat", SmPostRoutingChain); err != nil {
+	if err = util.CreateChainIfNotExists(ipt, "nat", SmPostRoutingChain); err != nil {
 		return fmt.Errorf("Unable to create %s chain in iptables: %v", SmPostRoutingChain, err)
 	}
 
 	klog.V(4).Infof("Insert %s rule that has rules for inter-cluster traffic", SmPostRoutingChain)
 	forwardToSubPostroutingRuleSpec := []string{"-j", SmPostRoutingChain}
-	if err = r.prependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
+	if err = util.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
 		klog.Errorf("Unable to insert iptable rule in NAT table, POSTROUTING chain: %v", err)
 	}
 
 	klog.V(4).Infof("Install/ensure SUBMARINER-INPUT chain exists")
-	if err = r.createChainIfNotExists(ipt, "filter", "SUBMARINER-INPUT"); err != nil {
+	if err = util.CreateChainIfNotExists(ipt, "filter", "SUBMARINER-INPUT"); err != nil {
 		return fmt.Errorf("Unable to create SUBMARINER-INPUT chain in iptables: %v", err)
 	}
 
@@ -44,7 +45,7 @@ func (r *Controller) createIPTableChains() error {
 
 	klog.V(4).Infof("Insert rule to allow traffic over %s interface in FORWARDing Chain", VxLANIface)
 	ruleSpec = []string{"-o", VxLANIface, "-j", "ACCEPT"}
-	if err = r.prependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
+	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
 		klog.Errorf("Unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
 	}
 
@@ -72,73 +73,4 @@ func (r *Controller) programIptableRulesForInterClusterTraffic(remoteCidrBlock s
 		}
 	}
 	return nil
-}
-
-func (r *Controller) prependUnique(ipt *iptables.IPTables, table string, chain string, ruleSpec []string) error {
-	rules, err := ipt.List(table, chain)
-	if err != nil {
-		return fmt.Errorf("error listing the rules in %s chain: %v", chain, err)
-	}
-
-	// Submariner requires certain iptable rules to be programmed at the beginning of an iptables Chain
-	// so that we can preserve the sourceIP for inter-cluster traffic and avoid K8s SDN making changes
-	// to the traffic.
-	// In this API, we check if the required iptable rule is present at the beginning of the chain.
-	// If the rule is already present and there are no stale[1] flows, we simply return. If not, we create one.
-	// [1] Sometimes after we program the rule at the beginning of the chain, K8s SDN might insert some
-	// new rules ahead of the rule that we programmed. In such cases, the rule that we programmed will
-	// not be the first rule to hit and Submariner behavior might get affected. So, we query the rules
-	// in the chain to see if the rule slipped its position, and if so, delete all such occurrences.
-	// We then re-program a new rule at the beginning of the chain as required.
-
-	isPresentAtRequiredPosition := false
-	numOccurrences := 0
-	for index, rule := range rules {
-		if strings.Contains(rule, strings.Join(ruleSpec, " ")) {
-			klog.V(4).Infof("In %s table, iptables rule \"%s\", exists at index %d.", table, strings.Join(ruleSpec, " "), index)
-			numOccurrences++
-
-			if index == 1 {
-				isPresentAtRequiredPosition = true
-			}
-		}
-	}
-
-	// The required rule is present in the Chain, but either there are multiple occurrences or its
-	// not at the desired location
-	if numOccurrences > 1 || !isPresentAtRequiredPosition {
-		for i := 0; i < numOccurrences; i++ {
-			if err = ipt.Delete(table, chain, ruleSpec...); err != nil {
-				return fmt.Errorf("error deleting stale iptable rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
-			}
-		}
-	}
-
-	// The required rule is present only once and is at the desired location
-	if numOccurrences == 1 && isPresentAtRequiredPosition {
-		klog.V(4).Infof("In %s table, iptables rule \"%s\", already exists.", table, strings.Join(ruleSpec, " "))
-		return nil
-	} else {
-		if err = ipt.Insert(table, chain, 1, ruleSpec...); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *Controller) createChainIfNotExists(ipt *iptables.IPTables, table, chain string) error {
-	existingChains, err := ipt.ListChains(table)
-	if err != nil {
-		return err
-	}
-
-	for _, val := range existingChains {
-		if val == chain {
-			// Chain already exists
-			return nil
-		}
-	}
-
-	return ipt.NewChain(table, chain)
 }

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: submariner-globalnet
     spec:
+      hostNetwork: true
       containers:
         - name: submariner-globalnet
           image: submariner-globalnet:local
@@ -22,6 +23,24 @@ spec:
               value: 169.254.2.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
-
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - ALL
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+          volumeMounts:
+            # Because we don't actually run iptables locally, but chroot in to the host
+            - mountPath: /host
+              name: host-slash
+              readOnly: true
       serviceAccountName: submariner-globalnet
       serviceAccount: submariner-globalnet
+      nodeSelector:
+        submariner.io/gateway: "true"
+      volumes:
+        - name: host-slash
+          hostPath:
+            path: /

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: submariner-globalnet
     spec:
+      hostNetwork: true
       containers:
         - name: submariner-globalnet
           image: submariner-globalnet:local
@@ -22,6 +23,24 @@ spec:
               value: 169.254.3.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
-
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - ALL
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+          volumeMounts:
+            # Because we don't actually run iptables locally, but chroot in to the host
+            - mountPath: /host
+              name: host-slash
+              readOnly: true
       serviceAccountName: submariner-globalnet
       serviceAccount: submariner-globalnet
+      nodeSelector:
+        submariner.io/gateway: "true"
+      volumes:
+        - name: host-slash
+          hostPath:
+            path: /


### PR DESCRIPTION
This patch implements the following
1. Spawns Globalnet Controller on the GatewayNode
2. Initializes Globalnet Controller only when the Cluster uses kubeproxy
3. Programs necessary egress rules for PODs
4. Programs necessary ingress rules for ClusterIPServices

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>