### PR TITLE
Fix build issue when re-running the build in an existing setup

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -327,6 +327,12 @@ function test_with_e2e_tests {
 
 function deploy_globalnet {
     for i in 2 3; do
+      if kubectl --context=cluster${i} -n $subm_ns get serviceaccount submariner-globalnet > /dev/null 2>&1; then
+        echo submariner-globalnet already exists in cluster${i}, deleting the existing deployment
+        sed "s|namespace: operators|namespace: $subm_ns|g" ${PRJ_ROOT}/scripts/kind-e2e/globalnet/role-globalnet.yaml | kubectl --context=cluster${i} delete -f -
+        kubectl --context=cluster${i} -n $subm_ns delete -f ${PRJ_ROOT}/scripts/kind-e2e/globalnet/deploy-globalnet-${i}.yaml
+        kubectl --context=cluster${i} -n $subm_ns delete serviceaccount submariner-globalnet
+      fi
       kubectl --context=cluster${i} -n $subm_ns create serviceaccount submariner-globalnet
       sed "s|namespace: operators|namespace: $subm_ns|g" ${PRJ_ROOT}/scripts/kind-e2e/globalnet/role-globalnet.yaml | kubectl --context=cluster${i} apply -f -
       kubectl --context=cluster${i} -n $subm_ns apply -f ${PRJ_ROOT}/scripts/kind-e2e/globalnet/deploy-globalnet-${i}.yaml


### PR DESCRIPTION
In an existing Submariner (with globalnet) deployment, when we re-run
the command "make build package e2e status=keep", the following error
is seen and this patch fixes it.

kubectl --context=cluster2 -n submariner create serviceaccount submariner-globalnet
Error from server (AlreadyExists): serviceaccounts "submariner-globalnet" already exists
[submariner]$ ./scripts/e2e keep 1.14.2 false false helm false
FATA[0224] exit status 1
make: *** [Makefile:18: e2e] Error 1

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>