### PR TITLE
Fix pod scheduling in E2E part 2

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -216,37 +216,35 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 }
 
 func nodeAffinity(scheduling NetworkPodScheduling) *v1.Affinity {
-	var nodeSelReqs []v1.NodeSelectorRequirement
+	var nodeSelTerms []v1.NodeSelectorTerm
 
 	switch scheduling {
 	case GatewayNode:
-		nodeSelReqs = addNodeSelectorRequirement(nodeSelReqs, GatewayLabel, v1.NodeSelectorOpIn, []string{"true"})
+		nodeSelTerms = addNodeSelectorTerm(nodeSelTerms, GatewayLabel, v1.NodeSelectorOpIn, []string{"true"})
 
 	case NonGatewayNode:
-		nodeSelReqs = addNodeSelectorRequirement(nodeSelReqs, GatewayLabel, v1.NodeSelectorOpDoesNotExist, nil)
-		nodeSelReqs = addNodeSelectorRequirement(nodeSelReqs, GatewayLabel, v1.NodeSelectorOpNotIn, []string{"true"})
+		nodeSelTerms = addNodeSelectorTerm(nodeSelTerms, GatewayLabel, v1.NodeSelectorOpDoesNotExist, nil)
+		nodeSelTerms = addNodeSelectorTerm(nodeSelTerms, GatewayLabel, v1.NodeSelectorOpNotIn, []string{"true"})
 	}
 
 	return &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
-						MatchExpressions: nodeSelReqs,
-					},
-				},
+				NodeSelectorTerms: nodeSelTerms,
 			},
 		},
 	}
 }
 
-func addNodeSelectorRequirement(nodeSelReqs []v1.NodeSelectorRequirement, label string,
-	op v1.NodeSelectorOperator, values []string) []v1.NodeSelectorRequirement {
-	return append(nodeSelReqs, v1.NodeSelectorRequirement{
-		Key:      label,
-		Operator: op,
-		Values:   values,
-	})
+func addNodeSelectorTerm(nodeSelTerms []v1.NodeSelectorTerm, label string,
+	op v1.NodeSelectorOperator, values []string) []v1.NodeSelectorTerm {
+	return append(nodeSelTerms, v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+		{
+			Key:      label,
+			Operator: op,
+			Values:   values,
+		},
+	}})
 }
 
 func removeDupDataplaneLines(output string) string {


### PR DESCRIPTION
The NodeAffinity for non-gateway scheduling is incorrect - it has
2 terms that need to be ORed together, however grouping 2
MatchExpressions ANDs them. We need to group 2 NodeSelectorTerms
as they are ORed.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>