### PR TITLE
E2E tests not running by default

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -440,7 +440,7 @@ fi
 
 test_connection
 
-if [[ $1 = keep ]]; then
+if [[ $1 = keep || $1 = onetime ]]; then
     test_with_e2e_tests
 fi
 


### PR DESCRIPTION
PR https://github.com/submariner-io/submariner/pull/228/ modified e2e.sh so
it only runs the E2E tests if 'status=keep' and thus the tests no longer run
with 'status=onetime', which is the default via 'make ci e2e' as documented.
Therefore modified e2e.sh to also check for 'status=onetime'.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>