### PR TITLE
Work around the UBI8 microdnf bug

### DIFF
--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -1,11 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
-
-# Pinned to image 8.0 because of this bug
-#    https://github.com/rpm-software-management/microdnf/issues/50
-# TODO(dimaunx,majopela):  we should remove the :8.0 pin when the
-#                          bug has been solved for the UBI image.
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /var/submariner
+
+# Workaround for
+# https://github.com/rpm-software-management/microdnf/issues/50
+RUN mkdir -p /run/user/$(id -u)
 
 # These are all available in the UBI8 base OS repository
 RUN microdnf -y install --nodocs iproute iptables && \


### PR DESCRIPTION
This applies the published workaround for
https://github.com/rpm-software-management/microdnf/issues/50 allowing
us to track :latest again.

Signed-off-by: Stephen Kitt <skitt@redhat.com>