### PR TITLE
Remove IsFull check in IpPool.Allocate

### DIFF
--- a/pkg/globalnet/controllers/ipam/ippool.go
+++ b/pkg/globalnet/controllers/ipam/ippool.go
@@ -54,9 +54,6 @@ func intToIP(ip int) net.IP {
 }
 
 func (p *IpPool) Allocate(key string) (string, error) {
-	if p.IsFull() {
-		return "", errors.New("IPAM: No IP available for allocation")
-	}
 	p.Lock()
 	defer p.Unlock()
 	allocatedIp := p.allocated[key]
@@ -66,7 +63,7 @@ func (p *IpPool) Allocate(key string) (string, error) {
 			delete(p.available, k)
 			return k, nil
 		}
-		return "", errors.New("IPAM: Unable to allocate IP")
+		return "", errors.New("IPAM: No IP available for allocation")
 	}
 	return allocatedIp, nil
 }
@@ -91,14 +88,6 @@ func (p *IpPool) GetAllocatedIp(key string) string {
 	ip := p.allocated[key]
 	p.RUnlock()
 	return ip
-}
-
-func (p *IpPool) IsFull() bool {
-	var result bool
-	p.RLock()
-	result = len(p.available) == 0
-	p.RUnlock()
-	return result
 }
 
 func (p *IpPool) RequestIp(key string, ip string) (string, error) {


### PR DESCRIPTION
This function is coded to return the existing allocated IP, if any, however the
IsFull check elides that if there's no available IPs. I assume this isn't
the intent so remove the up-front check as this case is handled anyway by the
subsequent code.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>