### PR TITLE
Add more details for subctl installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ by using its operator. All three methods are described here.
 Download the latest binary for your operating system and architecture, then install it on your
 path. The binary has no external dependencies so you won’t need anything else.
 
+For example, to download v0.0.2 for Linux amd64 and install it in `~/.local/bin`:
+
+    mkdir -p ~/.local/bin
+    wget https://github.com/submariner-io/submariner-operator/releases/download/v0.0.2/subctl-v0.0.2-linux-amd64
+    install subctl-v0.0.2-linux-amd64 ~/.local/bin/subctl
+    rm subctl-v0.0.2-linux-amd64
+
+If `~/.local/bin` is on your `PATH`, you will then be able to run `subctl`.
+
 ### Broker
 
 To deploy only the broker in a cluster, run


### PR DESCRIPTION
This lists the steps involved to download and install subctl somewhere
on the PATH.

Signed-off-by: Stephen Kitt <skitt@redhat.com>