### PR TITLE
Only build master branch, ignoring local branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: xenial
 language: go
 
+branches:
+  only:
+  - master
+
 git:
   depth: 1
 


### PR DESCRIPTION
With local branches, and automatically created ones travis is doing extra unnecessary work duplication. This fixes it. 

Pull requests will be tested regardless of this, but changes to specific branches  (not through PRs) will be ignored.