### PR TITLE
Disable add cluster E2E test for now

### DIFF
--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -10,7 +10,7 @@ import (
 	"github.com/submariner-io/submariner/test/e2e/framework"
 )
 
-var _ = Describe("[expansion] Test expanding/shrinking an existing cluster fleet", func() {
+var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster fleet", func() {
 	f := framework.NewDefaultFramework("add-remove-cluster")
 
 	It("Should be able to add and remove third cluster", func() {


### PR DESCRIPTION
It's failing frequently on travis, it seems due to some random initial delay
when settng up vxlan tunnels. See https://github.com/submariner-io/submariner/issues/257.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>