### PR TITLE
Add third gateway fail-over E2E scenario test

### DIFF
--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -1,0 +1,34 @@
+package framework
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (f *Framework) FindDeployment(cluster ClusterIndex, appName string, namespace string) *appsv1.Deployment {
+	deployments := AwaitUntil("list deployments", func() (interface{}, error) {
+		return f.ClusterClients[cluster].AppsV1().Deployments(namespace).List(metav1.ListOptions{
+			LabelSelector: "app=" + appName,
+		})
+	}, NoopCheckResult).(*appsv1.DeploymentList)
+	Expect(deployments.Items).To(HaveLen(1), fmt.Sprintf("Expected one %q deployment on %q",
+		appName, TestContext.KubeContexts[cluster]))
+
+	return &deployments.Items[0]
+}
+
+func (f *Framework) FindSubmarinerEngineDeployment(cluster ClusterIndex) *appsv1.Deployment {
+	return f.FindDeployment(cluster, SubmarinerEngine, TestContext.SubmarinerNamespace)
+}
+
+func (f *Framework) SetReplicas(cluster ClusterIndex, deployment *appsv1.Deployment, replicas uint32) {
+	PatchInt("/spec/replicas", replicas,
+		func(pt types.PatchType, payload []byte) error {
+			_, err := f.ClusterClients[cluster].AppsV1().Deployments(deployment.Namespace).Patch(deployment.Name, pt, payload)
+			return err
+		})
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -50,6 +50,12 @@ type PatchStringValue struct {
 	Value string `json:"value"`
 }
 
+type PatchUInt32Value struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value uint32 `json:"value"`
+}
+
 type DoOperationFunc func() (interface{}, error)
 type CheckResultFunc func(result interface{}) (bool, string, error)
 
@@ -300,14 +306,29 @@ func createNamespace(client kubeclientset.Interface, name string, labels map[str
 	return namespace
 }
 
-// DoPatchOperation performs a REST patch operation for the given path and value.
-func DoPatchOperation(path string, value string, patchFunc PatchFunc) {
+// PatchString performs a REST patch operation for the given path and string value.
+func PatchString(path string, value string, patchFunc PatchFunc) {
 	payload := []PatchStringValue{{
 		Op:    "add",
 		Path:  path,
 		Value: value,
 	}}
 
+	doPatchOperation(payload, patchFunc)
+}
+
+// PatchInt performs a REST patch operation for the given path and int value.
+func PatchInt(path string, value uint32, patchFunc PatchFunc) {
+	payload := []PatchUInt32Value{{
+		Op:    "add",
+		Path:  path,
+		Value: value,
+	}}
+
+	doPatchOperation(payload, patchFunc)
+}
+
+func doPatchOperation(payload interface{}, patchFunc PatchFunc) {
 	payloadBytes, err := json.Marshal(payload)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -38,7 +38,7 @@ func (f *Framework) FindNodesByGatewayLabel(cluster ClusterIndex, isGateway bool
 // SetGatewayLabelOnNode sets the 'submariner.io/gateway' value for a node to the specified value.
 func (f *Framework) SetGatewayLabelOnNode(cluster ClusterIndex, nodeName string, isGateway bool) {
 	// Escape the '/' char in the label name with the special sequence "~1" so it isn't treated as part of the path
-	DoPatchOperation("/metadata/labels/"+strings.Replace(GatewayLabel, "/", "~1", -1), strconv.FormatBool(isGateway),
+	PatchString("/metadata/labels/"+strings.Replace(GatewayLabel, "/", "~1", -1), strconv.FormatBool(isGateway),
 		func(pt types.PatchType, payload []byte) error {
 			_, err := f.ClusterClients[cluster].CoreV1().Nodes().Patch(nodeName, pt, payload)
 			return err

--- a/test/e2e/framework/submariner_resources.go
+++ b/test/e2e/framework/submariner_resources.go
@@ -1,10 +1,13 @@
 package framework
 
 import (
+	"fmt"
+
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type CheckEndpointFunc func(endpoint *submarinerv1.Endpoint) (bool, string, error)
@@ -46,4 +49,14 @@ func (f *Framework) AwaitSubmarinerEndpoint(cluster ClusterIndex, checkEndpoint 
 	})
 
 	return retEndpoint
+}
+
+func (f *Framework) AwaitNewSubmarinerEndpoint(cluster ClusterIndex, prevEndpointUID types.UID) *submarinerv1.Endpoint {
+	return f.AwaitSubmarinerEndpoint(cluster, func(endpoint *submarinerv1.Endpoint) (bool, string, error) {
+		if endpoint.ObjectMeta.UID != prevEndpointUID {
+			return true, "", nil
+		}
+
+		return false, fmt.Sprintf("Expecting new Endpoint instance (UUID %q matches previous instance)", endpoint.ObjectMeta.UID), nil
+	})
 }


### PR DESCRIPTION
Two gateway nodes configured with 2 submariner engine replicas. This tests
the leader election fail-over.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>