### PR TITLE
Enhancements to Submariner Globalnet Controller

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -7,7 +7,8 @@ type Operation string
 const (
 	handlerResync          = time.Hour * 24
 	submarinerIpamGlobalIp = "submariner.io/globalIp"
-	submarinerGlobalNet    = "SUBMARINER-GLOBALNET"
+	submarinerIngress      = "SUBMARINER-GN-INGRESS"
+	submarinerEgress       = "SUBMARINER-GN-EGRESS"
 
 	// Currently Submariner Globalnet implementation (for services) works with kube-proxy
 	// and uses iptable chain-names programmed by kube-proxy. If the internal implementation

--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -9,6 +9,14 @@ const (
 	submarinerIpamGlobalIp = "submariner.io/globalIp"
 	submarinerIngress      = "SUBMARINER-GN-INGRESS"
 	submarinerEgress       = "SUBMARINER-GN-EGRESS"
+	submarinerMark         = "SUBMARINER-GN-MARK"
+
+	// Globalnet uses MARK target to mark traffic destined to remote clusters.
+	// Some of the CNIs also use iptable MARK targets in the pipeline. This should not
+	// be a problem because Globalnet is only marking traffic destined to Submariner
+	// connected clusters where Submariner takes full control on how the traffic is
+	// steered in the pipeline. Normal traffic should not be affected because of this.
+	globalNetIPTableMark = "0xC0000/0xC0000"
 
 	// Currently Submariner Globalnet implementation (for services) works with kube-proxy
 	// and uses iptable chain-names programmed by kube-proxy. If the internal implementation

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -1,0 +1,228 @@
+package ipam
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	submarinerInformers "github.com/submariner-io/submariner/pkg/client/informers/externalversions"
+)
+
+const defaultResync = 60 * time.Second
+
+func NewGatewayMonitor(spec *SubmarinerIpamControllerSpecification, cfg *rest.Config, stopCh <-chan struct{}) (*GatewayMonitor, error) {
+	gatewayMonitor := &GatewayMonitor{
+		clusterID:         spec.ClusterID,
+		endpointWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Endpoints"),
+		ipamSpec:          spec,
+		stopProcessing:    nil,
+		isGatewayNode:     false,
+		syncMutex:         &sync.Mutex{},
+	}
+
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error building k8s clientset: %s", err.Error())
+	}
+
+	submarinerClient, err := submarinerClientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error building submariner clientset: %s", err.Error())
+	}
+
+	submarinerInformerFactory := submarinerInformers.NewSharedInformerFactoryWithOptions(submarinerClient,
+		time.Second*30, submarinerInformers.WithNamespace(spec.Namespace))
+	EndpointInformer := submarinerInformerFactory.Submariner().V1().Endpoints()
+
+	gatewayMonitor.kubeClientSet = clientSet
+	gatewayMonitor.submarinerClientSet = submarinerClient
+	gatewayMonitor.endpointsSynced = EndpointInformer.Informer().HasSynced
+
+	EndpointInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			gatewayMonitor.enqueueEndpoint(obj)
+		},
+		UpdateFunc: func(old, newObj interface{}) {
+			gatewayMonitor.enqueueEndpoint(newObj)
+		},
+		DeleteFunc: gatewayMonitor.handleRemovedEndpoint,
+	}, handlerResync)
+
+	submarinerInformerFactory.Start(stopCh)
+	return gatewayMonitor, nil
+}
+
+func (i *GatewayMonitor) Run(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+
+	klog.Info("Starting GatewayMonitor to monitor the active Gateway node in the cluster.")
+
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, i.endpointsSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.Info("Starting endpoint worker.")
+	go wait.Until(i.runEndpointWorker, time.Second, stopCh)
+	<-stopCh
+	klog.Info("Shutting down endpoint worker.")
+	return nil
+}
+
+func (r *GatewayMonitor) runEndpointWorker() {
+	for r.processNextEndpoint() {
+	}
+}
+
+func (i *GatewayMonitor) processNextEndpoint() bool {
+	obj, shutdown := i.endpointWorkqueue.Get()
+	if shutdown {
+		return false
+	}
+	err := func() error {
+		defer i.endpointWorkqueue.Done(obj)
+		key := obj.(string)
+		ns, name, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			i.endpointWorkqueue.Forget(obj)
+			return fmt.Errorf("error while splitting meta namespace key %s: %v", key, err)
+		}
+		endpoint, err := i.submarinerClientSet.SubmarinerV1().Endpoints(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			i.endpointWorkqueue.Forget(obj)
+			return fmt.Errorf("error retrieving submariner endpoint object %s: %v", name, err)
+		}
+
+		if endpoint.Spec.ClusterID != i.clusterID {
+			klog.V(6).Infof("Endpoint didn't match the cluster ID of this cluster")
+			i.endpointWorkqueue.Forget(obj)
+			return nil
+		}
+
+		hostname, err := os.Hostname()
+		if err != nil {
+			klog.Fatalf("Unable to determine hostname: %v", err)
+		}
+
+		// If the endpoint hostname matches with our hostname, it implies we are on gateway node
+		if endpoint.Spec.Hostname == hostname {
+			klog.V(4).Infof("We are now on GatewayNode %s", endpoint.Spec.PrivateIP)
+			i.syncMutex.Lock()
+			if !i.isGatewayNode {
+				i.isGatewayNode = true
+				i.initializeIpamController()
+			}
+			i.syncMutex.Unlock()
+		} else {
+			klog.V(4).Infof("We are on non-gatewayNode. GatewayNode ip is %s", endpoint.Spec.PrivateIP)
+			i.syncMutex.Lock()
+			if i.isGatewayNode {
+				i.stopIpamController()
+				i.isGatewayNode = false
+			}
+			i.syncMutex.Unlock()
+		}
+
+		i.endpointWorkqueue.Forget(obj)
+		return nil
+	}()
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+	return true
+}
+
+func (i *GatewayMonitor) enqueueEndpoint(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	klog.V(4).Infof("Enqueueing endpoint in gatewayMonitor %v", obj)
+	i.endpointWorkqueue.AddRateLimited(key)
+}
+
+func (i *GatewayMonitor) handleRemovedEndpoint(obj interface{}) {
+	var object *v1.Endpoint
+	var ok bool
+	if object, ok = obj.(*v1.Endpoint); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Could not convert object %v to an Endpoint", obj)
+			return
+		}
+		object, ok = tombstone.Obj.(*v1.Endpoint)
+		if !ok {
+			klog.Errorf("Could not convert object tombstone %v to an Endpoint", tombstone.Obj)
+			return
+		}
+		klog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+	}
+
+	klog.V(4).Infof("Informed of removed endpoint for gateway monitor: %v", object)
+	hostname, err := os.Hostname()
+	if err != nil {
+		klog.Fatalf("Could not retrieve hostname: %v", err)
+	}
+
+	if object.Spec.Hostname == hostname && object.Spec.ClusterID == i.clusterID {
+		i.syncMutex.Lock()
+		if i.isGatewayNode {
+			i.stopIpamController()
+			i.isGatewayNode = false
+		}
+		i.syncMutex.Unlock()
+	}
+}
+
+func (i *GatewayMonitor) initializeIpamController() {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(i.kubeClientSet, defaultResync)
+
+	informerConfig := InformerConfigStruct{
+		KubeClientSet:   i.kubeClientSet,
+		ServiceInformer: informerFactory.Core().V1().Services(),
+		PodInformer:     informerFactory.Core().V1().Pods(),
+	}
+
+	klog.V(4).Infof("On Gateway Node, initializing ipamController.")
+	ipamController, err := NewController(i.ipamSpec, &informerConfig)
+	if err != nil {
+		klog.Fatalf("Error creating controller: %s", err.Error())
+	}
+
+	i.stopProcessing = make(chan struct{})
+
+	go func() {
+		if err = ipamController.Run(i.stopProcessing); err != nil {
+			klog.Fatalf("Error running ipamController: %s", err.Error())
+		}
+	}()
+
+	informerFactory.Start(i.stopProcessing)
+	klog.V(4).Infof("Successfully initialized ipamController.")
+}
+
+func (i *GatewayMonitor) stopIpamController() {
+	if i.stopProcessing != nil {
+		klog.V(4).Infof("Submariner GatewayEngine migrated to a new node, stopping ipamController.")
+		close(i.stopProcessing)
+		i.stopProcessing = nil
+	}
+	klog.V(4).Infof("Notified ipamController to stop processing.")
+}

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -5,20 +5,18 @@ import (
 	"strings"
 
 	"k8s.io/klog"
-
-	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
 )
 
 func (i *Controller) updateEgressRulesForPod(podIP, globalIP string, addRules bool) error {
 	ruleSpec := []string{"-p", "all", "-s", podIP, "-j", "SNAT", "--to", globalIP}
 	if addRules {
 		klog.V(4).Infof("Installing iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
-		if err := i.ipt.AppendUnique("nat", route.SmPostRoutingChain, ruleSpec...); err != nil {
+		if err := i.ipt.AppendUnique("nat", submarinerEgress, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(4).Infof("Deleting iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
-		if err := i.ipt.Delete("nat", route.SmPostRoutingChain, ruleSpec...); err != nil {
+		if err := i.ipt.Delete("nat", submarinerEgress, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/coreos/go-iptables/iptables"
 	"k8s.io/klog"
 )
 
 func (i *Controller) updateEgressRulesForPod(podIP, globalIP string, addRules bool) error {
-	ruleSpec := []string{"-p", "all", "-s", podIP, "-j", "SNAT", "--to", globalIP}
+	ruleSpec := []string{"-p", "all", "-s", podIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", globalIP}
 	if addRules {
 		klog.V(4).Infof("Installing iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
 		if err := i.ipt.AppendUnique("nat", submarinerEgress, ruleSpec...); err != nil {
@@ -21,4 +22,19 @@ func (i *Controller) updateEgressRulesForPod(podIP, globalIP string, addRules bo
 		}
 	}
 	return nil
+}
+
+func MarkRemoteClusterTraffic(ipt *iptables.IPTables, remoteCidr string, addRules bool) {
+	ruleSpec := []string{"-d", remoteCidr, "-j", "MARK", "--set-mark", globalNetIPTableMark}
+	if addRules {
+		klog.V(4).Infof("Marking traffic destined to remote cluster: %s", strings.Join(ruleSpec, " "))
+		if err := ipt.AppendUnique("nat", submarinerMark, ruleSpec...); err != nil {
+			klog.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	} else {
+		klog.V(4).Infof("Deleting rule that marks remote cluster traffic: %s", strings.Join(ruleSpec, " "))
+		if err := ipt.Delete("nat", submarinerMark, ruleSpec...); err != nil {
+			klog.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	}
 }

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -2,7 +2,6 @@ package ipam
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -68,18 +67,10 @@ func NewController(spec *SubmarinerIpamControllerSpecification, config *Informer
 }
 
 func (i *Controller) Run(stopCh <-chan struct{}) error {
-	var wg sync.WaitGroup
-	wg.Add(1)
 	defer utilruntime.HandleCrash()
 
 	// Start the informer factories to begin populating the informer caches
 	klog.Info("Starting IPAM Controller")
-
-	// Wait for the caches to be synced before starting workers
-	klog.Info("Waiting for informer caches to sync")
-	if ok := cache.WaitForCacheSync(stopCh, i.servicesSynced, i.podsSynced); !ok {
-		return fmt.Errorf("failed to wait for caches to sync")
-	}
 
 	// Query kube-proxy pods in the cluster
 	kubeProxyPodList, err := i.kubeClientSet.CoreV1().Pods(kubeProxyNameSpace).List(metav1.ListOptions{LabelSelector: kubeProxyLabelSelector})
@@ -97,13 +88,18 @@ func (i *Controller) Run(stopCh <-chan struct{}) error {
 		return fmt.Errorf("initIPTableChains returned error. %v", err)
 	}
 
+	// Wait for the caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, i.servicesSynced, i.podsSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
 	klog.Info("Starting workers")
 	go wait.Until(i.runServiceWorker, time.Second, stopCh)
 	go wait.Until(i.runPodWorker, time.Second, stopCh)
-	wg.Wait()
 	<-stopCh
 	klog.Info("Shutting down workers")
-
+	i.cleanupIPTableRules()
 	return nil
 }
 
@@ -335,33 +331,27 @@ func (i *Controller) handleRemovedPod(obj interface{}) {
 	}
 }
 
-func (i *Controller) annotateGlobalIp(key string, annotations map[string]string) (map[string]string, error) {
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
+func (i *Controller) annotateGlobalIp(key string, globalIp string) (string, error) {
 	var ip string
 	var err error
-	globalIp := annotations[submarinerIpamGlobalIp]
 	if globalIp == "" {
 		ip, err = i.pool.Allocate(key)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		annotations[submarinerIpamGlobalIp] = ip
 		klog.V(4).Infof("Allocating GlobalIp %s to %s ", ip, key)
-		return annotations, nil
+		return ip, nil
 	}
 	givenIp, err := i.pool.RequestIp(key, globalIp)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	if globalIp != givenIp {
 		// This resource has been allocated a different IP
-		annotations[submarinerIpamGlobalIp] = givenIp
 		klog.V(4).Infof("Updating GlobalIp for %s from %s to %s", key, globalIp, givenIp)
-		return annotations, nil
+		return givenIp, nil
 	}
-	return nil, nil
+	return "", nil
 }
 
 func (i *Controller) serviceGetter(namespace, name string) (runtime.Object, error) {
@@ -374,16 +364,30 @@ func (i *Controller) podGetter(namespace, name string) (runtime.Object, error) {
 
 func (i *Controller) serviceUpdater(obj runtime.Object, key string) error {
 	service := obj.(*k8sv1.Service)
-	annotations, err := i.annotateGlobalIp(key, service.GetAnnotations())
+	existingGlobalIp := service.GetAnnotations()[submarinerIpamGlobalIp]
+	allocatedIp, err := i.annotateGlobalIp(key, existingGlobalIp)
 	if err != nil { // failed to get globalIp or failed to update, we want to retry
 		logAndRequeue(key, i.serviceWorkqueue)
 		return fmt.Errorf("failed to annotate GlobalIp to service %s: %v", key, err)
 	}
-	if annotations != nil {
+
+	// This case is hit when the Service does not have the globalIp annotation and a new globalIp is allocated
+	// or when the existing annotation on the Service does not match with the allocated globalIp.
+	if allocatedIp != "" {
+		annotations := service.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[submarinerIpamGlobalIp] = allocatedIp
 		service.SetAnnotations(annotations)
-		i.syncServiceRules(service, annotations[submarinerIpamGlobalIp], AddRules)
+		i.syncServiceRules(service, allocatedIp, AddRules)
 		_, updateErr := i.kubeClientSet.CoreV1().Services(service.Namespace).Update(service)
 		return updateErr
+	} else if existingGlobalIp != "" {
+		// When Globalnet Controller is migrated, we get notification for all the existing services.
+		// For services that already have the annotation, we update the local ipPool cache and sync
+		// the iptable rules on the node.
+		i.syncServiceRules(service, existingGlobalIp, AddRules)
 	}
 	return nil
 }
@@ -391,16 +395,30 @@ func (i *Controller) serviceUpdater(obj runtime.Object, key string) error {
 func (i *Controller) podUpdater(obj runtime.Object, key string) error {
 	pod := obj.(*k8sv1.Pod)
 	pod.GetSelfLink()
-	annotations, err := i.annotateGlobalIp(key, pod.GetAnnotations())
+	existingGlobalIp := pod.GetAnnotations()[submarinerIpamGlobalIp]
+	allocatedIp, err := i.annotateGlobalIp(key, existingGlobalIp)
 	if err != nil { // failed to get globalIp or failed to update, we want to retry
 		logAndRequeue(key, i.podWorkqueue)
 		return fmt.Errorf("failed to annotate GlobalIp to Pod %s: %v", key, err)
 	}
-	if annotations != nil {
+
+	// This case is hit when the POD does not have the globalIp annotation and a new globalIp is allocated
+	// or when the existing annotation on the POD does not match with the allocated globalIp.
+	if allocatedIp != "" {
+		annotations := pod.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[submarinerIpamGlobalIp] = allocatedIp
 		pod.SetAnnotations(annotations)
-		i.syncPodRules(pod.Status.PodIP, annotations[submarinerIpamGlobalIp], AddRules)
+		i.syncPodRules(pod.Status.PodIP, allocatedIp, AddRules)
 		_, updateErr := i.kubeClientSet.CoreV1().Pods(pod.Namespace).Update(pod)
 		return updateErr
+	} else if existingGlobalIp != "" {
+		// When Globalnet Controller is migrated, we get notification for all the existing PODs.
+		// For PODs that already have the annotation, we update the local ipPool cache and sync
+		// the iptable rules on the node.
+		i.syncPodRules(pod.Status.PodIP, existingGlobalIp, AddRules)
 	}
 	return nil
 }

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -45,6 +45,7 @@ type GatewayMonitor struct {
 	endpointWorkqueue   workqueue.RateLimitingInterface
 	endpointsSynced     cache.InformerSynced
 	ipamSpec            *SubmarinerIpamControllerSpecification
+	ipt                 *iptables.IPTables
 	stopProcessing      chan struct{}
 	isGatewayNode       bool
 	syncMutex           *sync.Mutex

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -1,17 +1,22 @@
 package ipam
 
 import (
+	"sync"
+
 	"github.com/coreos/go-iptables/iptables"
 	kubeInformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 )
 
 type SubmarinerIpamControllerSpecification struct {
 	ClusterID  string
 	GlobalCIDR string
 	ExcludeNS  []string
+	Namespace  string
 }
 
 type InformerConfigStruct struct {
@@ -31,4 +36,16 @@ type Controller struct {
 	pool              *IpPool
 
 	ipt *iptables.IPTables
+}
+
+type GatewayMonitor struct {
+	clusterID           string
+	kubeClientSet       kubernetes.Interface
+	submarinerClientSet clientset.Interface
+	endpointWorkqueue   workqueue.RateLimitingInterface
+	endpointsSynced     cache.InformerSynced
+	ipamSpec            *SubmarinerIpamControllerSpecification
+	stopProcessing      chan struct{}
+	isGatewayNode       bool
+	syncMutex           *sync.Mutex
 }

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
@@ -1,13 +1,12 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: submariner-globalnet
 spec:
   selector:
     matchLabels:
       app: submariner-globalnet
-  replicas: 1
   template:
     metadata:
       labels:
@@ -19,10 +18,16 @@ spec:
           image: submariner-globalnet:local
           imagePullPolicy: IfNotPresent
           env:
+            - name: SUBMARINER_CLUSTERID
+              value: "cluster2"
             - name: SUBMARINER_GLOBALCIDR
               value: 169.254.2.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
+            - name: SUBMARINER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
@@ -1,13 +1,12 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: submariner-globalnet
 spec:
   selector:
     matchLabels:
       app: submariner-globalnet
-  replicas: 1
   template:
     metadata:
       labels:
@@ -19,10 +18,16 @@ spec:
           image: submariner-globalnet:local
           imagePullPolicy: IfNotPresent
           env:
+            - name: SUBMARINER_CLUSTERID
+              value: "cluster3"
             - name: SUBMARINER_GLOBALCIDR
               value: 169.254.3.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
+            - name: SUBMARINER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:

--- a/scripts/kind-e2e/globalnet/role-globalnet.yaml
+++ b/scripts/kind-e2e/globalnet/role-globalnet.yaml
@@ -20,6 +20,14 @@ rules:
       - nodes
     verbs:
       - get
+  - apiGroups:
+      - "submariner.io"
+    resources:
+      - endpoints
+    verbs:
+      - list
+      - watch
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This patch implements the following features

1. Modifies the Globalnet controller to a DaemonSet with
   nodeSelector so that it gets scheduled on all the nodes
   labelled with submariner.io/gateway: "true"
2. Initializes ipamController only on the active GatewayNode
   of the Cluster. On all the other nodes, we just keep
   monitoring for any leader changes and react accordingly.
3. When a clusterLeader (aka GatewayNode) migrates to a new
   node, ipamController running on that node will be stopped
   and all the existing globalnet ingress/egress rules are
   deleted. On the new clusterLeader, ipamController will
   be initialized and it reprograms the necessary ingress,
   egress rules.
4. Inorder to support the above use-cases and to optimize
   the flow, globalnet ingress and egress rules are now
   programmed in their respective chains.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>