### PR TITLE
E2E: make connection timeout configurable

### DIFF
--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -66,7 +66,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 
 func RunConnectivityTest(f *framework.Framework, useService bool, listenerScheduling framework.NetworkPodScheduling, connectorScheduling framework.NetworkPodScheduling, listenerCluster framework.ClusterIndex, connectorCluster framework.ClusterIndex) (*framework.NetworkPod, *framework.NetworkPod) {
 
-	listenerPod, connectorPod := createPods(f, useService, listenerScheduling, connectorScheduling, listenerCluster, connectorCluster, 45)
+	listenerPod, connectorPod := createPods(f, useService, listenerScheduling, connectorScheduling, listenerCluster, connectorCluster,
+		framework.TestContext.ConnectionTimeout, framework.TestContext.ConnectionAttempts)
 	listenerPod.CheckSuccessfulFinish()
 	connectorPod.CheckSuccessfulFinish()
 
@@ -82,7 +83,7 @@ func RunConnectivityTest(f *framework.Framework, useService bool, listenerSchedu
 }
 
 func RunNoConnectivityTest(f *framework.Framework, useService bool, listenerScheduling framework.NetworkPodScheduling, connectorScheduling framework.NetworkPodScheduling, listenerCluster framework.ClusterIndex, connectorCluster framework.ClusterIndex) (*framework.NetworkPod, *framework.NetworkPod) {
-	listenerPod, connectorPod := createPods(f, useService, listenerScheduling, connectorScheduling, listenerCluster, connectorCluster, 5)
+	listenerPod, connectorPod := createPods(f, useService, listenerScheduling, connectorScheduling, listenerCluster, connectorCluster, 5, 1)
 
 	By("Verifying that listener pod exits with non-zero code and timed out message")
 	Expect(listenerPod.TerminationMessage).To(ContainSubstring("nc: timeout"))
@@ -96,13 +97,16 @@ func RunNoConnectivityTest(f *framework.Framework, useService bool, listenerSche
 	return listenerPod, connectorPod
 }
 
-func createPods(f *framework.Framework, useService bool, listenerScheduling framework.NetworkPodScheduling, connectorScheduling framework.NetworkPodScheduling, listenerCluster framework.ClusterIndex, connectorCluster framework.ClusterIndex, connectionTimeout int) (*framework.NetworkPod, *framework.NetworkPod) {
+func createPods(f *framework.Framework, useService bool, listenerScheduling framework.NetworkPodScheduling, connectorScheduling framework.NetworkPodScheduling, listenerCluster framework.ClusterIndex,
+	connectorCluster framework.ClusterIndex, connectionTimeout uint, connectionAttempts uint) (*framework.NetworkPod, *framework.NetworkPod) {
+
 	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP", framework.TestContext.KubeContexts[listenerCluster]))
 	listenerPod := f.NewNetworkPod(&framework.NetworkPodConfig{
-		Type:              framework.ListenerPod,
-		Cluster:           listenerCluster,
-		Scheduling:        listenerScheduling,
-		ConnectionTimeout: connectionTimeout,
+		Type:               framework.ListenerPod,
+		Cluster:            listenerCluster,
+		Scheduling:         listenerScheduling,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
 	})
 
 	remoteIP := listenerPod.Pod.Status.PodIP
@@ -116,11 +120,12 @@ func createPods(f *framework.Framework, useService bool, listenerScheduling fram
 
 	By(fmt.Sprintf("Creating a connector pod in cluster %q, which will attempt the specific UUID handshake over TCP", framework.TestContext.KubeContexts[connectorCluster]))
 	connectorPod := f.NewNetworkPod(&framework.NetworkPodConfig{
-		Type:              framework.ConnectorPod,
-		Cluster:           connectorCluster,
-		Scheduling:        connectorScheduling,
-		RemoteIP:          remoteIP,
-		ConnectionTimeout: connectionTimeout,
+		Type:               framework.ConnectorPod,
+		Cluster:            connectorCluster,
+		Scheduling:         connectorScheduling,
+		RemoteIP:           remoteIP,
+		ConnectionTimeout:  connectionTimeout,
+		ConnectionAttempts: connectionAttempts,
 	})
 
 	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -331,7 +331,7 @@ func AwaitUntil(opMsg string, doOperation DoOperationFunc, checkResult CheckResu
 func AwaitResultOrError(opMsg string, doOperation DoOperationFunc, checkResult CheckResultFunc) (interface{}, string, error) {
 	var finalResult interface{}
 	var lastMsg string
-	err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(5*time.Second, time.Duration(TestContext.OperationTimeout)*time.Second, func() (bool, error) {
 		result, err := doOperation()
 		if err != nil {
 			if IsTransientError(err, opMsg) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -16,6 +16,8 @@ type TestContextType struct {
 	ReportDir           string
 	ReportPrefix        string
 	SubmarinerNamespace string
+	ConnectionTimeout   uint
+	ConnectionAttempts  uint
 }
 
 func (contexts *contextArray) String() string {
@@ -36,6 +38,8 @@ func registerFlags(t *TestContextType) {
 	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
 	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner", "Namespace in which the submariner components are deployed.")
+	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 6, "The timeout in seconds per connection attempt when verifying communication between clusters.")
+	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 10, "The number of connection attempts when verifying communication between clusters.")
 }
 
 func validateFlags(t *TestContextType) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -18,6 +18,7 @@ type TestContextType struct {
 	SubmarinerNamespace string
 	ConnectionTimeout   uint
 	ConnectionAttempts  uint
+	OperationTimeout    uint
 }
 
 func (contexts *contextArray) String() string {
@@ -40,6 +41,7 @@ func registerFlags(t *TestContextType) {
 	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner", "Namespace in which the submariner components are deployed.")
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 6, "The timeout in seconds per connection attempt when verifying communication between clusters.")
 	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 10, "The number of connection attempts when verifying communication between clusters.")
+	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 60, "The general operation timeout in seconds.")
 }
 
 func validateFlags(t *TestContextType) {


### PR DESCRIPTION
Added 'connection-timeout' and `connection-attempts' test params.
Defaults are 6 and 10 for total timeout of 60 s.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>