### PR TITLE
Use Endpoint CRD to configure routes

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -19,6 +19,7 @@ type ClusterSpec struct {
 	ColorCodes  []string `json:"color_codes"`
 	ServiceCIDR []string `json:"service_cidr"`
 	ClusterCIDR []string `json:"cluster_cidr"`
+	GlobalCIDR  []string `json:"global_cidr"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.GlobalCIDR != nil {
+		in, out := &in.GlobalCIDR, &out.GlobalCIDR
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/routeagent/main.go
+++ b/pkg/routeagent/main.go
@@ -73,7 +73,6 @@ func main() {
 	informerConfig := route.InformerConfigStruct{
 		SubmarinerClientSet: submarinerClient,
 		ClientSet:           clientSet,
-		ClusterInformer:     submarinerInformerFactory.Submariner().V1().Clusters(),
 		EndpointInformer:    submarinerInformerFactory.Submariner().V1().Endpoints(),
 		PodInformer:         informerFactory.Core().V1().Pods(),
 	}


### PR DESCRIPTION
Currently the `submariner-agent` makes use of `Cluster` CRDs to set
up the routes. This, however, is information that is more natural to
the `Endpoint` CRD as it describes the subnets that are to be found
when connecting that endpoint. Moreover, having a single source of
truth instead of two simplifies the code and allows for easier
integration with `submariner-globalnet`.

This patch makes the `Endpoint` be the source of truth for setting up
routes. By doing so, there is no need for the `submariner-routeagent` to
monitor `Cluster`s anymore and therefore the code that is related has
been removed, simplifying the codebase in consequence.