### PR TITLE
Support Global CIDR in submariner-engine

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,19 +79,27 @@ func main() {
 		submarinerInformers.WithNamespace(submSpec.Namespace))
 
 	start := func(context.Context) {
+		var localSubnets []string
+
 		localCluster, err := util.GetLocalCluster(submSpec)
 		if err != nil {
 			klog.Fatalf("Fatal error occurred while retrieving local cluster from %#v: %v", submSpec, err)
 		}
 
+		if len(submSpec.GlobalCidr) > 0 {
+			localSubnets = submSpec.GlobalCidr
+		} else {
+			localSubnets = append(submSpec.ServiceCidr, submSpec.ClusterCidr...)
+		}
+
 		localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, "ipsec", nil, submSpec.NatEnabled,
-			append(submSpec.ServiceCidr, submSpec.ClusterCidr...), util.GetLocalIP())
+			localSubnets, util.GetLocalIP())
 
 		if err != nil {
 			klog.Fatalf("Fatal error occurred while retrieving local endpoint from %#v: %v", submSpec, err)
 		}
 
-		cableEngine, err := ipsec.NewEngine(append(submSpec.ClusterCidr, submSpec.ServiceCidr...), localCluster, localEndpoint)
+		cableEngine, err := ipsec.NewEngine(localSubnets, localCluster, localEndpoint)
 		if err != nil {
 			klog.Fatalf("Fatal error occurred creating ipsec engine: %v", err)
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,6 +20,7 @@ type SubmarinerSpecification struct {
 	Token       string
 	ClusterCidr []string
 	ServiceCidr []string
+	GlobalCidr  []string
 	ColorCodes  []string
 	NatEnabled  bool
 	Broker      string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,6 +83,7 @@ func GetLocalCluster(ss types.SubmarinerSpecification) (types.SubmarinerCluster,
 	localCluster.Spec.ClusterID = ss.ClusterID
 	localCluster.Spec.ClusterCIDR = ss.ClusterCidr
 	localCluster.Spec.ServiceCIDR = ss.ServiceCidr
+	localCluster.Spec.GlobalCIDR = ss.GlobalCidr
 	localCluster.Spec.ColorCodes = ss.ColorCodes
 	return localCluster, nil
 }


### PR DESCRIPTION
The Cluster CRD has now support for a Global CIDR segment. However,
`submariner-engine` is not aware of it and thus it cannot properly
react to it. The `submariner-routeagent` uses the information stored on
each Endpoint CRDs to set routes based on the Subnets each Endpoint acts
as a gateway for. Therefore, `submariner-agent` needs to populate that
information with the correct Subnets. That means current behavior if
the Global CIDR is not present or the Global CIDR otherwise.

This patch allows `submariner-agent` to properly handle this case. For
this it introduces a new environmental variable `SUBMARINER_GLOBALCIDR`
which when present tells `submariner-agent` that the Global CIDR is to
be preferred over the Service and Pod CIDRs.