### PR TITLE
Fix build issues on the overlapping-cidrs branch

### DIFF
--- a/package/Dockerfile.globalnet
+++ b/package/Dockerfile.globalnet
@@ -18,6 +18,6 @@ RUN chmod +x /usr/local/bin/submariner-globalnet.sh
 COPY submariner-globalnet /usr/local/bin
 
 # Wrapper scripts to use iptables from the host when that's available
-COPY ./iptables*.wrapper /usr/sbin/
+COPY ./iptables-wrapper.in /usr/sbin/
 
 ENTRYPOINT submariner-globalnet.sh

--- a/package/submariner-globalnet.sh
+++ b/package/submariner-globalnet.sh
@@ -16,20 +16,21 @@ function find_iptables_on_host() {
 }
 
 
-# if host is mounted on /host and host has it's own iptables version
+# If host is mounted on /host and host has its own iptables version
 # use that one instead via the shipped iptables wrapper, we do this
 # to avoid configuring iptables and nftables on the host which
 # could lead to functional failures because some hosts use an iptables
 # and iptables-save which program nftables under the hood.
+# Since we're using UBI8, we only have nftables in the container so we
+# can't use the Kubernetes approach (see
+# https://github.com/kubernetes/kubernetes/pull/82966 and
+# https://github.com/kubernetes/website/pull/16271 for details).
 
 for f in iptables-save iptables; do
-  iptablesLocation=$(find_iptables_on_host $f)
-  if [ $iptablesLocation == "/usr/sbin" ]; then
-    echo "$f is present on the host at /usr/sbin/$f"
-    cp /usr/sbin/${f}.wrapper /usr/sbin/$f
-  elif [ $iptablesLocation == "/sbin" ]; then
-    echo "$f is present on the host at /sbin/$f"
-    cp /usr/sbin/${f}.sbin.wrapper /usr/sbin/$f
+  location=$(find_iptables_on_host $f)
+  if [ "${location}" != "unknown" ]; then
+    echo "$f is present on the host at ${location}/$f"
+	sed "s!@@PATH@@!${location}!" /usr/sbin/iptables-wrapper.in > /usr/sbin/$f
   else
     echo "WARNING: not using iptables wrapper because iptables was not detected on the"
     echo "host at the following paths [/usr/sbin, /sbin]."

--- a/pkg/globalnet/controllers/ipam/ippool_test.go
+++ b/pkg/globalnet/controllers/ipam/ippool_test.go
@@ -121,10 +121,6 @@ func testIpAllocation() {
 		It("should mark allocated IP as not available", func() {
 			Expect(pool.IsAvailable(service1Ip)).To(BeFalse())
 		})
-
-		It("IsFull should return false", func() {
-			Expect(pool.IsFull()).To(BeFalse())
-		})
 	})
 
 	When("Specific IP is Requested", func() {
@@ -161,16 +157,10 @@ func testIpAllocation() {
 	When("All IPs are allocated", func() {
 		pool, _ := NewIpPool(testCidr)
 		service1Ip, err := pool.Allocate(service1)
-		_, err = pool.Allocate(pod1)
+		pod1Ip, err := pool.Allocate(pod1)
 
 		It("should not return an error", func() {
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		When("IsFull is called", func() {
-			It("should return true", func() {
-				Expect(pool.IsFull()).To(BeTrue())
-			})
 		})
 
 		When("any IP is requested for an unallocated key", func() {
@@ -194,12 +184,15 @@ func testIpAllocation() {
 			})
 		})
 
-		When("a different IP is requested for an allocated key", func() {
-			requestedIp, err := pool.RequestIp(pod1, requestIp1)
+		When("an allocated IP is requested for an allocated key", func() {
+			requestedIp, err := pool.RequestIp(pod1, service1Ip)
 
-			It("should return an error", func() {
-				Expect(err).To(HaveOccurred())
-				Expect(requestedIp).Should(Equal(""))
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return same IP", func() {
+				Expect(requestedIp).Should(Equal(pod1Ip))
 			})
 		})
 	})


### PR DESCRIPTION
This PR fixes two issues.

1. Patch [https://github.com/submariner-io/submariner/pull/251] removed an
   API from ippool, but the associated unit tests were not updated. This
   patch fixes those issues.
2. PR [https://github.com/submariner-io/submariner/pull/232] modified the
   iptable wrappers. Similar changes are required in the globalnet controller.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>