### PR TITLE
Enable CI on overlapping-cidrs branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 branches:
   only:
   - master
+  - overlapping-cidrs
 
 git:
   depth: 1

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -216,9 +216,6 @@ function kind_import_images() {
         kind --name cluster${i} load docker-image submariner:local
         kind --name cluster${i} load docker-image submariner-route-agent:local
         kind --name cluster${i} load docker-image submariner-globalnet:local
-        if [[ "$deploy_operator" = true ]]; then
-             kind --name cluster${i} load docker-image submariner-operator:local
-	fi
     done
 }
 


### PR DESCRIPTION
The following change [https://github.com/submariner-io/submariner/pull/254]
modifies travis configuration to validate only master branch ignorning local
branches. Since we are interested in validating overlapping-cidrs branch,
this PR enables overlapping-cidrs as part of travis configuration.

Along with this, it also fixes a build issue with submariner-operator.