### PR TITLE
Avoid deleting the globalnet-marking rule on non-gw node

### DIFF
--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -203,7 +203,8 @@ func (i *GatewayMonitor) handleRemovedEndpoint(obj interface{}) {
 			i.isGatewayNode = false
 		}
 		i.syncMutex.Unlock()
-	} else {
+	} else if object.Spec.ClusterID != i.clusterID {
+		// Endpoint associated with remote cluster is removed, delete the associated flows.
 		for _, remoteSubnet := range object.Spec.Subnets {
 			MarkRemoteClusterTraffic(i.ipt, remoteSubnet, DeleteRules)
 		}


### PR DESCRIPTION
Currently, when the gateway node transitions to a new node in a cluster,
the code tries to delete the globalnet-marking rule for the current cluster
on the non-gw node. This results in a (non-fatal) error message as part of
logs. This patch fixes it.

Signed-off-by: Sridhar Gaddam sgaddam@redhat.com