### PR TITLE
Use globalCIDR from ClusterCRD

### DIFF
--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -135,10 +135,33 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 		// If the endpoint hostname matches with our hostname, it implies we are on gateway node
 		if endpoint.Spec.Hostname == hostname {
 			klog.V(4).Infof("We are now on GatewayNode %s", endpoint.Spec.PrivateIP)
+
+			clusterList, err := i.submarinerClientSet.SubmarinerV1().Clusters(i.ipamSpec.Namespace).List(metav1.ListOptions{})
+			if err != nil {
+				i.endpointWorkqueue.AddRateLimited(key)
+				return fmt.Errorf("error while retrieving the cluster info: %v", err)
+			}
+
+			globalCIDR := ""
+			for _, cluster := range clusterList.Items {
+				if cluster.Spec.ClusterID == i.clusterID {
+					klog.V(4).Infof("GlobalCidr configured in %s is %s", i.clusterID, cluster.Spec.GlobalCIDR)
+					if cluster.Spec.GlobalCIDR != nil && len(cluster.Spec.GlobalCIDR) > 0 {
+						// TODO: Revisit when support for more than one globalCIDR is implemented.
+						globalCIDR = cluster.Spec.GlobalCIDR[0]
+					}
+					break
+				}
+			}
+
 			i.syncMutex.Lock()
 			if !i.isGatewayNode {
 				i.isGatewayNode = true
-				i.initializeIpamController()
+				if globalCIDR != "" {
+					i.initializeIpamController(globalCIDR)
+				} else {
+					klog.Errorf("Cluster %s is not configured to use globalCidr", i.clusterID)
+				}
 			}
 			i.syncMutex.Unlock()
 		} else {
@@ -210,7 +233,7 @@ func (i *GatewayMonitor) handleRemovedEndpoint(obj interface{}) {
 	}
 }
 
-func (i *GatewayMonitor) initializeIpamController() {
+func (i *GatewayMonitor) initializeIpamController(globalCIDR string) {
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(i.kubeClientSet, defaultResync)
 
 	informerConfig := InformerConfigStruct{
@@ -220,7 +243,7 @@ func (i *GatewayMonitor) initializeIpamController() {
 	}
 
 	klog.V(4).Infof("On Gateway Node, initializing ipamController.")
-	ipamController, err := NewController(i.ipamSpec, &informerConfig)
+	ipamController, err := NewController(i.ipamSpec, &informerConfig, globalCIDR)
 	if err != nil {
 		klog.Fatalf("Error creating controller: %s", err.Error())
 	}

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -17,12 +17,12 @@ import (
 	"k8s.io/klog"
 )
 
-func NewController(spec *SubmarinerIpamControllerSpecification, config *InformerConfigStruct) (*Controller, error) {
+func NewController(spec *SubmarinerIpamControllerSpecification, config *InformerConfigStruct, globalCIDR string) (*Controller, error) {
 	exclusionMap := make(map[string]bool)
 	for _, v := range spec.ExcludeNS {
 		exclusionMap[v] = true
 	}
-	pool, err := NewIpPool(spec.GlobalCIDR)
+	pool, err := NewIpPool(globalCIDR)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -13,10 +13,9 @@ import (
 )
 
 type SubmarinerIpamControllerSpecification struct {
-	ClusterID  string
-	GlobalCIDR string
-	ExcludeNS  []string
-	Namespace  string
+	ClusterID string
+	ExcludeNS []string
+	Namespace string
 }
 
 type InformerConfigStruct struct {

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-2.yaml
@@ -20,8 +20,6 @@ spec:
           env:
             - name: SUBMARINER_CLUSTERID
               value: "cluster2"
-            - name: SUBMARINER_GLOBALCIDR
-              value: 169.254.2.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
             - name: SUBMARINER_NAMESPACE

--- a/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
+++ b/scripts/kind-e2e/globalnet/deploy-globalnet-3.yaml
@@ -20,8 +20,6 @@ spec:
           env:
             - name: SUBMARINER_CLUSTERID
               value: "cluster3"
-            - name: SUBMARINER_GLOBALCIDR
-              value: 169.254.3.0/24
             - name: SUBMARINER_EXCLUDENS
               value: "submariner,kube-system,operators"
             - name: SUBMARINER_NAMESPACE

--- a/scripts/kind-e2e/globalnet/role-globalnet.yaml
+++ b/scripts/kind-e2e/globalnet/role-globalnet.yaml
@@ -24,6 +24,7 @@ rules:
       - "submariner.io"
     resources:
       - endpoints
+      - clusters
     verbs:
       - list
       - watch


### PR DESCRIPTION
Currently, globalCIDR is configured/stored as part of clusterCRD and
Submariner uses this value to populate the endpoint subnets. At the
same time, globalnet controller is reading this value as an environment
parameter in the globalnet POD. Storing/reading globalCIDR from two
different places could be error prone if not configured/deployed properly.
This patch modifies globalnet controller to read the globalCIDR from the
clusterCRD which is the source of truth for a cluster.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>