### PR TITLE
Update e2e redundancy tests for SM engine deployed as DaemonSet

### DIFF
--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (f *Framework) FindDeployment(cluster ClusterIndex, appName string, namespace string) *appsv1.Deployment {
@@ -19,16 +18,4 @@ func (f *Framework) FindDeployment(cluster ClusterIndex, appName string, namespa
 		appName, TestContext.KubeContexts[cluster]))
 
 	return &deployments.Items[0]
-}
-
-func (f *Framework) FindSubmarinerEngineDeployment(cluster ClusterIndex) *appsv1.Deployment {
-	return f.FindDeployment(cluster, SubmarinerEngine, TestContext.SubmarinerNamespace)
-}
-
-func (f *Framework) SetReplicas(cluster ClusterIndex, deployment *appsv1.Deployment, replicas uint32) {
-	PatchInt("/spec/replicas", replicas,
-		func(pt types.PatchType, payload []byte) error {
-			_, err := f.ClusterClients[cluster].AppsV1().Deployments(deployment.Namespace).Patch(deployment.Name, pt, payload)
-			return err
-		})
 }

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -7,42 +7,26 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner/test/e2e/framework"
 	"github.com/submariner-io/submariner/test/e2e/tcp"
-	appsv1 "k8s.io/api/apps/v1"
 )
 
-var _ = PDescribe("[redundancy] Gateway fail-over tests", func() {
+var _ = Describe("[redundancy] Gateway fail-over tests", func() {
 	f := framework.NewDefaultFramework("gateway-redundancy")
 
 	When("one gateway node is configured and the submariner engine pod fails", func() {
 		It("should start a new submariner engine pod and be able to connect from another cluster", func() {
-			testOneGatewayNode(f)
+			testEnginePodRestartScenario(f)
 		})
 	})
 
-	When("two gateway nodes are configured with one submariner engine replica and the gateway node fails", func() {
-		It("should start a new submariner engine pod on the second gateway node and be able to connect from another cluster", func() {
-			testTwoGatewayNodesWithOneReplica(f)
+	When("a new node is labeled as a gateway node and the label on the existing gateway node is removed", func() {
+		It("should start a submariner engine on the new gateway node and be able to connect from another cluster", func() {
+			testGatewayFailOverScenario(f)
 		})
 	})
 
-	When("two gateway nodes are configured with two submariner engine replicas and the active gateway node fails", func() {
-		var deployment *appsv1.Deployment
-
-		BeforeEach(func() {
-			deployment = f.FindSubmarinerEngineDeployment(framework.ClusterA)
-		})
-
-		It("should fail over to the second submariner engine running on the second gateway node and be able to connect from another cluster", func() {
-			testTwoGatewayNodesWithTwoReplicas(f, deployment)
-		})
-
-		AfterEach(func() {
-			f.SetReplicas(framework.ClusterA, deployment, 1)
-		})
-	})
 })
 
-func testOneGatewayNode(f *framework.Framework) {
+func testEnginePodRestartScenario(f *framework.Framework) {
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
@@ -66,7 +50,7 @@ func testOneGatewayNode(f *framework.Framework) {
 	tcp.RunConnectivityTest(f, false, framework.PodNetworking, framework.NonGatewayNode, framework.NonGatewayNode, framework.ClusterA, framework.ClusterB)
 }
 
-func testTwoGatewayNodesWithOneReplica(f *framework.Framework) {
+func testGatewayFailOverScenario(f *framework.Framework) {
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
@@ -91,13 +75,10 @@ func testTwoGatewayNodesWithOneReplica(f *framework.Framework) {
 	By(fmt.Sprintf("Setting the gateway label for node %q to true", initialNonGatewayNode.Name))
 	f.SetGatewayLabelOnNode(framework.ClusterA, initialNonGatewayNode.Name, true)
 
-	// Set the gateway label for the active gateway worker node to false so the new submariner engine pod won't be
-	// scheduled on it.
+	// Set the gateway label for the active gateway worker node to false so the submariner engine pod will be
+	// terminated.
 	By(fmt.Sprintf("Setting the gateway label for node %q to false", initialGatewayNode.Name))
 	f.SetGatewayLabelOnNode(framework.ClusterA, initialGatewayNode.Name, false)
-
-	By(fmt.Sprintf("Deleting submariner engine pod %q", enginePod.Name))
-	f.DeletePod(framework.ClusterA, enginePod.Name, framework.TestContext.SubmarinerNamespace)
 
 	// Ensure the new engine pod is started before we run the connectivity tests to eliminate possible timing issue where,
 	// after deleting the old pod, we actually run the connectivity test against the oold engine instance before k8s has
@@ -109,53 +90,6 @@ func testTwoGatewayNodesWithOneReplica(f *framework.Framework) {
 
 	// Verify a new Endpoint instance is created by the new engine instance. This is a bit whitebox but it's a ssanity check
 	// and also gives it a bit more of a cushion to avoid premature timeout in the connectivity test.
-	newSubmEndpoint := f.AwaitNewSubmarinerEndpoint(framework.ClusterA, submEndpoint.ObjectMeta.UID)
-	By(fmt.Sprintf("Found new submariner endpoint for %q: %#v", clusterAName, newSubmEndpoint))
-
-	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(f, false, framework.PodNetworking, framework.GatewayNode, framework.GatewayNode, framework.ClusterA, framework.ClusterB)
-
-	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(f, false, framework.PodNetworking, framework.NonGatewayNode, framework.NonGatewayNode, framework.ClusterA, framework.ClusterB)
-}
-
-func testTwoGatewayNodesWithTwoReplicas(f *framework.Framework, deployment *appsv1.Deployment) {
-	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
-	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
-
-	gatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, true)
-	Expect(gatewayNodes).To(HaveLen(1), fmt.Sprintf("Expected only one gateway node on %q", clusterAName))
-	initGatewayNode := gatewayNodes[0]
-	By(fmt.Sprintf("Found gateway node %q on %q", initGatewayNode.Name, clusterAName))
-
-	nonGatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, false)
-	Expect(nonGatewayNodes).ToNot(BeZero(), fmt.Sprintf("Expected at least one non-gateway node on %q", clusterAName))
-	nonGatewayNode := nonGatewayNodes[0]
-	By(fmt.Sprintf("Found non-gateway node %q on %q", nonGatewayNode.Name, clusterAName))
-
-	firstEnginePod := f.AwaitSubmarinerEnginePod(framework.ClusterA)
-	By(fmt.Sprintf("Found active submariner engine pod %q on %q", firstEnginePod.Name, clusterAName))
-
-	submEndpoint := f.AwaitSubmarinerEndpoint(framework.ClusterA, framework.NoopCheckEndpoint)
-	By(fmt.Sprintf("Found submariner endpoint for %q: %#v", clusterAName, submEndpoint))
-
-	By(fmt.Sprintf("Setting the replicas to 2 for submariner engine deployment %q on %q", deployment.Name, clusterAName))
-	f.SetReplicas(framework.ClusterA, deployment, 2)
-
-	By(fmt.Sprintf("Setting the gateway label for node %q to true", nonGatewayNode.Name))
-	f.SetGatewayLabelOnNode(framework.ClusterA, nonGatewayNode.Name, true)
-
-	By(fmt.Sprintf("Awaiting second submariner engine pod running on %q...", clusterAName))
-	enginePods := f.AwaitPodsByAppLabel(framework.ClusterA, framework.SubmarinerEngine, framework.TestContext.SubmarinerNamespace, 2)
-	By(fmt.Sprintf("2 submariner engine pods now running on %q: %q and %q", clusterAName, enginePods.Items[0].Name, enginePods.Items[1].Name))
-
-	By(fmt.Sprintf("Setting the gateway label for node %q to false", initGatewayNode.Name))
-	f.SetGatewayLabelOnNode(framework.ClusterA, initGatewayNode.Name, false)
-
-	By(fmt.Sprintf("Deleting active submariner engine pod %q", firstEnginePod.Name))
-	f.DeletePod(framework.ClusterA, firstEnginePod.Name, framework.TestContext.SubmarinerNamespace)
-
-	By(fmt.Sprintf("Awaiting new submariner endpoint on %q...", clusterAName))
 	newSubmEndpoint := f.AwaitNewSubmarinerEndpoint(framework.ClusterA, submEndpoint.ObjectMeta.UID)
 	By(fmt.Sprintf("Found new submariner endpoint for %q: %#v", clusterAName, newSubmEndpoint))
 

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -9,7 +9,7 @@ import (
 	"github.com/submariner-io/submariner/test/e2e/tcp"
 )
 
-var _ = Describe("[redundancy] Gateway fail-over tests", func() {
+var _ = PDescribe("[redundancy] Gateway fail-over tests", func() {
 	f := framework.NewDefaultFramework("gateway-redundancy")
 
 	When("one gateway node is configured and the submariner engine pod fails", func() {


### PR DESCRIPTION
This PR updates the e2e tests to validate fail-over use-cases when
Submariner engine is deployed as a DaemonSet.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>