### PR TITLE
Temporarily disable gateway E2E

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -10,7 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-var _ = Describe("[redundancy] Gateway fail-over tests", func() {
+var _ = PDescribe("[redundancy] Gateway fail-over tests", func() {
 	f := framework.NewDefaultFramework("gateway-redundancy")
 
 	When("one gateway node is configured and the submariner engine pod fails", func() {


### PR DESCRIPTION
While we're transitioning the subm engine from Deployment to
DaemonSet in the helm chart and operator...

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>