### PR TITLE
Handle local dapper-base changes when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ kubefed ?= false
 deploytool ?= helm
 debug ?= false
 
-TARGETS := $(shell ls scripts)
+TARGETS := $(shell ls scripts | grep -v dapper-image)
 
 .dapper:
 	@echo Downloading dapper
@@ -14,7 +14,10 @@ TARGETS := $(shell ls scripts)
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper
 
-$(TARGETS): .dapper
+dapper-image: .dapper
+	./.dapper -m bind dapper-image
+
+$(TARGETS): .dapper dapper-image
 	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug)
 
 .DEFAULT_GOAL := ci

--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+#
+# The purpose of this script is to ensure that dapper-base:latest is updated and available locally
+# and if dapper-base is modified we make sure it's rebuilt and tagged locally so any next
+# execution through dapper will have the new image.
+#
+
+source $(dirname $0)/lib/debug_functions
+source $(dirname $0)/lib/version
+
+ARCH=${ARCH:-"amd64"}
+SUFFIX=""
+[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
+
+TAG=${TAG:-${VERSION}${SUFFIX}}
+REPO=${REPO:-quay.io/submariner}
+
+DAPPER_BASE_IMAGE=${REPO}/dapper-base:${TAG}
+
+# always compare with upstream master, which is the source for the published dapper image
+UPSTREAM_REMOTE=$(git remote -v | grep submariner-io/submariner | awk '{ print $1 }' | head -n 1)
+CHANGED_FILES_LOCAL=$(git diff --name-only remotes/$UPSTREAM_REMOTE/master)
+
+if [[ "${CHANGED_FILES_PR[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
+   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "package/Dockerfile.dapper-base" ]] ; then
+      echo "Dockerfile.dapper-base was modified, rebuilding dapper image"
+      docker build -t ${DAPPER_BASE_IMAGE} -f package/Dockerfile.dapper-base .
+      docker tag ${DAPPER_BASE_IMAGE} ${REPO}/dapper-base:latest
+else
+      docker pull ${REPO}/dapper-base:latest || :
+      # make sure the tag is also available for release, even if no changes happened
+      docker tag ${REPO}/dapper-base:latest ${DAPPER_BASE_IMAGE}
+fi
+
+

--- a/scripts/package
+++ b/scripts/package
@@ -20,18 +20,12 @@ cp ../bin/submariner-globalnet submariner-globalnet
 ENGINE_IMAGE=${REPO}/submariner:${TAG}
 ROUTEAGENT_IMAGE=${REPO}/submariner-route-agent:${TAG}
 GLOBALNET_IMAGE=${REPO}/submariner-globalnet:${TAG}
-DAPPER_BASE_IMAGE=${REPO}/dapper-base:${TAG}
-
-# We expect the Dapper base image to change rarely, so pull it first
-docker pull ${REPO}/dapper-base:latest || :
 
 docker build -t ${ENGINE_IMAGE} .
 docker build -t ${ROUTEAGENT_IMAGE} -f Dockerfile.routeagent .
 docker build -t ${GLOBALNET_IMAGE} -f Dockerfile.globalnet .
-docker build -t ${DAPPER_BASE_IMAGE} -f Dockerfile.dapper-base .
 
 echo "Built the following images:"
 echo "* Submariner engine in ${ENGINE_IMAGE}"
 echo "* Submariner route agent in ${ROUTEAGENT_IMAGE}"
 echo "* Submariner globalnet in ${GLOBALNET_IMAGE}"
-echo "* Dapper base image in ${DAPPER_BASE_IMAGE}"


### PR DESCRIPTION
When packages/Dockerfile.dapper-base is modified it will be detected
and the image will be regenerated locally.

The base dapper image is built and published from the master branch
so if any change has happened between the upstream master branch
and the local files, the local dapper image will be rebuilt
before any other build procedure is handled.