### PR TITLE
Support Connectivity from HostNetwork to RemoteCluster

### DIFF
--- a/pkg/routeagent/controllers/route/driver.go
+++ b/pkg/routeagent/controllers/route/driver.go
@@ -3,32 +3,57 @@ package route
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 
-	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
 )
 
-const FlannelInterface = "flannel.1"
-
-func isFlannelCNI() error {
-	_, err := netlink.LinkByName(FlannelInterface)
+func discoverCNIInterface(clusterCIDR string) *cniInterface {
+	_, clusterNetwork, err := net.ParseCIDR(clusterCIDR)
 	if err != nil {
-		return fmt.Errorf("error retrieving link by name %s: %v", FlannelInterface, err)
+		klog.Errorf("Unable to ParseCIDR %q : %v", clusterCIDR, err)
+		return nil
 	}
 
-	// FlannelInterface exists, return nil
+	hostInterfaces, err := net.Interfaces()
+	if err != nil {
+		klog.Errorf("net.Interfaces() returned error : %v", err)
+		return nil
+	}
+
+	for _, iface := range hostInterfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			klog.Errorf("For interface %q, iface.Addrs returned error: %v", iface.Name, err)
+			return nil
+		}
+
+		for i := range addrs {
+			ipAddr, _, err := net.ParseCIDR(addrs[i].String())
+			if err != nil {
+				klog.Errorf("Unable to ParseCIDR : %q", addrs[i].String())
+			} else if ipAddr.To4() != nil {
+				klog.V(4).Infof("Interface %q has %q address", iface.Name, ipAddr)
+				address := net.ParseIP(ipAddr.String())
+
+				// Verify that interface has an address from cluster CIDR
+				if clusterNetwork.Contains(address) {
+					klog.V(4).Infof("Found CNI Interface %q that has IP %q from ClusterCIDR %q",
+						iface.Name, ipAddr.String(), clusterCIDR)
+					return &cniInterface{ipAddress: ipAddr.String(), name: iface.Name}
+				}
+			}
+		}
+	}
 	return nil
 }
 
-func toggleCNISpecificConfiguration() error {
-	// When using Flannel CNI, reverse path filtering has to be configured with loose mode on the FlannelInterface
-	if isFlannelCNI() == nil {
-		err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+FlannelInterface+"/rp_filter", []byte("2"), 0644)
-		if err != nil {
-			return fmt.Errorf("unable to update rp_filter for "+FlannelInterface+", err: %s", err)
-		} else {
-			klog.Info("Successfully configured rp_filter to loose mode(2) on " + FlannelInterface)
-		}
+func toggleCNISpecificConfiguration(iface string) error {
+	err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+iface+"/rp_filter", []byte("2"), 0644)
+	if err != nil {
+		return fmt.Errorf("unable to update rp_filter for cni_interface %q, err: %s", iface, err)
+	} else {
+		klog.Infof("Successfully configured rp_filter to loose mode(2) on cniInterface %q", iface)
 	}
 	return nil
 }

--- a/pkg/routeagent/controllers/route/iptables.go
+++ b/pkg/routeagent/controllers/route/iptables.go
@@ -18,35 +18,45 @@ func (r *Controller) createIPTableChains() error {
 
 	klog.V(4).Infof("Install/ensure %s chain exists", SmPostRoutingChain)
 	if err = util.CreateChainIfNotExists(ipt, "nat", SmPostRoutingChain); err != nil {
-		return fmt.Errorf("Unable to create %s chain in iptables: %v", SmPostRoutingChain, err)
+		return fmt.Errorf("unable to create %s chain in iptables: %v", SmPostRoutingChain, err)
 	}
 
 	klog.V(4).Infof("Insert %s rule that has rules for inter-cluster traffic", SmPostRoutingChain)
 	forwardToSubPostroutingRuleSpec := []string{"-j", SmPostRoutingChain}
 	if err = util.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
-		klog.Errorf("Unable to insert iptable rule in NAT table, POSTROUTING chain: %v", err)
+		return fmt.Errorf("unable to insert iptable rule in NAT table, POSTROUTING chain: %v", err)
 	}
 
 	klog.V(4).Infof("Install/ensure SUBMARINER-INPUT chain exists")
 	if err = util.CreateChainIfNotExists(ipt, "filter", "SUBMARINER-INPUT"); err != nil {
-		return fmt.Errorf("Unable to create SUBMARINER-INPUT chain in iptables: %v", err)
+		return fmt.Errorf("unable to create SUBMARINER-INPUT chain in iptables: %v", err)
 	}
 
 	forwardToSubInputRuleSpec := []string{"-p", "udp", "-m", "udp", "-j", "SUBMARINER-INPUT"}
 	if err = ipt.AppendUnique("filter", "INPUT", forwardToSubInputRuleSpec...); err != nil {
-		klog.Errorf("Unable to append iptables rule \"%s\": %v\n", strings.Join(forwardToSubInputRuleSpec, " "), err)
+		return fmt.Errorf("unable to append iptables rule %q: %v\n", strings.Join(forwardToSubInputRuleSpec, " "), err)
 	}
 
 	klog.V(4).Infof("Allow VxLAN incoming traffic in SUBMARINER-INPUT Chain")
 	ruleSpec := []string{"-p", "udp", "-m", "udp", "--dport", strconv.Itoa(VxLANPort), "-j", "ACCEPT"}
 	if err = ipt.AppendUnique("filter", "SUBMARINER-INPUT", ruleSpec...); err != nil {
-		klog.Errorf("Unable to append iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		return fmt.Errorf("unable to append iptables rule %q: %v\n", strings.Join(ruleSpec, " "), err)
 	}
 
 	klog.V(4).Infof("Insert rule to allow traffic over %s interface in FORWARDing Chain", VxLANIface)
 	ruleSpec = []string{"-o", VxLANIface, "-j", "ACCEPT"}
 	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
-		klog.Errorf("Unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
+		return fmt.Errorf("unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
+	}
+
+	if r.cniIface != nil {
+		// Program rules to support communication from HostNetwork to remoteCluster
+		sourceAddress := strconv.Itoa(VxLANVTepNetworkPrefix) + ".0.0.0/8"
+		ruleSpec = []string{"-s", sourceAddress, "-o", VxLANIface, "-j", "SNAT", "--to", r.cniIface.ipAddress}
+		klog.V(4).Infof("Installing rule for host network to remote cluster communication: %s", strings.Join(ruleSpec, " "))
+		if err = ipt.AppendUnique("nat", SmPostRoutingChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error appending iptables rule %q: %v\n", strings.Join(ruleSpec, " "), err)
+		}
 	}
 
 	return nil

--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -35,6 +35,11 @@ type InformerConfigStruct struct {
 	PodInformer         podinformer.PodInformer
 }
 
+type cniInterface struct {
+	name      string
+	ipAddress string
+}
+
 type Controller struct {
 	clusterID       string
 	objectNamespace string
@@ -57,6 +62,8 @@ type Controller struct {
 
 	isGatewayNode    bool
 	defaultHostIface *net.Interface
+
+	cniIface *cniInterface
 }
 
 const (
@@ -142,14 +149,17 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	// Configure CNI Specific changes
-	err := toggleCNISpecificConfiguration()
-	if err != nil {
-		return fmt.Errorf("toggleCNISpecificConfiguration returned error. %v", err)
+	r.cniIface = discoverCNIInterface(r.localClusterCidr[0])
+	if r.cniIface != nil {
+		// Configure CNI Specific changes
+		err := toggleCNISpecificConfiguration(r.cniIface.name)
+		if err != nil {
+			return fmt.Errorf("toggleCNISpecificConfiguration returned error. %v", err)
+		}
 	}
 
 	// Create the necessary IPTable chains in the filter and nat tables.
-	err = r.createIPTableChains()
+	err := r.createIPTableChains()
 	if err != nil {
 		return fmt.Errorf("createIPTableChains returned error. %v", err)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/rdegges/go-ipify"
+	"github.com/vishvananda/netlink"
+
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
 )
 


### PR DESCRIPTION
Currently, Submariner configures necessary tunnels and routing rules to
support connectivity between the PODs in different Clusters. However, if
we try to connect from the underlying host to a remotePOD/Service it does
not work. While working on some of the Storage use-cases in K8s, we realized
that connectivity from underlying Host to remoteCluster is required. This
patch addresses this use-case.

Fixes Issue: https://github.com/submariner-io/submariner/issues/298

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>