### PR TITLE
Add Armada-based kind k8s cluster deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ version ?= 1.14.2
 logging ?= false
 kubefed ?= false
 deploytool ?= helm
+armada ?= true
 debug ?= false
 
 TARGETS := $(shell ls scripts | grep -v dapper-image)
@@ -21,7 +22,7 @@ shell:
 	./.dapper -m bind -s
 
 $(TARGETS): .dapper dapper-image vendor/modules.txt
-	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug)
+	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(armada) $(debug)
 
 vendor/modules.txt: .dapper go.mod
 	./.dapper -m bind vendor

--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -30,6 +30,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # findutils      | e2e cleanup (xargs)
 # upx            | binary compression
 # jq             | JSON processing (GitHub API)
+# armada         | abstracting kind to deploy multiple k8s clusters in CI
 RUN dnf -y distrosync && \
     dnf -y install --nodocs --setopt=install_weak_deps=False gcc git-core curl moby-engine make golang kubernetes-client findutils upx jq && \
     dnf -y clean all && \
@@ -39,5 +40,7 @@ RUN dnf -y distrosync && \
     curl -LO "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" && \
     tar -xzf kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz && cp kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
+    # FIXME: Use a release from submariner-io/armada GitHub once one is available
+    curl -L https://github.com/dimaunx/armada/releases/download/v0.1.3/armada_0.1.3_linux_amd64.tar.gz | tar -xzf - && mv ./armada /usr/bin/armada && chmod a+x /usr/bin/armada && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports

--- a/scripts/build
+++ b/scripts/build
@@ -6,6 +6,6 @@ source $(dirname $0)/lib/version
 
 cd $(dirname $0)/
 
-./build-engine $6
-./build-routeagent $6
-./build-globalnet $6
+./build-engine $7
+./build-routeagent $7
+./build-globalnet $7

--- a/scripts/kind-e2e/lib_armada_deploy_kind.sh
+++ b/scripts/kind-e2e/lib_armada_deploy_kind.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This should only be sourced
+if [ "${0##*/}" = "lib_armada_deploy_kind.sh" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
+
+### Variables ###
+
+# FIXME: Use subctl info to collect these vs hard-coding
+# https://github.com/submariner-io/submariner-operator/tree/master/pkg/discovery/network
+declare -A cluster_CIDRs=( ["cluster1"]="10.4.0.0/14" ["cluster2"]="10.8.0.0/14" ["cluster3"]="10.12.0.0/14" )
+declare -A service_CIDRs=( ["cluster1"]="100.1.0.0/16" ["cluster2"]="100.2.0.0/16" ["cluster3"]="100.3.0.0/16" )
+
+kubecfgs_rel_dir=scripts/output/kube-config/container/
+kubecfgs_dir=${DAPPER_SOURCE}/$kubecfgs_rel_dir
+
+### Functions ###
+
+function create_kind_clusters() {
+    version=$2
+    deploy=$3
+
+    # FIXME: Somehow don't leak helm/operator-specific logic into this lib
+    if [[ $deploy = operator ]]; then
+        /usr/bin/armada create clusters --image=kindest/node:v${version} -n 3 --weave
+    elif [ "$deploy" = helm ]; then
+        /usr/bin/armada create clusters --image=kindest/node:v${version} -n 3 --weave --tiller
+    fi
+}
+
+function import_subm_images() {
+    docker tag quay.io/submariner/submariner:dev submariner:local
+    docker tag quay.io/submariner/submariner-route-agent:dev submariner-route-agent:local
+
+    /usr/bin/armada load docker-images --clusters cluster1,cluster2,cluster3 --images submariner:local,submariner-route-agent:local
+}
+
+function destroy_kind_clusters() {
+    /usr/bin/armada destroy clusters
+}

--- a/scripts/kind-e2e/lib_bash_deploy_kind.sh
+++ b/scripts/kind-e2e/lib_bash_deploy_kind.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# This should only be sourced
+if [ "${0##*/}" = "lib_bash_deploy_kind.sh" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
+
+### Variables ###
+
+declare -A cluster_CIDRs=( ["cluster1"]="10.244.0.0/16" ["cluster2"]="10.245.0.0/16" ["cluster3"]="10.246.0.0/16" )
+declare -A service_CIDRs=( ["cluster1"]="100.94.0.0/16" ["cluster2"]="100.95.0.0/16" ["cluster3"]="100.96.0.0/16" )
+
+kubecfgs_rel_dir=output/kind-config/dapper
+kubecfgs_dir=${DAPPER_SOURCE}/$kubecfgs_rel_dir
+
+### Functions ###
+
+function kind_clusters() {
+    status=$1
+    version=$2
+    pids=(-1 -1 -1)
+    logs=()
+    for i in 1 2 3; do
+        if [[ $(kind get clusters | grep cluster${i} | wc -l) -gt 0  ]]; then
+            echo Cluster cluster${i} already exists, skipping cluster creation...
+        else
+            logs[$i]=$(mktemp)
+            echo Creating cluster${i}, logging to ${logs[$i]}...
+            (
+            if [[ -n ${version} ]]; then
+                kind create cluster --image=kindest/node:v${version} --name=cluster${i} --config=${DAPPER_SOURCE}/scripts/kind-e2e/cluster${i}-config.yaml
+            else
+                kind create cluster --name=cluster${i} --config=${DAPPER_SOURCE}/scripts/kind-e2e/cluster${i}-config.yaml
+            fi
+            master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster${i}-control-plane | head -n 1)
+            sed -i -- "s/user: kubernetes-admin/user: cluster$i/g" $(kind get kubeconfig-path --name="cluster$i")
+            sed -i -- "s/name: kubernetes-admin.*/name: cluster$i/g" $(kind get kubeconfig-path --name="cluster$i")
+            sed -i -- "s/current-context: kubernetes-admin.*/current-context: cluster$i/g" $(kind get kubeconfig-path --name="cluster$i")
+
+            if [[ ${status} = keep ]]; then
+                cp -r $(kind get kubeconfig-path --name="cluster$i") ${DAPPER_SOURCE}/output/kind-config/local-dev/kind-config-cluster${i}
+            fi
+
+            sed -i -- "s/server: .*/server: https:\/\/$master_ip:6443/g" $(kind get kubeconfig-path --name="cluster$i")
+            cp -r $(kind get kubeconfig-path --name="cluster$i") ${DAPPER_SOURCE}/output/kind-config/dapper/kind-config-cluster${i}
+            ) > ${logs[$i]} 2>&1 &
+            set pids[$i] = $!
+        fi
+    done
+    print_logs "${logs[@]}"
+}
+
+function import_subm_images() {
+    docker tag quay.io/submariner/submariner:$VERSION submariner:local
+    docker tag quay.io/submariner/submariner-route-agent:$VERSION submariner-route-agent:local
+
+    for i in 1 2 3; do
+        echo "Loading submariner images in to cluster${i}..."
+        kind --name cluster${i} load docker-image submariner:local
+        kind --name cluster${i} load docker-image submariner-route-agent:local
+    done
+}
+
+function setup_custom_cni() {
+    for i in 2 3; do
+        if kubectl --context=cluster${i} wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=60s > /dev/null 2>&1; then
+            echo "Weave already deployed cluster${i}."
+        else
+            echo "Applying weave network in to cluster${i}..."
+            kubectl --context=cluster${i} apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=${cluster_CIDRs[cluster${i}]}"
+            echo "Waiting for weave-net pods to be ready cluster${i}..."
+            kubectl --context=cluster${i} wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=300s
+            echo "Waiting for core-dns deployment to be ready cluster${i}..."
+            kubectl --context=cluster${i} -n kube-system rollout status deploy/coredns --timeout=300s
+        fi
+    done
+}
+
+function create_kind_clusters() {
+    kind_clusters "$@"
+    setup_custom_cni
+}
+
+function destroy_kind_clusters() {
+    for i in 1 2 3; do
+      if [[ $(kind get clusters | grep cluster${i} | wc -l) -gt 0  ]]; then
+        kind delete cluster --name=cluster${i};
+      fi
+    done
+}

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -41,13 +41,13 @@ function setup_broker() {
     context=$1
     echo Installing broker on $context.
     kubectl config use-context $context
-    subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context deploy-broker --no-dataplane
+    subctl --kubeconfig ${kubecfgs_dir}/kind-config-$context deploy-broker --no-dataplane
 }
 
 function subctl_install_subm() {
     context=$1
     kubectl config use-context $context
-    subctl join --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context \
+    subctl join --kubeconfig ${kubecfgs_dir}/kind-config-$context \
                 --clusterid ${context} \
                 --repository ${subm_engine_image_repo} \
                 --version ${subm_engine_image_tag} \


### PR DESCRIPTION
Support Armada-abstracting-kind k8s cluster deployments in CI.

Allows us to use Armada for multicluster management and custom
networking, vs duplicating common bash between many repositories.

Defaults to using Armada, but keeps the old bash-based logic for now. It
can be removed once we have confidence enough to fully move to Armada.
Can also be removed in a distinct commit to make it easy to revert.

Closes #291

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>