### PR TITLE
Fix branch merge issues where travis CI is unable to checkout the branch sha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   - overlapping-cidrs
 
 git:
-  depth: 1
+  depth: false
 
 services:
   - docker


### PR DESCRIPTION


Fixes: https://travis-ci.com/submariner-io/submariner/builds/146943642#L168
See: https://stackoverflow.com/questions/31278233/disadvantages-of-shallow-cloning-on-travis-and-other-ci-services