### PR TITLE
Fix PANIC in route-agent pod during gw migration

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -487,7 +487,7 @@ func (r *Controller) enqueuePod(obj interface{}) {
 
 	pod := obj.(*k8sv1.Pod)
 	// Add the POD event to the workqueue only if the sm-route-agent podIP does not exist in the local cache.
-	if !r.remoteVTEPs.Contains(pod.Status.HostIP) {
+	if pod.Status.HostIP != "" && !r.remoteVTEPs.Contains(pod.Status.HostIP) {
 		klog.V(4).Infof("Enqueueing sm-route-agent-pod event, ip: %s", pod.Status.HostIP)
 		r.podWorkqueue.AddRateLimited(key)
 	}

--- a/pkg/routeagent/controllers/route/vxlan.go
+++ b/pkg/routeagent/controllers/route/vxlan.go
@@ -135,6 +135,10 @@ func (iface *vxLanIface) AddFDB(ipAddress net.IP, hwAddr string) error {
 		return fmt.Errorf("invalid MAC Address (%s) supplied. %v", hwAddr, err)
 	}
 
+	if ipAddress == nil {
+		return fmt.Errorf("invalid ipAddress (%v) supplied", ipAddress)
+	}
+
 	neigh := &netlink.Neigh{
 		LinkIndex:    iface.link.Index,
 		Family:       unix.AF_BRIDGE,


### PR DESCRIPTION
During gateway node migration, on some occasions, it was observed
that there was an error while adding an FDB entry which results
in PANIC and route-agent pod gets restarted. The reason why FDB
entry failed is because of trying to configure an FDB entry with
empty ipAddress. This patch fixes this issue by ensuring that we
wait until a POD gets an IPAddress and process it only after one
is assigned to it.

Fixes issue: https://github.com/submariner-io/submariner/issues/331

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>