### PR TITLE
Fix "flag provided but not defined" when running go test (1.13)

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"testing"
 
 	"k8s.io/klog"
 )
@@ -58,6 +59,11 @@ func validateFlags(t *TestContextType) {
 
 func ParseFlags() {
 	registerFlags(TestContext)
+	// Since Go 1.13, testing.Init() is required to register testing flags before calling flag.Parse()
+	var _ = func() bool {
+		testing.Init()
+		return true
+	}()
 	flag.Parse()
 	validateFlags(TestContext)
 }


### PR DESCRIPTION
Since Go 1.13, testing.Init() is required to register testing
flags before calling flag.Parse(), otherwise debugging may fail on:
flag provided but not defined: -test.timeout # or -test.v

See golang issue:
https://github.com/golang/go/issues/31859#issuecomment-489889428