### PR TITLE
Fix KIND redeployment error when using operator

### DIFF
--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -31,6 +31,7 @@ function deploytool_prereqs() {
 function setup_broker() {
     context=$1
     echo Installing broker on $context.
+    kubectl config use-context $context
     subctl --kubeconfig ${PRJ_ROOT}/output/kind-config/dapper/kind-config-$context deploy-broker --no-dataplane
 }
 


### PR DESCRIPTION
When installing KIND based K8s clusters using the operator as
shown below[#], the initial deployment goes fine. However, when
we try to redeploy (i.e, re-run the same command), it's failing.

[#] make ci e2e status=keep deploytool=operator

Fixes issue: https://github.com/submariner-io/submariner/issues/337

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>