### PR TITLE
Fix KIND redeploy issue when using helm

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -82,7 +82,7 @@ function kind_import_images() {
     docker tag quay.io/submariner/submariner-route-agent:dev submariner-route-agent:local
 
     for i in 1 2 3; do
-        echo "Loading submariner images in to cluster${i}..."
+        echo "Loading submariner images into cluster${i}..."
         kind --name cluster${i} load docker-image submariner:local
         kind --name cluster${i} load docker-image submariner-route-agent:local
     done


### PR DESCRIPTION
When installing KIND based K8s clusters using helm[#], the initial
deployment goes fine. However, when we try to redeploy (i.e, re-run
the same command), it's failing and this PR fixes it.

[#] make ci e2e status=keep deploytool=helm

Fixes issue: https://github.com/submariner-io/submariner/issues/339

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>