### PR TITLE
Hide the Set field and add Elements method to StringSet

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -289,7 +289,7 @@ func (r *Controller) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP) e
 			return fmt.Errorf("failed to create vxlan interface on Gateway Node: %v", err)
 		}
 
-		for fdbAddress := range r.remoteVTEPs.Set {
+		for _, fdbAddress := range r.remoteVTEPs.Elements() {
 			err = r.vxlanDevice.AddFDB(net.ParseIP(fdbAddress), "00:00:00:00:00:00")
 			if err != nil {
 				return fmt.Errorf("failed to add FDB entry on the Gateway Node vxlan iface %v", err)
@@ -652,7 +652,7 @@ func (r *Controller) reconcileRoutes(vxlanGw net.IP) error {
 	}
 
 	// let's now add the routes that are missing
-	for cidrBlock := range r.remoteSubnets.Set {
+	for _, cidrBlock := range r.remoteSubnets.Elements() {
 		_, dst, err := net.ParseCIDR(cidrBlock)
 		if err != nil {
 			klog.Errorf("Error parsing cidr block %s: %v", cidrBlock, err)

--- a/pkg/util/stringset.go
+++ b/pkg/util/stringset.go
@@ -6,21 +6,21 @@ import (
 
 type StringSet struct {
 	syncMutex *sync.Mutex
-	Set       map[string]bool
+	set       map[string]bool
 }
 
 func NewStringSet() *StringSet {
 	return &StringSet{
 		syncMutex: &sync.Mutex{},
-		Set:       make(map[string]bool)}
+		set:       make(map[string]bool)}
 }
 
 func (set *StringSet) Add(s string) bool {
 	set.syncMutex.Lock()
 	defer set.syncMutex.Unlock()
 
-	_, found := set.Set[s]
-	set.Set[s] = true
+	_, found := set.set[s]
+	set.set[s] = true
 	return !found
 }
 
@@ -28,7 +28,7 @@ func (set *StringSet) Contains(s string) bool {
 	set.syncMutex.Lock()
 	defer set.syncMutex.Unlock()
 
-	_, found := set.Set[s]
+	_, found := set.set[s]
 	return found
 }
 
@@ -36,12 +36,26 @@ func (set *StringSet) Size() int {
 	set.syncMutex.Lock()
 	defer set.syncMutex.Unlock()
 
-	return len(set.Set)
+	return len(set.set)
 }
 
 func (set *StringSet) Delete(s string) {
 	set.syncMutex.Lock()
 	defer set.syncMutex.Unlock()
 
-	delete(set.Set, s)
+	delete(set.set, s)
+}
+
+func (set *StringSet) Elements() []string {
+	set.syncMutex.Lock()
+	defer set.syncMutex.Unlock()
+
+	elements := make([]string, len(set.set))
+	i := 0
+	for v := range set.set {
+		elements[i] = v
+		i++
+	}
+
+	return elements
 }


### PR DESCRIPTION
StringSet exposed the Set field publicly which is unsafe.
The Set was accessed and iterated unprotected by code in route.go.

Made the field package-scoped and added an Elements method to return
a new []string. Also updated the unit tests.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>