### PR TITLE
Vendor as needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ TARGETS := $(shell ls scripts | grep -v dapper-image)
 dapper-image: .dapper
 	./.dapper -m bind dapper-image
 
-$(TARGETS): .dapper dapper-image
+$(TARGETS): .dapper dapper-image vendor/modules.txt
 	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug)
+
+vendor/modules.txt: .dapper go.mod
+	./.dapper -m bind vendor
 
 .DEFAULT_GOAL := ci
 


### PR DESCRIPTION
vendor/modules.txt is updated whenever "go mod vendor" is run, so we
can use that to track vendor freshness compared to go.mod. This avoids
problems with an already-present but out-dated vendor directory when
we add or update dependencies.

Signed-off-by: Stephen Kitt <skitt@redhat.com>