### PR TITLE
Split CI into jobs for more concurrency, coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ branches:
 git:
   depth: false
 
+jobs:
+  include:
+  - env: CMD="make test validate"
+  - env: CMD="make build package e2e status=keep deploytool=operator"
+  - env: CMD="make build package e2e status=keep deploytool=helm"
+
 install:
   - sudo apt-get install moreutils # make ts available
 services:
@@ -17,12 +23,12 @@ before_script:
   - CHANGED_FILES_PR=$(git diff --name-only HEAD $(git merge-base HEAD $TRAVIS_BRANCH))
 script:
   - set -o pipefail;
-    make ci e2e status=keep deploytool=operator 2>&1 | ts '[%H:%M:%.S]' -s
+    $CMD 2>&1 | ts '[%H:%M:%.S]' -s
 after_success:
   - if [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/kind-e2e/e2e.sh" ]]; then
       echo "scripts/kind-e2e/e2e.sh was modified, testing recurring run on already deployed infrastructure.";
       set -o pipefail;
-      make e2e status=keep deploytool=operator 2>&1 |  ts '[%H:%M:%.S]' -s;
+      $CMD 2>&1 |  ts '[%H:%M:%.S]' -s;
     fi;
     echo "Testing cleaning up clusters";
     set -o pipefail;


### PR DESCRIPTION
Split Travis CI configuration into three jobs to reduce execution time
through parallelism and achieve better test coverage of both
Operator-based and Helm-based deployments.

Instead of using the meta "ci" make target in both Operator/Helm jobs,
use the more narrow build/package targets and extract the common
test/validate to a third job. This reduces duplication and total can
shorten time-till-results.

Closes: #283

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>