### PR TITLE
Support for deploying Globalnet Controller with KIND/Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ logging ?= false
 kubefed ?= false
 deploytool ?= helm
 debug ?= false
+globalnet ?= false
 
 TARGETS := $(shell ls scripts | grep -v dapper-image)
 
@@ -21,7 +22,7 @@ shell:
 	./.dapper -m bind -s
 
 $(TARGETS): .dapper dapper-image vendor/modules.txt
-	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug)
+	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug) $(globalnet)
 
 vendor/modules.txt: .dapper go.mod
 	./.dapper -m bind vendor

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40
 	github.com/spf13/pflag v0.0.0-20180412120913-583c0c0531f0 // indirect
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/inf.v0 v0.0.0-20150911125757-3887ee99ecf0 // indirect

--- a/scripts/kind-e2e/lib_helm_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_helm_deploy_subm.sh
@@ -60,7 +60,7 @@ function helm_install_subm() {
     cluster_cidr=$3
     service_cidr=$4
     global_cidr=$5
-    globalnet_enable="true" && [[ -z $global_cidr ]] && globalnet_enable="false"
+    if [ -z $global_cidr ]; then globalnet_enable="false"; else globalnet_enable="true"; fi
 
     kubectl config use-context $cluster_id
     helm --kube-context ${cluster_id} install submariner-latest/submariner \

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -13,6 +13,10 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 
 	verifyInteraction := func(listenerScheduling, connectorScheduling framework.NetworkPodScheduling) {
 		It("should have sent the expected data from the pod to the other pod", func() {
+			if framework.TestContext.GlobalnetEnabled {
+				framework.Skipf("Globalnet enabled, skipping the test...")
+				return
+			}
 			tcp.RunConnectivityTest(f, useService, networkType, listenerScheduling, connectorScheduling, framework.ClusterB, framework.ClusterA)
 		})
 	}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -21,6 +21,7 @@ type TestContextType struct {
 	ConnectionTimeout   uint
 	ConnectionAttempts  uint
 	OperationTimeout    uint
+	GlobalnetEnabled    bool
 }
 
 func (contexts *contextArray) String() string {


### PR DESCRIPTION
This patch includes support in KIND (deploytool=helm) for deploying
Globalnet controller.

Usage:
make ci e2e status=keep deploytool=helm globalnet=true

Fixes issue: https://github.com/submariner-io/submariner/issues/381

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>