### PR TITLE
Only query the latest subctl release

### DIFF
--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -17,7 +17,7 @@ subm_ns=submariner-operator
 ### Functions ###
 
 function get_latest_subctl_tag() {
-    curl https://api.github.com/repos/submariner-io/submariner-operator/releases | jq -r '.[0].tag_name'
+    curl https://api.github.com/repos/submariner-io/submariner-operator/releases/latest | jq -r '.tag_name'
 }
 
 function travis_retry() {


### PR DESCRIPTION
When determining the version of subctl to download, only query the
latest release, instead of querying all releases and extracting the
latest.

Signed-off-by: Stephen Kitt <skitt@redhat.com>