### PR TITLE
Add Datastoresyncer tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,9 +152,9 @@ func main() {
 		}
 
 		klog.Info("Creating the datastore syncer")
-		dsSyncer := datastoresyncer.NewDatastoreSyncer(submSpec.ClusterID, submSpec.Namespace, kubeClient, submarinerClient,
-			submarinerInformerFactory.Submariner().V1().Clusters(), submarinerInformerFactory.Submariner().V1().Endpoints(), datastore,
-			submSpec.ColorCodes, localCluster, localEndpoint)
+		dsSyncer := datastoresyncer.NewDatastoreSyncer(submSpec.ClusterID, submarinerClient.SubmarinerV1().Clusters(submSpec.Namespace),
+			submarinerInformerFactory.Submariner().V1().Clusters(), submarinerClient.SubmarinerV1().Endpoints(submSpec.Namespace),
+			submarinerInformerFactory.Submariner().V1().Endpoints(), datastore, submSpec.ColorCodes, localCluster, localEndpoint)
 
 		submarinerInformerFactory.Start(stopCh)
 

--- a/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
@@ -1,0 +1,184 @@
+package datastoresyncer_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/datastore"
+	. "github.com/submariner-io/submariner/pkg/gomega"
+	"github.com/submariner-io/submariner/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var _ = Describe("", func() {
+	Context("Local Cluster syncing", testLocalClusterSyncing)
+	Context("Remote Cluster syncing", testRemoteClusterSyncing)
+})
+
+func testLocalClusterSyncing() {
+	var d *testDriver
+
+	BeforeEach(func() {
+		d = newTestDiver()
+	})
+
+	JustBeforeEach(func() {
+		d.run()
+	})
+
+	AfterEach(func() {
+		d.stop(nil)
+	})
+
+	It("should create the Cluster object locally and sync to the central datastore", func() {
+		var foundCluster *submarinerv1.Cluster
+		err := wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+			cluster, err := d.submarinerClusters.Get(d.localCluster.Spec.ClusterID, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			foundCluster = cluster
+			return true, nil
+		})
+
+		Expect(err).To(Succeed())
+		Expect(foundCluster.Spec).To(Equal(d.localCluster.Spec))
+		d.mockDatastore.VerifySetCluster(d.localCluster)
+	})
+
+	When("a remote Cluster is received", func() {
+		It("should not sync it to the central datastore", func() {
+			d.mockDatastore.VerifySetCluster(d.localCluster)
+
+			_, err := d.submarinerClusters.Create(&submarinerv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: otherClusterID,
+				},
+			})
+			Expect(err).To(Succeed())
+
+			d.mockDatastore.VerifyNoSetCluster()
+		})
+	})
+
+	When("the central datastore fails to sync a Cluster", func() {
+		var expectedErr error
+
+		BeforeEach(func() {
+			expectedErr = d.mockDatastore.SetupErrOnFirstSetCluster()
+		})
+
+		It("should log the error", func() {
+			Eventually(d.handledError, 5).Should(Receive(ContainErrorSubstring(expectedErr)))
+		})
+	})
+}
+
+func testRemoteClusterSyncing() {
+	var (
+		d               *testDriver
+		remoteCluster   *types.SubmarinerCluster
+		onClusterChange datastore.OnClusterChange
+	)
+
+	BeforeEach(func() {
+		d = newTestDiver()
+		remoteCluster = newSubmarinerCluster(otherClusterID)
+	})
+
+	JustBeforeEach(func() {
+		d.run()
+		onClusterChange = d.mockDatastore.VerifyWatchClusters()
+	})
+
+	AfterEach(func() {
+		d.stop(nil)
+	})
+
+	When("invoked for a new remote Cluster that doesn't exist in the local datastore", func() {
+		It("should be created in the local datastore", func() {
+			Expect(onClusterChange(remoteCluster, false)).To(Succeed())
+
+			localCluster, err := d.submarinerClusters.Get(getClusterName(remoteCluster), metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(localCluster.Spec).To(Equal(remoteCluster.Spec))
+		})
+	})
+
+	When("invoked for an updated remote Cluster that already exists in the local datastore", func() {
+		It("should be updated in the local datastore", func() {
+			clusterName := createCluster(remoteCluster, d.submarinerClusters)
+
+			remoteCluster.Spec.ServiceCIDR = []string{"1.2.3.4/16"}
+			Expect(onClusterChange(remoteCluster, false)).To(Succeed())
+
+			localCluster, err := d.submarinerClusters.Get(clusterName, metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(localCluster.Spec).To(Equal(remoteCluster.Spec))
+
+			// Should be a no-op
+			Expect(onClusterChange(remoteCluster, false)).To(Succeed())
+		})
+	})
+
+	When("invoked for a deleted remote Cluster that exists in the local datastore", func() {
+		It("should be deleted from the local datastore", func() {
+			clusterName := createCluster(remoteCluster, d.submarinerClusters)
+
+			Expect(onClusterChange(remoteCluster, true)).To(Succeed())
+
+			_, err := d.submarinerClusters.Get(clusterName, metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("invoked for a deleted remote Cluster that doesn't exist in the local datastore", func() {
+		It("should succeed", func() {
+			Expect(onClusterChange(remoteCluster, true)).To(Succeed())
+
+			_, err := d.submarinerClusters.Get(getClusterName(remoteCluster), metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("local datastore creation fails", func() {
+		It("should return an error", func() {
+			d.submarinerClusters.FailOnCreate = errors.New("mock Create error")
+			Expect(onClusterChange(remoteCluster, false)).To(ContainErrorSubstring(d.submarinerClusters.FailOnCreate))
+		})
+	})
+
+	When("local datastore update fails", func() {
+		It("should return an error", func() {
+			createCluster(remoteCluster, d.submarinerClusters)
+			remoteCluster.Spec.ServiceCIDR = []string{"1.2.3.4/16"}
+
+			d.submarinerClusters.FailOnUpdate = errors.New("mock Update error")
+			Expect(onClusterChange(remoteCluster, false)).To(ContainErrorSubstring(d.submarinerClusters.FailOnUpdate))
+		})
+	})
+
+	When("local datastore delete fails", func() {
+		It("should return an error", func() {
+			createCluster(remoteCluster, d.submarinerClusters)
+			d.submarinerClusters.FailOnDelete = errors.New("mock Delete error")
+			Expect(onClusterChange(remoteCluster, true)).To(ContainErrorSubstring(d.submarinerClusters.FailOnDelete))
+		})
+	})
+
+	When("local datastore retrieval fails", func() {
+		It("should return an error", func() {
+			d.submarinerClusters.FailOnGet = errors.New("mock Get error")
+			Expect(onClusterChange(remoteCluster, false)).To(ContainErrorSubstring(d.submarinerClusters.FailOnGet))
+		})
+	})
+}

--- a/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
@@ -24,7 +24,7 @@ func testLocalClusterSyncing() {
 	var d *testDriver
 
 	BeforeEach(func() {
-		d = newTestDiver()
+		d = newTestDriver()
 	})
 
 	JustBeforeEach(func() {
@@ -91,7 +91,7 @@ func testRemoteClusterSyncing() {
 	)
 
 	BeforeEach(func() {
-		d = newTestDiver()
+		d = newTestDriver()
 		remoteCluster = newSubmarinerCluster(otherClusterID)
 	})
 

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -26,7 +26,7 @@ func testLocalEndpointSyncing() {
 	var d *testDriver
 
 	BeforeEach(func() {
-		d = newTestDiver()
+		d = newTestDriver()
 	})
 
 	JustBeforeEach(func() {
@@ -135,7 +135,7 @@ func testRemoteEndpointSyncing() {
 	)
 
 	BeforeEach(func() {
-		d = newTestDiver()
+		d = newTestDriver()
 		remoteEndpoint = newSubmarinerEndpoint(otherClusterID)
 	})
 
@@ -234,7 +234,7 @@ func testEndpointExclusivityFailures() {
 
 	BeforeEach(func() {
 		expectedErr = nil
-		d = newTestDiver()
+		d = newTestDriver()
 		existingEndpoint = &types.SubmarinerEndpoint{
 			Spec: submarinerv1.EndpointSpec{
 				CableName: "submariner-cable-east-1-2-3-4",

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -1,0 +1,307 @@
+package datastoresyncer_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/datastore"
+	. "github.com/submariner-io/submariner/pkg/gomega"
+	"github.com/submariner-io/submariner/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var _ = Describe("", func() {
+	Context("Local Endpoint syncing", testLocalEndpointSyncing)
+	Context("Remote Endpoint syncing", testRemoteEndpointSyncing)
+	Context("Failures while ensuring Endpoint exclusivity", testEndpointExclusivityFailures)
+})
+
+func testLocalEndpointSyncing() {
+	var d *testDriver
+
+	BeforeEach(func() {
+		d = newTestDiver()
+	})
+
+	JustBeforeEach(func() {
+		d.run()
+	})
+
+	AfterEach(func() {
+		d.stop(nil)
+	})
+
+	It("should create the Endpoint object locally and sync to the central datastore", func() {
+		endpointName := getEndpointName(d.localEndpoint)
+
+		var foundEndpoint *submarinerv1.Endpoint
+		err := wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+			endpoint, err := d.submarinerEndpoints.Get(endpointName, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+
+			foundEndpoint = endpoint
+			return true, nil
+		})
+
+		Expect(err).To(Succeed())
+		Expect(foundEndpoint.Spec).To(Equal(d.localEndpoint.Spec))
+		d.mockDatastore.VerifySetEndpoint(d.localEndpoint)
+	})
+
+	When("a remote Endpoint is received", func() {
+		It("should not sync it to the central datastore", func() {
+			d.mockDatastore.VerifySetEndpoint(d.localEndpoint)
+
+			_, err := d.submarinerEndpoints.Create(newEndpoint(otherClusterID))
+			Expect(err).To(Succeed())
+
+			d.mockDatastore.VerifyNoSetEndpoint()
+		})
+	})
+
+	When("an Endpoint matching the local Endpoint is received", func() {
+		It("should not sync it to the central datastore", func() {
+			d.mockDatastore.VerifySetEndpoint(d.localEndpoint)
+
+			_, err := d.submarinerEndpoints.Create(newEndpoint(clusterID))
+			Expect(err).To(Succeed())
+
+			d.mockDatastore.VerifyNoSetEndpoint()
+		})
+	})
+
+	When("the central datastore fails to sync an Endpoint", func() {
+		var expectedErr error
+
+		BeforeEach(func() {
+			expectedErr = errors.New("mock SetEndpoint error")
+			d.mockDatastore.SetupErrOnFirstSetEndpoint(expectedErr)
+		})
+
+		It("should log the error", func() {
+			Eventually(d.handledError, 5).Should(Receive(ContainErrorSubstring(expectedErr)))
+		})
+	})
+
+	When("an Endpoint initially exists in the central datastore that doesn't match the local Endpoint", func() {
+		var initialEndpoint *submarinerv1.Endpoint
+		var submarinerEndpoint *types.SubmarinerEndpoint
+
+		BeforeEach(func() {
+			submarinerEndpoint = &types.SubmarinerEndpoint{
+				Spec: submarinerv1.EndpointSpec{
+					CableName: "submariner-cable-east-1-2-3-4",
+					ClusterID: clusterID,
+				},
+			}
+
+			d.mockDatastore.SetupGetEndpoints(clusterID, nil, *submarinerEndpoint)
+
+			initialEndpoint = &submarinerv1.Endpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getEndpointName(submarinerEndpoint),
+					Namespace: namespace,
+				},
+			}
+
+			d.initialObjs = append(d.initialObjs, initialEndpoint)
+		})
+
+		It("should remove the Endpoint from the local and central datastores to ensure exclusivity", func() {
+			d.mockDatastore.VerifyRemoveEndpoint(submarinerEndpoint.Spec.ClusterID, submarinerEndpoint.Spec.CableName)
+
+			_, err := d.submarinerEndpoints.Get(initialEndpoint.Name, metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+}
+
+func testRemoteEndpointSyncing() {
+	var (
+		d                *testDriver
+		remoteEndpoint   *types.SubmarinerEndpoint
+		onEndpointChange datastore.OnEndpointChange
+	)
+
+	BeforeEach(func() {
+		d = newTestDiver()
+		remoteEndpoint = newSubmarinerEndpoint(otherClusterID)
+	})
+
+	JustBeforeEach(func() {
+		d.run()
+		onEndpointChange = d.mockDatastore.VerifyWatchEndpoints()
+	})
+
+	AfterEach(func() {
+		d.stop(nil)
+	})
+
+	When("invoked for a new remote Endpoint that doesn't exist in the local datastore", func() {
+		It("should be created in the local datastore", func() {
+			Expect(onEndpointChange(remoteEndpoint, false)).To(Succeed())
+
+			localEndpoint, err := d.submarinerEndpoints.Get(getEndpointName(remoteEndpoint), metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(localEndpoint.Spec).To(Equal(remoteEndpoint.Spec))
+		})
+	})
+
+	When("invoked for an updated remote Endpoint that already exists in the local datastore", func() {
+		It("should be updated in the local datastore", func() {
+			endpointName := createEndpoint(remoteEndpoint, d.submarinerEndpoints)
+			remoteEndpoint.Spec.Subnets = []string{"1.2.3.4/16"}
+			Expect(onEndpointChange(remoteEndpoint, false)).To(Succeed())
+
+			localEndpoint, err := d.submarinerEndpoints.Get(endpointName, metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(localEndpoint.Spec).To(Equal(remoteEndpoint.Spec))
+
+			// Should be a no-op
+			Expect(onEndpointChange(remoteEndpoint, false)).To(Succeed())
+		})
+	})
+
+	When("invoked for a deleted remote Endpoint that exists in the local datastore", func() {
+		It("should be deleted from the local datastore", func() {
+			endpointName := createEndpoint(remoteEndpoint, d.submarinerEndpoints)
+			Expect(onEndpointChange(remoteEndpoint, true)).To(Succeed())
+
+			_, err := d.submarinerEndpoints.Get(endpointName, metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("invoked for a deleted remote Endpoint that doesn't exist in the local datastore", func() {
+		It("should succeed", func() {
+			Expect(onEndpointChange(remoteEndpoint, true)).To(Succeed())
+
+			_, err := d.submarinerEndpoints.Get(getEndpointName(remoteEndpoint), metav1.GetOptions{})
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	When("local datastore creation fails", func() {
+		It("should return an error", func() {
+			d.submarinerEndpoints.FailOnCreate = errors.New("mock Create error")
+			Expect(onEndpointChange(remoteEndpoint, false)).To(ContainErrorSubstring(d.submarinerEndpoints.FailOnCreate))
+		})
+	})
+
+	When("local datastore update fails", func() {
+		It("should return an error", func() {
+			createEndpoint(remoteEndpoint, d.submarinerEndpoints)
+			remoteEndpoint.Spec.Subnets = []string{"1.2.3.4/16"}
+
+			d.submarinerEndpoints.FailOnUpdate = errors.New("mock Update error")
+			Expect(onEndpointChange(remoteEndpoint, false)).To(ContainErrorSubstring(d.submarinerEndpoints.FailOnUpdate))
+		})
+	})
+
+	When("local datastore delete fails", func() {
+		It("should return an error", func() {
+			createEndpoint(remoteEndpoint, d.submarinerEndpoints)
+			d.submarinerEndpoints.FailOnDelete = errors.New("mock Delete error")
+			Expect(onEndpointChange(remoteEndpoint, true)).To(ContainErrorSubstring(d.submarinerEndpoints.FailOnDelete))
+		})
+	})
+
+	When("local datastore retrieval fails", func() {
+		It("should return an error", func() {
+			d.submarinerEndpoints.FailOnGet = errors.New("mock Get error")
+			Expect(onEndpointChange(remoteEndpoint, false)).To(ContainErrorSubstring(d.submarinerEndpoints.FailOnGet))
+		})
+	})
+}
+
+func testEndpointExclusivityFailures() {
+	var (
+		expectedErr      error
+		d                *testDriver
+		existingEndpoint *types.SubmarinerEndpoint
+	)
+
+	BeforeEach(func() {
+		expectedErr = nil
+		d = newTestDiver()
+		existingEndpoint = &types.SubmarinerEndpoint{
+			Spec: submarinerv1.EndpointSpec{
+				CableName: "submariner-cable-east-1-2-3-4",
+				ClusterID: clusterID,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		d.run()
+	})
+
+	AfterEach(func() {
+		d.stop(expectedErr)
+	})
+
+	When("retrieval of Endpoints from the central datastore fails", func() {
+		BeforeEach(func() {
+			expectedErr = errors.New("mock GetEndpoints error")
+			d.mockDatastore.SetupGetEndpoints(clusterID, expectedErr)
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("removal of the found Endpoint from the central datastore fails", func() {
+		BeforeEach(func() {
+			d.mockDatastore.SetupGetEndpoints(clusterID, nil, *existingEndpoint)
+			expectedErr = errors.New("mock RemoveEndpoint error")
+			d.mockDatastore.SetupErrOnFirstRemoveEndpoint(expectedErr)
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("the found Endpoint no longer exists in the central datastore", func() {
+		BeforeEach(func() {
+			d.mockDatastore.SetupGetEndpoints(clusterID, nil, *existingEndpoint)
+			d.mockDatastore.SetupErrOnFirstRemoveEndpoint(apierrors.NewNotFound(schema.GroupResource{}, existingEndpoint.Spec.CableName))
+		})
+
+		It("should succeed", func() {
+			d.mockDatastore.VerifySetEndpoint(d.localEndpoint)
+		})
+	})
+
+	When("removal of the found Endpoint from the local datastore fails", func() {
+		BeforeEach(func() {
+			d.mockDatastore.SetupGetEndpoints(clusterID, nil, *existingEndpoint)
+			expectedErr = errors.New("mock Delete error")
+			d.submarinerEndpoints.FailOnDelete = expectedErr
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("the found Endpoint does not exist in the local datastore", func() {
+		BeforeEach(func() {
+			d.mockDatastore.SetupGetEndpoints(clusterID, nil, *existingEndpoint)
+			d.submarinerEndpoints.FailOnDelete = apierrors.NewNotFound(schema.GroupResource{}, existingEndpoint.Spec.CableName)
+		})
+
+		It("should succeed", func() {
+			d.mockDatastore.VerifySetEndpoint(d.localEndpoint)
+		})
+	})
+}

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
 	submarinerInformers "github.com/submariner-io/submariner/pkg/client/informers/externalversions/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/datastore"
 	"github.com/submariner-io/submariner/pkg/log"
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
@@ -25,11 +24,10 @@ import (
 )
 
 type DatastoreSyncer struct {
-	objectNamespace            string
 	thisClusterID              string
 	colorCodes                 []string
-	kubeClientSet              kubernetes.Interface
-	submarinerClientset        submarinerClientset.Interface
+	submarinerClusters         submarinerClientset.ClusterInterface
+	submarinerEndpoints        submarinerClientset.EndpointInterface
 	submarinerClusterInformer  submarinerInformers.ClusterInformer
 	submarinerEndpointInformer submarinerInformers.EndpointInformer
 	datastore                  datastore.Datastore
@@ -40,12 +38,14 @@ type DatastoreSyncer struct {
 	endpointWorkqueue workqueue.RateLimitingInterface
 }
 
-func NewDatastoreSyncer(thisClusterID string, objectNamespace string, kubeClientSet kubernetes.Interface, submarinerClientset submarinerClientset.Interface, submarinerClusterInformer submarinerInformers.ClusterInformer, submarinerEndpointInformer submarinerInformers.EndpointInformer, datastore datastore.Datastore, colorcodes []string, localCluster types.SubmarinerCluster, localEndpoint types.SubmarinerEndpoint) *DatastoreSyncer {
+func NewDatastoreSyncer(thisClusterID string, submarinerClusters submarinerClientset.ClusterInterface, submarinerClusterInformer submarinerInformers.ClusterInformer,
+	submarinerEndpoints submarinerClientset.EndpointInterface, submarinerEndpointInformer submarinerInformers.EndpointInformer, datastore datastore.Datastore, colorcodes []string,
+	localCluster types.SubmarinerCluster, localEndpoint types.SubmarinerEndpoint) *DatastoreSyncer {
+
 	newDatastoreSyncer := DatastoreSyncer{
 		thisClusterID:              thisClusterID,
-		objectNamespace:            objectNamespace,
-		kubeClientSet:              kubeClientSet,
-		submarinerClientset:        submarinerClientset,
+		submarinerClusters:         submarinerClusters,
+		submarinerEndpoints:        submarinerEndpoints,
 		datastore:                  datastore,
 		submarinerClusterInformer:  submarinerClusterInformer,
 		submarinerEndpointInformer: submarinerEndpointInformer,
@@ -86,19 +86,19 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint() error {
 		if !util.CompareEndpointSpec(endpoint.Spec, d.localEndpoint.Spec) {
 			endpointName, err := util.GetEndpointCRDName(&endpoint)
 			if err != nil {
-				klog.Errorf("error extracting the submariner Endpoint name from %#v: %v", endpoint, err)
+				klog.Errorf("Error extracting the submariner Endpoint name from %#v: %v", endpoint, err)
 				continue
 			}
 
 			// we need to remove this endpoint
-			err = d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Delete(endpointName, &metav1.DeleteOptions{})
-			if err != nil {
-				klog.Errorf("error deleting submariner Endpoint %q from the local datastore: %v", endpointName, err)
+			err = d.submarinerEndpoints.Delete(endpointName, &metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("error deleting submariner Endpoint %q from the local datastore: %v", endpointName, err)
 			}
 
 			err = d.datastore.RemoveEndpoint(d.localCluster.ID, endpoint.Spec.CableName)
-			if err != nil {
-				klog.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v", endpoint.Spec.CableName, err)
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v", endpoint.Spec.CableName, err)
 			}
 
 			klog.Infof("Successfully deleted existing submariner Endpoint %q", endpointName)
@@ -243,13 +243,13 @@ func (d *DatastoreSyncer) processNextEndpointWorkItem() bool {
 	err := func() error {
 		defer d.endpointWorkqueue.Done(key)
 
-		ns, name, err := cache.SplitMetaNamespaceKey(key.(string))
+		_, name, err := cache.SplitMetaNamespaceKey(key.(string))
 		if err != nil {
 			d.endpointWorkqueue.Forget(key)
 			return err
 		}
 
-		endpoint, err := d.submarinerClientset.SubmarinerV1().Endpoints(ns).Get(name, metav1.GetOptions{})
+		endpoint, err := d.submarinerEndpoints.Get(name, metav1.GetOptions{})
 		if err != nil {
 			d.endpointWorkqueue.Forget(key)
 			return err
@@ -299,7 +299,7 @@ func (d *DatastoreSyncer) reconcileClusterCRD(fromCluster *types.SubmarinerClust
 	}
 
 	var found bool
-	cluster, err := d.submarinerClientset.SubmarinerV1().Clusters(d.objectNamespace).Get(clusterName, metav1.GetOptions{})
+	cluster, err := d.submarinerClusters.Get(clusterName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("error retrieving submariner Cluster object %q from the local datastore: %v", clusterName, err)
@@ -312,7 +312,7 @@ func (d *DatastoreSyncer) reconcileClusterCRD(fromCluster *types.SubmarinerClust
 
 	if delete {
 		if found {
-			err = d.submarinerClientset.SubmarinerV1().Clusters(d.objectNamespace).Delete(clusterName, &metav1.DeleteOptions{})
+			err = d.submarinerClusters.Delete(clusterName, &metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("error deleting submariner Cluster %q from the local datastore: %v", clusterName, err)
 			}
@@ -330,7 +330,7 @@ func (d *DatastoreSyncer) reconcileClusterCRD(fromCluster *types.SubmarinerClust
 				Spec: fromCluster.Spec,
 			}
 
-			_, err = d.submarinerClientset.SubmarinerV1().Clusters(d.objectNamespace).Create(cluster)
+			_, err = d.submarinerClusters.Create(cluster)
 			if err != nil {
 				return fmt.Errorf("error creating submariner Cluster %#v in the local datastore: %v", cluster, err)
 			}
@@ -343,13 +343,13 @@ func (d *DatastoreSyncer) reconcileClusterCRD(fromCluster *types.SubmarinerClust
 			}
 
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := d.submarinerClientset.SubmarinerV1().Clusters(d.objectNamespace).Get(clusterName, metav1.GetOptions{})
+				result, getErr := d.submarinerClusters.Get(clusterName, metav1.GetOptions{})
 				if getErr != nil {
 					return fmt.Errorf("error retrieving submariner Cluster object %q from the local datastore: %v", clusterName, getErr)
 				}
 
 				result.Spec = fromCluster.Spec
-				_, updateErr := d.submarinerClientset.SubmarinerV1().Clusters(d.objectNamespace).Update(result)
+				_, updateErr := d.submarinerClusters.Update(result)
 				return updateErr
 			})
 
@@ -372,7 +372,7 @@ func (d *DatastoreSyncer) reconcileEndpointCRD(fromEndpoint *types.SubmarinerEnd
 	}
 
 	var found bool
-	endpoint, err := d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Get(endpointName, metav1.GetOptions{})
+	endpoint, err := d.submarinerEndpoints.Get(endpointName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("error retrieving submariner Endpoint object %q from the local datastore: %v", endpointName, err)
@@ -385,7 +385,7 @@ func (d *DatastoreSyncer) reconcileEndpointCRD(fromEndpoint *types.SubmarinerEnd
 
 	if delete {
 		if found {
-			err = d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Delete(endpointName, &metav1.DeleteOptions{})
+			err = d.submarinerEndpoints.Delete(endpointName, &metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("error deleting submariner Endpoint %q from the local datastore: %v", endpointName, err)
 			}
@@ -403,7 +403,7 @@ func (d *DatastoreSyncer) reconcileEndpointCRD(fromEndpoint *types.SubmarinerEnd
 				Spec: fromEndpoint.Spec,
 			}
 
-			_, err = d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Create(endpoint)
+			_, err = d.submarinerEndpoints.Create(endpoint)
 			if err != nil {
 				return fmt.Errorf("error creating submariner Endpoint %#v in the local datastore: %v", endpoint, err)
 			}
@@ -416,12 +416,12 @@ func (d *DatastoreSyncer) reconcileEndpointCRD(fromEndpoint *types.SubmarinerEnd
 			}
 
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Get(endpointName, metav1.GetOptions{})
+				result, getErr := d.submarinerEndpoints.Get(endpointName, metav1.GetOptions{})
 				if getErr != nil {
 					return fmt.Errorf("error retrieving submariner Endpoint object %q from the local datastore: %v", endpointName, getErr)
 				}
 				result.Spec = fromEndpoint.Spec
-				_, updateErr := d.submarinerClientset.SubmarinerV1().Endpoints(d.objectNamespace).Update(result)
+				_, updateErr := d.submarinerEndpoints.Update(result)
 				return updateErr
 			})
 

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -1,0 +1,197 @@
+package datastoresyncer_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	fakeClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	clientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
+	fakeClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1/fake"
+	informers "github.com/submariner-io/submariner/pkg/client/informers/externalversions"
+	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
+	fakeDatastore "github.com/submariner-io/submariner/pkg/datastore/fake"
+	. "github.com/submariner-io/submariner/pkg/gomega"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+)
+
+const (
+	clusterID      = "east"
+	otherClusterID = "west"
+	namespace      = "submariner"
+)
+
+func TestDatastoresyncer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Datastore syncer Suite")
+}
+
+var _ = Describe("", func() {
+	klog.InitFlags(nil)
+})
+
+type testDriver struct {
+	syncer              *datastoresyncer.DatastoreSyncer
+	mockDatastore       *fakeDatastore.Datastore
+	localCluster        *types.SubmarinerCluster
+	localEndpoint       *types.SubmarinerEndpoint
+	submarinerClusters  *fakeClientsetv1.FailingClusters
+	submarinerEndpoints *fakeClientsetv1.FailingEndpoints
+	stopCh              chan struct{}
+	runCompleted        chan error
+	handledError        chan error
+	savedErrorHandlers  []func(error)
+	initialObjs         []runtime.Object
+}
+
+func newTestDiver() *testDriver {
+	return &testDriver{
+		mockDatastore:       fakeDatastore.New(),
+		localCluster:        newSubmarinerCluster(clusterID),
+		localEndpoint:       newSubmarinerEndpoint(clusterID),
+		stopCh:              make(chan struct{}),
+		runCompleted:        make(chan error, 1),
+		handledError:        make(chan error, 1000),
+		submarinerClusters:  &fakeClientsetv1.FailingClusters{},
+		submarinerEndpoints: &fakeClientsetv1.FailingEndpoints{},
+	}
+}
+
+func (t *testDriver) run() {
+	clientset := fakeClientset.NewSimpleClientset(t.initialObjs...)
+	t.submarinerClusters.ClusterInterface = clientset.SubmarinerV1().Clusters(namespace)
+	t.submarinerEndpoints.EndpointInterface = clientset.SubmarinerV1().Endpoints(namespace)
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientset, 0,
+		informers.WithNamespace(namespace))
+
+	t.syncer = datastoresyncer.NewDatastoreSyncer(clusterID, t.submarinerClusters, informerFactory.Submariner().V1().Clusters(),
+		t.submarinerEndpoints, informerFactory.Submariner().V1().Endpoints(), t.mockDatastore, []string{}, *t.localCluster, *t.localEndpoint)
+
+	informerFactory.Start(t.stopCh)
+
+	t.savedErrorHandlers = utilruntime.ErrorHandlers
+	utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers, func(err error) {
+		t.handledError <- err
+	})
+
+	go func() {
+		t.runCompleted <- t.syncer.Run(t.stopCh)
+	}()
+}
+
+func (t *testDriver) stop(expectedErr error) {
+	if t.stopCh == nil {
+		return
+	}
+
+	utilruntime.ErrorHandlers = t.savedErrorHandlers
+
+	if expectedErr == nil {
+		close(t.stopCh)
+	}
+
+	err := func() error {
+		timeout := 5 * time.Second
+		select {
+		case err := <-t.runCompleted:
+			return errors.WithMessage(err, "Run returned an error")
+		case <-time.After(timeout):
+			return fmt.Errorf("Run did not complete after %v", timeout)
+		}
+	}()
+
+	t.stopCh = nil
+	if expectedErr == nil {
+		Expect(err).To(Succeed())
+	} else {
+		Expect(err).To(ContainErrorSubstring(expectedErr))
+	}
+}
+
+func newEndpoint(clusterID string) *submarinerv1.Endpoint {
+	return &submarinerv1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterID + "-cable",
+		},
+		Spec: submarinerv1.EndpointSpec{
+			CableName: "submariner-cable-" + clusterID,
+			ClusterID: clusterID,
+		},
+	}
+}
+
+func newSubmarinerCluster(clusterID string) *types.SubmarinerCluster {
+	return &types.SubmarinerCluster{
+		ID: clusterID,
+		Spec: submarinerv1.ClusterSpec{
+			ClusterID:   clusterID,
+			ServiceCIDR: []string{"100.0.0.0/16"},
+			ClusterCIDR: []string{"10.0.0.0/14"},
+		},
+	}
+}
+
+func newSubmarinerEndpoint(clusterID string) *types.SubmarinerEndpoint {
+	return &types.SubmarinerEndpoint{
+		Spec: submarinerv1.EndpointSpec{
+			CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
+			ClusterID: clusterID,
+			Hostname:  "redsox",
+			PrivateIP: "192.68.1.2",
+			Subnets:   []string{"100.0.0.0/16", "10.0.0.0/14"},
+			Backend:   "ipsec",
+		},
+	}
+}
+
+func createEndpoint(from *types.SubmarinerEndpoint, endpoints clientsetv1.EndpointInterface) string {
+	endpointName := getEndpointName(from)
+
+	_, err := endpoints.Create(&submarinerv1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      endpointName,
+			Namespace: namespace,
+		},
+		Spec: from.Spec,
+	})
+
+	Expect(err).To(Succeed())
+	return endpointName
+}
+
+func createCluster(from *types.SubmarinerCluster, clusters clientsetv1.ClusterInterface) string {
+	clusterName := getClusterName(from)
+
+	_, err := clusters.Create(&submarinerv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: from.Spec,
+	})
+
+	Expect(err).To(Succeed())
+	return clusterName
+}
+
+func getEndpointName(from *types.SubmarinerEndpoint) string {
+	endpointName, err := util.GetEndpointCRDName(from)
+	Expect(err).To(Succeed())
+	return endpointName
+}
+
+func getClusterName(from *types.SubmarinerCluster) string {
+	clusterName, err := util.GetClusterCRDName(from)
+	Expect(err).To(Succeed())
+	return clusterName
+}

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -53,7 +53,7 @@ type testDriver struct {
 	initialObjs         []runtime.Object
 }
 
-func newTestDiver() *testDriver {
+func newTestDriver() *testDriver {
 	return &testDriver{
 		mockDatastore:       fakeDatastore.New(),
 		localCluster:        newSubmarinerCluster(clusterID),

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -94,8 +94,6 @@ func (t *testDriver) stop(expectedErr error) {
 		return
 	}
 
-	utilruntime.ErrorHandlers = t.savedErrorHandlers
-
 	if expectedErr == nil {
 		close(t.stopCh)
 	}
@@ -111,6 +109,7 @@ func (t *testDriver) stop(expectedErr error) {
 	}()
 
 	t.stopCh = nil
+	utilruntime.ErrorHandlers = t.savedErrorHandlers
 	if expectedErr == nil {
 		Expect(err).To(Succeed())
 	} else {

--- a/pkg/gomega/matchers.go
+++ b/pkg/gomega/matchers.go
@@ -1,0 +1,33 @@
+package gomega
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	gomegaTypes "github.com/onsi/gomega/types"
+)
+
+type containErrorSubstring struct {
+	expected error
+}
+
+func ContainErrorSubstring(expected error) gomegaTypes.GomegaMatcher {
+	return &containErrorSubstring{expected}
+}
+
+func (m *containErrorSubstring) Match(x interface{}) (bool, error) {
+	actual, ok := x.(error)
+	if !ok {
+		return false, fmt.Errorf("ContainErrorSubstring matcher requires an error.  Got:\n%s", format.Object(x, 1))
+	}
+	return strings.Contains(actual.Error(), m.expected.Error()), nil
+}
+
+func (m *containErrorSubstring) FailureMessage(actual interface{}) string {
+	return format.Message(actual, "to contain substring", m.expected.Error())
+}
+
+func (m *containErrorSubstring) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to contain substring", m.expected.Error())
+}


### PR DESCRIPTION
Also:
    

- removed unused kubeClientSet field and ctor param
- changed DatastoreSyncer to take a submariner ClusterInterface and EndpointInterface instead of a submarinerClientset.Interface as the former are much easier to mock failures.
- Modified ensureExclusiveEndpoint to return errors on deletion failures. This makes sense sinnce such failures mean exclusivity couldn't be achieved. I think the reason it just logged the errors before was b/c the original author was not aware of how to distinguish the "not found" error in order to ignore it.
