### PR TITLE
Add dynamic/ephemeral files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ package/strongswan-*
 .project
 .settings
 *.coverprofile
+junit.xml
+scripts/broker-info.subm*
+Dockerfile.dapper[0-9]*


### PR DESCRIPTION
Ignore:
* Various junit test results files throughout the repo.
* Encoded datafiles for specific local cluster configs, perhaps many
  from previous runs.
* Old/crashed/running local dapper config files.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>