### PR TITLE
Use lower maxDelay for route agent rate limiter

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -100,8 +100,13 @@ const (
 	SmRouteAgentFilter     = "app=submariner-routeagent"
 )
 
+func newRateLimiter() workqueue.RateLimiter {
+	return workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 30*time.Second)
+}
+
 func NewController(clusterID string, ClusterCidr []string, ServiceCidr []string, objectNamespace string,
 	link *net.Interface, config InformerConfigStruct) *Controller {
+
 	controller := Controller{
 		clusterID:              clusterID,
 		objectNamespace:        objectNamespace,
@@ -116,8 +121,8 @@ func NewController(clusterID string, ClusterCidr []string, ServiceCidr []string,
 		endpointsSynced:        config.EndpointInformer.Informer().HasSynced,
 		smRouteAgentPodsSynced: config.PodInformer.Informer().HasSynced,
 		gwVxLanMutex:           &sync.Mutex{},
-		endpointWorkqueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Endpoints"),
-		podWorkqueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Pods"),
+		endpointWorkqueue:      workqueue.NewNamedRateLimitingQueue(newRateLimiter(), "Endpoints"),
+		podWorkqueue:           workqueue.NewNamedRateLimitingQueue(newRateLimiter(), "Pods"),
 	}
 
 	config.EndpointInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
The default exponential rate limiter uses a maxDelay of 1000 sec or ~16 min
which is reached on the 19 retry:

1: 5ms
2: 10ms
3: 20ms
4: 40ms
5: 80ms
6: 160ms
7: 320ms
8: 640ms
9: 1.28s
10: 2.56s
11: 5.12s
12: 10.24s
13: 20.48s
14: 40.96s
15: 1m21.92s
16: 2m43.84s
17: 5m27.68s
18: 10m55.36s
19: 16m40s

Even the 15th retry is over a minute. This is too long - we should cap it lower.
I picked 30 sec - same as the resync period.

Also changed the new submariner workqueue for when the route agent is migrated to use it.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>