### PR TITLE
Detect CIDRs vs hardcoding for Helm deploys

### DIFF
--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -16,25 +16,8 @@ subm_ns=submariner-operator
 
 ### Functions ###
 
-function get_latest_subctl_tag() {
-    curl https://api.github.com/repos/submariner-io/submariner-operator/releases | jq -r '.[0].tag_name'
-}
-
-function travis_retry() {
-    # We don't pretend to support commands with multiple words
-    $1 || (sleep 2 && $1) || (sleep 10 && $1)
-}
-
-function get_subctl() {
-    test -x /go/bin/subctl && return
-    version=$(travis_retry get_latest_subctl_tag || echo v0.1.0)
-    curl -L https://github.com/submariner-io/submariner-operator/releases/download/${version}/subctl-${version}-linux-amd64 \
-         -o /go/bin/subctl
-    chmod a+x /go/bin/subctl
-}
-
 function deploytool_prereqs() {
-    get_subctl
+    install_subctl
 }
 
 function setup_broker() {


### PR DESCRIPTION
Use subctl's networking information tooling to dynamically detect
Cluster/Service CIDRs required by Helm. Avoids a fragile dependency on
the internal details of the deployment logic.

Closes: #372

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>