### PR TITLE
Fix race loop when ClusterCRD is updated with globalCIDR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect
@@ -29,8 +28,8 @@ require (
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/inf.v0 v0.0.0-20150911125757-3887ee99ecf0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apimachinery v0.0.0-20190629003722-e20a3a656cff
 	k8s.io/client-go v0.0.0-20190521190702-177766529176

--- a/pkg/datastore/kubernetes/kubernetes.go
+++ b/pkg/datastore/kubernetes/kubernetes.go
@@ -196,10 +196,12 @@ func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, col
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
-				ID:   object.Spec.ClusterID,
-				Spec: object.Spec,
-			}, false))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
+					ID:   object.Spec.ClusterID,
+					Spec: object.Spec,
+				}, false))
+			}
 		},
 		UpdateFunc: func(old, obj interface{}) {
 			var object *submarinerv1.Cluster
@@ -219,10 +221,12 @@ func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, col
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
-				ID:   object.Spec.ClusterID,
-				Spec: object.Spec,
-			}, false))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
+					ID:   object.Spec.ClusterID,
+					Spec: object.Spec,
+				}, false))
+			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			var object *submarinerv1.Cluster
@@ -242,10 +246,12 @@ func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, col
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
-				ID:   object.Spec.ClusterID,
-				Spec: object.Spec,
-			}, true))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onClusterChange(&types.SubmarinerCluster{
+					ID:   object.Spec.ClusterID,
+					Spec: object.Spec,
+				}, true))
+			}
 		},
 	}, time.Second*30)
 
@@ -274,9 +280,11 @@ func (k *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, co
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
-				Spec: object.Spec,
-			}, false))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
+					Spec: object.Spec,
+				}, false))
+			}
 		},
 		UpdateFunc: func(old, obj interface{}) {
 			var object *submarinerv1.Endpoint
@@ -296,9 +304,11 @@ func (k *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, co
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
-				Spec: object.Spec,
-			}, false))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
+					Spec: object.Spec,
+				}, false))
+			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			var object *submarinerv1.Endpoint
@@ -318,9 +328,11 @@ func (k *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, co
 				klog.V(log.DEBUG).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
 
-			utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
-				Spec: object.Spec,
-			}, true))
+			if selfClusterID != object.Spec.ClusterID {
+				utilruntime.HandleError(onEndpointChange(&types.SubmarinerEndpoint{
+					Spec: object.Spec,
+				}, true))
+			}
 		},
 	}, time.Second*30)
 


### PR DESCRIPTION
In the current implementation, when the ClusterCRD is updated, its seen
that there is a race loop between the old and the new CRD on the Broker
cluster as well as local cluster. Basically, datastore syncer that watches
the cluster and endpoint CRDs on the broker cluster was notifying the
change even when the CRDInfo belongs to the localCluster.

The source of truth for the clusterCRD and endpointCRD would be the local
cluster and not the information on the Broker Cluster. This patch includes
appropriate checks in the datastoresyncer to notify only changes associated
to remote clusters.

Fixes issue: https://github.com/submariner-io/submariner/issues/366

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>