### PR TITLE
Remove unused functions in Datastore interface

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -15,17 +15,8 @@ type OnClusterChange func(cluster *types.SubmarinerCluster, deleted bool) error
 type OnEndpointChange func(endpoint *types.SubmarinerEndpoint, deleted bool) error
 
 type Datastore interface {
-	// This gets all clusters that match the color code
-	GetClusters(colorCodes []string) ([]types.SubmarinerCluster, error)
-
-	// This gets a single cluster based on cluster ID and returns a v1.Cluster or error based on what it retrieves
-	GetCluster(clusterID string) (*types.SubmarinerCluster, error)
-
 	// This gets all endpoints for the given cluster ID
 	GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, error)
-
-	// This gets a single endpoint based on the cluster ID and cableName passed in
-	GetEndpoint(clusterID string, cableName string) (*types.SubmarinerEndpoint, error)
 
 	// Watches all clusters and calls the passed in function on cluster change
 	WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange OnClusterChange) error
@@ -41,7 +32,4 @@ type Datastore interface {
 
 	// This should be called to remove an endpoint from use
 	RemoveEndpoint(clusterID, cableName string) error
-
-	// This should be called to remove a cluster from use
-	RemoveCluster(clusterID string) error
 }

--- a/pkg/datastore/kubernetes/kubernetes.go
+++ b/pkg/datastore/kubernetes/kubernetes.go
@@ -42,7 +42,7 @@ type datastoreSpecification struct {
 	Ca              string
 }
 
-func NewDatastore(thisClusterID string, stopCh <-chan struct{}) (*Datastore, error) {
+func NewDatastore(thisClusterID string, stopCh <-chan struct{}) (datastore.Datastore, error) {
 	k8sSpec := datastoreSpecification{}
 
 	err := envconfig.Process("broker_k8s", &k8sSpec)
@@ -87,60 +87,6 @@ func NewDatastore(thisClusterID string, stopCh <-chan struct{}) (*Datastore, err
 	}, nil
 }
 
-func stringSliceOverlaps(left []string, right []string) bool {
-	hash := make(map[string]bool)
-	for _, s := range left {
-		hash[s] = true
-	}
-
-	for _, s := range right {
-		if hash[s] {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (k *Datastore) GetClusters(colorCodes []string) ([]types.SubmarinerCluster, error) {
-	var clusters []types.SubmarinerCluster
-
-	k8sClusters, err := k.client.SubmarinerV1().Clusters(k.remoteNamespace).List(metav1.ListOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, cluster := range k8sClusters.Items {
-		if stringSliceOverlaps(cluster.Spec.ColorCodes, colorCodes) {
-			clusters = append(clusters, types.SubmarinerCluster{
-				ID:   cluster.Spec.ClusterID,
-				Spec: cluster.Spec,
-			}) // this is likely going to add duplicate clusters
-		}
-	}
-	return clusters, nil
-}
-
-func (k *Datastore) GetCluster(clusterID string) (*types.SubmarinerCluster, error) {
-	k8sClusters, err := k.client.SubmarinerV1().Clusters(k.remoteNamespace).List(metav1.ListOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, cluster := range k8sClusters.Items {
-		if cluster.Spec.ClusterID == clusterID {
-			return &types.SubmarinerCluster{
-				ID:   clusterID,
-				Spec: cluster.Spec,
-			}, nil
-		}
-	}
-
-	return nil, fmt.Errorf("cluster wasn't found")
-}
-
 func (k *Datastore) GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, error) {
 
 	k8sEndpoints, err := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).List(metav1.ListOptions{})
@@ -158,21 +104,6 @@ func (k *Datastore) GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, 
 	}
 
 	return endpoints, nil
-}
-
-func (k *Datastore) GetEndpoint(clusterID string, cableName string) (*types.SubmarinerEndpoint, error) {
-	k8sEndpoints, err := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).List(metav1.ListOptions{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, endpoint := range k8sEndpoints.Items {
-		if endpoint.Spec.ClusterID == clusterID && endpoint.Spec.CableName == cableName {
-			return &types.SubmarinerEndpoint{Spec: endpoint.Spec}, nil
-		}
-	}
-	return nil, fmt.Errorf("endpoint wasn't found")
 }
 
 func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange datastore.OnClusterChange) error {
@@ -440,9 +371,4 @@ func (k *Datastore) RemoveEndpoint(clusterID, cableName string) error {
 	}
 
 	return k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Delete(endpointName, &metav1.DeleteOptions{})
-}
-
-func (k *Datastore) RemoveCluster(clusterID string) error {
-	// not implemented yet
-	return nil
 }

--- a/pkg/datastore/phpapi/phpapi.go
+++ b/pkg/datastore/phpapi/phpapi.go
@@ -31,7 +31,7 @@ type Specification struct {
 	Server string
 }
 
-func NewPHPAPI(apitoken string) (*PHPAPI, error) {
+func NewPHPAPI(apitoken string) (datastore.Datastore, error) {
 	var pais Specification
 	err := envconfig.Process("backend_phpapi", &pais)
 	if err != nil {
@@ -116,10 +116,6 @@ func (p *PHPAPI) GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, err
 		return nil, fmt.Errorf("error unmarshalling JSON %s: %v", string(endpointsRaw[:]), err)
 	}
 	return endpoints, nil
-}
-
-func (p *PHPAPI) GetEndpoint(clusterID string, cableName string) (*types.SubmarinerEndpoint, error) {
-	return nil, fmt.Errorf("GetEndpoint is not implemented")
 }
 
 func (p *PHPAPI) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onChange datastore.OnClusterChange) error {
@@ -244,8 +240,4 @@ func (p *PHPAPI) RemoveEndpoint(clusterID, cableName string) error {
 	}
 	defer poster.Body.Close()
 	return nil
-}
-
-func (p *PHPAPI) RemoveCluster(clusterID string) error {
-	return fmt.Errorf("RemoveCluster is not implemented")
 }


### PR DESCRIPTION
Simplifies implementations and unit tests. We can add functions
back if ever needed.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>