### PR TITLE
Fix Travis env var syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ git:
 jobs:
   include:
   - env: CMD="make test validate"
-  - env: CMD="make build package e2e status=keep deploytool=operator"
-    env: DEPLOY=true
+  - env: CMD="make build package e2e status=keep deploytool=operator" DEPLOY=true
   - env: CMD="make build package e2e status=keep deploytool=helm"
 
 install:


### PR DESCRIPTION
The previous syntax resulted in only the second environment variable
being set. Put all env vars for each job on a single line.

Relates to: #396

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>