### PR TITLE
Use portable paths for kind-e2e files

### DIFF
--- a/scripts/kind-e2e/README.md
+++ b/scripts/kind-e2e/README.md
@@ -6,7 +6,7 @@ E2E environment consists of:
 - 3 k8s clusters deployed with [kind].
   - Cluster1: One master node for broker and elasticsearch if required.
   - Cluster{2..3}: One master node and two workers for gateways nodes.
-  The configuration can be viewed or changed at **scripts/kind-e2e/cluster{1..3}-config.yaml**.
+  The configuration can be viewed or changed at **/kind-e2e/cluster{1..3}-config.yaml**.
 - Submariner installed and configured on top of the clusters.
 
 [kind] is a tool for running local Kubernetes clusters using Docker container “nodes”.
@@ -134,7 +134,7 @@ To get the status of federated clusters:
 kubectl -n kube-federation-system get kubefedclusters
 ``` 
 
-Federated deployment example resides in **scripts/kind-e2e/nginx-federated.sh**. 
+Federated deployment example resides in **/kind-e2e/nginx-federated.sh**.
 To federate resources across the clusters [kubefedctl] tool must be installed on the local system.
 
 #### Cleanup


### PR DESCRIPTION
Allows for more robust use across submariner-io/* CIs, where the scripts
will be live in and be addressed from different locations.

Relates to: #369

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>