### PR TITLE
Use getopt for robust params in e2e.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ version ?= 1.14.6
 logging ?= false
 kubefed ?= false
 deploytool ?= helm
-debug ?= false
 globalnet ?= false
+build_debug ?= false
 
 TARGETS := $(shell ls scripts | grep -v dapper-image)
 
@@ -22,7 +22,7 @@ shell:
 	./.dapper -m bind -s
 
 $(TARGETS): .dapper dapper-image vendor/modules.txt
-	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug) $(globalnet)
+	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ --status $(status) --k8s_version $(version) --logging $(logging) --kubefed $(kubefed) --deploytool $(deploytool) --globalnet $(globalnet) --build_debug $(build_debug)
 
 vendor/modules.txt: .dapper go.mod
 	./.dapper -m bind vendor

--- a/scripts/build
+++ b/scripts/build
@@ -6,6 +6,27 @@ source $(dirname $0)/lib/version
 
 cd $(dirname $0)/
 
-./build-engine $6
-./build-routeagent $6
-./build-globalnet $6
+LONGOPTS=build_debug:
+# Only accept longopts, but must pass null shortopts or first param after "--" will be incorrectly used
+SHORTOPTS=""
+! PARSED=$(getopt --options=$SHORTOPTS --longoptions=$LONGOPTS --name "$0" -- "$@")
+eval set -- "$PARSED"
+
+while true; do
+    case "$1" in
+        --build_debug)
+            build_debug="$2"
+            ;;
+        --)
+            break
+            ;;
+        *)
+            echo "Ignoring unknown option: $1 $2"
+            ;;
+    esac
+    shift 2
+done
+
+./build-engine $build_debug
+./build-routeagent $build_debug
+./build-globalnet $build_debug

--- a/scripts/build-engine
+++ b/scripts/build-engine
@@ -4,14 +4,14 @@ set -e
 source $(dirname $0)/lib/debug_functions
 source $(dirname $0)/lib/version
 
-debug=${1:-false}
+build_debug=${1:-false}
 
 cd $(dirname $0)/..
 mkdir -p bin
 echo Building submariner-engine version $VERSION
 ldflags="-X main.VERSION=$VERSION"
-if [ "$debug" = "false" ]; then
+if [ "$build_debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"
 fi
 CGO_ENABLED=0 go build -ldflags "${ldflags}" -o bin/submariner-engine main.go
-[ "$debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-engine || :
+[ "$build_debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-engine || :

--- a/scripts/build-globalnet
+++ b/scripts/build-globalnet
@@ -4,14 +4,14 @@ set -e
 source $(dirname $0)/lib/debug_functions
 source $(dirname $0)/lib/version
 
-debug=${1:-false}
+build_debug=${1:-false}
 
 cd $(dirname $0)/..
 mkdir -p bin
 echo Building submariner-globalnet version $VERSION
 ldflags="-X main.VERSION=$VERSION"
-if [ "$debug" = "false" ]; then
+if [ "$build_debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"
 fi
 CGO_ENABLED=0 go build -ldflags "${ldflags}" -o bin/submariner-globalnet ./pkg/globalnet/main.go
-[ "$debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-globalnet || :
+[ "$build_debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-globalnet || :

--- a/scripts/build-routeagent
+++ b/scripts/build-routeagent
@@ -4,14 +4,14 @@ set -e
 source $(dirname $0)/lib/debug_functions
 source $(dirname $0)/lib/version
 
-debug=${1:-false}
+build_debug=${1:-false}
 
 cd $(dirname $0)/..
 mkdir -p bin
 echo Building submariner-route-agent version $VERSION
 ldflags="-X main.VERSION=$VERSION"
-if [ "$debug" = "false" ]; then
+if [ "$build_debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"
 fi
 CGO_ENABLED=0 go build -ldflags "${ldflags}" -o bin/submariner-route-agent ./pkg/routeagent/main.go
-[ "$debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-route-agent || :
+[ "$build_debug" = "false" ] && command -v upx > /dev/null && upx bin/submariner-route-agent || :

--- a/scripts/ci
+++ b/scripts/ci
@@ -7,5 +7,5 @@ cd $(dirname $0)
 
 ./validate
 ./test
-./build $*
+./build "$@"
 ./package


### PR DESCRIPTION
Convert e2e.sh to use getopt to accept parameters, vs positional
agreements. This makes calls more robust against breakages from changes
and doesn't require callers to be aware of all params.

Supports reusing e2e.sh and related scripts in other submariner-io/*
project CI systems.

Closes: #420

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>