### PR TITLE
Remove Info message in StartEngine

### DIFF
--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -56,7 +56,6 @@ func NewEngine(localSubnets []string, localCluster types.SubmarinerCluster, loca
 }
 
 func (i *engine) StartEngine() error {
-	klog.Infof("Starting IPSec Engine (Charon)")
 	return i.driver.Init()
 }
 


### PR DESCRIPTION
This code was refactored to be generic and this line was left-over.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>