### PR TITLE
E2E: move clientset creation et al to BeforeSuite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect

--- a/test/e2e/framework/logging.go
+++ b/test/e2e/framework/logging.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/onsi/ginkgo"
 	"github.com/submariner-io/submariner/test/e2e/framework/ginkgowrapper"
-
-	. "github.com/onsi/ginkgo"
 )
 
 func nowStamp() string {
@@ -14,7 +13,7 @@ func nowStamp() string {
 }
 
 func log(level string, format string, args ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
 func Errorf(format string, args ...interface{}) {

--- a/test/e2e/framework/submariner_resources.go
+++ b/test/e2e/framework/submariner_resources.go
@@ -12,8 +12,8 @@ import (
 
 type CheckEndpointFunc func(endpoint *submarinerv1.Endpoint) (bool, string, error)
 
-func (f *Framework) createSubmarinerClient(kubeConfig, context string) *submarinerClientset.Clientset {
-	restConfig := f.createRestConfig(kubeConfig, context)
+func createSubmarinerClient(kubeConfig, context string) *submarinerClientset.Clientset {
+	restConfig := createRestConfig(kubeConfig, context)
 	clientSet, err := submarinerClientset.NewForConfig(restConfig)
 	Expect(err).NotTo(HaveOccurred())
 	return clientSet

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"strings"
 
+	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -22,6 +25,11 @@ type TestContextType struct {
 	ConnectionAttempts  uint
 	OperationTimeout    uint
 	GlobalnetEnabled    bool
+	ClusterClients      []*kubeclientset.Clientset
+	SubmarinerClients   []*submarinerClientset.Clientset
+	ClientQPS           float32
+	ClientBurst         int
+	GroupVersion        *schema.GroupVersion
 }
 
 func (contexts *contextArray) String() string {
@@ -33,7 +41,10 @@ func (contexts *contextArray) Set(value string) error {
 	return nil
 }
 
-var TestContext *TestContextType = &TestContextType{}
+var TestContext *TestContextType = &TestContextType{
+	ClientQPS:   20,
+	ClientBurst: 50,
+}
 
 func registerFlags(t *TestContextType) {
 	flag.StringVar(&t.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"),


### PR DESCRIPTION
This is a follow-up to https://github.com/submariner-io/submariner/pull/363
to co-locate the globalnet check with clientset creation to avoid code
duplication and to have it in a normal Gingko test code path. To avoid re-creating the clientsets and performing the check for every test via `BeforeEach`, these were moved to a `BeforeSuite` function which is invoked from the top-level `SynchronizedBeforeSuite` in **e2e.go**. Since `Framework` instances are created locally per set of tests and there can only be one `BeforeSuite` defined and should be at the top-level, the clientsets are now defined and set in the global `TestContext`. The equivalent fields in `Framework` remain for now - their access sites can be migrated in another PR.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>