### PR TITLE
Skip dapper targets if status is clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ TARGETS := $(shell ls scripts | grep -v dapper-image)
 	@mv .dapper.tmp .dapper
 
 dapper-image: .dapper
+ifneq ($(status),clean)
 	./.dapper -m bind dapper-image
+endif
 
 shell:
 	./.dapper -m bind -s
@@ -25,7 +27,9 @@ $(TARGETS): .dapper dapper-image vendor/modules.txt
 	DAPPER_ENV="OPERATOR_IMAGE"  ./.dapper -m bind $@ $(status) $(version) $(logging) $(kubefed) $(deploytool) $(debug) $(globalnet)
 
 vendor/modules.txt: .dapper go.mod
+ifneq ($(status),clean)
 	./.dapper -m bind vendor
+endif
 
 .DEFAULT_GOAL := ci
 


### PR DESCRIPTION
In order to reduce the churn of unnecessary tasks, only perform these
make targets when we're not trying to clean the e2e tests.