### PR TITLE
Validate Globalnet Controller (deploytool=helm) in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
   - env: CMD="make test validate"
   - env: CMD="make build package e2e status=keep deploytool=operator" DEPLOY=true
-  - env: CMD="make build package e2e status=keep deploytool=helm"
+  - env: CMD="make build package e2e status=keep deploytool=helm globalnet=true"
 
 install:
   - sudo apt-get install moreutils # make ts available


### PR DESCRIPTION
Currently, we have two jobs which validate Submariner deployments
using Helm and Operator. Since we have limited resources on CI,
instead of creating new jobs for globalnet, this PR modifies the Helm
job to validate globalnet Controller.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>