### PR TITLE
Fix error message when globalnet fails to annotate a service

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -116,11 +116,12 @@ function kind_import_images() {
 
 function get_globalip() {
     svcname=$1
+    context=$2
     # It takes a while for globalIp annotation to show up on a service
     for i in {0..30}
     do
-        gip=$(kubectl get svc $svcname -o jsonpath='{.metadata.annotations.submariner\.io/globalIp}')
-        if [ $gip != "" ]; then
+        gip=$(kubectl --context=$context get svc $svcname -o jsonpath='{.metadata.annotations.submariner\.io/globalIp}')
+        if [[ -n ${gip} ]]; then
           echo $gip
           return
         fi
@@ -132,7 +133,7 @@ function get_globalip() {
 
 function test_connection() {
     if [[ $globalnet = "true" ]]; then
-        nginx_svc_ip_cluster3=$(get_globalip nginx-demo)
+        nginx_svc_ip_cluster3=$(get_globalip nginx-demo cluster3)
     else
         nginx_svc_ip_cluster3=$(kubectl --context=cluster3 get svc -l app=nginx-demo | awk 'FNR == 2 {print $3}')
     fi


### PR DESCRIPTION
When deploying a KIND cluster with globalnet=true, and for some
reason if the globalnet controller fails to annotate the nginx-demo
service with a globalIp, KIND should fail with an appropriate error
message.

Fixes Issue: https://github.com/submariner-io/submariner/issues/440

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>