### PR TITLE
Shrink the dapper-base image

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -30,14 +30,21 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # findutils      | e2e cleanup (xargs)
 # upx            | binary compression
 # jq             | JSON processing (GitHub API)
-RUN dnf -y distrosync && \
+# diffutils      | required for goimports
+RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     dnf -y install --nodocs --setopt=install_weak_deps=False gcc git-core curl moby-engine make golang kubernetes-client findutils upx jq && \
+    dnf -y remove acl dnf-yum langpacks-en libevent libsemanage libsss_idmap libxcrypt-compat mkpasswd openssl python3-pip python3-setuptools \
+           sssd-client unbound-libs whois-nls && \
+    rpm -e --nodeps selinux-policy-targeted && \
     dnf -y clean all && \
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${LINT_VERSION} && \
     curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
-    cp linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && \
-    curl -LO "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" && \
-    tar -xzf kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz && cp kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
+    mv linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && rm -rf linux-${ARCH} && \
+    curl -L "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" | tar -xzf - && \
+    mv kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports
+    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
+    upx /go/bin/ginkgo /go/bin/goimports /go/bin/golangci-lint /usr/bin/containerd /usr/bin/docker /usr/bin/dockerd /usr/bin/helm /usr/bin/kubectl \
+        /usr/bin/kubefedctl && \
+    ln -f /usr/bin/kubectl /usr/bin/hyperkube


### PR DESCRIPTION
This makes the following changes:
* avoid pulling in weak dependencies on distrosync
* clean out a number of unnecessary packages
* compress the large Go binaries we end up installing

removing 400 MiB from the image (1.83 GiB down to 1.43 GiB).

Signed-off-by: Stephen Kitt <skitt@redhat.com>