### PR TITLE
Default to Operator-based SubM deploys, vs Helm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ git:
 jobs:
   include:
   - env: CMD="make test validate"
-  - env: CMD="make build package e2e status=keep deploytool=operator" DEPLOY=true
+  - env: CMD="make build package e2e status=keep" DEPLOY=true
   - env: CMD="make build package e2e status=keep deploytool=helm globalnet=true"
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ status ?= onetime
 version ?= 1.14.6
 logging ?= false
 kubefed ?= false
-deploytool ?= helm
+deploytool ?= operator
 globalnet ?= false
 build_debug ?= false
 


### PR DESCRIPTION
Default to using submariner-operator to deploy SubM vs Helm. The
Operator is already the deploy method used for the job that publishes
built images, and seems to be generally considered the more important
of the two deploy methods. It will likely get the most attention going
forward.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>