### PR TITLE
Cleanup deploytool_postreqs in operator deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/evanphx/json-patch v0.0.0-20180908160633-36442dbdb585 // indirect
 	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 // indirect
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 // indirect
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
 	github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 // indirect

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -70,6 +70,4 @@ function deploytool_postreqs() {
     # subctl wants a gateway node labeled, or it will ask, but this script is not interactive,
     # and E2E expects cluster1 to not have the gateway configured at start, so we remove it
     del_subm_gateway_label cluster1
-    # Just removing the label does not stop Subm pod.
-    kubectl --context=cluster1 delete pod -n submariner-operator -l app=submariner-engine
 }


### PR DESCRIPTION
Now that we modified Submariner Engine as a DaemonSet, as-soon-as
the label is removed from the node, SM engine pod will be terminated.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>