### PR TITLE
install WireGuard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ jobs:
 
 install:
   - sudo apt-get install moreutils # make ts available
+  - sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
+  - sudo apt-get update
+  - sudo apt-get install wireguard -y
+
 services:
   - docker
 before_script:


### PR DESCRIPTION
e2e submariner WireGuard cable tests require WireGuard modules on the testing host. 
This PR installs WireGuard.