### PR TITLE
Globalnet: Annotate services without selectors

### DIFF
--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -80,14 +80,9 @@ func (i *Controller) evaluateService(service *k8sv1.Service) Operation {
 		return Ignore
 	}
 
-	if len(service.Spec.Selector) != 0 {
-		chainName := i.kubeProxyClusterIpServiceChainName(service)
-		if chainExists, _ := i.doesIPTablesChainExist("nat", chainName); !chainExists {
-			return Requeue
-		}
-	} else {
-		// Ignore services that do not have selectors
-		return Ignore
+	chainName := i.kubeProxyClusterIpServiceChainName(service)
+	if chainExists, _ := i.doesIPTablesChainExist("nat", chainName); !chainExists {
+		return Requeue
 	}
 	return Process
 }

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -31,7 +31,7 @@ func (i *Controller) kubeProxyClusterIpServiceChainName(service *k8sv1.Service) 
 	// CNIs that use kube-proxy with iptables for loadbalancing create an iptables chain for each service
 	// and incoming traffic to the clusterIP Service is directed into the respective chain.
 	// Reference: https://bit.ly/2OPhlwk
-	serviceName := service.GetNamespace() + "/" + service.GetName() + ":"
+	serviceName := service.GetNamespace() + "/" + service.GetName() + ":" + service.Spec.Ports[0].Name
 	protocol := strings.ToLower(string(service.Spec.Ports[0].Protocol))
 	hash := sha256.Sum256([]byte(serviceName + protocol))
 	encoded := base32.StdEncoding.EncodeToString(hash[:])


### PR DESCRIPTION
Services without selectors i.e no backend pod, are not accessible across clusters if globalnet is enabled. It works when clusters don't have overlapping CIDRs and globalnet is not used.

This PR addresses this issue by supporting services without selectors along with fixing an issue in the iptables chain name used by kube-proxy.

Fixes issue: https://github.com/submariner-io/submariner/issues/460

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>