### PR TITLE
Return error when kubeproxy is missing in the cluster

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -23,8 +23,7 @@ const (
 	// of kube-proxy changes, globalnet needs to be modified accordingly.
 	// Reference: https://bit.ly/2OPhlwk
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
-	kubeProxyNameSpace          = "kube-system"
-	kubeProxyLabelSelector      = "k8s-app=kube-proxy"
+	kubeProxyServiceChainName   = "KUBE-SERVICES"
 
 	AddRules    = true
 	DeleteRules = false


### PR DESCRIPTION
Current implementation of Globalnet Controller works only with
iptables based kube-proxy. This PR includes necessary validation
as part of initialization and returns appropriate error message
when cluster does not use kube-proxy.

Fixes issue: https://github.com/submariner-io/submariner/issues/458

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>