### PR TITLE
Allow running just the e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ TARGETS := $(shell ls -p scripts | grep -v -e /)
 
 clusters: build package
 
+e2e-tests:
+	./scripts/kind-e2e/e2e.sh --status keep --deploytool $(deploytool)
+
 e2e: deploy
 	./scripts/kind-e2e/e2e.sh --status $(status) --deploytool $(deploytool)
 


### PR DESCRIPTION
This is useful when working on the e2e tests, you can deploy once
and run e2e-tests many times.

```
make e2e status=keep
... modify your e2e tests here ...
make e2e-tests
```