### PR TITLE
Don't make build package explicitly in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ git:
 jobs:
   include:
   - env: CMD="make test validate"
-  - env: CMD="make build package e2e status=keep" DEPLOY=true
-  - env: CMD="make build package e2e status=keep deploytool=helm globalnet=true"
+  - env: CMD="make e2e status=keep" DEPLOY=true
+  - env: CMD="make e2e status=keep deploytool=helm globalnet=true"
 
 install:
   - sudo apt-get install moreutils # make ts available


### PR DESCRIPTION
Since the makefile already specifies the dependency tree, `make e2e`
will always perform these targets anyway.
Specifying them explicitly in travis, due to all targets being run
inside dapper, causes it to extranously perform these steps before the
e2e, thus it actually builds and packages everything twice.
Since the whole process takes a few minutes, removing these unnecessary
steps will shorten the CI run time quite significantly.