### PR TITLE
Globalnet: Host Network to remoteService globalIP connectivity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40
-	github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da
+	github.com/submariner-io/shipyard v0.0.0-20200415131458-43e0c8dc8ea3
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/submariner-io/shipyard v0.0.0-20200318121825-f090de57e01b/go.mod h1:tm9TSwLsOFQxsOgbXCC4EpPQF01K4fsxUJaV+0rn4pI=
 github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da h1:UdL2BuLqaFepyEI9BpSVZBYsxIF19hTxPkKbYohJtuM=
 github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da/go.mod h1:tm9TSwLsOFQxsOgbXCC4EpPQF01K4fsxUJaV+0rn4pI=
+github.com/submariner-io/shipyard v0.0.0-20200415131458-43e0c8dc8ea3 h1:ORpKiuzSyL3pMHt6y9RbMSlyBkhcVxO7mtddatr1HMo=
+github.com/submariner-io/shipyard v0.0.0-20200415131458-43e0c8dc8ea3/go.mod h1:tm9TSwLsOFQxsOgbXCC4EpPQF01K4fsxUJaV+0rn4pI=
 github.com/submariner-io/submariner v0.2.0/go.mod h1:rQ/EyWEE9fZT9xx1lsi6fP75ig9Rye+b4pmP2Tw8qSE=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -242,6 +242,7 @@ func (i *GatewayMonitor) initializeIpamController(globalCIDR string) {
 		KubeClientSet:   i.kubeClientSet,
 		ServiceInformer: informerFactory.Core().V1().Services(),
 		PodInformer:     informerFactory.Core().V1().Pods(),
+		NodeInformer:    informerFactory.Core().V1().Nodes(),
 	}
 
 	klog.V(log.DEBUG).Infof("On Gateway Node, initializing ipamController.")

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -87,6 +87,18 @@ func (i *Controller) evaluateService(service *k8sv1.Service) Operation {
 	return Process
 }
 
+func (i *Controller) evaluateNode(node *k8sv1.Node) Operation {
+	cniIfaceIP := node.GetAnnotations()[route.CniInterfaceIp]
+	if cniIfaceIP == "" {
+		// To support connectivity from HostNetwork to remoteCluster, globalnet requires the
+		// cniIfaceIP of the respective node. Route-agent running on the node annotates the
+		// respective node with the cniIfaceIP. In this API, we check for the presence of this
+		// annotation and process the node event only when the annotation exists.
+		return Requeue
+	}
+	return Process
+}
+
 func (i *Controller) cleanupIPTableRules() {
 	err := i.ipt.ClearChain("nat", submarinerIngress)
 	if err != nil {

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -53,7 +53,7 @@ func (i *Controller) initIPTableChains() error {
 }
 
 func (i *Controller) syncPodRules(podIP, globalIP string, addRules bool) {
-	err := i.updateEgressRulesForPod(podIP, globalIP, addRules)
+	err := i.updateEgressRulesForResource("Pod", podIP, globalIP, addRules)
 	if err != nil {
 		klog.Errorf("Error updating egress rules for pod %s: %v", podIP, err)
 		return
@@ -65,6 +65,14 @@ func (i *Controller) syncServiceRules(service *k8sv1.Service, globalIP string, a
 	err := i.updateIngressRulesForService(globalIP, chainName, addRules)
 	if err != nil {
 		klog.Errorf("Error updating ingress rules for service %#v: %v", service, err)
+		return
+	}
+}
+
+func (i *Controller) syncNodeRules(cniIfaceIP, globalIP string, addRules bool) {
+	err := i.updateEgressRulesForResource("Node", cniIfaceIP, globalIP, addRules)
+	if err != nil {
+		klog.Errorf("Error updating egress rules for Node %s: %v", cniIfaceIP, err)
 		return
 	}
 }

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -9,15 +9,15 @@ import (
 	"k8s.io/klog"
 )
 
-func (i *Controller) updateEgressRulesForPod(podIP, globalIP string, addRules bool) error {
-	ruleSpec := []string{"-p", "all", "-s", podIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", globalIP}
+func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, globalIP string, addRules bool) error {
+	ruleSpec := []string{"-p", "all", "-s", sourceIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", globalIP}
 	if addRules {
-		klog.V(log.DEBUG).Infof("Installing iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
+		klog.V(log.DEBUG).Infof("Installing iptable egress rules for %s: %s", resourceName, strings.Join(ruleSpec, " "))
 		if err := i.ipt.AppendUnique("nat", submarinerEgress, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
-		klog.V(log.DEBUG).Infof("Deleting iptable egress rules for pod: %s", strings.Join(ruleSpec, " "))
+		klog.V(log.DEBUG).Infof("Deleting iptable egress rules for %s : %s", resourceName, strings.Join(ruleSpec, " "))
 		if err := i.ipt.Delete("nat", submarinerEgress, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -22,6 +22,7 @@ type InformerConfigStruct struct {
 	KubeClientSet   kubernetes.Interface
 	ServiceInformer kubeInformers.ServiceInformer
 	PodInformer     kubeInformers.PodInformer
+	NodeInformer    kubeInformers.NodeInformer
 }
 
 type Controller struct {
@@ -30,6 +31,8 @@ type Controller struct {
 	servicesSynced   cache.InformerSynced
 	podWorkqueue     workqueue.RateLimitingInterface
 	podsSynced       cache.InformerSynced
+	nodeWorkqueue    workqueue.RateLimitingInterface
+	nodesSynced      cache.InformerSynced
 
 	excludeNamespaces map[string]bool
 	pool              *IpPool

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -30,7 +30,7 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 		})
 	}
 
-	When("a pod connects via TCP to a remote service globalIP", func() {
+	When("a pod connects via TCP to the globalIP of a remote service", func() {
 		BeforeEach(func() {
 			toEndpointType = tcp.GlobalIP
 			networking = framework.PodNetworking
@@ -53,7 +53,7 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 		})
 	})
 
-	When("a pod with HostNetworking connects via TCP to a remote service globalIP", func() {
+	When("a pod with HostNetworking connects via TCP to the globalIP of a remote service", func() {
 		BeforeEach(func() {
 			toEndpointType = tcp.GlobalIP
 			networking = framework.HostNetworking

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -8,6 +8,8 @@ import (
 
 var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across overlapping clusters without discovery", func() {
 	f := framework.NewFramework("dataplane-gn-conn-nd")
+	var toEndpointType tcp.EndpointType
+	var networking framework.NetworkingType
 
 	verifyInteraction := func(fromClusterScheduling, toClusterScheduling framework.NetworkPodScheduling) {
 		It("should have sent the expected data from the pod to the other pod", func() {
@@ -18,8 +20,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 
 			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
 				Framework:             f,
-				ToEndpointType:        tcp.GlobalIP,
-				Networking:            framework.PodNetworking,
+				ToEndpointType:        toEndpointType,
+				Networking:            networking,
 				FromCluster:           framework.ClusterA,
 				FromClusterScheduling: fromClusterScheduling,
 				ToCluster:             framework.ClusterB,
@@ -28,7 +30,12 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 		})
 	}
 
-	When("a pod connects via TCP to a remote service", func() {
+	When("a pod connects via TCP to a remote service globalIP", func() {
+		BeforeEach(func() {
+			toEndpointType = tcp.GlobalIP
+			networking = framework.PodNetworking
+		})
+
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
 			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
 		})
@@ -43,6 +50,21 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 
 		When("the pod is on a gateway and the remote service is on a gateway", func() {
 			verifyInteraction(framework.GatewayNode, framework.GatewayNode)
+		})
+	})
+
+	When("a pod with HostNetworking connects via TCP to a remote service globalIP", func() {
+		BeforeEach(func() {
+			toEndpointType = tcp.GlobalIP
+			networking = framework.HostNetworking
+		})
+
+		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
+			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
+		})
+
+		When("the pod is on a gateway and the remote service is not on a gateway", func() {
+			verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
 		})
 	})
 })


### PR DESCRIPTION
This PR includes a set of commits that support the use-case of connecting from HostNetwork to remoteService globalIP when using Globalnet.

Fixes Issue: https://github.com/submariner-io/submariner/issues/464

Depends-Onː https://github.com/submariner-io/submariner-charts/pull/20
Depends-Onː https://github.com/submariner-io/submariner-charts/pull/21
Depends-Onː https://github.com/submariner-io/submariner-operator/pull/304
Depends-Onː https://github.com/submariner-io/shipyard/pull/94/

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>