### PR TITLE
Add reload-images makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ e2e: deploy
 	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool)
 
 reload-images: build images
-	./scripts/$@ --globalnet true
+	./scripts/$@
 
 $(TARGETS): vendor/modules.txt
 	./scripts/$@ --build_debug $(build_debug)

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,16 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 include $(SHIPYARD_DIR)/Makefile.inc
 
-TARGETS := $(shell ls -p scripts | grep -v -e /)
+TARGETS := $(shell ls -p scripts | grep -v -e / | grep -v reload-images)
 CLUSTERS_ARGS = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_settings
 
 clusters: build images
 
 e2e: deploy
 	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool)
+
+reload-images: build images
+	./scripts/$@ --globalnet true
 
 $(TARGETS): vendor/modules.txt
 	./scripts/$@ --build_debug $(build_debug)

--- a/scripts/reload-images
+++ b/scripts/reload-images
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -em
+
+source ${SCRIPTS_DIR}/lib/debug_functions
+source ${SCRIPTS_DIR}/lib/version
+source ${SCRIPTS_DIR}/lib/deploy_funcs
+
+import_image quay.io/submariner/submariner
+import_image quay.io/submariner/submariner-route-agent
+import_image quay.io/submariner/submariner-globalnet
+


### PR DESCRIPTION
This target will push the images to the localhost registry on the clusters
so the developer can subsequently set imagePullPolicy to always on the desired
resource and force it to reload. Alowing a very quick developer cycle.