### PR TITLE
Fix codegen script and run in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 
 jobs:
   include:
-  - env: CMD="make test validate"
+  - env: CMD="make test validate codegen"
   - env: CMD="make e2e" DEPLOY=true
   - env: CMD="make e2e deploytool=helm globalnet=true"
 

--- a/scripts/codegen
+++ b/scripts/codegen
@@ -6,6 +6,8 @@ K8S_IO_DIR="${GOPATH:-~/go}/src/k8s.io"
 CODEGEN_SCRIPT_DIR="${K8S_IO_DIR}/code-generator"
 CODEGEN_SCRIPT="${CODEGEN_SCRIPT_DIR}/generate-groups.sh"
 CODEGEN_RELEASE_TAG=kubernetes-1.14.1
+export GO111MODULE=off
+mkdir -p $K8S_IO_DIR
 
 if [ ! -f "$CODEGEN_SCRIPT" ]; then
     echo "$CODEGEN_SCRIPT does not exist - downloading..."


### PR DESCRIPTION
The API codegen script had stopped running because we don't run it often,
this fixes the script and runs it as part of the unitest/validation job
in travis.