### PR TITLE
Allow running only the e2e part, and focusing on specific tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build_debug ?= false
 restart ?= all
+focus ?= .\*
 
 ifneq (,$(DAPPER_HOST_ARCH))
 
@@ -13,7 +14,7 @@ CLUSTERS_ARGS = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_set
 clusters: build images
 
 e2e: # internally depends on deploy target, which will execute only if not already deployed
-	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool)
+	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool) --focus $(focus)
 
 reload-images: build images
 	./scripts/$@ --restart $(restart)

--- a/scripts/kind-e2e/README.md
+++ b/scripts/kind-e2e/README.md
@@ -86,6 +86,28 @@ manually, then run:
 make reload-images restart=none
 ```
 
+#### Re-running e2e tests after your code changes
+Once your kind virtual clusters and submariner are deployed, you can re-run e2e just by repeating the `make e2e` call.
+Deployment and install will be avoided, hence the existing environment will remain as is.
+If you need to load new container images, please check `make reload-images` from the previous section.
+
+In case you want to re-run just the tests:
+```bash
+make e2e
+```
+
+In case you want to use updated images and re-run the tests:
+```bash
+make reload-images e2e
+```
+
+You can focus the e2e tests on specific tags by using the focus makefile env. The following
+example runs only the tests tagged as [redundancy].
+
+```bash
+make e2e focus=redundancy
+```
+
 #### Cleanup
 At any time you can run a cleanup command that will remove all the kind clusters.
 

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -4,11 +4,13 @@
 
 source /usr/share/shflags/shflags
 DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm)'
+DEFINE_string 'focus' '.*' 'Ginkgo focus for the E2E tests'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
 deploytool="${FLAGS_deploytool}"
-echo "Running with: deploytool=${deploytool}"
+focus="${FLAGS_focus}"
+echo "Running with: deploytool=${deploytool} focus=${focus}"
 
 set -em
 
@@ -51,6 +53,7 @@ function test_with_e2e_tests {
     go test -v -args -ginkgo.v -ginkgo.randomizeAllSpecs \
         -submariner-namespace $SUBM_NS -dp-context cluster2 -dp-context cluster3 -dp-context cluster1 \
         -ginkgo.noColor -ginkgo.reportPassed \
+        -ginkgo.focus "\[${focus}\]" \
         -ginkgo.reportFile ${DAPPER_OUTPUT}/e2e-junit.xml 2>&1 | \
         tee ${DAPPER_OUTPUT}/e2e-tests.log
 }


### PR DESCRIPTION
This PR addes the new e2e-tests target, as well as a focus env var which allows filtering e2e tests to be ran.
```
make e2e-tests focus=gateway
```

Will run only the e2e tests tagged as [gateway]