### PR TITLE
Deploy "lazily" so that e2e can be re run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CLUSTERS_ARGS = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_set
 
 clusters: build images
 
-e2e:
+e2e: # internally depends on deploy target, which will execute only if not already deployed
 	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool)
 
 reload-images: build images

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CLUSTERS_ARGS = --cluster_settings $(DAPPER_SOURCE)/scripts/kind-e2e/cluster_set
 
 clusters: build images
 
-e2e: deploy
+e2e:
 	./scripts/kind-e2e/e2e.sh --deploytool $(deploytool)
 
 reload-images: build images

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -34,6 +34,15 @@ function load_deploytool() {
     . $deploy_lib
 }
 
+function deploy_env() {
+    if with_context cluster3 kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=3s > /dev/null 2>&1; then
+        echo "Submariner already deployed, skipping deployment..."
+        return
+    fi
+
+    make deploy
+}
+
 function test_with_e2e_tests {
     set -o pipefail 
 
@@ -56,6 +65,7 @@ declare_kubeconfig
 
 load_deploytool
 
+deploy_env
 test_with_e2e_tests
 
 cat << EOM

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -34,7 +34,7 @@ function load_deploytool() {
     . $deploy_lib
 }
 
-function deploy_env() {
+function deploy_env_once() {
     if with_context cluster3 kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=3s > /dev/null 2>&1; then
         echo "Submariner already deployed, skipping deployment..."
         return
@@ -65,7 +65,7 @@ declare_kubeconfig
 
 load_deploytool
 
-deploy_env
+deploy_env_once
 test_with_e2e_tests
 
 cat << EOM


### PR DESCRIPTION
This allows consecutively re running the e2e tests without going through
the (reenrant, yet still time consuming) deploy process.