### PR TITLE
Fix rpm -e failure due to unmet dependencies.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     dnf -y clean all && \
     rpm -e gnupg2 rpm-sign-libs gpgme dnf libdnf yum python3-rpm \
            python3-dnf python3-gpg librepo python3-libdnf python3-hawkey \
-           glib2 libmodulemd1 libsolv libyaml libassuan \
+           glib2 libmodulemd1 libmodulemd libsolv libyaml libassuan \
            shadow-utils tss2 ima-evm-utils \
            zchunk-libs vim-minimal npth sudo tar libusbx acl dnf-data \
            libksba libreport-filesystem libsemanage libstdc++ openssl \


### PR DESCRIPTION
The build of the submariner Dockerfile started failing locally
probably due to changes in fedora, and another rpm package
needs to be removed.