### PR TITLE
Add Committer/Member request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/committership.md
+++ b/.github/ISSUE_TEMPLATE/committership.md
@@ -1,0 +1,30 @@
+---
+name: Submariner Committer Request
+about: Request Submariner Committer rights on some files
+title: 'REQUEST: New Committer rights request for <your-GH-handle>'
+labels: committer-request
+assignees: ''
+
+---
+
+### GitHub Username
+e.g. (at)example_user
+
+### Code you are requesting Committer rights for
+e.g. submariner-operator/\* or submariner-operator/scripts/\*
+
+### Requirements
+- [ ] I have reviewed the community membership guidelines (https://submariner-io.github.io/en/contributing/community-membership/)
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I have subscribed to the submariner-dev e-mail list (https://groups.google.com/forum/#!forum/submariner-dev)
+- [ ] I have been actively contributing to Submariner for at least 3 months
+- [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of required reviews to Submariner project PRs
+- At least 20 PRs to the relevant codebase that you reviewed
+- At least 5 PRs to the relevant codebase for which you were the primary reviewer

--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,0 +1,26 @@
+---
+name: Submariner Member Request
+about: Request Submariner GitHub org Membership
+title: 'REQUEST: New Membership request for <your-GH-handle>'
+labels: member-request
+assignees: ''
+
+---
+
+### GitHub Username
+e.g. (at)example_user
+
+### Requirements
+- [ ] I have reviewed the community membership guidelines (https://submariner-io.github.io/en/contributing/community-membership/)
+- [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
+- [ ] I have subscribed to the submariner-dev e-mail list (https://groups.google.com/forum/#!forum/submariner-dev)
+- [ ] I have multiple contributions to Submariner that meet the requirements listed in the community membership guidelines
+- [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+- [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+### Sponsors
+- (at)sponsor-1
+- (at)sponsor-2
+
+### List of contributions to the Submariner project
+- Multiple contributions to Submariner that meet the requirements listed in the community membership guidelines


### PR DESCRIPTION
Add GitHub Issue templates to help aid the Submariner community
membership process, in particular Committer and Member requests.

Relates-to: #499

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>