### PR TITLE
Remove gateway entry when gateway pod exits

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -39,7 +39,11 @@ func NewGatewaySyncer(engine cableengine.Engine, client v1typed.GatewayInterface
 }
 
 func (s *GatewaySyncer) Run(stopCh <-chan struct{}) {
-	go wait.Until(s.syncGatewayStatus, GatewayUpdateIntervalSeconds*time.Second, stopCh)
+	go func() {
+		wait.Until(s.syncGatewayStatus, GatewayUpdateIntervalSeconds*time.Second, stopCh)
+		s.CleanupGatewayEntry()
+	}()
+
 	klog.Info("CableEngine syncer started")
 }
 
@@ -170,4 +174,16 @@ func (i *GatewaySyncer) generateGatewayObject() (*v1.Gateway, error) {
 
 	klog.V(log.TRACE).Infof("generateGatewayObject: %+v", gateway)
 	return &gateway, nil
+}
+
+// CleanupGatewayEntry removes this Gateway entry from the k8s API, it does not
+// propagate error up because it's a termination function that we also provide externally
+func (s *GatewaySyncer) CleanupGatewayEntry() {
+	hostName := s.engine.GetLocalEndpoint().Spec.Hostname
+	err := s.client.Delete(hostName, &metav1.DeleteOptions{})
+	if err != nil {
+		klog.Errorf("Error happened when trying to delete own Gateway entry %q : %s", hostName, err)
+		return
+	}
+	klog.Infof("The Gateway entry for %q has been removed", hostName)
 }


### PR DESCRIPTION
Without this patch an active gateway pod could die and not
be respawn (no available passive node...) and in the meanwhile
nobody would remove the Gateway entry, appearing still reported
as active, connected etc...