### PR TITLE
Return error if CNIIface is not discovered

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -173,17 +173,20 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	r.cniIface = discoverCNIInterface(r.localClusterCidr[0])
-	if r.cniIface != nil {
+	cniIface, err := discoverCNIInterface(r.localClusterCidr[0])
+	if err != nil {
 		// Configure CNI Specific changes
+		r.cniIface = cniIface
 		err := toggleCNISpecificConfiguration(r.cniIface.name)
 		if err != nil {
 			return fmt.Errorf("toggleCNISpecificConfiguration returned error. %v", err)
 		}
+	} else {
+		return fmt.Errorf("discoverCNIInterface returned error. %v", err)
 	}
 
 	// Create the necessary IPTable chains in the filter and nat tables.
-	err := r.createIPTableChains()
+	err = r.createIPTableChains()
 	if err != nil {
 		return fmt.Errorf("createIPTableChains returned error. %v", err)
 	}


### PR DESCRIPTION
This PR returns an appropriate error message if we are unable to determine
the CNI Interface on the host at an early stage. Otherwise, the errors could
manifest at later stage making it difficult to understand what is going wrong.

Related to# https://github.com/submariner-io/submariner/issues/529

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>