### PR TITLE
Add templates for bugs/features/failing/flaking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug in Submariner
+labels: bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as
+possible. Not doing so may result in your bug not being addressed in a timely
+manner. Thanks!
+
+If the matter is security related, please disclose it privately to the
+Submariner Owners: https://github.com/orgs/submariner-io/teams/submariner-core
+-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Submariner version (use `subctl version`):
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Install tools:
+- Network plugin and version (if this is a network-related bug):
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the Submariner project
+labels: enhancement
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,0 +1,21 @@
+---
+name: Failing Test
+about: Report continuously failing tests or jobs in Submariner CI
+labels: failing-test
+
+---
+
+<!-- Please only use this template for submitting reports about continuously
+failing tests or jobs in Submariner CI -->
+
+**Which jobs are failing**:
+
+**Which test(s) are failing**:
+
+**Since when has it been failing**:
+
+**Testgrid link**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -1,0 +1,19 @@
+---
+name: Flaking Test
+about: Report flaky tests or jobs in Submariner CI
+labels: flake
+
+---
+
+<!-- Please only use this template for submitting reports about flaky tests or
+jobs (pass or fail with no underlying change in code) in Submariner CI -->
+
+**Which jobs are flaking**:
+
+**Which test(s) are flaking**:
+
+**Testgrid link**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,18 @@
+---
+name: Support Request
+about: Support request or question relating to Submariner
+labels: support
+
+---
+
+<!--
+GitHub may not the right place for support requests.
+
+You can also post your question on the [Submariner
+Slack](https://kubernetes.slack.com/archives/C010RJV694M) or the Submariner
+[users](https://bit.ly/submariner-users) or
+[developers](https://bit.ly/submariner-dev) mailing lists.
+
+If the matter is security related, please disclose it privately to the
+Submariner Owners: https://github.com/orgs/submariner-io/teams/submariner-core
+-->


### PR DESCRIPTION
Add GitHub Issue templates for reporting bugs, requesting enhancements,
reporting test failures, or reporting flaky tests.

The templates are based on the kubernetes/kubernetes repository examples.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>