### PR TITLE
Tweak leader election timings

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,9 +53,9 @@ type leaderConfig struct {
 
 const (
 	leadershipConfigEnvPrefix = "leadership"
-	defaultLeaseDuration      = 5 // In Seconds
-	defaultRenewDeadline      = 3 // In Seconds
-	defaultRetryPeriod        = 2 // In Seconds
+	defaultLeaseDuration      = 10 // In Seconds
+	defaultRenewDeadline      = 5  // In Seconds
+	defaultRetryPeriod        = 2  // In Seconds
 )
 
 var VERSION = "not-compiled-properly"


### PR DESCRIPTION
On some platforms, it was seen that the active leader node sometimes (not
frequent though) is unable to renew the lease for leaderLock and because
of this Gateway POD is getting restarted. In one of the earlier PRs, we
reduced these intervals to improve the failover detection. In this PR we
are increasing the interval slightly until we find a proper solution to
handle HA.

Related to# https://github.com/submariner-io/submariner/issues/540

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>