### PR TITLE
Remove UBI 8 microdnf --nodocs workaround

### DIFF
--- a/package/Dockerfile.globalnet
+++ b/package/Dockerfile.globalnet
@@ -1,9 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
-
-# Pinned to image 8.0 because of this bug
-#    https://github.com/rpm-software-management/microdnf/issues/50
-# TODO(dimaunx,majopela):  we should remove the :8.0 pin when the
-#                          bug has been solved for the UBI image.
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /var/submariner
 

--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -2,10 +2,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /var/submariner
 
-# Workaround for
-# https://github.com/rpm-software-management/microdnf/issues/50
-RUN mkdir -p /run/user/$(id -u)
-
 # These are all available in the UBI8 base OS repository
 RUN microdnf -y install --nodocs iproute iptables && \
     microdnf clean all


### PR DESCRIPTION
https://github.com/rpm-software-management/microdnf/issues/50 was
fixed in UBI 8.2 (see https://access.redhat.com/errata/RHEA-2020:1855
for details), so we no longer need the workaround.

(If this fails to build locally, make sure to refresh your UBI 8
image.)

Signed-off-by: Stephen Kitt <skitt@redhat.com>