### PR TITLE
Don't pass the make binary path down to dapper

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -11,7 +11,7 @@
 	@mv .dapper.tmp .dapper
 
 %: .dapper
-	./.dapper -m bind make $@ $(MAKEFLAGS)
+	+./.dapper -m bind make $@ $(MAKEFLAGS)
 
 shell: .dapper
 	./.dapper -m bind -s

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -11,7 +11,7 @@
 	@mv .dapper.tmp .dapper
 
 %: .dapper
-	./.dapper -m bind $(MAKE) $@ $(MAKEFLAGS)
+	./.dapper -m bind make $@ $(MAKEFLAGS)
 
 shell: .dapper
 	./.dapper -m bind -s


### PR DESCRIPTION
The host could be different from linux or have a weird path for make.

Fixes: #555