### PR TITLE
Fix type handling for linting

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -20,3 +20,4 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
 fi
 
 golangci-lint run
+


### PR DESCRIPTION
The new version of golangci-lint points out a type-casting issue in
ipam, which can be fixed by instantiating a new variable of the
appropriate type in a generic manner.

Running the updated linter also requires a new timeout, and excluding
the clientset (which is generated code and therefore not useful to
lint).

Signed-off-by: Stephen Kitt <skitt@redhat.com>