### PR TITLE
Wireguard: better localIP discovery search

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,9 +20,6 @@ jobs:
         exclude:
           - deploytool: 'helm'
             cable_driver: 'wireguard'
-# TODO: Remove exclusion when issue #552 is fixed
-          - globalnet: '--globalnet'
-            cable_driver: 'wireguard'
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master

--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -33,7 +33,7 @@ type Driver interface {
 }
 
 // Function prototype to create a new driver
-type DriverCreateFunc func(localSubnets []string, localEndpoint types.SubmarinerEndpoint) (Driver, error)
+type DriverCreateFunc func(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error)
 
 // Static map of supported drivers
 var drivers = map[string]DriverCreateFunc{}
@@ -50,12 +50,12 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 }
 
 // Returns a new driver according the required Backend
-func NewDriver(localSubnets []string, localEndpoint types.SubmarinerEndpoint) (Driver, error) {
+func NewDriver(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error) {
 	driverCreate, ok := drivers[localEndpoint.Spec.Backend]
 	if !ok {
 		return nil, fmt.Errorf("unsupported cable type %s", localEndpoint.Spec.Backend)
 	}
-	return driverCreate(localSubnets, localEndpoint)
+	return driverCreate(localSubnets, localEndpoint, localCluster)
 }
 
 // Sets the default cable driver name, if it is not specified by user.

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -20,7 +20,7 @@ type libreSwan struct {
 }
 
 // NewLibreSwan starts an IKE daemon using LibreSwan and configures it to manage Submariner's endpoints
-func NewLibreSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint) (cable.Driver, error) {
+func NewLibreSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	return &libreSwan{}, nil
 }
 

--- a/pkg/cable/strongswan/strongswan.go
+++ b/pkg/cable/strongswan/strongswan.go
@@ -72,7 +72,7 @@ const defaultIKEPort = "500"
 const defaultNATTPort = "4500"
 const ipsecSpecEnvVarPrefix = "ce_ipsec"
 
-func NewStrongSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint) (cable.Driver, error) {
+func NewStrongSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	ipSecSpec := specification{}
 
 	err := envconfig.Process(ipsecSpecEnvVarPrefix, &ipSecSpec)

--- a/pkg/cable/strongswan/strongswan_test.go
+++ b/pkg/cable/strongswan/strongswan_test.go
@@ -63,7 +63,7 @@ func testCharonPortConfiguration() {
 }
 
 func createStrongSwan() *strongSwan {
-	ss, err := NewStrongSwan([]string{}, types.SubmarinerEndpoint{})
+	ss, err := NewStrongSwan([]string{}, types.SubmarinerEndpoint{}, types.SubmarinerCluster{})
 	Expect(err).NotTo(HaveOccurred())
 	return ss.(*strongSwan)
 }

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -133,7 +133,7 @@ func (w *wireguard) Init() error {
 	}
 	d, err := w.client.Device(DefaultDeviceName)
 	if err != nil {
-		return fmt.Errorf("wgctrl cannot find WireGaurd device: %v", err)
+		return fmt.Errorf("wgctrl cannot find WireGuard device: %v", err)
 	}
 	k, err := keyFromSpec(&w.localEndpoint.Spec)
 	if err != nil {
@@ -245,7 +245,11 @@ func (w *wireguard) ConnectToEndpoint(remoteEndpoint types.SubmarinerEndpoint) (
 			Table:     routingTable,
 		}
 		if err = netlink.RouteAdd(&route); err != nil {
-			return "", fmt.Errorf("failed to add route %s: %v", route, err)
+			klog.V(log.DEBUG).Infof("adding route %s", route)
+			if !os.IsExist(err) {
+				return "", fmt.Errorf("failed to add route %s: %v", route, err)
+			}
+			klog.V(log.DEBUG).Infof("route already exists")
 		}
 	}
 

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -95,8 +95,8 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	}
 	if lc < 2*keepAliveMS {
 		// grace period, leave status unchanged
-		klog.Warningf("No traffic for connection; handshake was %.1f seconds ago: %v", lcSec,
-			connection)
+		klog.Warningf("No traffic for %.1f seconds; handshake was %.1f seconds ago: %v", lcSec,
+			handshakeDelta.Seconds(), connection)
 		return
 	}
 	// soft error, no traffic, stale handshake

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -81,7 +81,7 @@ func (i *engine) StartEngine() error {
 func (i *engine) startDriver() error {
 	var err error
 
-	if i.driver, err = cable.NewDriver(i.localSubnets, i.localEndpoint); err != nil {
+	if i.driver, err = cable.NewDriver(i.localSubnets, i.localEndpoint, i.localCluster); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Add the Cluster Spec as input during driver creation:**
- Cross-cluster traffic from pods on host network are assigned the source address of the WG interface, according to the routing rules; therefore, this should be an allowed IP
- The driver looks for a valid address within the local node interfaces; however, with GN, the allowed IPs (`localSubnets`) passed to driver are GN CIDRs and do not match any local interface IP
- Cluster CIDR is now used to look for a valid IP if not found in `localSubnets`
- GN will SNAT this address to a the GN CIDR, which is an allowed IP for the WG tunnel

**Misc**
- For better robustness, a FW mark was added to WG interface to block any circular routing, in case there is a routing rule back to WG device 
- More debug logging.