### PR TITLE
Framework E2E detection should be independent of cluster IDs

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -45,26 +45,25 @@ func beforeSuite() {
 
 func queryAndUpdateGlobalnetStatus() {
 	framework.TestContext.GlobalnetEnabled = false
-	clusterIndex := framework.ClusterB
-	clusterName := framework.TestContext.ClusterIDs[clusterIndex]
-	clusters := SubmarinerClients[clusterIndex].SubmarinerV1().Clusters(framework.TestContext.SubmarinerNamespace)
-	framework.AwaitUntil("find the submariner Cluster for "+clusterName, func() (interface{}, error) {
-		cluster, err := clusters.Get(clusterName, metav1.GetOptions{})
+	clusters := SubmarinerClients[framework.ClusterB].SubmarinerV1().Clusters(framework.TestContext.SubmarinerNamespace)
+	framework.AwaitUntil("find clusters to figure out if Globalnet is enabled", func() (interface{}, error) {
+		clusters, err := clusters.List(metav1.ListOptions{})
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return cluster, err
+		return clusters, err
 	}, func(result interface{}) (bool, string, error) {
 		if result == nil {
 			return false, "No Cluster found", nil
 		}
 
-		cluster := result.(*submarinerv1.Cluster)
-		if len(cluster.Spec.GlobalCIDR) != 0 {
-			// Based on the status of GlobalnetEnabled, certain tests will be skipped/executed.
-			framework.TestContext.GlobalnetEnabled = true
+		clusterList := result.(*submarinerv1.ClusterList)
+		for _, cluster := range clusterList.Items {
+			if len(cluster.Spec.GlobalCIDR) != 0 {
+				// Based on the status of GlobalnetEnabled, certain tests will be skipped/executed.
+				framework.TestContext.GlobalnetEnabled = true
+			}
 		}
-
 		return true, "", nil
 	})
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -58,6 +58,9 @@ func queryAndUpdateGlobalnetStatus() {
 		}
 
 		clusterList := result.(*submarinerv1.ClusterList)
+		if len(clusterList.Items) == 0 {
+			return false, "No Cluster found", nil
+		}
 		for _, cluster := range clusterList.Items {
 			if len(cluster.Spec.GlobalCIDR) != 0 {
 				// Based on the status of GlobalnetEnabled, certain tests will be skipped/executed.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,7 +46,7 @@ func beforeSuite() {
 func queryAndUpdateGlobalnetStatus() {
 	framework.TestContext.GlobalnetEnabled = false
 	clusterIndex := framework.ClusterB
-	clusterName := framework.TestContext.KubeContexts[clusterIndex]
+	clusterName := framework.TestContext.ClusterIDs[clusterIndex]
 	clusters := SubmarinerClients[clusterIndex].SubmarinerV1().Clusters(framework.TestContext.SubmarinerNamespace)
 	framework.AwaitUntil("find the submariner Cluster for "+clusterName, func() (interface{}, error) {
 		cluster, err := clusters.Get(clusterName, metav1.GetOptions{})


### PR DESCRIPTION
Otherwise when used from verify-connectivity it will fail, because we don't pass contexts
and also, the context could be different from the cluster name.

Related-Issue: https://github.com/submariner-io/submariner-operator/issues/381
Related-PR: https://github.com/submariner-io/submariner-operator/pull/382