### PR TITLE
Validate CIDRs before making changes to the Cluster

### DIFF
--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -131,10 +131,11 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 			}
 			if overlap {
 				// When GlobalNet is used, globalCIDRs allocated to the clusters should not overlap.
-				// If they overlap, it implies that its an invalid configuration which we do not support.
+				// If they overlap, skip the endpoint as its an invalid configuration which is not supported.
 				klog.Errorf("GlobalCIDR %q of local cluster %q overlaps with remote cluster %s",
 					i.ipamSpec.GlobalCIDR[0], i.ipamSpec.ClusterID, endpoint.Spec.ClusterID)
-				os.Exit(1)
+				i.endpointWorkqueue.Forget(obj)
+				return nil
 			}
 
 			for _, remoteSubnet := range endpoint.Spec.Subnets {

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -13,9 +13,10 @@ import (
 )
 
 type SubmarinerIpamControllerSpecification struct {
-	ClusterID string
-	ExcludeNS []string
-	Namespace string
+	ClusterID  string
+	ExcludeNS  []string
+	Namespace  string
+	GlobalCIDR []string
 }
 
 type InformerConfigStruct struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -246,3 +246,20 @@ func PrependUnique(ipt *iptables.IPTables, table string, chain string, ruleSpec 
 
 	return nil
 }
+
+func IsOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
+	_, newNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, err
+	}
+	for _, v := range cidrList {
+		_, baseNet, err := net.ParseCIDR(v)
+		if err != nil {
+			return false, err
+		}
+		if baseNet.Contains(newNet.IP) || newNet.Contains(baseNet.IP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Submariner supports clusters with Overlapping CIDRs (via Globalnet) as well as
clusters with non-overlapping CIDRs. However, if administrator accidentally tries
deploying submariner with wrong configuration, Submariner should log a warning
message and avoid making changes in the local cluster which otherwise can disrupt
the functionality of the local cluster.

This PR specifically validates the following and logs an appropriate warning.

1. In a Vanilla Submariner deployment, if administrator is trying to join clusters
   with Overlapping Pod/Service CIDRs.
   Note: For such clusters, Submariner Globalnet should be used.

2. In a Globalnet deployment, if GlobalCIDRs are overlapping across the clusters.

3. In a Globalnet deployment, if localCluster Pod/Service CIDRs overlap with globalCIDR
   of other clusters.

Fixes Issue# https://github.com/submariner-io/submariner/issues/545

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>