### PR TITLE
Don't use continue-on error

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,6 @@ name: End to End Tests
 jobs:
   e2e:
     timeout-minutes: 30
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
It seems it marks the job as optional, and prevents reruns