### PR TITLE
Increase go test timeout to 15 mins

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -39,7 +39,7 @@ function test_with_e2e_tests {
 
     go test -v -args -ginkgo.v -ginkgo.randomizeAllSpecs \
         -submariner-namespace $SUBM_NS -dp-context cluster2 -dp-context cluster3 -dp-context cluster1 \
-        -ginkgo.noColor -ginkgo.reportPassed \
+        -ginkgo.noColor -test.timeout 15m -ginkgo.reportPassed \
         -ginkgo.focus "\[${focus}\]" \
         -ginkgo.reportFile ${DAPPER_OUTPUT}/e2e-junit.xml 2>&1 | \
         tee ${DAPPER_OUTPUT}/e2e-tests.log


### PR DESCRIPTION
Currently, we are not configuring any timeout while running the e2e
tests, so the default timeout of 10 minutes is used. However, it
was seen that since we are now running more number of tests, at times,
the tests are unable to complete its execution in 10 mins and because
of this the test is abruptly stopped with PANIC. This PR explicitly
configures the timeout to 15 mins to give sufficient time for tests
to run.

Fixes issue # https://github.com/submariner-io/submariner/issues/593
Related to # https://github.com/submariner-io/submariner/issues/544

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>