### PR TITLE
Globalnet Controller to skip annotating master nodes with globalIp

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -25,6 +25,8 @@ const (
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
 	kubeProxyServiceChainName   = "KUBE-SERVICES"
 
+	k8sMasterNode = "node-role.kubernetes.io/master"
+
 	AddRules    = true
 	DeleteRules = false
 

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -95,7 +95,23 @@ func (i *Controller) evaluateService(service *k8sv1.Service) Operation {
 	return Process
 }
 
+func (i *Controller) isControlNode(node *k8sv1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == k8sMasterNode && taint.Effect == "NoSchedule" {
+			return true
+		}
+	}
+	return false
+}
+
 func (i *Controller) evaluateNode(node *k8sv1.Node) Operation {
+	if i.isControlNode(node) {
+		// On the control nodes, we do not run the submariner route-agent pod which annotates
+		// the node with route.CniInterfaceIp. So, we skip control nodes in globalnet.
+		klog.V(log.DEBUG).Infof("Skip processing %q node, as its a master node.", node.Name)
+		return Ignore
+	}
+
 	cniIfaceIP := node.GetAnnotations()[route.CniInterfaceIp]
 	if cniIfaceIP == "" {
 		// To support connectivity from HostNetwork to remoteCluster, globalnet requires the

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -183,6 +183,9 @@ func (i *Controller) processNextObject(objWorkqueue workqueue.RateLimitingInterf
 				}
 			case *k8sv1.Node:
 				switch i.evaluateNode(runtimeObj) {
+				case Ignore:
+					objWorkqueue.Forget(obj)
+					return nil
 				case Requeue:
 					objWorkqueue.AddRateLimited(obj)
 					return fmt.Errorf("Node %s requeued %d times", key, objWorkqueue.NumRequeues(obj))
@@ -295,6 +298,11 @@ func (i *Controller) handleUpdateNode(old interface{}, newObj interface{}) {
 		return
 	}
 
+	if i.isControlNode(newObj.(*k8sv1.Node)) {
+		klog.V(log.TRACE).Infof("Node %q is a control node, skip processing.", newObj.(*k8sv1.Node).Name)
+		return
+	}
+
 	oldCniIfaceIpOnNode := old.(*k8sv1.Node).GetAnnotations()[route.CniInterfaceIp]
 	newCniIfaceIpOnNode := newObj.(*k8sv1.Node).GetAnnotations()[route.CniInterfaceIp]
 	if oldCniIfaceIpOnNode == "" && newCniIfaceIpOnNode == "" {
@@ -393,6 +401,11 @@ func (i *Controller) handleRemovedNode(obj interface{}) {
 			klog.Errorf("Could not convert object tombstone %v to Node", tombstone.Obj)
 			return
 		}
+	}
+
+	if i.isControlNode(node) {
+		klog.V(log.TRACE).Infof("Node %q is a control node, skip processing.", node.Name)
+		return
 	}
 
 	globalIp := node.Annotations[submarinerIpamGlobalIp]


### PR DESCRIPTION
In order to support hostNetwork to remoteCluster connectivity, globalnet needs
the CNIInterfaceIP of all the worker nodes. The CNIInterfaceIP for the nodes is
annotated by submariner-route-agent. However, submariner-route-agent runs ONLY
on the worker nodes and not on the master nodes. Globalnet controller has a
listener for nodes and will wait for this annotation before it can program rules
for HostNetwork to remoteCluster support. In the current code, the master nodes
are constantly getting re-queued as the annotation will never be added on such
nodes.

In this PR we check if the node is capable of scheduling pods (aka worker node)
and only process (or re-queue) such nodes.

Fixes Issue: https://github.com/submariner-io/submariner/issues/553

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>