### PR TITLE
Remove separate subnet arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)
 	}
 
-	cableEngine, err := cableengine.NewEngine(localSubnets, localCluster, localEndpoint)
+	cableEngine, err := cableengine.NewEngine(localCluster, localEndpoint)
 
 	if err != nil {
 		klog.Fatalf("Fatal error occurred creating engine: %v", err)

--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -33,7 +33,7 @@ type Driver interface {
 }
 
 // Function prototype to create a new driver
-type DriverCreateFunc func(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error)
+type DriverCreateFunc func(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error)
 
 // Static map of supported drivers
 var drivers = map[string]DriverCreateFunc{}
@@ -50,12 +50,12 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 }
 
 // Returns a new driver according the required Backend
-func NewDriver(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error) {
+func NewDriver(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (Driver, error) {
 	driverCreate, ok := drivers[localEndpoint.Spec.Backend]
 	if !ok {
 		return nil, fmt.Errorf("unsupported cable type %s", localEndpoint.Spec.Backend)
 	}
-	return driverCreate(localSubnets, localEndpoint, localCluster)
+	return driverCreate(localEndpoint, localCluster)
 }
 
 // Sets the default cable driver name, if it is not specified by user.

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -20,7 +20,7 @@ type libreSwan struct {
 }
 
 // NewLibreSwan starts an IKE daemon using LibreSwan and configures it to manage Submariner's endpoints
-func NewLibreSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
+func NewLibreSwan(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	return &libreSwan{}, nil
 }
 

--- a/pkg/cable/strongswan/strongswan.go
+++ b/pkg/cable/strongswan/strongswan.go
@@ -46,7 +46,6 @@ func init() {
 }
 
 type strongSwan struct {
-	localSubnets              []string
 	localEndpoint             types.SubmarinerEndpoint
 	remoteEndpoints           map[string]subv1.EndpointSpec
 	secretKey                 string
@@ -72,7 +71,7 @@ const defaultIKEPort = "500"
 const defaultNATTPort = "4500"
 const ipsecSpecEnvVarPrefix = "ce_ipsec"
 
-func NewStrongSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
+func NewStrongSwan(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	ipSecSpec := specification{}
 
 	err := envconfig.Process(ipsecSpecEnvVarPrefix, &ipSecSpec)
@@ -88,7 +87,6 @@ func NewStrongSwan(localSubnets []string, localEndpoint types.SubmarinerEndpoint
 		ipSecNATTPort:             ipSecSpec.NATTPort,
 		localEndpoint:             localEndpoint,
 		remoteEndpoints:           map[string]subv1.EndpointSpec{},
-		localSubnets:              localSubnets,
 		secretKey:                 ipSecSpec.PSK,
 		debug:                     ipSecSpec.Debug,
 		logFile:                   ipSecSpec.LogFile,
@@ -135,7 +133,7 @@ func (i *strongSwan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (strin
 
 	var localTs, remoteTs, localAddr, remoteAddr []string
 	localTs = append(localTs, fmt.Sprintf("%s/32", i.localEndpoint.Spec.PrivateIP))
-	localTs = append(localTs, i.localSubnets...)
+	localTs = append(localTs, i.localEndpoint.Spec.Subnets...)
 
 	localAddr = append(localAddr, i.localEndpoint.Spec.PrivateIP)
 

--- a/pkg/cable/strongswan/strongswan_test.go
+++ b/pkg/cable/strongswan/strongswan_test.go
@@ -63,7 +63,7 @@ func testCharonPortConfiguration() {
 }
 
 func createStrongSwan() *strongSwan {
-	ss, err := NewStrongSwan([]string{}, types.SubmarinerEndpoint{}, types.SubmarinerCluster{})
+	ss, err := NewStrongSwan(types.SubmarinerEndpoint{}, types.SubmarinerCluster{})
 	Expect(err).NotTo(HaveOccurred())
 	return ss.(*strongSwan)
 }

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -61,7 +61,7 @@ type wireguard struct {
 }
 
 // NewDriver creates a new WireGuard driver
-func NewDriver(localSubnets []string, localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
+func NewDriver(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	var err error
 
 	w := wireguard{
@@ -69,7 +69,7 @@ func NewDriver(localSubnets []string, localEndpoint types.SubmarinerEndpoint, lo
 		localEndpoint: localEndpoint,
 	}
 
-	if err = w.setWGLink(localSubnets, localCluster); err != nil {
+	if err = w.setWGLink(localEndpoint.Spec.Subnets, localCluster); err != nil {
 		return nil, fmt.Errorf("failed to setup WireGuard link: %v", err)
 	}
 

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -43,18 +43,16 @@ type Engine interface {
 type engine struct {
 	sync.Mutex
 	driver        cable.Driver
-	localSubnets  []string
 	localCluster  types.SubmarinerCluster
 	localEndpoint types.SubmarinerEndpoint
 }
 
 // NewEngine creates a new Engine for the local cluster
-func NewEngine(localSubnets []string, localCluster types.SubmarinerCluster, localEndpoint types.SubmarinerEndpoint) (Engine, error) {
+func NewEngine(localCluster types.SubmarinerCluster, localEndpoint types.SubmarinerEndpoint) (Engine, error) {
 
 	i := engine{
 		localCluster:  localCluster,
 		localEndpoint: localEndpoint,
-		localSubnets:  localSubnets,
 		driver:        nil,
 	}
 
@@ -81,7 +79,7 @@ func (i *engine) StartEngine() error {
 func (i *engine) startDriver() error {
 	var err error
 
-	if i.driver, err = cable.NewDriver(i.localSubnets, i.localEndpoint, i.localCluster); err != nil {
+	if i.driver, err = cable.NewDriver(i.localEndpoint, i.localCluster); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The cable driver currently takes separate arguments for subnets and
endpoint, but the endpoint includes the subnet information. This patch
removes the separate subnets argument.

Signed-off-by: Stephen Kitt <skitt@redhat.com>