### PR TITLE
Update the wireguard azure fix to be more flexible

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,12 +29,13 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
           sudo apt-get update
-          sudo apt-get install  linux-headers-$(uname -r) wireguard  -y
+          sudo apt-get install  linux-headers-$(uname -r) wireguard  -y || true
           
           # temporary solution for Ubuntu 16.04 azure-1020
           WIREGUARD_SRC=$(find /usr/src/ -name "wireguard-1.0.*")
           echo "Downloading queuing.h to ${WIREGUARD_SRC}"
           sudo curl -Lk https://git.zx2c4.com/wireguard-linux/plain/drivers/net/wireguard/queueing.h\?id\=428c491332bca498c8eb2127669af51506c346c7  -o "${WIREGUARD_SRC}/queueing.h"
+          sudo apt-get install  linux-headers-$(uname -r) wireguard  -y #2nd retry (now with the queueing.h in place)
           
           sudo dpkg-reconfigure wireguard-dkms
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,6 +30,7 @@ jobs:
           sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
           sudo apt-get update
           sudo apt-get install  linux-headers-$(uname -r) wireguard  -y || true
+          cat /var/lib/dkms/wireguard/1.0.20200520/build/make.log
           
           # temporary solution for Ubuntu 16.04 azure-1020
           WIREGUARD_SRC=$(find /usr/src/ -name "wireguard-1.0.*")

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,8 +30,12 @@ jobs:
           sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
           sudo apt-get update
           sudo apt-get install  linux-headers-$(uname -r) wireguard  -y
+          
           # temporary solution for Ubuntu 16.04 azure-1020
-          sudo curl -Lk https://git.zx2c4.com/wireguard-linux/plain/drivers/net/wireguard/queueing.h\?id\=428c491332bca498c8eb2127669af51506c346c7  -o /usr/src/wireguard-1.0.20200506/queueing.h
+          WIREGUARD_SRC=$(find /usr/src/ -name "wireguard-1.0.*")
+          echo "Downloading queuing.h to ${WIREGUARD_SRC}"
+          sudo curl -Lk https://git.zx2c4.com/wireguard-linux/plain/drivers/net/wireguard/queueing.h\?id\=428c491332bca498c8eb2127669af51506c346c7  -o "${WIREGUARD_SRC}/queueing.h"
+          
           sudo dpkg-reconfigure wireguard-dkms
 
           sudo modprobe wireguard


### PR DESCRIPTION
The azure Ubuntu Image has broken headers for wireguard, and as they change versions our patch needs to be updated.

This makes the workaround a little bit more flexible until the image is fixed.