### PR TITLE
Annotate globalIp only after programming ingress/egress rules

### DIFF
--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -52,29 +52,29 @@ func (i *Controller) initIPTableChains() error {
 	return nil
 }
 
-func (i *Controller) syncPodRules(podIP, globalIP string, addRules bool) {
+func (i *Controller) syncPodRules(podIP, globalIP string, addRules bool) error {
 	err := i.updateEgressRulesForResource("Pod", podIP, globalIP, addRules)
 	if err != nil {
-		klog.Errorf("Error updating egress rules for pod %s: %v", podIP, err)
-		return
+		return fmt.Errorf("error updating egress rules for pod %s: %v", podIP, err)
 	}
+	return nil
 }
 
-func (i *Controller) syncServiceRules(service *k8sv1.Service, globalIP string, addRules bool) {
+func (i *Controller) syncServiceRules(service *k8sv1.Service, globalIP string, addRules bool) error {
 	chainName := i.kubeProxyClusterIpServiceChainName(service)
 	err := i.updateIngressRulesForService(globalIP, chainName, addRules)
 	if err != nil {
-		klog.Errorf("Error updating ingress rules for service %#v: %v", service, err)
-		return
+		return fmt.Errorf("error updating ingress rules for service %#v: %v", service, err)
 	}
+	return nil
 }
 
-func (i *Controller) syncNodeRules(cniIfaceIP, globalIP string, addRules bool) {
+func (i *Controller) syncNodeRules(cniIfaceIP, globalIP string, addRules bool) error {
 	err := i.updateEgressRulesForResource("Node", cniIfaceIP, globalIP, addRules)
 	if err != nil {
-		klog.Errorf("Error updating egress rules for Node %s: %v", cniIfaceIP, err)
-		return
+		return fmt.Errorf("error updating egress rules for Node %s: %v", cniIfaceIP, err)
 	}
+	return nil
 }
 
 func (i *Controller) evaluateService(service *k8sv1.Service) Operation {


### PR DESCRIPTION
Currently, Globanet annotates the Pod/Service/Nodes with globalIP and programs
necessary ingress/egress rules on the node. However, if there is an issue while
programming the iptable rules, its not handled.

This PR fixes it and also annotates the Pod/Service/Nodes only after it successfully
programs the necessary ingress/egress rules on the Gateway node.

Fixes Issue: https://github.com/submariner-io/submariner/issues/595

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>