### PR TITLE
Cleanup globalnet rules when globalnet pod is migrated

### DIFF
--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -77,6 +77,7 @@ func NewGatewayMonitor(spec *SubmarinerIpamControllerSpecification, cfg *rest.Co
 
 func (i *GatewayMonitor) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
+	defer ClearGlobalNetChains(i.ipt)
 
 	klog.Info("Starting GatewayMonitor to monitor the active Gateway node in the cluster.")
 
@@ -93,7 +94,6 @@ func (i *GatewayMonitor) Run(stopCh <-chan struct{}) error {
 	go wait.Until(i.runEndpointWorker, time.Second, stopCh)
 	<-stopCh
 	klog.Info("Shutting down endpoint worker.")
-	ClearGlobalNetMarkingChain(i.ipt)
 	return nil
 }
 

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -127,8 +127,18 @@ func CreateGlobalNetMarkingChain(ipt *iptables.IPTables) error {
 	return nil
 }
 
-func ClearGlobalNetMarkingChain(ipt *iptables.IPTables) {
-	err := ipt.ClearChain("nat", submarinerMark)
+func ClearGlobalNetChains(ipt *iptables.IPTables) {
+	err := ipt.ClearChain("nat", submarinerIngress)
+	if err != nil {
+		klog.Errorf("Error while flushing rules in %s chain: %v", submarinerIngress, err)
+	}
+
+	err = ipt.ClearChain("nat", submarinerEgress)
+	if err != nil {
+		klog.Errorf("Error while flushing rules in %s chain: %v", submarinerEgress, err)
+	}
+
+	err = ipt.ClearChain("nat", submarinerMark)
 	if err != nil {
 		klog.Errorf("Error while flushing rules in %s chain: %v", submarinerMark, err)
 	}


### PR DESCRIPTION
When the submariner.io/gateway label is deleted from the node, k8s deletes
the submariner engine and also the submariner globalnet pod from that node.
It was seen that when the globalnet pod is terminated, it was only deleting
SUBMARINER-GN-MARK chain and not the other chains like SUBMARINER-GN-INGRESS
and SUBMARINER-GN-EGRESS. This is causing random failures in CI for the
globalnet jobs.

In this PR we handle this by ensuring that when globalnet pod is terminated,
it will cleanup the associated iptable rules that were programmed on that node.

Fixes Issue: https://github.com/submariner-io/submariner/issues/596

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>