### PR TITLE
Fix the Wireguard workaround

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,12 +28,13 @@ jobs:
         if: matrix.cable_driver == 'wireguard'
         run: |
           sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
-          sudo apt-get update
-          sudo apt-get install  linux-headers-$(uname -r) wireguard  -y
-          # temporary solution for Ubuntu 16.04 azure-1020
-          sudo curl -Lk https://git.zx2c4.com/wireguard-linux/plain/drivers/net/wireguard/queueing.h\?id\=428c491332bca498c8eb2127669af51506c346c7  -o /usr/src/wireguard-1.0.20200506/queueing.h
-          sudo dpkg-reconfigure wireguard-dkms
-
+          sudo apt update
+          sudo apt install -y linux-headers-$(uname -r) wireguard
+          # if the kernel doesn't have skb_reset_redirect in skbuff.h, patch Wireguard so it doesn't need it
+          if ! grep -q skb_reset_redirect /lib/modules/$(uname -r)/source/include/linux/skbuff.h; then
+            curl https://git.zx2c4.com/wireguard-linux/patch/drivers/net/wireguard/queueing.h\?id=2c64605b590edadb3fb46d1ec6badb49e940b479 | sudo patch -R /usr/src/wireguard*/queueing.h
+            sudo dpkg-reconfigure wireguard-dkms
+          fi
           sudo modprobe wireguard
 
       - name: Reclaim free space!


### PR DESCRIPTION
Wireguard now fails to build because a recent commit in the kernel
(https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2c64605b590edad)
moved various skb helpers to skbuff.h, and changed Wireguard’s
queueing.h to use them. The kernel we get in the test setup doesn’t
have this change, so the current Wireguard module package no longer
builds.

This patch changes the Wireguard setup to check for the change in
skbuff.h, and apply a revert patch to queueing.h if it isn’t present.

Signed-off-by: Stephen Kitt <skitt@redhat.com>