### PR TITLE
Avoid relying on skbuff.h

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,8 +33,8 @@ jobs:
           sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
           sudo apt update
           sudo apt install -y linux-headers-$(uname -r) wireguard
-          # if the kernel doesn't have skb_reset_redirect in skbuff.h, patch Wireguard so it doesn't need it
-          if ! grep -q skb_reset_redirect /lib/modules/$(uname -r)/source/include/linux/skbuff.h; then
+          if [[ "$(uname -r)" =~ -1020- ]]; then
+            # the 1020 kernel doesn't have skb_reset_redirect in skbuff.h, patch Wireguard so it doesn't need it
             curl https://git.zx2c4.com/wireguard-linux/patch/drivers/net/wireguard/queueing.h\?id=2c64605b590edadb3fb46d1ec6badb49e940b479 | sudo patch -R /usr/src/wireguard*/queueing.h
             sudo dpkg-reconfigure wireguard-dkms
           fi


### PR DESCRIPTION
The Azure kernel headers apparently don't have skbuff.h in the
expected place, so instead of checking that, look explicitly for
version -1020- of the kernel. This avoids failing the builds on kernel
1022 which includes an updated skbuff.h and doesn't need the Wireguard
patch.

Signed-off-by: Stephen Kitt <skitt@redhat.com>