### PR TITLE
Don't try to shrink submariner image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -8,14 +8,7 @@ WORKDIR /var/submariner
 RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     dnf -y install --nodocs --setopt=install_weak_deps=False \
                    iproute iptables libreswan strongswan procps-ng && \
-    dnf -y clean all && \
-    rpm -e gnupg2 rpm-sign-libs gpgme dnf libdnf yum python3-rpm \
-           python3-dnf python3-gpg librepo python3-libdnf python3-hawkey \
-           glib2 libmodulemd libsolv libyaml libassuan \
-           shadow-utils tss2 ima-evm-utils \
-           zchunk-libs vim-minimal npth sudo tar libusbx acl dnf-data \
-           libksba libreport-filesystem libsemanage libstdc++ openssl \
-           python3-libcomps rpm-build-libs sssd-client
+    dnf -y clean all
 
 COPY submariner.sh pluto submariner-engine /usr/local/bin/
 


### PR DESCRIPTION
The DNF layer adds about 50MB (out of which several are due to
distrosync).
Removing stuff actually doesn't clean much since most of these packages
were already there in the base image, so it saves around 7MB but makes
the whole thing needlessly complicated.

We can live with a few extra MB but a much simpler Dockerfile