### PR TITLE
Wait for Pluto to start

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"k8s.io/klog"
@@ -374,6 +375,19 @@ func (i *libreswan) runPluto() error {
 		defer outputFile.Close()
 		klog.Fatalf("Pluto exited: %v", cmd.Wait())
 	}()
+
+	// Wait up to 5s for the control socket
+	for i := 0; i < 5; i++ {
+		_, err := os.Stat("/run/pluto/pluto.ctl")
+		if err == nil {
+			break
+		}
+		if !os.IsNotExist(err) {
+			klog.Infof("Failed to stat the control socket: %v", err)
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
 
 	return nil
 }


### PR DESCRIPTION
In the function which starts the IKE daemon, wait for it to start (up
to 5s) before returning. This helps avoid races when starting the
gateway; if we don't wait, the daemon starts alongside the gateway,
and in some cases we end up trying to set tunnels up before the daemon
is ready, resulting in delays (the tunnels aren't set up until the
next resync round).

Signed-off-by: Stephen Kitt <skitt@redhat.com>