### PR TITLE
Only build images for `deploy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 # Targets to make
 
-clusters: build images
+deploy: images
 
 reload-images: build images
 	./scripts/$@ --restart $(restart)


### PR DESCRIPTION
Since we dont need them to just create the kind clusters, they should be
built only if we plan to deploy.

Also deploy should depend on images, which would make sure the images
are up to date. No need for deploy target to depend explicitly on build.