### PR TITLE
libreswan: do not replicate connections in list

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -150,15 +150,9 @@ func (i *libreswan) refreshConnectionStatus() error {
 
 // GetActiveConnections returns an array of all the active connections for the given cluster.
 func (i *libreswan) GetActiveConnections(clusterID string) ([]string, error) {
-	if err := i.refreshConnectionStatus(); err != nil {
-		return []string{}, err
-	}
-
 	connections := []string{}
 	for j := range i.connections {
-		if i.connections[j].Status == subv1.Connected {
-			connections = append(connections, i.connections[j].Endpoint.CableName)
-		}
+		connections = append(connections, i.connections[j].Endpoint.CableName)
 	}
 	klog.Infof("Active connections: %v", connections)
 	return connections, nil


### PR DESCRIPTION
GetActiveConnections from cable drivers is supposed to return the
list of created cables instead of the connected cables.

If we only return connected ones connections will eventually get
replicated.

Related-Issue: #642