### PR TITLE
libreswan: initiate connections asynchronously and retry whacks (stricter err checking)

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -201,7 +201,7 @@ func whack(args ...string) error {
 			break
 		}
 
-		klog.Errorf("error %v whacking with args: %v", err, args)
+		klog.Warningf("error %v whacking with args: %v", err, args)
 		time.Sleep(1 * time.Second)
 
 	}

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -14,6 +14,7 @@ import (
 
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/log"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/util"
 )
@@ -186,6 +187,31 @@ func extractSubnets(endpoint subv1.EndpointSpec) []string {
 	return subnets
 }
 
+func whack(args ...string) error {
+
+	var err error
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("/usr/libexec/ipsec/whack", args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		klog.V(log.TRACE).Infof("Whacking with %v", args)
+
+		if err = cmd.Run(); err == nil {
+			break
+		}
+
+		klog.Errorf("error %v whacking with args: %v", err, args)
+		time.Sleep(1 * time.Second)
+
+	}
+
+	if err != nil {
+		return fmt.Errorf("error whacking with args %v: %v", args, err)
+	}
+	return nil
+}
+
 // ConnectToEndpoint establishes a connection to the given endpoint and returns a string
 // representation of the IP address of the target endpoint.
 func (i *libreswan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (string, error) {
@@ -203,11 +229,7 @@ func (i *libreswan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (string
 	rightSubnets := extractSubnets(endpoint.Spec)
 
 	// Ensure we’re listening
-	cmd := exec.Command("/usr/libexec/ipsec/whack", "--listen")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
+	if err := whack("--listen"); err != nil {
 		return "", fmt.Errorf("error listening: %v", err)
 	}
 
@@ -237,35 +259,16 @@ func (i *libreswan) ConnectToEndpoint(endpoint types.SubmarinerEndpoint) (string
 				args = append(args, "--client", rightSubnets[rsi])
 
 				klog.Infof("Creating connection to %v", endpoint)
-				klog.Infof("Whacking with %v", args)
 
-				cmd = exec.Command("/usr/libexec/ipsec/whack", args...)
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-
-				if err := cmd.Run(); err != nil {
-					switch err := err.(type) {
-					case *exec.ExitError:
-						klog.Errorf("error adding a connection with args %v; got exit code %d: %v", args, err.ExitCode(), err)
-					default:
-						return "", fmt.Errorf("error adding a connection with args %v: %v", args, err)
-					}
+				if err := whack(args...); err != nil {
+					return "", err
 				}
 
-				cmd = exec.Command("/usr/libexec/ipsec/whack", "--route", "--name", connectionName)
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-
-				if err := cmd.Run(); err != nil {
-					klog.Errorf("error routing connection %s: %v", connectionName, err)
+				if err := whack("--route", "--name", connectionName); err != nil {
+					return "", err
 				}
-
-				cmd = exec.Command("/usr/libexec/ipsec/whack", "--initiate", "--name", connectionName)
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-
-				if err := cmd.Run(); err != nil {
-					klog.Errorf("error initiating a connection with args %v: %v", args, err)
+				if err := whack("--initiate", "--asynchronous", "--name", connectionName); err != nil {
+					return "", err
 				}
 			}
 		}


### PR DESCRIPTION
Connection initiation is now done asynchronously, so whack --initiate
won't keep waiting if the other side isn't ready (eliminating potential
timing issues).

If whack fails we retry at least 3 times (as we did for strongswan vici
connections).

Fail hard on any whack exit error, which will result on a later retry
because the endpoint is enqueued for retry by the cable engine.

Closes-Issue: #642