### PR TITLE
Update Gateway StatusFailure when ListConnections fails

### DIFF
--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -1,0 +1,64 @@
+package fake
+
+import (
+	"sync"
+
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cableengine"
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+type Engine struct {
+	sync.Mutex
+	Connections               []v1.Connection
+	ListCableConnectionsError error
+	HAStatus                  v1.HAStatus
+	LocalEndPoint             *types.SubmarinerEndpoint
+}
+
+var _ cableengine.Engine = &Engine{}
+
+func New() *Engine {
+	return &Engine{
+		HAStatus:    v1.HAStatusPassive,
+		Connections: []v1.Connection{},
+	}
+}
+
+func (e *Engine) StartEngine() error {
+	return nil
+}
+
+func (e *Engine) InstallCable(remote types.SubmarinerEndpoint) error {
+	return nil
+}
+
+func (e *Engine) RemoveCable(remote types.SubmarinerEndpoint) error {
+	return nil
+}
+
+func (e *Engine) GetLocalEndpoint() *types.SubmarinerEndpoint {
+	return e.LocalEndPoint
+}
+
+func (e *Engine) ListCableConnections() (*[]v1.Connection, error) {
+	e.Lock()
+	defer e.Unlock()
+
+	if e.ListCableConnectionsError != nil {
+		return nil, e.ListCableConnectionsError
+	}
+
+	if e.Connections == nil {
+		return nil, nil
+	}
+
+	return &e.Connections, nil
+}
+
+func (e *Engine) GetHAStatus() v1.HAStatus {
+	e.Lock()
+	defer e.Unlock()
+
+	return e.HAStatus
+}

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -129,11 +129,6 @@ func (i *GatewaySyncer) cleanupStaleGatewayEntries(localGatewayName string) erro
 }
 
 func isGatewayStale(gateway v1.Gateway) (bool, error) {
-
-	if gateway.ObjectMeta.Annotations == nil {
-		return true, nil
-	}
-
 	timestamp, ok := gateway.ObjectMeta.Annotations[updateTimestampAnnotation]
 	if !ok {
 		return true, fmt.Errorf("%q annotation not found", updateTimestampAnnotation)

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -92,19 +92,24 @@ func (i *GatewaySyncer) syncGatewayStatus() {
 	}
 
 	if gatewayObj.Status.HAStatus == v1.HAStatusActive {
-		err := i.cleanupStaleGatewayEntries()
+		err := i.cleanupStaleGatewayEntries(gatewayObj.Name)
 		if err != nil {
 			klog.Errorf("error cleaning up stale gateway entries: %s", err)
 		}
 	}
 }
 
-func (i *GatewaySyncer) cleanupStaleGatewayEntries() error {
+func (i *GatewaySyncer) cleanupStaleGatewayEntries(localGatewayName string) error {
 	gateways, err := i.client.List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
+
 	for _, gw := range gateways.Items {
+		if gw.Name == localGatewayName {
+			continue
+		}
+
 		stale, err := isGatewayStale(gw)
 		if err != nil {
 			// In this case we don't want to stop the cleanup loop and just log it

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -160,11 +160,14 @@ func (i *GatewaySyncer) generateGatewayObject() (*v1.Gateway, error) {
 
 	connections, err := i.engine.ListCableConnections()
 	if err != nil {
-		gateway.Status.StatusFailure = fmt.Sprintf("Error getting driver connections: %s", err)
-		klog.Errorf("error getting driver connections: %s", err)
-		return nil, err
+		gateway.Status.StatusFailure = fmt.Sprintf("Error retrieving driver connections: %s", err)
 	}
-	gateway.Status.Connections = *connections
+
+	if connections != nil {
+		gateway.Status.Connections = *connections
+	} else {
+		gateway.Status.Connections = []v1.Connection{}
+	}
 
 	klog.V(log.TRACE).Infof("Generated Gateway object: %+v", gateway)
 	return &gateway, nil

--- a/pkg/client/clientset/versioned/typed/submariner.io/v1/fake/failing_gateways.go
+++ b/pkg/client/clientset/versioned/typed/submariner.io/v1/fake/failing_gateways.go
@@ -1,0 +1,57 @@
+package fake
+
+import (
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	submarinerClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FailingGateways struct {
+	submarinerClientsetv1.GatewayInterface
+
+	FailOnCreate error
+	FailOnUpdate error
+	FailOnDelete error
+	FailOnGet    error
+	FailOnList   error
+}
+
+func (f *FailingGateways) Create(g *v1.Gateway) (*v1.Gateway, error) {
+	if f.FailOnCreate != nil {
+		return nil, f.FailOnCreate
+	}
+
+	return f.GatewayInterface.Create(g)
+}
+
+func (f *FailingGateways) Update(g *v1.Gateway) (*v1.Gateway, error) {
+	if f.FailOnUpdate != nil {
+		return nil, f.FailOnUpdate
+	}
+
+	return f.GatewayInterface.Update(g)
+}
+
+func (f *FailingGateways) Delete(name string, options *metav1.DeleteOptions) error {
+	if f.FailOnDelete != nil {
+		return f.FailOnDelete
+	}
+
+	return f.GatewayInterface.Delete(name, options)
+}
+
+func (f *FailingGateways) Get(name string, options metav1.GetOptions) (*v1.Gateway, error) {
+	if f.FailOnGet != nil {
+		return nil, f.FailOnGet
+	}
+
+	return f.GatewayInterface.Get(name, options)
+}
+
+func (f *FailingGateways) List(opts metav1.ListOptions) (*v1.GatewayList, error) {
+	if f.FailOnList != nil {
+		return nil, f.FailOnList
+	}
+
+	return f.GatewayInterface.List(opts)
+}


### PR DESCRIPTION
The code intended to update `StatusFailure` but instead returned the error thus eliding the update.
    
Also handle nil from `ListConnections` to be safe.

This PR also adds unit tests for the cable engine `Syncer` and corresponding changes in a series of small commits.
