### PR TITLE
Simplify GatewayStaleTimeout calculation

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -25,7 +25,7 @@ type GatewaySyncer struct {
 }
 
 var GatewayUpdateInterval = 5 * time.Second
-var GatewayStaleTimeout = time.Duration(GatewayUpdateInterval.Seconds()) * 3 * time.Second
+var GatewayStaleTimeout = GatewayUpdateInterval * 3
 
 const updateTimestampAnnotation = "update-timestamp"
 


### PR DESCRIPTION
As per comment in https://github.com/submariner-io/submariner/pull/687.

I also had to push https://github.com/submariner-io/submariner/pull/690/commits/4eb60092feb0e38ab027084a59535e07a808d95a to fix a race failure during the validation check.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>