### PR TITLE
Tag latest stable image as `latest`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,5 +41,9 @@ jobs:
           RELEASE_ARGS: submariner submariner-route-agent submariner-globalnet
           IMAGES_ARGS: --nocache
         run: |
-          [[ $GITHUB_REF =~ "/tags/" ]] && RELEASE_ARGS+=" --tag ${GITHUB_REF##*/}"
+          if [[ $GITHUB_REF =~ "/tags/" ]]; then
+              tags="${GITHUB_REF##*/}"
+              { echo $tags | grep -q -v -; } && tags+=" latest"
+              RELEASE_ARGS+=" --tag \"$tags\""
+          fi
           make images release


### PR DESCRIPTION
As https://github.com/submariner-io/shipyard/pull/235 defines that
`devel` is now used to tag latest development images, tag the latest
stable released image with `latest`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>