### PR TITLE
Add golangci-lint config file, add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,37 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 20
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    #- dupl
+    - errcheck
+    #- funlen
+    #- gochecknoinits
+    #- goconst
+    #- gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    #- golint
+    #- gosec
+    - gosimple
+    - govet
+    - ineffassign
+    #- interfacer
+    #- lll
+    #- misspell
+    - nakedret
+    #- scopelint
+    - staticcheck
+    - structcheck
+    #- stylecheck
+    - typecheck
+    - unconvert
+    #- unparam
+    - unused
+    - varcheck
+    #- whitespace


### PR DESCRIPTION
Explicitly declare linters to for golangci-lint to enable. This will
keep our checks more consistent, but also is required for adding
non-standard linters.

This adds linters:

* bodyclose: checks whether HTTP response body is closed successfully
* depguard: Go linter that checks if package imports are in a list of
  acceptable packages
* gocyclo: Computes and checks the cyclomatic complexity of functions
* gofmt: Gofmt checks whether code was gofmt-ed. By default this tool
  runs with -s option to check for code simplification
* goimports: Goimports does everything that gofmt does. Additionally it
  checks unused imports
* nakedret: Finds naked returns in functions greater than a specified
  function length
* unconvert: Remove unnecessary type conversions

Other linters from the golangci-lint example configuration that seem
desirable but currently fail are included but left commented out. We
should enable them as we fix violations in future changes.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>