### PR TITLE
Remove unnecessary use of Sprintf

### DIFF
--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -49,7 +49,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		enginePod := f.AwaitSubmarinerEnginePod(framework.ClusterC)
 		By(fmt.Sprintf("Found submariner engine pod %q on %q", enginePod.Name, clusterCName))
 
-		By(fmt.Sprintf("Checking connectivity between clusters"))
+		By("Checking connectivity between clusters")
 		tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterB,


### PR DESCRIPTION
The latest release of golangci-lint (1.28.0) now flags this as an error
via the newer version of the gosimple linter. Fix before upgrading the
version in Shipyard to keep the verify job here passing.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>