### PR TITLE
Avoid exposing range pointers

### DIFF
--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -21,8 +21,8 @@ func (w *wireguard) GetConnections() (*[]v1.Connection, error) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	for _, p := range d.Peers {
-		key := p.PublicKey
+	for i := range d.Peers {
+		key := d.Peers[i].PublicKey
 		connection, err := w.connectionByKey(&key)
 		if err != nil {
 			klog.Warningf("Found unknown peer with key %s, removing", key)
@@ -31,7 +31,7 @@ func (w *wireguard) GetConnections() (*[]v1.Connection, error) {
 			}
 			continue
 		}
-		w.updateConnectionForPeer(&p, connection)
+		w.updateConnectionForPeer(&d.Peers[i], connection)
 		connections = append(connections, *connection.DeepCopy())
 	}
 	return &connections, nil

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -81,11 +81,11 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint() error {
 		return fmt.Errorf("error retrieving submariner Endpoints %v", err)
 	}
 
-	for _, endpoint := range endpoints {
-		if !util.CompareEndpointSpec(endpoint.Spec, d.localEndpoint.Spec) {
-			endpointName, err := util.GetEndpointCRDName(&endpoint)
+	for i := range endpoints {
+		if !util.CompareEndpointSpec(endpoints[i].Spec, d.localEndpoint.Spec) {
+			endpointName, err := util.GetEndpointCRDName(&endpoints[i])
 			if err != nil {
-				klog.Errorf("Error extracting the submariner Endpoint name from %#v: %v", endpoint, err)
+				klog.Errorf("Error extracting the submariner Endpoint name from %#v: %v", endpoints[i], err)
 				continue
 			}
 
@@ -95,9 +95,9 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint() error {
 				return fmt.Errorf("error deleting submariner Endpoint %q from the local datastore: %v", endpointName, err)
 			}
 
-			err = d.datastore.RemoveEndpoint(d.localCluster.ID, endpoint.Spec.CableName)
+			err = d.datastore.RemoveEndpoint(d.localCluster.ID, endpoints[i].Spec.CableName)
 			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v", endpoint.Spec.CableName, err)
+				return fmt.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v", endpoints[i].Spec.CableName, err)
 			}
 
 			klog.Infof("Successfully deleted existing submariner Endpoint %q", endpointName)

--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -792,15 +792,15 @@ func (r *Controller) cleanVxSubmarinerRoutes() {
 		klog.Errorf("Unable to cleanup routes, error retrieving routes on the link %s: %v", VxLANIface, err)
 		return
 	}
-	for _, route := range currentRouteList {
-		klog.V(log.DEBUG).Infof("Processing route %v", route)
-		if route.Dst == nil || route.Gw == nil {
+	for i := range currentRouteList {
+		klog.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])
+		if currentRouteList[i].Dst == nil || currentRouteList[i].Gw == nil {
 			klog.V(log.DEBUG).Infof("Found nil gw or dst")
 		} else {
-			if r.remoteSubnets.Contains(route.Dst.String()) {
-				klog.V(log.DEBUG).Infof("Removing route %s", route.String())
-				if err = netlink.RouteDel(&route); err != nil {
-					klog.Errorf("Error removing route %s: %v", route.String(), err)
+			if r.remoteSubnets.Contains(currentRouteList[i].Dst.String()) {
+				klog.V(log.DEBUG).Infof("Removing route %s", currentRouteList[i])
+				if err = netlink.RouteDel(&currentRouteList[i]); err != nil {
+					klog.Errorf("Error removing route %s: %v", currentRouteList[i], err)
 				}
 			}
 		}
@@ -833,10 +833,10 @@ func (r *Controller) cleanXfrmPolicies() {
 	if len(currentXfrmPolicyList) > 0 {
 		klog.Infof("Cleaning up %d XFRM policies", len(currentXfrmPolicyList))
 	}
-	for _, xfrmPolicy := range currentXfrmPolicyList {
-		klog.V(log.DEBUG).Infof("Deleting XFRM policy %s", xfrmPolicy.String())
-		if err = netlink.XfrmPolicyDel(&xfrmPolicy); err != nil {
-			klog.Errorf("Error Deleting XFRM policy %s: %v", xfrmPolicy.String(), err)
+	for i := range currentXfrmPolicyList {
+		klog.V(log.DEBUG).Infof("Deleting XFRM policy %s", currentXfrmPolicyList[i])
+		if err = netlink.XfrmPolicyDel(&currentXfrmPolicyList[i]); err != nil {
+			klog.Errorf("Error Deleting XFRM policy %s: %v", currentXfrmPolicyList[i], err)
 		}
 	}
 }
@@ -857,18 +857,18 @@ func (r *Controller) reconcileRoutes(vxlanGw net.IP) error {
 	}
 
 	// First lets delete all of the routes that don't match
-	for _, route := range currentRouteList {
+	for i := range currentRouteList {
 		// contains(endpoint destinations, route destination string, and the route gateway is our actual destination
-		klog.V(log.DEBUG).Infof("Processing route %v", route)
-		if route.Dst == nil || route.Gw == nil {
+		klog.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])
+		if currentRouteList[i].Dst == nil || currentRouteList[i].Gw == nil {
 			klog.V(log.DEBUG).Infof("Found nil gw or dst")
 		} else {
-			if r.remoteSubnets.Contains(route.Dst.String()) && route.Gw.Equal(vxlanGw) {
-				klog.V(log.DEBUG).Infof("Found route %s with gw %s already installed", route.String(), route.Gw.String())
+			if r.remoteSubnets.Contains(currentRouteList[i].Dst.String()) && currentRouteList[i].Gw.Equal(vxlanGw) {
+				klog.V(log.DEBUG).Infof("Found route %s with gw %s already installed", currentRouteList[i], currentRouteList[i].Gw)
 			} else {
-				klog.V(log.DEBUG).Infof("Removing route %s", route.String())
-				if err = netlink.RouteDel(&route); err != nil {
-					klog.Errorf("Error removing route %s: %v", route.String(), err)
+				klog.V(log.DEBUG).Infof("Removing route %s", currentRouteList[i])
+				if err = netlink.RouteDel(&currentRouteList[i]); err != nil {
+					klog.Errorf("Error removing route %s: %v", currentRouteList[i], err)
 				}
 			}
 		}


### PR DESCRIPTION
When looping over a range, if a value variable is declared, the range
can be copied before processing; this means that passing a pointer to
a range value can cause issues. Using the index to address slice items
avoids a copy and means that pointers to slice items are canonical.

Signed-off-by: Stephen Kitt <skitt@redhat.com>