### PR TITLE
Enable exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,10 @@ linters:
     - depguard
     #- dupl
     - errcheck
+    - exportloopref
     #- funlen
+    #- gochecknoglobals
     #- gochecknoinits
-    #- goconst
     #- gocritic
     - gocyclo
     - gofmt
@@ -28,10 +29,10 @@ linters:
     - maligned
     - misspell
     - nakedret
-    #- scopelint
     - staticcheck
     - structcheck
     #- stylecheck
+    #- testpackage
     - typecheck
     - unconvert
     #- unparam


### PR DESCRIPTION
With golangci-lint 1.28.0, scopelint is now obsoleted and the
recommendation is to use exportloopref. Remove (commented, suggestion)
config for scopelint and enable exportloopref.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>