### PR TITLE
Enable maligned memory linting, fix issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 linters-settings:
   gocyclo:
     min-complexity: 20
+  maligned:
+    suggest-new: true
 linters:
   disable-all: true
   enable:
@@ -23,6 +25,7 @@ linters:
     - ineffassign
     - interfacer
     #- lll
+    - maligned
     - misspell
     - nakedret
     #- scopelint

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -14,17 +14,17 @@ type SubmarinerEndpoint struct {
 }
 
 type SubmarinerSpecification struct {
-	Namespace   string
-	Debug       bool
-	ClusterID   string
-	Token       string
 	ClusterCidr []string
-	ServiceCidr []string
-	GlobalCidr  []string
 	ColorCodes  []string
-	NatEnabled  bool
+	GlobalCidr  []string
+	ServiceCidr []string
 	Broker      string
 	CableDriver string
+	ClusterID   string
+	Namespace   string
+	Token       string
+	Debug       bool
+	NatEnabled  bool
 }
 
 type Secure struct {


### PR DESCRIPTION
Saves a few bytes of memory by aligning structures with themselves
better, without requiring padding.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>