### PR TITLE
Enable lll line length linting, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 linters-settings:
   gocyclo:
     min-complexity: 20
+  lll:
+    line-length: 140
   maligned:
     suggest-new: true
 linters:
@@ -24,7 +26,7 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    #- lll
+    - lll
     - maligned
     - misspell
     - nakedret

--- a/main.go
+++ b/main.go
@@ -41,7 +41,8 @@ var (
 
 func init() {
 	flag.StringVar(&localKubeconfig, "kubeconfig", "", "Path to kubeconfig of local cluster. Only required if out-of-cluster.")
-	flag.StringVar(&localMasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&localMasterURL, "master", "",
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }
 
 type leaderConfig struct {
@@ -230,7 +231,8 @@ func startLeaderElection(leaderElectionClient kubernetes.Interface, recorder res
 	namespace, _, err := kubeconfig.Namespace()
 	if err != nil {
 		namespace = "submariner"
-		klog.Infof("Could not obtain a namespace to use for the leader election lock - the error was: %v. Using the default %q namespace.", namespace, err)
+		klog.Infof("Could not obtain a namespace to use for the leader election lock - the error was: %v. Using the default %q namespace.",
+			namespace, err)
 	} else {
 		klog.Infof("Using namespace %q for the leader election lock", namespace)
 	}

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -38,8 +38,9 @@ type DatastoreSyncer struct {
 	endpointWorkqueue workqueue.RateLimitingInterface
 }
 
-func NewDatastoreSyncer(thisClusterID string, submarinerClusters submarinerClientset.ClusterInterface, submarinerClusterInformer submarinerInformers.ClusterInformer,
-	submarinerEndpoints submarinerClientset.EndpointInterface, submarinerEndpointInformer submarinerInformers.EndpointInformer, datastore datastore.Datastore, colorcodes []string,
+func NewDatastoreSyncer(thisClusterID string, submarinerClusters submarinerClientset.ClusterInterface,
+	submarinerClusterInformer submarinerInformers.ClusterInformer, submarinerEndpoints submarinerClientset.EndpointInterface,
+	submarinerEndpointInformer submarinerInformers.EndpointInformer, datastore datastore.Datastore, colorcodes []string,
 	localCluster types.SubmarinerCluster, localEndpoint types.SubmarinerEndpoint) *DatastoreSyncer {
 	newDatastoreSyncer := DatastoreSyncer{
 		thisClusterID:              thisClusterID,
@@ -97,7 +98,8 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint() error {
 
 			err = d.datastore.RemoveEndpoint(d.localCluster.ID, endpoints[i].Spec.CableName)
 			if err != nil && !errors.IsNotFound(err) {
-				return fmt.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v", endpoints[i].Spec.CableName, err)
+				return fmt.Errorf("error removing submariner Endpoint with cable name %q from the central datastore: %v",
+					endpoints[i].Spec.CableName, err)
 			}
 
 			klog.Infof("Successfully deleted existing submariner Endpoint %q", endpointName)
@@ -138,7 +140,8 @@ func (d *DatastoreSyncer) Run(stopCh <-chan struct{}) error {
 	klog.Info("Starting the datastore syncer")
 
 	klog.Info("Waiting for informer caches to sync")
-	if ok := cache.WaitForCacheSync(stopCh, d.submarinerClusterInformer.Informer().HasSynced, d.submarinerEndpointInformer.Informer().HasSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, d.submarinerClusterInformer.Informer().HasSynced,
+		d.submarinerEndpointInformer.Informer().HasSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
@@ -255,14 +258,16 @@ func (d *DatastoreSyncer) processNextEndpointWorkItem() bool {
 		}
 
 		if d.thisClusterID != endpoint.Spec.ClusterID {
-			klog.V(log.DEBUG).Infof("The updated submariner Endpoint %q is not for this cluster - skipping updating the datastore", endpoint.Spec.ClusterID)
+			klog.V(log.DEBUG).Infof("The updated submariner Endpoint %q is not for this cluster - skipping updating the datastore",
+				endpoint.Spec.ClusterID)
 			// not actually an error but we should forget about this and return
 			d.endpointWorkqueue.Forget(key)
 			return nil
 		}
 
 		if d.localEndpoint.Spec.CableName != endpoint.Spec.CableName {
-			klog.V(log.DEBUG).Infof("The updated submariner Endpoint with CableName %q is not mine - skipping updating the datastore", endpoint.Spec.CableName)
+			klog.V(log.DEBUG).Infof("The updated submariner Endpoint with CableName %q is not mine - skipping updating the datastore",
+				endpoint.Spec.CableName)
 			d.endpointWorkqueue.Forget(key)
 			return nil
 		}

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -324,10 +324,12 @@ func (t *testDatastore) RemoveEndpoint(clusterID, cableName string) error {
 	return t.endpoints.Delete(endpointName, &metav1.DeleteOptions{})
 }
 
-func (t *testDatastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange datastore.OnClusterChange) error {
+func (t *testDatastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string,
+	onClusterChange datastore.OnClusterChange) error {
 	return nil
 }
 
-func (t *testDatastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string, onEndpointChange datastore.OnEndpointChange) error {
+func (t *testDatastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string,
+	onEndpointChange datastore.OnEndpointChange) error {
 	return nil
 }

--- a/pkg/datastore/fake/datastore.go
+++ b/pkg/datastore/fake/datastore.go
@@ -58,12 +58,14 @@ func (d *Datastore) GetEndpoint(clusterID string, cableName string) (*types.Subm
 	return nil, errors.New("Not implemented")
 }
 
-func (d *Datastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange datastore.OnClusterChange) error {
+func (d *Datastore) WatchClusters(ctx context.Context, selfClusterID string, icolorCodes []string,
+	onClusterChange datastore.OnClusterChange) error {
 	d.watchClusters <- onClusterChange
 	return nil
 }
 
-func (d *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string, onEndpointChange datastore.OnEndpointChange) error {
+func (d *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string,
+	onEndpointChange datastore.OnEndpointChange) error {
 	d.watchEndpoints <- onEndpointChange
 	return nil
 }

--- a/pkg/datastore/kubernetes/kubernetes.go
+++ b/pkg/datastore/kubernetes/kubernetes.go
@@ -143,7 +143,8 @@ func (k *Datastore) GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, 
 	return endpoints, nil
 }
 
-func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange datastore.OnClusterChange) error {
+func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string,
+	onClusterChange datastore.OnClusterChange) error {
 	k.informerFactory.Submariner().V1().Clusters().Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			var object *submarinerv1.Cluster
@@ -226,7 +227,8 @@ func (k *Datastore) WatchClusters(ctx context.Context, selfClusterID string, col
 	return nil
 }
 
-func (k *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string, onEndpointChange datastore.OnEndpointChange) error {
+func (k *Datastore) WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string,
+	onEndpointChange datastore.OnEndpointChange) error {
 	k.informerFactory.Submariner().V1().Endpoints().Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			var object *submarinerv1.Endpoint

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -127,7 +127,8 @@ func (i *Controller) runNodeWorker() {
 	}
 }
 
-func (i *Controller) processNextObject(objWorkqueue workqueue.RateLimitingInterface, objGetter func(namespace, name string) (runtime.Object, error), objUpdater func(runtimeObj runtime.Object, key string) error) bool {
+func (i *Controller) processNextObject(objWorkqueue workqueue.RateLimitingInterface, objGetter func(namespace, name string) (runtime.Object,
+	error), objUpdater func(runtimeObj runtime.Object, key string) error) bool {
 	obj, shutdown := objWorkqueue.Get()
 	if shutdown {
 		return false

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -79,5 +79,6 @@ func main() {
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "",
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }

--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -182,7 +182,8 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 
 	// Start the informer factories to begin populating the informer caches
-	klog.Infof("Starting Route Controller. ClusterID: %s, localClusterCIDR: %v, localServiceCIDR: %v", r.clusterID, r.localClusterCidr, r.localServiceCidr)
+	klog.Infof("Starting Route Controller. ClusterID: %s, localClusterCIDR: %v, localServiceCIDR: %v", r.clusterID, r.localClusterCidr,
+		r.localServiceCidr)
 
 	// Wait for the caches to be synced before starting workers
 	klog.Info("Waiting for Endpoint informer caches to sync.")

--- a/pkg/routeagent/main.go
+++ b/pkg/routeagent/main.go
@@ -58,14 +58,16 @@ func main() {
 		klog.Fatalf("Error building submariner clientset: %s", err.Error())
 	}
 
-	submarinerInformerFactory := submarinerInformers.NewSharedInformerFactoryWithOptions(submarinerClient, time.Second*30, submarinerInformers.WithNamespace(srcs.Namespace))
+	submarinerInformerFactory := submarinerInformers.NewSharedInformerFactoryWithOptions(submarinerClient, time.Second*30,
+		submarinerInformers.WithNamespace(srcs.Namespace))
 
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		klog.Fatalf("Error building clientset: %s", err.Error())
 	}
 
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientSet, time.Second*60, informers.WithNamespace(srcs.Namespace), informers.WithTweakListOptions(filterRouteAgentPods))
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientSet, time.Second*60, informers.WithNamespace(srcs.Namespace),
+		informers.WithTweakListOptions(filterRouteAgentPods))
 
 	informerConfig := route.InformerConfigStruct{
 		SubmarinerClientSet: submarinerClient,
@@ -102,5 +104,6 @@ func main() {
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "",
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }


### PR DESCRIPTION
Enable golangci-lint lll line length linting, set max length at 140 chars.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>