### PR TITLE
Enable gocritic linting, fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,13 @@
 linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      #- performance
+      - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
   gocyclo:
     min-complexity: 20
   lll:
@@ -17,7 +26,7 @@ linters:
     #- funlen
     #- gochecknoglobals
     #- gochecknoinits
-    #- gocritic
+    - gocritic
     - gocyclo
     - gofmt
     - goimports

--- a/main.go
+++ b/main.go
@@ -100,10 +100,11 @@ func main() {
 	if len(submSpec.GlobalCidr) > 0 {
 		localSubnets = submSpec.GlobalCidr
 	} else {
-		localSubnets = append(submSpec.ServiceCidr, submSpec.ClusterCidr...)
+		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
+		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
 	}
 
-	if len(submSpec.CableDriver) == 0 {
+	if submSpec.CableDriver == "" {
 		submSpec.CableDriver = cable.GetDefaultCableDriver()
 	}
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -50,7 +50,7 @@ func createLibreswan() *libreswan {
 	return ls.(*libreswan)
 }
 
-func checkLibreswanPorts(ikePort string, nattPort string) {
+func checkLibreswanPorts(ikePort, nattPort string) {
 	ls := createLibreswan()
 	Expect(ls.ipSecIKEPort).To(Equal(ikePort))
 	Expect(ls.ipSecNATTPort).To(Equal(nattPort))

--- a/pkg/cable/strongswan/strongswan.go
+++ b/pkg/cable/strongswan/strongswan.go
@@ -415,7 +415,7 @@ func (i *strongSwan) writeCharonConfig(path string) error {
 		return fmt.Errorf("error creating charon config file %q: %s", path, err)
 	}
 
-	if err = i.renderCharonConfigTemplate(f); err != nil {
+	if err := i.renderCharonConfigTemplate(f); err != nil {
 		return err
 	}
 

--- a/pkg/cable/strongswan/strongswan_test.go
+++ b/pkg/cable/strongswan/strongswan_test.go
@@ -67,7 +67,7 @@ func createStrongSwan() *strongSwan {
 	return ss.(*strongSwan)
 }
 
-func checkStrongSwanPorts(ikePort string, nattPort string) {
+func checkStrongSwanPorts(ikePort, nattPort string) {
 	ss := createStrongSwan()
 	Expect(ss.ipSecIKEPort).To(Equal(ikePort))
 	Expect(ss.ipSecNATTPort).To(Equal(nattPort))

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -41,7 +41,7 @@ const (
 	transmitBytes   = "TransmitBytes" // for peer connection status
 	lastChecked     = "LastChecked"   // for connection peer status
 
-	//TODO use submariner prefix
+	// TODO use submariner prefix
 	specEnvPrefix = "ce_ipsec"
 )
 
@@ -227,7 +227,7 @@ func (w *wireguard) ConnectToEndpoint(remoteEndpoint types.SubmarinerEndpoint) (
 		PresharedKey: w.psk,
 		Endpoint: &net.UDPAddr{
 			IP:   remoteIP,
-			Port: w.spec.NATTPort, //TODO move port to endpoint spec
+			Port: w.spec.NATTPort, // TODO move port to endpoint spec
 		},
 		PersistentKeepaliveInterval: &ka,
 		ReplaceAllowedIPs:           true,

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -127,7 +127,7 @@ func peerTrafficDelta(c *v1.Connection, key string, newVal int64) int64 {
 }
 
 // Save backendConfig[key]
-func savePeerTraffic(c *v1.Connection, lc int64, tx int64, rx int64) {
+func savePeerTraffic(c *v1.Connection, lc, tx, rx int64) {
 	c.Endpoint.BackendConfig[lastChecked] = strconv.FormatInt(lc, 10)
 	c.Endpoint.BackendConfig[transmitBytes] = strconv.FormatInt(tx, 10)
 	c.Endpoint.BackendConfig[receiveBytes] = strconv.FormatInt(rx, 10)

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -80,7 +80,7 @@ func (i *engine) startDriver() error {
 		return err
 	}
 
-	if err = i.driver.Init(); err != nil {
+	if err := i.driver.Init(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -79,9 +79,10 @@ func (e *Engine) ListCableConnections() (*[]v1.Connection, error) {
 
 func (e *Engine) GetHAStatus() v1.HAStatus {
 	e.Lock()
-	defer e.Unlock()
+	ret := e.HAStatus
+	e.Unlock()
 
-	return e.HAStatus
+	return ret
 }
 
 func (e *Engine) VerifyInstallCable(expected *v1.EndpointSpec) {

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/submariner-io/admiral/pkg/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	fakeClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
-	clientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
 	fakeClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1/fake"
 	informers "github.com/submariner-io/submariner/pkg/client/informers/externalversions"
@@ -161,7 +160,7 @@ func newEndpoint(spec *submarinerv1.EndpointSpec) *submarinerv1.Endpoint {
 	}
 }
 
-func createEndpoint(endpoints clientsetv1.EndpointInterface, spec *submarinerv1.EndpointSpec) string {
+func createEndpoint(endpoints submarinerClientset.EndpointInterface, spec *submarinerv1.EndpointSpec) string {
 	endpointName := getEndpointName(spec)
 	_, err := endpoints.Create(&submarinerv1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/datastore/fake/datastore.go
+++ b/pkg/datastore/fake/datastore.go
@@ -54,7 +54,7 @@ func (d *Datastore) GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, 
 	return []types.SubmarinerEndpoint{}, nil
 }
 
-func (d *Datastore) GetEndpoint(clusterID string, cableName string) (*types.SubmarinerEndpoint, error) {
+func (d *Datastore) GetEndpoint(clusterID, cableName string) (*types.SubmarinerEndpoint, error) {
 	return nil, errors.New("Not implemented")
 }
 

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
 	k8sv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
@@ -78,7 +77,7 @@ func (i *Controller) syncNodeRules(cniIfaceIP, globalIP string, addRules bool) e
 }
 
 func (i *Controller) evaluateService(service *k8sv1.Service) Operation {
-	if service.Spec.Type != v1.ServiceTypeClusterIP {
+	if service.Spec.Type != k8sv1.ServiceTypeClusterIP {
 		// Normally ClusterIPServices can be accessed only within the local cluster.
 		// When multiple K8s clusters are connected via Submariner, it enables access
 		// to ClusterIPService even from remote clusters. So, as part of Submariner

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -211,10 +211,10 @@ func (i *Controller) processNextObject(objWorkqueue workqueue.RateLimitingInterf
 	return true
 }
 
-func (i *Controller) enqueueObject(obj interface{}, workqueue workqueue.RateLimitingInterface) {
+func (i *Controller) enqueueObject(obj interface{}, queue workqueue.RateLimitingInterface) {
 	if key := i.getEnqueueKey(obj); key != "" {
 		klog.V(log.TRACE).Infof("Enqueueing %v for ipam controller", key)
-		workqueue.AddRateLimited(key)
+		queue.AddRateLimited(key)
 	}
 }
 
@@ -236,7 +236,7 @@ func (i *Controller) getEnqueueKey(obj interface{}) string {
 	return key
 }
 
-func (i *Controller) handleUpdateService(old interface{}, newObj interface{}) {
+func (i *Controller) handleUpdateService(old, newObj interface{}) {
 	//TODO: further minimize duplication between this and handleUpdatePod
 	var key string
 	var err error
@@ -263,7 +263,7 @@ func (i *Controller) handleUpdateService(old interface{}, newObj interface{}) {
 	}
 }
 
-func (i *Controller) handleUpdatePod(old interface{}, newObj interface{}) {
+func (i *Controller) handleUpdatePod(old, newObj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(newObj); err != nil {
@@ -312,7 +312,7 @@ func (i *Controller) handleUpdatePod(old interface{}, newObj interface{}) {
 	}
 }
 
-func (i *Controller) handleUpdateNode(old interface{}, newObj interface{}) {
+func (i *Controller) handleUpdateNode(old, newObj interface{}) {
 	// Todo minimize the duplication
 	var key string
 	var err error
@@ -458,7 +458,7 @@ func (i *Controller) handleRemovedNode(obj interface{}) {
 	}
 }
 
-func (i *Controller) annotateGlobalIp(key string, globalIp string) (string, error) {
+func (i *Controller) annotateGlobalIp(key, globalIp string) (string, error) {
 	var ip string
 	var err error
 	if globalIp == "" {
@@ -635,7 +635,7 @@ func (i *Controller) nodeUpdater(obj runtime.Object, key string) error {
 	return nil
 }
 
-func logAndRequeue(key string, workqueue workqueue.RateLimitingInterface) {
-	klog.V(log.DEBUG).Infof("%s enqueued %d times", key, workqueue.NumRequeues(key))
-	workqueue.AddRateLimited(key)
+func logAndRequeue(key string, queue workqueue.RateLimitingInterface) {
+	klog.V(log.DEBUG).Infof("%s enqueued %d times", key, queue.NumRequeues(key))
+	queue.AddRateLimited(key)
 }

--- a/pkg/globalnet/controllers/ipam/ippool.go
+++ b/pkg/globalnet/controllers/ipam/ippool.go
@@ -12,8 +12,8 @@ type IpPool struct {
 	cidr      string
 	net       *net.IPNet
 	size      int
-	available map[string]bool   //IP.String() is key
-	allocated map[string]string //resource "namespace/name" is key, ipString is value
+	available map[string]bool   // IP.String() is key
+	allocated map[string]string // resource "namespace/name" is key, ipString is value
 	sync.RWMutex
 }
 
@@ -96,7 +96,7 @@ func (p *IpPool) GetAllocatedIp(key string) string {
 	return ip
 }
 
-func (p *IpPool) RequestIp(key string, ip string) (string, error) {
+func (p *IpPool) RequestIp(key, ip string) (string, error) {
 	if p.GetAllocatedIp(key) == ip {
 		return ip, nil
 	}

--- a/pkg/routeagent/controllers/route/vxlan.go
+++ b/pkg/routeagent/controllers/route/vxlan.go
@@ -87,9 +87,9 @@ func (iface *vxLanIface) deleteVxLanIface() error {
 	return nil
 }
 
-func isVxlanConfigTheSame(new, current netlink.Link) bool {
-	required := new.(*netlink.Vxlan)
-	existing := current.(*netlink.Vxlan)
+func isVxlanConfigTheSame(newLink, currentLink netlink.Link) bool {
+	required := newLink.(*netlink.Vxlan)
+	existing := currentLink.(*netlink.Vxlan)
 
 	if required.VxlanId != existing.VxlanId {
 		klog.Errorf("VxlanId of existing interface (%d) does not match with required VxlanId (%d)", existing.VxlanId, required.VxlanId)


### PR DESCRIPTION
Disable if-else chain linting as it seems to only flag false positives
in our code base. Our two violations don't switch on a single condition,
so while one of them can be written as a switch, it's less clear.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>