### PR TITLE
Libreswan: simplify connection removal

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -320,14 +320,8 @@ func (i *libreswan) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) er
 func removeConnectionForEndpoint(connections []subv1.Connection, endpoint types.SubmarinerEndpoint) []subv1.Connection {
 	for j := range connections {
 		if connections[j].Endpoint.CableName == endpoint.Spec.CableName {
-			if j == 0 && j == len(connections)-1 {
-				return []subv1.Connection{}
-			} else if j == 0 {
-				return connections[j+1:]
-			} else if j == len(connections)-1 {
-				return connections[:j]
-			}
-			return append(connections[:j], connections[j+1:]...)
+			copy(connections[j:], connections[j+1:])
+			return connections[:len(connections)-1]
 		}
 	}
 	return connections


### PR DESCRIPTION
Comparing the index and the length isn't particularly useful, and
confuses linters (and reviewers).

Signed-off-by: Stephen Kitt <skitt@redhat.com>