### PR TITLE
Fix shutdown path in Submariner Gateway Pod

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,10 @@ func main() {
 		klog.Fatalf("Leader election lost, shutting down")
 	}
 
-	startLeaderElection(leClient, recorder, becameLeader, lostLeader)
+	go startLeaderElection(leClient, recorder, becameLeader, lostLeader)
+	<-stopCh
+	cableEngineSyncer.CleanupGatewayEntry()
+	klog.Info("All controllers stopped or exited. Stopping main loop")
 }
 
 func startLeaderElection(leaderElectionClient kubernetes.Interface, recorder resourcelock.EventRecorder,


### PR DESCRIPTION
In the current code, it was seen that GatewayPod was not handling the
shutdown signal properly and was finally getting terminated by K8s
after the terminationGracePeriod interval is exhaused. This is because
leaderelection.RunOrDie does not return. This PR fixes it by running
the leaderelection in a Goroutine and using stopCh to wait for shutdown
signal.

Partially fixes: https://github.com/submariner-io/submariner/issues/694

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>