### PR TITLE
AWS: Fix missing cniIfaceIP annotation for Node (pr2)

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -243,7 +243,8 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 		r.populateRemoteVtepIps(pod.Status.PodIP)
 		// On some platforms (like AWS), it was seen that nodeName is configured as FQDN
 		podNodeName := strings.Split(pod.Spec.NodeName, ".")
-		if hostname == podNodeName[0] {
+		// Similarly, hostnames on some platforms are configured in FQDN
+		if hostname == pod.Spec.NodeName || hostname == podNodeName[0] {
 			routeAgentNodeName = pod.Spec.NodeName
 		}
 	}


### PR DESCRIPTION
Normally, most of the platforms are configured with hostname without the domainname.
However, on AWS, for one of the nodes, it was seen that hostname was configured as
FQDN (i.e., hostname.domainname) while all the remaining nodes were configured with
just the hostname alone. Because of this, route-agent was failing to start on that
node. This PR fixes it.

Fixes issue: https://github.com/submariner-io/submariner/issues/736

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>