### PR TITLE
Use the main Fedora image

### DIFF
--- a/package/Dockerfile.submariner
+++ b/package/Dockerfile.submariner
@@ -1,13 +1,13 @@
-FROM registry.fedoraproject.org/fedora-minimal:32
+FROM fedora:32
 
 WORKDIR /var/submariner
 
 # iproute and iptables are used internally
 # libreswan or strongswan provide IKE
 # procps-ng is needed for sysctl
-RUN microdnf -y install --nodocs --setopt=install_weak_deps=0 \
-             iproute iptables libreswan strongswan procps-ng && \
-    microdnf -y clean all
+RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
+           iproute iptables libreswan strongswan procps-ng && \
+    dnf -y clean all
 
 COPY package/submariner.sh package/pluto bin/submariner-engine /usr/local/bin/
 


### PR DESCRIPTION
... to avoid issues with the Fedora registry. Given that the libreswan
package pulls in Python, the practical differences between the minimal
and main images aren’t significant for us anyway.

Signed-off-by: Stephen Kitt <skitt@redhat.com>