### PR TITLE
Exec pluto

### DIFF
--- a/package/pluto
+++ b/package/pluto
@@ -11,4 +11,4 @@ set -e
 /usr/sbin/ipsec --checknflog
 
 # Start the daemon itself with any additional arguments passed in
-/usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork  "$@"
+exec /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork  "$@"


### PR DESCRIPTION
The pluto launcher should exec pluto to avoid leaving a shell process.

Signed-off-by: Stephen Kitt <skitt@redhat.com>