### PR TITLE
Preserve datapath when GlobalnetPod is restarted

### DIFF
--- a/pkg/cable/cleanup/route_cleanup_handler.go
+++ b/pkg/cable/cleanup/route_cleanup_handler.go
@@ -19,11 +19,15 @@ func (rt *RoutingTableCleanupHandler) GetName() string {
 	return "Routing table cleanup handler"
 }
 
-func (rt *RoutingTableCleanupHandler) GatewayToNonGatewayTransition() error {
+func (rt *RoutingTableCleanupHandler) NonGatewayCleanup() error {
 	tableStr := strconv.Itoa(rt.routingTable)
 	cmd := exec.Command("/sbin/ip", "r", "flush", "table", tableStr)
 	_ = cmd.Run()
 	// We can safely ignore run errors error, as this table
 	// won't exist in most nodes (only gateway nodes)
+	return nil
+}
+
+func (rt *RoutingTableCleanupHandler) GatewayToNonGatewayTransition() error {
 	return nil
 }

--- a/pkg/cable/cleanup/xfrm_cleanup_handler.go
+++ b/pkg/cable/cleanup/xfrm_cleanup_handler.go
@@ -21,7 +21,7 @@ func (xc *XFRMCleanupHandler) GetName() string {
 	return "XFRM cleanup handler"
 }
 
-func (xc *XFRMCleanupHandler) GatewayToNonGatewayTransition() error {
+func (xc *XFRMCleanupHandler) NonGatewayCleanup() error {
 	currentXfrmPolicyList, err := netlink.XfrmPolicyList(syscall.AF_INET)
 
 	if err != nil {
@@ -40,5 +40,9 @@ func (xc *XFRMCleanupHandler) GatewayToNonGatewayTransition() error {
 		}
 	}
 
+	return nil
+}
+
+func (xc *XFRMCleanupHandler) GatewayToNonGatewayTransition() error {
 	return nil
 }

--- a/pkg/globalnet/cleanup/gn_cleanup.go
+++ b/pkg/globalnet/cleanup/gn_cleanup.go
@@ -21,21 +21,21 @@ const (
 
 type GlobalnetStatus int
 
-func GlobalnetCleanupHandler(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) []cleanup.Handler {
+func GetGlobalnetCleanupHandlers(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) []cleanup.Handler {
 	return []cleanup.Handler{
-		NewGlobalnetCleanupHandler(clusterID, objectNamespace, submarinerClientSet),
+		newCleanupGlobalnetRules(clusterID, objectNamespace, submarinerClientSet),
 	}
 }
 
-type CleanupGlobalnetRules struct {
+type cleanupGlobalnetRules struct {
 	clusterID       string
 	objectNamespace string
 	clientSet       clientset.Interface
 	globalnetStatus GlobalnetStatus
 }
 
-func NewGlobalnetCleanupHandler(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) cleanup.Handler {
-	return &CleanupGlobalnetRules{
+func newCleanupGlobalnetRules(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) cleanup.Handler {
+	return &cleanupGlobalnetRules{
 		clusterID:       clusterID,
 		objectNamespace: objectNamespace,
 		clientSet:       submarinerClientSet,
@@ -43,15 +43,15 @@ func NewGlobalnetCleanupHandler(clusterID, objectNamespace string, submarinerCli
 	}
 }
 
-func (gn *CleanupGlobalnetRules) GetName() string {
-	return "Globalnet cleanup handler"
+func (gn *cleanupGlobalnetRules) GetName() string {
+	return "Globalnet rules cleanup handler"
 }
 
-func (gn *CleanupGlobalnetRules) NonGatewayCleanup() error {
+func (gn *cleanupGlobalnetRules) NonGatewayCleanup() error {
 	return nil
 }
 
-func (gn *CleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
+func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 	if gn.globalnetStatus == GN_Status_Not_Verified {
 		localCluster, err := gn.clientSet.SubmarinerV1().Clusters(gn.objectNamespace).Get(gn.clusterID, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/globalnet/cleanup/gn_cleanup.go
+++ b/pkg/globalnet/cleanup/gn_cleanup.go
@@ -1,0 +1,90 @@
+package cleanup
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
+
+	"k8s.io/klog"
+)
+
+const (
+	GN_Status_Not_Verified = iota
+	GN_Enabled
+	GN_Disabled
+)
+
+type GlobalnetStatus int
+
+func GlobalnetCleanupHandler(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) []cleanup.Handler {
+	return []cleanup.Handler{
+		NewGlobalnetCleanupHandler(clusterID, objectNamespace, submarinerClientSet),
+	}
+}
+
+type CleanupGlobalnetRules struct {
+	clusterID       string
+	objectNamespace string
+	clientSet       clientset.Interface
+	globalnetStatus GlobalnetStatus
+}
+
+func NewGlobalnetCleanupHandler(clusterID, objectNamespace string, submarinerClientSet clientset.Interface) cleanup.Handler {
+	return &CleanupGlobalnetRules{
+		clusterID:       clusterID,
+		objectNamespace: objectNamespace,
+		clientSet:       submarinerClientSet,
+		globalnetStatus: GN_Status_Not_Verified,
+	}
+}
+
+func (gn *CleanupGlobalnetRules) GetName() string {
+	return "Globalnet cleanup handler"
+}
+
+func (gn *CleanupGlobalnetRules) NonGatewayCleanup() error {
+	return nil
+}
+
+func (gn *CleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
+	if gn.globalnetStatus == GN_Status_Not_Verified {
+		localCluster, err := gn.clientSet.SubmarinerV1().Clusters(gn.objectNamespace).Get(gn.clusterID, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error while retrieving the local ClusterInfo: %v", err)
+		}
+
+		if len(localCluster.Spec.GlobalCIDR) > 0 {
+			gn.globalnetStatus = GN_Enabled
+		} else {
+			gn.globalnetStatus = GN_Disabled
+		}
+	}
+
+	if gn.globalnetStatus == GN_Enabled {
+		klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
+
+		ipt, err := iptables.New()
+		if err != nil {
+			return fmt.Errorf("error initializing iptables: %v", err)
+		}
+
+		if err = ipt.ClearChain("nat", constants.SmGlobalnetIngressChain); err != nil {
+			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetIngressChain, err)
+		}
+
+		if err = ipt.ClearChain("nat", constants.SmGlobalnetEgressChain); err != nil {
+			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetEgressChain, err)
+		}
+
+		if err = ipt.ClearChain("nat", constants.SmGlobalnetMarkChain); err != nil {
+			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetMarkChain, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -7,9 +7,6 @@ type Operation string
 const (
 	handlerResync          = time.Hour * 24
 	submarinerIpamGlobalIp = "submariner.io/globalIp"
-	submarinerIngress      = "SUBMARINER-GN-INGRESS"
-	submarinerEgress       = "SUBMARINER-GN-EGRESS"
-	submarinerMark         = "SUBMARINER-GN-MARK"
 
 	// Globalnet uses MARK target to mark traffic destined to remote clusters.
 	// Some of the CNIs also use iptable MARK targets in the pipeline. This should not

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -163,7 +163,6 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 
 			for _, endpoint := range endpoints.Items {
 				if endpoint.Spec.ClusterID != i.clusterID {
-					klog.Infof("Marking rules for remote endpoint %q", endpoint.Spec.ClusterID)
 					for _, remoteSubnet := range endpoint.Spec.Subnets {
 						MarkRemoteClusterTraffic(i.ipt, remoteSubnet, AddRules)
 					}

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -95,10 +95,7 @@ func (i *GatewayMonitor) Run(stopCh <-chan struct{}) error {
 
 	go wait.Until(i.runEndpointWorker, time.Second, stopCh)
 	<-stopCh
-	// TODO (revisit): This cleanup should ideally be handled in some other Pod just like
-	// how route-agent is cleaning up stale rules when there is a migration.
-	ClearGlobalNetChains(i.ipt)
-	klog.Info("Cleared GlobalNet rules, shutting down endpoint worker.")
+	klog.Info("Shutting down endpoint worker.")
 
 	return nil
 }
@@ -157,6 +154,21 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 			i.endpointWorkqueue.Forget(obj)
 
 			return nil
+		} else {
+			endpoints, err := i.submarinerClientSet.SubmarinerV1().Endpoints(ns).List(metav1.ListOptions{})
+			if err != nil {
+				i.endpointWorkqueue.Forget(obj)
+				return fmt.Errorf("error retrieving submariner endpoint list %v", err)
+			}
+
+			for _, endpoint := range endpoints.Items {
+				if endpoint.Spec.ClusterID != i.clusterID {
+					klog.Infof("Marking rules for remote endpoint %q", endpoint.Spec.ClusterID)
+					for _, remoteSubnet := range endpoint.Spec.Subnets {
+						MarkRemoteClusterTraffic(i.ipt, remoteSubnet, AddRules)
+					}
+				}
+			}
 		}
 
 		hostname, err := os.Hostname()

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -154,18 +154,18 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 			i.endpointWorkqueue.Forget(obj)
 
 			return nil
-		} else {
-			endpoints, err := i.submarinerClientSet.SubmarinerV1().Endpoints(ns).List(metav1.ListOptions{})
-			if err != nil {
-				i.endpointWorkqueue.Forget(obj)
-				return fmt.Errorf("error retrieving submariner endpoint list %v", err)
-			}
+		}
 
-			for _, endpoint := range endpoints.Items {
-				if endpoint.Spec.ClusterID != i.clusterID {
-					for _, remoteSubnet := range endpoint.Spec.Subnets {
-						MarkRemoteClusterTraffic(i.ipt, remoteSubnet, AddRules)
-					}
+		endpoints, err := i.submarinerClientSet.SubmarinerV1().Endpoints(ns).List(metav1.ListOptions{})
+		if err != nil {
+			i.endpointWorkqueue.Forget(obj)
+			return fmt.Errorf("error retrieving submariner endpoint list %v", err)
+		}
+
+		for _, endpoint := range endpoints.Items {
+			if endpoint.Spec.ClusterID != i.clusterID {
+				for _, remoteSubnet := range endpoint.Spec.Subnets {
+					MarkRemoteClusterTraffic(i.ipt, remoteSubnet, AddRules)
 				}
 			}
 		}

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -9,36 +9,37 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
 	"github.com/submariner-io/submariner/pkg/util"
 )
 
 func (i *Controller) initIPTableChains() error {
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", route.SmGlobalnetIngressChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetIngressChain)
 
-	if err := util.CreateChainIfNotExists(i.ipt, "nat", route.SmGlobalnetIngressChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", route.SmGlobalnetIngressChain, err)
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetIngressChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetIngressChain, err)
 	}
 
-	forwardToSubGlobalNetChain := []string{"-j", route.SmGlobalnetIngressChain}
+	forwardToSubGlobalNetChain := []string{"-j", constants.SmGlobalnetIngressChain}
 	if err := util.PrependUnique(i.ipt, "nat", "PREROUTING", forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error appending iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", route.SmGlobalnetEgressChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChain)
 
-	if err := util.CreateChainIfNotExists(i.ipt, "nat", route.SmGlobalnetEgressChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", route.SmGlobalnetEgressChain, err)
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChain, err)
 	}
 
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", route.SmPostRoutingChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
 
-	if err := util.CreateChainIfNotExists(i.ipt, "nat", route.SmPostRoutingChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", route.SmPostRoutingChain, err)
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmPostRoutingChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmPostRoutingChain, err)
 	}
 
-	forwardToSubGlobalNetChain = []string{"-j", route.SmGlobalnetEgressChain}
-	if err := util.PrependUnique(i.ipt, "nat", route.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChain}
+	if err := util.PrependUnique(i.ipt, "nat", constants.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
@@ -46,8 +47,8 @@ func (i *Controller) initIPTableChains() error {
 		return err
 	}
 
-	forwardToSubGlobalNetChain = []string{"-j", route.SmGlobalnetMarkChain}
-	if err := util.PrependUnique(i.ipt, "nat", route.SmGlobalnetEgressChain, forwardToSubGlobalNetChain); err != nil {
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetMarkChain}
+	if err := util.PrependUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
@@ -135,10 +136,10 @@ func (i *Controller) evaluateNode(node *k8sv1.Node) Operation {
 }
 
 func CreateGlobalNetMarkingChain(ipt *iptables.IPTables) error {
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", route.SmGlobalnetMarkChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetMarkChain)
 
-	if err := util.CreateChainIfNotExists(ipt, "nat", route.SmGlobalnetMarkChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", route.SmGlobalnetMarkChain, err)
+	if err := util.CreateChainIfNotExists(ipt, "nat", constants.SmGlobalnetMarkChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetMarkChain, err)
 	}
 
 	return nil

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -7,6 +7,8 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
 	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
 )
 
 func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, globalIP string, addRules bool) error {
@@ -15,12 +17,12 @@ func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, global
 	if addRules {
 		klog.V(log.DEBUG).Infof("Installing iptable egress rules for %s: %s", resourceName, strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.AppendUnique("nat", submarinerEgress, ruleSpec...); err != nil {
+		if err := i.ipt.AppendUnique("nat", route.SmGlobalnetEgressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting iptable egress rules for %s : %s", resourceName, strings.Join(ruleSpec, " "))
-		if err := i.ipt.Delete("nat", submarinerEgress, ruleSpec...); err != nil {
+		if err := i.ipt.Delete("nat", route.SmGlobalnetEgressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}
@@ -34,12 +36,12 @@ func MarkRemoteClusterTraffic(ipt *iptables.IPTables, remoteCidr string, addRule
 	if addRules {
 		klog.V(log.DEBUG).Infof("Marking traffic destined to remote cluster: %s", strings.Join(ruleSpec, " "))
 
-		if err := ipt.AppendUnique("nat", submarinerMark, ruleSpec...); err != nil {
+		if err := ipt.AppendUnique("nat", route.SmGlobalnetMarkChain, ruleSpec...); err != nil {
 			klog.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting rule that marks remote cluster traffic: %s", strings.Join(ruleSpec, " "))
-		if err := ipt.Delete("nat", submarinerMark, ruleSpec...); err != nil {
+		if err := ipt.Delete("nat", route.SmGlobalnetMarkChain, ruleSpec...); err != nil {
 			klog.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -8,7 +8,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
 )
 
 func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, globalIP string, addRules bool) error {
@@ -17,12 +17,12 @@ func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, global
 	if addRules {
 		klog.V(log.DEBUG).Infof("Installing iptable egress rules for %s: %s", resourceName, strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.AppendUnique("nat", route.SmGlobalnetEgressChain, ruleSpec...); err != nil {
+		if err := i.ipt.AppendUnique("nat", constants.SmGlobalnetEgressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting iptable egress rules for %s : %s", resourceName, strings.Join(ruleSpec, " "))
-		if err := i.ipt.Delete("nat", route.SmGlobalnetEgressChain, ruleSpec...); err != nil {
+		if err := i.ipt.Delete("nat", constants.SmGlobalnetEgressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}
@@ -36,12 +36,12 @@ func MarkRemoteClusterTraffic(ipt *iptables.IPTables, remoteCidr string, addRule
 	if addRules {
 		klog.V(log.DEBUG).Infof("Marking traffic destined to remote cluster: %s", strings.Join(ruleSpec, " "))
 
-		if err := ipt.AppendUnique("nat", route.SmGlobalnetMarkChain, ruleSpec...); err != nil {
+		if err := ipt.AppendUnique("nat", constants.SmGlobalnetMarkChain, ruleSpec...); err != nil {
 			klog.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting rule that marks remote cluster traffic: %s", strings.Join(ruleSpec, " "))
-		if err := ipt.Delete("nat", route.SmGlobalnetMarkChain, ruleSpec...); err != nil {
+		if err := ipt.Delete("nat", constants.SmGlobalnetMarkChain, ruleSpec...); err != nil {
 			klog.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -10,7 +10,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
 )
 
 func (i *Controller) updateIngressRulesForService(globalIP, chainName string, addRules bool) error {
@@ -19,13 +19,13 @@ func (i *Controller) updateIngressRulesForService(globalIP, chainName string, ad
 	if addRules {
 		klog.V(log.DEBUG).Infof("Installing iptables rule for Service %s", strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.AppendUnique("nat", route.SmGlobalnetIngressChain, ruleSpec...); err != nil {
+		if err := i.ipt.AppendUnique("nat", constants.SmGlobalnetIngressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting iptable ingress rule for Service: %s", strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.Delete("nat", route.SmGlobalnetIngressChain, ruleSpec...); err != nil {
+		if err := i.ipt.Delete("nat", constants.SmGlobalnetIngressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -9,6 +9,8 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
 )
 
 func (i *Controller) updateIngressRulesForService(globalIP, chainName string, addRules bool) error {
@@ -17,13 +19,13 @@ func (i *Controller) updateIngressRulesForService(globalIP, chainName string, ad
 	if addRules {
 		klog.V(log.DEBUG).Infof("Installing iptables rule for Service %s", strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.AppendUnique("nat", submarinerIngress, ruleSpec...); err != nil {
+		if err := i.ipt.AppendUnique("nat", route.SmGlobalnetIngressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	} else {
 		klog.V(log.DEBUG).Infof("Deleting iptable ingress rule for Service: %s", strings.Join(ruleSpec, " "))
 
-		if err := i.ipt.Delete("nat", submarinerIngress, ruleSpec...); err != nil {
+		if err := i.ipt.Delete("nat", route.SmGlobalnetIngressChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -113,7 +113,6 @@ func (i *Controller) Run(stopCh <-chan struct{}) error {
 	go wait.Until(i.runNodeWorker, time.Second, stopCh)
 	<-stopCh
 	klog.Info("Shutting down workers")
-	i.cleanupIPTableRules()
 
 	return nil
 }

--- a/pkg/routeagent/cleanup/cleanup.go
+++ b/pkg/routeagent/cleanup/cleanup.go
@@ -3,4 +3,5 @@ package cleanup
 type Handler interface {
 	GetName() string
 	GatewayToNonGatewayTransition() error
+	NonGatewayCleanup() error
 }

--- a/pkg/routeagent/constants/constants.go
+++ b/pkg/routeagent/constants/constants.go
@@ -1,7 +1,6 @@
-package route
+package constants
 
 const (
-	// IPTable chains used by Globalnet Controller
 	SmGlobalnetIngressChain = "SUBMARINER-GN-INGRESS"
 	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
 	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"

--- a/pkg/routeagent/controllers/route/cleanup_handling.go
+++ b/pkg/routeagent/controllers/route/cleanup_handling.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+
 	"k8s.io/klog"
 )
 
@@ -9,11 +10,23 @@ func (r *Controller) installCleanupHandlers(handlers []cleanup.Handler) {
 	r.cleanupHandlers = append(r.cleanupHandlers, handlers...)
 }
 
-func (r *Controller) gatewayToNonGatewayTransitionCleanups() {
+func (r *Controller) nonGatewayCleanups() {
 	for _, handler := range r.cleanupHandlers {
-		if err := handler.GatewayToNonGatewayTransition(); err != nil {
-			klog.Errorf("Error handling GatewayToNonGateway cleanup in %q, %s",
+		if err := handler.NonGatewayCleanup(); err != nil {
+			klog.Errorf("Error handling NonGatewayCleanup in %q, %s",
 				handler.GetName(), err)
+		}
+	}
+}
+
+func (r *Controller) gatewayToNonGatewayTransitionCleanups() {
+	if r.wasGatewayPreviously {
+		r.wasGatewayPreviously = false
+		for _, handler := range r.cleanupHandlers {
+			if err := handler.GatewayToNonGatewayTransition(); err != nil {
+				klog.Errorf("Error handling GatewayToNonGateway cleanup in %q, %s",
+					handler.GetName(), err)
+			}
 		}
 	}
 }

--- a/pkg/routeagent/controllers/route/constants.go
+++ b/pkg/routeagent/controllers/route/constants.go
@@ -1,0 +1,11 @@
+package route
+
+const (
+	// IPTable chains used by Globalnet Controller
+	SmGlobalnetIngressChain = "SUBMARINER-GN-INGRESS"
+	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
+	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
+
+	// IPTable chains used by RouteAgent
+	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
+)

--- a/pkg/routeagent/controllers/route/iptables.go
+++ b/pkg/routeagent/controllers/route/iptables.go
@@ -104,7 +104,7 @@ func (r *Controller) clearGlobalnetChains() error {
 			return fmt.Errorf("error while retrieving the local ClusterInfo: %v", err)
 		}
 
-		if localCluster.Spec.GlobalCIDR != nil && len(localCluster.Spec.GlobalCIDR) > 0 {
+		if len(localCluster.Spec.GlobalCIDR) > 0 {
 			r.globalnetStatus = GN_Enabled
 		} else {
 			r.globalnetStatus = GN_Disabled

--- a/pkg/routeagent/controllers/route/iptables.go
+++ b/pkg/routeagent/controllers/route/iptables.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/submariner/pkg/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 func (r *Controller) createIPTableChains() error {
@@ -18,14 +19,14 @@ func (r *Controller) createIPTableChains() error {
 		return fmt.Errorf("error initializing iptables: %v", err)
 	}
 
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", SmPostRoutingChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
 
-	if err = util.CreateChainIfNotExists(ipt, "nat", SmPostRoutingChain); err != nil {
-		return fmt.Errorf("unable to create %s chain in iptables: %v", SmPostRoutingChain, err)
+	if err = util.CreateChainIfNotExists(ipt, "nat", constants.SmPostRoutingChain); err != nil {
+		return fmt.Errorf("unable to create %s chain in iptables: %v", constants.SmPostRoutingChain, err)
 	}
 
-	klog.V(log.DEBUG).Infof("Insert %s rule that has rules for inter-cluster traffic", SmPostRoutingChain)
-	forwardToSubPostroutingRuleSpec := []string{"-j", SmPostRoutingChain}
+	klog.V(log.DEBUG).Infof("Insert %s rule that has rules for inter-cluster traffic", constants.SmPostRoutingChain)
+	forwardToSubPostroutingRuleSpec := []string{"-j", constants.SmPostRoutingChain}
 	if err = util.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
 		return fmt.Errorf("unable to insert iptable rule in NAT table, POSTROUTING chain: %v", err)
 	}
@@ -63,7 +64,7 @@ func (r *Controller) createIPTableChains() error {
 		ruleSpec = []string{"-s", sourceAddress, "-o", VxLANIface, "-j", "SNAT", "--to", r.cniIface.ipAddress}
 		klog.V(log.DEBUG).Infof("Installing rule for host network to remote cluster communication: %s", strings.Join(ruleSpec, " "))
 
-		if err = ipt.AppendUnique("nat", SmPostRoutingChain, ruleSpec...); err != nil {
+		if err = ipt.AppendUnique("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule %q: %v\n", strings.Join(ruleSpec, " "), err)
 		}
 	}
@@ -81,7 +82,7 @@ func (r *Controller) programIptableRulesForInterClusterTraffic(remoteCidrBlock s
 		ruleSpec := []string{"-s", localClusterCidr, "-d", remoteCidrBlock, "-j", "ACCEPT"}
 		klog.V(log.DEBUG).Infof("Installing iptables rule for outgoing traffic: %s", strings.Join(ruleSpec, " "))
 
-		if err = ipt.AppendUnique("nat", SmPostRoutingChain, ruleSpec...); err != nil {
+		if err = ipt.AppendUnique("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
 
@@ -89,49 +90,9 @@ func (r *Controller) programIptableRulesForInterClusterTraffic(remoteCidrBlock s
 		ruleSpec = []string{"-s", remoteCidrBlock, "-d", localClusterCidr, "-j", "ACCEPT"}
 		klog.V(log.DEBUG).Infof("Installing iptables rule for incoming traffic: %s", strings.Join(ruleSpec, " "))
 
-		if err = ipt.AppendUnique("nat", SmPostRoutingChain, ruleSpec...); err != nil {
+		if err = ipt.AppendUnique("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
 			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
 		}
-	}
-
-	return nil
-}
-
-func (r *Controller) clearGlobalnetChains() error {
-	if r.globalnetStatus == GN_Status_Not_Verified {
-		localCluster, err := r.submarinerClientSet.SubmarinerV1().Clusters(r.objectNamespace).Get(r.clusterID, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error while retrieving the local ClusterInfo: %v", err)
-		}
-
-		if len(localCluster.Spec.GlobalCIDR) > 0 {
-			r.globalnetStatus = GN_Enabled
-		} else {
-			r.globalnetStatus = GN_Disabled
-		}
-	}
-
-	if r.globalnetStatus == GN_Enabled && r.wasGatewayPreviously {
-		ipt, err := iptables.New()
-		if err != nil {
-			return fmt.Errorf("error initializing iptables: %v", err)
-		}
-
-		klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
-
-		if err = ipt.ClearChain("nat", SmGlobalnetIngressChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", SmGlobalnetIngressChain, err)
-		}
-
-		if err = ipt.ClearChain("nat", SmGlobalnetEgressChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", SmGlobalnetEgressChain, err)
-		}
-
-		if err = ipt.ClearChain("nat", SmGlobalnetMarkChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", SmGlobalnetMarkChain, err)
-		}
-
-		r.wasGatewayPreviously = false
 	}
 
 	return nil

--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -167,7 +167,7 @@ func NewController(clusterID string, clusterCidr, serviceCidr []string, objectNa
 
 	// For now we get all the cleanups
 	controller.installCleanupHandlers(cableCleanup.GetCleanupHandlers())
-	controller.installCleanupHandlers(globalnetCleanup.GlobalnetCleanupHandler(clusterID, objectNamespace, config.SubmarinerClientSet))
+	controller.installCleanupHandlers(globalnetCleanup.GetGlobalnetCleanupHandlers(clusterID, objectNamespace, config.SubmarinerClientSet))
 
 	config.EndpointInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueEndpoint,


### PR DESCRIPTION
In the current implementation of Globalnet, when the Globalnet Pod
is restarted, the datapath goes down as Globalnet controller flushes
the IPTable chains that support inter-cluster connectivity.

In this PR we move the cleanup to RouteAgent Pod which does the cleanup
(aka flushing of iptable chains) when there is a Gateway migration.

This PR also moves the IPTable Chain names to routeAgent code to avoid
cyclic dependency and to have all the chain names at a single place.

Fixes Issue: https://github.com/submariner-io/submariner/issues/721

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>