### PR TITLE
Fixes double gateway entry removal

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,7 +204,6 @@ func main() {
 
 	go startLeaderElection(leClient, recorder, becameLeader, lostLeader)
 	<-stopCh
-	cableEngineSyncer.CleanupGatewayEntry()
 	klog.Info("All controllers stopped or exited. Stopping main loop")
 }
 


### PR DESCRIPTION
The gateway synchronizer will handle the removal when the stopCh is closed.

The synchronizer removal happens here: https://github.com/submariner-io/submariner/blob/38ff81bf48a8d1709b60c2b3793646528585de31/pkg/cableengine/syncer/syncer.go#L45

Fixes-Issue: #765