### PR TITLE
Remove a possible race condition during  WireGuard driver initialization 

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,17 +157,13 @@ func main() {
 
 		submarinerInformerFactory.Start(stopCh)
 
+		if err = cableEngine.StartEngine(); err != nil {
+			klog.Fatalf("Error starting the cable engine: %v", err)
+		}
+
 		var wg sync.WaitGroup
 
-		wg.Add(3)
-
-		go func() {
-			defer wg.Done()
-
-			if err = cableEngine.StartEngine(); err != nil {
-				klog.Fatalf("Error starting the cable engine: %v", err)
-			}
-		}()
+		wg.Add(2)
 
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
check https://github.com/submariner-io/submariner-operator/issues/461#issuecomment-680021600