### PR TITLE
Fix route-agent error on Rancher cluster

### DIFF
--- a/pkg/routeagent/controllers/route/route.go
+++ b/pkg/routeagent/controllers/route/route.go
@@ -248,10 +248,10 @@ func (r *Controller) Run(stopCh <-chan struct{}) error {
 			r.populateRemoteVtepIps(pod.Status.PodIP)
 		}
 
-		// On some platforms (like AWS), it was seen that nodeName is configured as FQDN
-		podNodeName := strings.Split(pod.Spec.NodeName, ".")
-		// Similarly, hostnames on some platforms are configured in FQDN
-		if hostname == pod.Spec.NodeName || hostname == podNodeName[0] {
+		// On some platforms, it was seen that nodeNames/hostnames are configured as FQDN.
+		podNodeNameWithoutFQDN := strings.Split(pod.Spec.NodeName, ".")
+		hostnameWithoutFQDN := strings.Split(hostname, ".")
+		if podNodeNameWithoutFQDN[0] == hostnameWithoutFQDN[0] {
 			routeAgentNodeName = pod.Spec.NodeName
 		}
 	}


### PR DESCRIPTION
On Rancher cluster, it was observed that OS.Hostname was configured
as "node-01.example.com" whereas the corresponding nodeName was "node-01".
This was not handled in the code and was causing RouteAgent to fail.
This PR fixes it.

Fixes Issue: https://github.com/submariner-io/submariner/issues/736

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>