### PR TITLE
Merge the package owners, align entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,11 +3,10 @@
 /scripts/ 		@mkolesnik
 Makefile* 		@mkolesnik
 Dockerfile.dapper 	@mkolesnik
-package/* 		@mkolesnik
-/pkg/globalnet/* @sridhargaddam
-/pkg/routeagent/* @sridhargaddam
+/pkg/globalnet/*	@sridhargaddam
+/pkg/routeagent/*	@sridhargaddam
 /pkg/cable/strongswan/* @sridhargaddam
-go.mod @skitt
-go.sum @skitt
-/package/* @skitt
-/pkg/cable/libreswan/* @skitt
+go.mod			@skitt
+go.sum 			@skitt
+/package/* 		@mkolesnik @skitt
+/pkg/cable/libreswan/*	@skitt


### PR DESCRIPTION
package/* is associated with mkolesnik, /package/* with skitt, this
merges both entries so that shared ownership actually works.

Signed-off-by: Stephen Kitt <skitt@redhat.com>