### PR TITLE
Make CODEOWNERS additive before enabling admin enforcement

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,12 @@
-* @mangelajo @tpantelis @Oats87
-/.github/workflows/ 	@mkolesnik
-/scripts/ 		@mkolesnik
-Makefile* 		@mkolesnik
-Dockerfile.dapper 	@mkolesnik
-package/* 		@mkolesnik
-/pkg/globalnet/* @sridhargaddam
-/pkg/routeagent/* @sridhargaddam
-/pkg/cable/strongswan/* @sridhargaddam
-go.mod @skitt
-go.sum @skitt
-/package/* @skitt
-/pkg/cable/libreswan/* @skitt
+*				@mangelajo @tpantelis @Oats87
+/.github/workflows/		@mangelajo @tpantelis @Oats87 @mkolesnik
+/scripts/			@mangelajo @tpantelis @Oats87 @mkolesnik
+Makefile*			@mangelajo @tpantelis @Oats87 @mkolesnik
+Dockerfile.dapper		@mangelajo @tpantelis @Oats87 @mkolesnik
+/pkg/globalnet/*		@mangelajo @tpantelis @Oats87 @sridhargaddam
+/pkg/routeagent/*		@mangelajo @tpantelis @Oats87 @sridhargaddam
+/pkg/cable/strongswan/*		@mangelajo @tpantelis @Oats87 @sridhargaddam
+go.mod				@mangelajo @tpantelis @Oats87 @skitt
+go.sum				@mangelajo @tpantelis @Oats87 @skitt
+/package/*			@mangelajo @tpantelis @Oats87 @skitt @mkolesnik
+/pkg/cable/libreswan/*		@mangelajo @tpantelis @Oats87 @skitt


### PR DESCRIPTION
As discussed during the Submariner community meeting [1], we will
be enabling "enforcement on admin of CI and votes", but with CODEOWNERS
as they work on github (they are not additive, and every time you add a new line
the previous "codeowners" aren't anymore) will make some files depending
on a single person precluding others core contributors from merging patches
when necessary.

This was proposed as a solution during the meeting.

[1] https://docs.google.com/document/d/1qnZ2LpF_rXGfnYYPNTldQ4WbeEUxwnuQD-xTC6GbZdg/edit#heading=h.ek692hgyg1a4