### PR TITLE
Fail codegen "validation" if it caused a change

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run codegen
         run: make codegen
+      - name: Make sure there's no pending changes
+        run: git add -A && git diff --staged --exit-code
 
   dco:
     name: DCO in Commit Message(s)

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run codegen
         run: make codegen
-      - name: Make sure there's no pending changes
+      - name: Verify generated code matches committed code
         run: git add -A && git diff --staged --exit-code
 
   dco:


### PR DESCRIPTION
If the repo is dirty after running the validation, fail as it indicates
that the API changed and needs to ge updated.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>