### PR TITLE
Add a cleanup handling interface to route agent

### DIFF
--- a/pkg/cable/cleanup/default_cleanup.go
+++ b/pkg/cable/cleanup/default_cleanup.go
@@ -1,0 +1,17 @@
+package cleanup
+
+import (
+	"github.com/submariner-io/submariner/pkg/cable/strongswan"
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+)
+
+// TODO(mangelajo) This is a generic GetCleanupHandlers as a first step, on a later step
+//                 we should remove this and use the GetCleanupHandlers from the specific
+//                 cable driver(s) in use
+
+func GetCleanupHandlers() []cleanup.Handler {
+	return []cleanup.Handler{
+		NewRoutingTableCleanup(strongswan.DefaultRoutingTable),
+		NewXFRMCleanupHandler(),
+	}
+}

--- a/pkg/cable/cleanup/route_cleanup_handler.go
+++ b/pkg/cable/cleanup/route_cleanup_handler.go
@@ -1,0 +1,29 @@
+package cleanup
+
+import (
+	"os/exec"
+	"strconv"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+)
+
+type RoutingTableCleanupHandler struct {
+	routingTable int
+}
+
+func NewRoutingTableCleanup(routingTable int) cleanup.Handler {
+	return &RoutingTableCleanupHandler{routingTable: routingTable}
+}
+
+func (rt *RoutingTableCleanupHandler) GetName() string {
+	return "Routing table cleanup handler"
+}
+
+func (rt *RoutingTableCleanupHandler) GatewayToNonGatewayTransition() error {
+	tableStr := strconv.Itoa(rt.routingTable)
+	cmd := exec.Command("/sbin/ip", "r", "flush", "table", tableStr)
+	_ = cmd.Run()
+	// We can safely ignore run errors error, as this table
+	// won't exist in most nodes (only gateway nodes)
+	return nil
+}

--- a/pkg/cable/cleanup/xfrm_cleanup_handler.go
+++ b/pkg/cable/cleanup/xfrm_cleanup_handler.go
@@ -1,0 +1,44 @@
+package cleanup
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+)
+
+type XFRMCleanupHandler struct{}
+
+func NewXFRMCleanupHandler() cleanup.Handler {
+	return &XFRMCleanupHandler{}
+}
+
+func (xc *XFRMCleanupHandler) GetName() string {
+	return "XFRM cleanup handler"
+}
+
+func (xc *XFRMCleanupHandler) GatewayToNonGatewayTransition() error {
+	currentXfrmPolicyList, err := netlink.XfrmPolicyList(syscall.AF_INET)
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving current xfrm policies: %v", err)
+	}
+
+	if len(currentXfrmPolicyList) > 0 {
+		klog.Infof("Cleaning up %d XFRM policies", len(currentXfrmPolicyList))
+	}
+
+	for i := range currentXfrmPolicyList {
+		klog.V(log.DEBUG).Infof("Deleting XFRM policy %s", currentXfrmPolicyList[i])
+
+		if err = netlink.XfrmPolicyDel(&currentXfrmPolicyList[i]); err != nil {
+			return fmt.Errorf("Error Deleting XFRM policy %s: %v", currentXfrmPolicyList[i], err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cable/strongswan/strongswan.go
+++ b/pkg/cable/strongswan/strongswan.go
@@ -71,6 +71,8 @@ const defaultIKEPort = "500"
 const defaultNATTPort = "4500"
 const ipsecSpecEnvVarPrefix = "ce_ipsec"
 
+const DefaultRoutingTable = 220
+
 func NewStrongSwan(localEndpoint types.SubmarinerEndpoint, localCluster types.SubmarinerCluster) (cable.Driver, error) {
 	ipSecSpec := specification{}
 

--- a/pkg/routeagent/cleanup/cleanup.go
+++ b/pkg/routeagent/cleanup/cleanup.go
@@ -1,0 +1,6 @@
+package cleanup
+
+type Handler interface {
+	GetName() string
+	GatewayToNonGatewayTransition() error
+}

--- a/pkg/routeagent/controllers/route/cleanup_handling.go
+++ b/pkg/routeagent/controllers/route/cleanup_handling.go
@@ -1,0 +1,19 @@
+package route
+
+import (
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+	"k8s.io/klog"
+)
+
+func (r *Controller) installCleanupHandlers(handlers []cleanup.Handler) {
+	r.cleanupHandlers = append(r.cleanupHandlers, handlers...)
+}
+
+func (r *Controller) gatewayToNonGatewayTransitionCleanups() {
+	for _, handler := range r.cleanupHandlers {
+		if err := handler.GatewayToNonGatewayTransition(); err != nil {
+			klog.Errorf("Error handling GatewayToNonGateway cleanup in %q, %s",
+				handler.GetName(), err)
+		}
+	}
+}


### PR DESCRIPTION
This removes technical debt where specific knowledge
related to cable drivers was implemented in the route-agent.

Introduces an interface which can be exposed from multiple
places, for example can be used by [1] to improve the
separation of concerns in the code.

[1] https://github.com/submariner-io/submariner/pull/762

Co-authored-by: Sridhar Gaddam <sgaddam@redhat.com>