### PR TITLE
Split validate job into Go and MD jobs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Run gitlint
         run: make gitlint
 
+  golangci-lint:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@master
+      - name: Run golangci-lint
+        run: make golangci-lint
+
   markdown-link-check:
     name: Markdown Links (modified files)
     runs-on: ubuntu-latest
@@ -55,14 +64,14 @@ jobs:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
 
-  validate:
-    name: Go and Markdown
+  markdownlint:
+    name: Markdown
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@master
-      - name: Run golangci-lint
-        run: make validate
+      - name: Run markdownlint
+        run: make markdownlint
 
   yaml-lint:
     name: YAML


### PR DESCRIPTION
The current validate job arbitrarily groups MD and Go linting. Split
them into two different jobs for clarity.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>