### PR TITLE
Annotate to declare the Gateway print column

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -65,6 +65,7 @@ type EndpointList struct {
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:printcolumn:JSONPath=".status.haStatus",name="HA Status",description="High availability status of the Gateway",type="string"
 
 type Gateway struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
So that we can generate the Gateway CRD automatically, annotate the
Gateway type with the appropriate directive to generate the additional
printer column.

Signed-off-by: Stephen Kitt <skitt@redhat.com>