### PR TITLE
Use Shipyard-provided yamllint, not GHA

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -79,9 +79,5 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
-
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@v1
-        with:
-          file_or_dir: .
-          config_file: .yamllint.yml
+        run: make yamllint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
     enabled-tags:
       - diagnostic
       - opinionated
-      #- performance
+      # - performance
       - style
     disabled-checks:
       - ifElseChain


### PR DESCRIPTION
We now ship yamllint with Shipyard, so use that instead of a third-party
GitHub Action.

Also fix a YAML warning flagged by `make yamllint`.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>