### PR TITLE
Remove the cluster owned tag from submariner sg

### DIFF
--- a/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
+++ b/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
@@ -45,6 +45,5 @@ resource "aws_security_group" "submariner_gw_sg" {
 
   tags = merge(map(
     "Name", "${var.cluster_id}-submariner-gw-sg",
-    "kubernetes.io/cluster/${var.cluster_id}", "owned"
   ))
 }


### PR DESCRIPTION
We should not set the submariner security group as cluster-owned,
otherwise the LoadBalancer controller stops working, because that's
not supported.

```text
Warning  SyncLoadBalancerFailed  16s (x4 over 53s)  service-controller
         Error syncing load balancer: failed to ensure load balancer:
         Multiple tagged security groups found for instance i-03fcabdc39f37f25c;
         ensure only the k8s security group is tagged; the tagged groups were
         sg-06cf365995bf20f3f(majopela-cluster-a-09-b7ch5-submariner-gw-sg)
         sg-0c4abc1fcf12d5c3b(terraform-20200922090409222000000002)
```