### PR TITLE
Use v2 of GHA checkout action everywhere

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
             cable_driver: 'libreswan'
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Install WireGuard kernel module (only in WireGuard jobs)
         if: matrix.cable_driver == 'wireguard'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run codegen
         run: make codegen
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Run gitlint
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run golangci-lint
         run: make golangci-lint
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Run markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Run markdownlint
         run: make markdownlint
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Run yamllint
         uses: ibiqlik/action-yamllint@v1

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Run markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Reclaim free space
         run: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Create artifacts directory
         run: mkdir artifacts


### PR DESCRIPTION
Currently using a mix of v1 and master. Instead, use the latest
everywhere.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>