### PR TITLE
Change framework e2e test to allow testing with only 1 cluster

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,7 +46,7 @@ func beforeSuite() {
 
 func queryAndUpdateGlobalnetStatus() {
 	framework.TestContext.GlobalnetEnabled = false
-	clusters := SubmarinerClients[framework.ClusterB].SubmarinerV1().Clusters(framework.TestContext.SubmarinerNamespace)
+	clusters := SubmarinerClients[framework.ClusterA].SubmarinerV1().Clusters(framework.TestContext.SubmarinerNamespace)
 	framework.AwaitUntil("find clusters to figure out if Globalnet is enabled", func() (interface{}, error) {
 		clusters, err := clusters.List(metav1.ListOptions{})
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Needed to enable latency and throughput intra-cluster tests
https://github.com/submariner-io/submariner-operator/issues/706

Signed-off-by: Maayan Friedman <maafried@redhat.com>