### PR TITLE
AWS Terraform scripts: m5n.large and dedicated instance

### DIFF
--- a/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/machine-set-resources.tf
+++ b/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/machine-set-resources.tf
@@ -44,7 +44,6 @@ data "template_file" "machine_set_template" {
     rhos_ami_id          = data.aws_instance.worker_instance.ami
     submariner_sg_name   = aws_security_group.submariner_gw_sg.name
     public_subnet_name   = "${var.cluster_id}-public-${data.aws_subnet.target_public_subnet.availability_zone}"
-    worker_instance_type = data.aws_instance.worker_instance.instance_type
   }
 
   depends_on = [

--- a/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/templates/machine-set.yaml
+++ b/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/templates/machine-set.yaml
@@ -24,22 +24,20 @@ spec:
       metadata:
         labels:
           submariner.io/gateway: "true"
+      taints:
+        - effect: NoSchedule
+          key: node-role.submariner.io/gateway
       providerSpec:
         value:
           ami:
             id: ${rhos_ami_id}
           apiVersion: awsproviderconfig.openshift.io/v1beta1
-          blockDevices:
-            - ebs:
-                iops: 0
-                volumeSize: 120
-                volumeType: gp2
           credentialsSecret:
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
             id: ${cluster_id}-worker-profile
-          instanceType: ${worker_instance_type}
+          instanceType: m5n.large
           kind: AWSMachineProviderConfig
           placement:
             availabilityZone: ${az}


### PR DESCRIPTION
This commit makes use of our new support for taints making
the submariner gateway node dedicated to submariner, selecting
a network specific instance type which supports higher bandwidth
in Amazon EC2. We also remove an attached volume that it's not
necessary.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>