### PR TITLE
Handle external-ip changes on Gateway node

### DIFF
--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -108,12 +108,33 @@ func (i *engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 		return err
 	}
 
+	var connections *[]v1.Connection
+	if len(activeConnections) > 0 {
+		connections, err = i.driver.GetConnections()
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, active := range activeConnections {
 		klog.V(log.TRACE).Infof("Analyzing currently active connection %q", active)
 
 		if active == endpoint.Spec.CableName {
-			klog.V(log.DEBUG).Infof("Cable %q is already installed - not installing again", active)
-			return nil
+			activeEndpointInfo := i.getEndpointInfo(active, connections)
+			if activeEndpointInfo != nil {
+				// There could be scenarios where the cableName would be the same but the
+				// PublicIP of the active GatewayNode changes.
+				if activeEndpointInfo.PublicIP == endpoint.Spec.PublicIP {
+					klog.V(log.DEBUG).Infof("Cable %q is already installed - not installing again", active)
+					return nil
+				} else {
+					klog.V(log.DEBUG).Infof("Cable %q is already installed - but PublicIP changed", active)
+					err = i.driver.DisconnectFromEndpoint(endpoint)
+					if err != nil {
+						return err
+					}
+				}
+			}
 		}
 
 		if util.GetClusterIDFromCableName(active) == endpoint.Spec.ClusterID {
@@ -127,6 +148,16 @@ func (i *engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 	}
 
 	klog.Infof("Successfully installed Endpoint cable %q with remote IP %s", endpoint.Spec.CableName, remoteEndpointIP)
+
+	return nil
+}
+
+func (i *engine) getEndpointInfo(cableName string, connections *[]v1.Connection) *v1.EndpointSpec {
+	for _, conn := range *connections {
+		if conn.Endpoint.CableName == cableName {
+			return &conn.Endpoint
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
When Submariner is deployed in a Cluster with NAT disabled, the local endpoint
of the cluster includes the external-ip (aka public-ip) of the active gateway
node. The active gateway node of the cluster updates the endpoint info on the
Broker which is subsequently sync'ed by all the member clusters. The member
clusters then try to connect to the public-ip configured in the endpoint CRD
to setup IPsec tunnels. When the external-ip (or public-ip) of an endpoint
changes, tunnels should be reconfigured successfully with the new public-ip.
This is not happening in the current code and this PR fixes it.

Fixes Issue: https://github.com/submariner-io/submariner/issues/826

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
Co-authored-by: Aswin Surayanarayanan <asuryana@redhat.com>