### PR TITLE
Simplify/Refactor tunnel controller to use ResourceSyncer

### DIFF
--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -1,164 +1,88 @@
 package tunnel
 
 import (
-	"fmt"
-	"time"
-
+	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/syncer"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine"
-	submarinerInformers "github.com/submariner-io/submariner/pkg/client/informers/externalversions/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog"
 )
 
-type Controller struct {
-	ce                cableengine.Engine
-	informer          cache.SharedIndexInformer
-	endpointWorkqueue workqueue.RateLimitingInterface
+type controller struct {
+	engine cableengine.Engine
 }
 
-func NewController(ce cableengine.Engine, endpointInformer submarinerInformers.EndpointInformer) *Controller {
-	tunnelController := &Controller{
-		ce:                ce,
-		informer:          endpointInformer.Informer(),
-		endpointWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Endpoints"),
-	}
-
-	tunnelController.informer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
-		AddFunc: tunnelController.enqueueEndpoint,
-		UpdateFunc: func(old, new interface{}) {
-			tunnelController.enqueueEndpoint(new)
-		},
-		DeleteFunc: tunnelController.handleRemovedEndpoint,
-	}, 60*time.Second)
-
-	return tunnelController
-}
-
-func (t *Controller) Run(stopCh <-chan struct{}) error {
-	defer utilruntime.HandleCrash()
-
-	// Start the informer factories to begin populating the informer caches
+func StartController(engine cableengine.Engine, namespace string, client dynamic.Interface, restMapper meta.RESTMapper,
+	scheme *runtime.Scheme, stopCh <-chan struct{}) error {
 	klog.Info("Starting the tunnel controller")
 
-	// Wait for the caches to be synced before starting workers
-	klog.Info("Waiting for informer caches to sync")
+	c := &controller{engine: engine}
 
-	if ok := cache.WaitForCacheSync(stopCh, t.informer.HasSynced); !ok {
-		return fmt.Errorf("failed to wait for caches to sync")
+	endpointSyncer, err := syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
+		Name:            "Tunnel controller",
+		SourceClient:    client,
+		SourceNamespace: namespace,
+		Direction:       syncer.LocalToRemote,
+		RestMapper:      restMapper,
+		Federator:       federate.NewNoopFederator(),
+		ResourceType:    &v1.Endpoint{},
+		Transform:       c.processEndpoint,
+		Scheme:          scheme,
+	})
+	if err != nil {
+		return err
 	}
 
-	go wait.Until(t.runWorker, time.Second, stopCh)
-
-	klog.Info("Tunnel controller started")
-	<-stopCh
-	klog.Info("Tunnel controller stopping")
+	err = endpointSyncer.Start(stopCh)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func (t *Controller) runWorker() {
-	for t.processNextEndpoint() {
+func (c *controller) processEndpoint(obj runtime.Object, op syncer.Operation) (runtime.Object, bool) {
+	endpoint := obj.(*v1.Endpoint)
 
-	}
-}
-
-func (t *Controller) processNextEndpoint() bool {
-	key, shutdown := t.endpointWorkqueue.Get()
-	if shutdown {
-		return false
+	if op == syncer.Delete {
+		return nil, c.handleRemovedEndpoint(endpoint)
 	}
 
-	err := func() error {
-		defer t.endpointWorkqueue.Done(key)
-
-		obj, exists, err := t.informer.GetStore().GetByKey(key.(string))
-		if err != nil {
-			t.endpointWorkqueue.Forget(key)
-			return fmt.Errorf("error retrieving submariner Endpoint %q: %v", key, err)
-		}
-
-		if !exists {
-			klog.V(log.DEBUG).Infof("Tunnel controller processing - submariner Endpoint object not found for key %q", key)
-			t.endpointWorkqueue.Forget(key)
-
-			return nil
-		}
-
-		endpoint := obj.(*v1.Endpoint)
-
-		klog.V(log.DEBUG).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
-
-		myEndpoint := types.SubmarinerEndpoint{
-			Spec: endpoint.Spec,
-		}
-
-		err = t.ce.InstallCable(myEndpoint)
-		if err != nil {
-			t.endpointWorkqueue.AddRateLimited(key)
-			return fmt.Errorf("error installing cable for Endpoint %#v, %v", myEndpoint, err)
-		}
-
-		t.endpointWorkqueue.Forget(key)
-		klog.V(log.DEBUG).Infof("Tunnel controller successfully installed Endpoint cable %s in the engine", endpoint.Spec.CableName)
-
-		return nil
-	}()
-
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Tunnel controller failed to process submariner Endpoint with key %q: %v", key, err))
-	}
-
-	return true
-}
-
-func (t *Controller) enqueueEndpoint(obj interface{}) {
-	var key string
-	var err error
-	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-
-	klog.V(log.TRACE).Infof("Tunnel controller enqueueing Endpoint %v", obj)
-	t.endpointWorkqueue.AddRateLimited(key)
-}
-
-func (t *Controller) handleRemovedEndpoint(obj interface{}) {
-	var object *v1.Endpoint
-	var ok bool
-	if object, ok = obj.(*v1.Endpoint); !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Could not convert object %v to an Endpoint", obj))
-			return
-		}
-
-		object, ok = tombstone.Obj.(*v1.Endpoint)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Could not convert object tombstone %v to an Endpoint", tombstone.Obj))
-			return
-		}
-
-		klog.V(log.DEBUG).Infof("Tunnel controller recovered deleted Endpoint %q from tombstone", object.Name)
-	}
-
-	klog.V(log.DEBUG).Infof("Tunnel controller processing removed submariner Endpoint object: %#v", object)
+	klog.V(log.DEBUG).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
 
 	myEndpoint := types.SubmarinerEndpoint{
-		Spec: object.Spec,
+		Spec: endpoint.Spec,
 	}
 
-	if err := t.ce.RemoveCable(myEndpoint); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v",
-			myEndpoint, err))
-		return
+	err := c.engine.InstallCable(myEndpoint)
+	if err != nil {
+		klog.Errorf("error installing cable for Endpoint %#v, %v", myEndpoint, err)
+		return nil, true
 	}
 
-	klog.V(log.DEBUG).Infof("Tunnel controller successfully removed Endpoint cable %s from the engine", object.Spec.CableName)
+	klog.V(log.DEBUG).Infof("Tunnel controller successfully installed Endpoint cable %s in the engine", endpoint.Spec.CableName)
+
+	return nil, false
+}
+
+func (c *controller) handleRemovedEndpoint(endpoint *v1.Endpoint) bool {
+	klog.V(log.DEBUG).Infof("Tunnel controller processing removed submariner Endpoint object: %#v", endpoint)
+
+	myEndpoint := types.SubmarinerEndpoint{
+		Spec: endpoint.Spec,
+	}
+
+	if err := c.engine.RemoveCable(myEndpoint); err != nil {
+		klog.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v", myEndpoint, err)
+		return true
+	}
+
+	klog.V(log.DEBUG).Infof("Tunnel controller successfully removed Endpoint cable %s from the engine", endpoint.Spec.CableName)
+
+	return false
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -181,8 +181,8 @@ func (f *Framework) GatewayCleanup() {
 		ginkgo.By(fmt.Sprintf("Cleaning up any non-active gateways: %v", gatewayNames(passiveGateways)))
 
 		for _, nonActiveGw := range passiveGateways {
-			f.SetGatewayLabelOnNode(framework.ClusterA, nonActiveGw.Name, false)
-			f.AwaitGatewayRemoved(framework.ClusterA, nonActiveGw.Name)
+			f.SetGatewayLabelOnNode(framework.ClusterIndex(cluster), nonActiveGw.Name, false)
+			f.AwaitGatewayRemoved(framework.ClusterIndex(cluster), nonActiveGw.Name)
 		}
 	}
 }

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -60,6 +60,7 @@ func testEnginePodRestartScenario(f *subFramework.Framework) {
 
 	gatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, true)
 	Expect(gatewayNodes).To(HaveLen(1), fmt.Sprintf("Expected only one gateway node on %q", clusterAName))
+	By(fmt.Sprintf("Found gateway on node %q on %q", gatewayNodes[0].Name, clusterAName))
 
 	enginePod := f.AwaitSubmarinerEnginePod(framework.ClusterA)
 	By(fmt.Sprintf("Found submariner engine pod %q on %q", enginePod.Name, clusterAName))
@@ -68,7 +69,7 @@ func testEnginePodRestartScenario(f *subFramework.Framework) {
 
 	activeGateway := f.AwaitGatewayFullyConnected(framework.ClusterA, gatewayNodes[0].Name)
 
-	By(fmt.Sprintf("Deleting submariner engine pod and gateway entries %q", enginePod.Name))
+	By(fmt.Sprintf("Deleting submariner engine pod %q", enginePod.Name))
 	f.DeletePod(framework.ClusterA, enginePod.Name, framework.TestContext.SubmarinerNamespace)
 
 	newEnginePod := f.AwaitSubmarinerEnginePod(framework.ClusterA)


### PR DESCRIPTION
The tunnel controller doesn't actually sync a k8s resource but it does transform an Endpoint to a tunnel connection and thus can use the `ResourceSyncer` infrastructure to eliminate a lot of informer/event handler boilerplate.

Relatee to #375
