### PR TITLE
Don't run linting on tags

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,9 +3,6 @@ name: Linting
 
 on:
   pull_request:
-  push:
-    tags:
-      - 'v**'
 
 jobs:
   code-gen:


### PR DESCRIPTION
DCO checks fail on jobs triggered by tags.

It shouldn't be necessary to run linting on tags, as the code was
already gated by PR-triggered jobs.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>