### PR TITLE
Don't run unit or E2E tests on tags

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,6 @@ name: End to End Tests
 
 on:
   pull_request:
-  push:
-    tags:
-      - 'v**'
 
 jobs:
   e2e:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,9 +3,6 @@ name: Unit Tests
 
 on:
   pull_request:
-  push:
-    tags:
-      - 'v**'
 
 jobs:
   unit-testing:


### PR DESCRIPTION
Following up on the change to not run linting on tags, it doesn't seem
to make sense to run anything other than the release workflow on tags.

The assumption was these jobs would be clearly shown by the tags,
documenting for users which checks were successfully run against that
tag at the time. Looking at our tags and releases in more detail, that
doesn't seem to be the case. Each commit in the repo history shows the
job results, but that's it.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>