### PR TITLE
Download and keep the Terraform state inside the cluster directory

### DIFF
--- a/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
+++ b/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
@@ -64,6 +64,9 @@ if [[ -z "$REGION" ]]; then
   exit 4
 fi
 
+mkdir -p $OCP_INS_DIR/submariner_prep
+cd $OCP_INS_DIR/submariner_prep
+
 if [[ ! -d ocp-ipi-aws-prep ]]; then
   download_ocp_ipi_aws_tool
 fi


### PR DESCRIPTION
Otherwise configuring multiple clusters with prep_for_subm.sh as we explain
on the quickstarts [1] does not work, and the machineset yaml files
are overwritten.

[1] https://submariner.io/quickstart/openshift/service_discovery/

Fixes-Issue: #876

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>