### PR TITLE
Fix prep_for_subm.sh to not ignore local ocp-ipi-aws yamls

### DIFF
--- a/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
+++ b/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
@@ -64,15 +64,14 @@ if [[ -z "$REGION" ]]; then
   exit 4
 fi
 
-mkdir -p $OCP_INS_DIR/submariner_prep
-cd $OCP_INS_DIR/submariner_prep
+cd "$OCP_INS_DIR"
 
 if [[ ! -d ocp-ipi-aws-prep ]]; then
   download_ocp_ipi_aws_tool
 fi
 
-sed -i "s/\"cluster_id\"/\"$INFRA_ID\"/g" main.tf
-sed -i "s/\"aws_region\"/\"$REGION\"/g" main.tf
+sed -r "s/(cluster_id = ).*/\1\"$INFRA_ID\"/" -i main.tf
+sed -r "s/(aws_region = ).*/\1\"$REGION\"/" -i main.tf
 
 terraform init
 terraform apply "${TERRAFORM_ARGS[@]}"


### PR DESCRIPTION
Fix prep_for_subm.sh to not ignore local ocp-ipi-aws yamls
    
- Fix for #880
- Safer way to replace values of 'cluster_id' and 'aws_region' keys
- Change directory to $OCP_INS_DIR before downloading ocp-ipi-aws

Signed-off-by: Noam Manos <nmanos@redhat.com>