### PR TITLE
Call framework.By instead of ginkgo in e2e framework beforeSuite

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -35,7 +35,7 @@ func NewFramework(baseName string) *Framework {
 }
 
 func beforeSuite() {
-	ginkgo.By("Creating submariner clients")
+	framework.By("Creating submariner clients")
 
 	for _, restConfig := range framework.RestConfigs {
 		SubmarinerClients = append(SubmarinerClients, createSubmarinerClient(restConfig))


### PR DESCRIPTION
Related to: submariner-io/submariner-operator#748

This will enable using any By() method set in the framework
Usefull when running tests with verbose=false

Signed-off-by: Maayan Friedman <maafried@redhat.com>