### PR TITLE
Alert user the supported terraform version in prep_for_subm.sh

### DIFF
--- a/tools/openshift/ocp-ipi-aws/versions.tf
+++ b/tools/openshift/ocp-ipi-aws/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+    required_version = ">= 0.12, < 0.13"
+}

--- a/tools/openshift/ocp-ipi-aws/versions.tf
+++ b/tools/openshift/ocp-ipi-aws/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-    required_version = ">= 0.12, < 0.13"
+    required_version = ">= 0.12, <= 0.12.12"
 }


### PR DESCRIPTION
Currently, while preparing the AWS cluster for Submariner as
part of prep_for_subm.sh script, we only support terraform
version 12.x

In this PR, we display an appropriate error message if users
are trying to run the script with a different version of terraform.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>