### PR TITLE
Eventhandler registry

### DIFF
--- a/pkg/event/event_suite_test.go
+++ b/pkg/event/event_suite_test.go
@@ -1,0 +1,140 @@
+package event_test
+
+import (
+	"testing"
+
+	k8sV1 "k8s.io/api/core/v1"
+
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEventPackage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Event suite")
+}
+
+type TestEvent struct {
+	Name      string
+	Handler   string
+	Parameter interface{}
+}
+
+type TestHandler struct {
+	event.HandlerBase
+	Name          string
+	NetworkPlugin string
+	FailOnEvent   error
+	Events        chan TestEvent
+	Initialized   bool
+}
+
+var allTestEvents chan TestEvent = make(chan TestEvent, 1000)
+
+func cleanupTestEvents() {
+	allTestEvents = make(chan TestEvent, 1000)
+}
+
+func NewTestHandler(name, networkPlugin string) *TestHandler {
+	return &TestHandler{
+		Name:          name,
+		NetworkPlugin: networkPlugin,
+		Events:        make(chan TestEvent, 100),
+		Initialized:   false,
+	}
+}
+
+func (t *TestHandler) addEvent(eventName string, param interface{}) error {
+	if t.FailOnEvent == nil {
+		ev := TestEvent{
+			Name:      eventName,
+			Parameter: param,
+		}
+
+		t.Events <- ev
+
+		// On the global channel we also include the handler name
+		// so we can verify ordering
+		ev.Handler = t.Name
+		allTestEvents <- ev
+	}
+
+	return t.FailOnEvent
+}
+func (t *TestHandler) Init() error {
+	t.Initialized = true
+
+	return nil
+}
+
+func (t *TestHandler) GetName() string {
+	return t.Name
+}
+
+func (t *TestHandler) GetNetworkPlugin() string {
+	return t.NetworkPlugin
+}
+
+const evTransitionToNonGateway = "TransitionToNonGateway"
+const evTransitionToGateway = "TransitionToGateway"
+const evLocalEndpointCreated = "LocalEndpointCreated"
+const evLocalEndpointUpdated = "LocalEndpointUpdated"
+const evLocalEndpointRemoved = "LocalEndpointRemoved"
+const evRemoteEndpointCreated = "RemoteEndpointCreated"
+const evRemoteEndpointUpdated = "RemoteEndpointUpdated"
+const evRemoteEndpointRemoved = "RemoteEndpointRemoved"
+const evNodeCreated = "NodeCreated"
+const evNodeUpdated = "NodeUpdated"
+const evNodeRemoved = "NodeRemoved"
+const evStop = "Stop"
+
+func (t *TestHandler) Stop(uninstall bool) error {
+	return t.addEvent(evStop, uninstall)
+}
+
+func (t *TestHandler) TransitionToNonGateway() error {
+	return t.addEvent(evTransitionToNonGateway, nil)
+}
+
+func (t *TestHandler) TransitionToGateway() error {
+	return t.addEvent(evTransitionToGateway, nil)
+}
+
+func (t *TestHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evLocalEndpointCreated, endpoint)
+}
+
+func (t *TestHandler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evLocalEndpointUpdated, endpoint)
+}
+
+func (t *TestHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evLocalEndpointRemoved, endpoint)
+}
+
+func (t *TestHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evRemoteEndpointCreated, endpoint)
+}
+
+func (t *TestHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evRemoteEndpointUpdated, endpoint)
+}
+
+func (t *TestHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	return t.addEvent(evRemoteEndpointRemoved, endpoint)
+}
+
+func (t *TestHandler) NodeCreated(node *k8sV1.Node) error {
+	return t.addEvent(evNodeCreated, node)
+}
+
+func (t *TestHandler) NodeUpdated(node *k8sV1.Node) error {
+	return t.addEvent(evNodeUpdated, node)
+}
+
+func (t *TestHandler) NodeRemoved(node *k8sV1.Node) error {
+	return t.addEvent(evNodeRemoved, node)
+}

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -47,8 +47,8 @@ type Handler interface {
 	// RemoteEndpointRemoved is called when an endpoint associated with a remote cluster is removed
 	RemoteEndpointRemoved(endpoint *submV1.Endpoint) error
 
-	// NodeAdded indicates when a node has been added to the cluster
-	NodeAdded(node *k8sV1.Node) error
+	// NodeCreated indicates when a node has been added to the cluster
+	NodeCreated(node *k8sV1.Node) error
 
 	// NodeUpdated indicates when a node has been updated in the cluster
 	NodeUpdated(node *k8sV1.Node) error
@@ -101,7 +101,7 @@ func (ev *HandlerBase) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	return nil
 }
 
-func (ev *HandlerBase) NodeAdded(node *k8sV1.Node) error {
+func (ev *HandlerBase) NodeCreated(node *k8sV1.Node) error {
 	return nil
 }
 

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -13,6 +13,10 @@ type Handler struct {
 	event.HandlerBase
 }
 
+func NewHandler() event.Handler {
+	return &Handler{}
+}
+
 func (l *Handler) GetName() string {
 	return "logger"
 }
@@ -64,7 +68,7 @@ func (l *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	return nil
 }
 
-func (l *Handler) NodeAdded(node *k8sV1.Node) error {
+func (l *Handler) NodeCreated(node *k8sV1.Node) error {
 	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
 		node.Name, node.Status.Addresses)
 	return nil

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -1,0 +1,111 @@
+package event_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	k8sV1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/event/logger"
+)
+
+const npOVNKubernetes = "OVNKubernetes"
+const npGenericKubeproxyIptables = "GenericKubeproxyIptables"
+
+var _ = Describe("Event Registry", func() {
+	When("handlers with different network plugin are added to the registry", func() {
+		var (
+			ovn, generic, wildcard *TestHandler
+			registry               event.Registry
+		)
+
+		BeforeEach(func() {
+			registry = event.NewRegistry("test-registry", npGenericKubeproxyIptables)
+			ovn = NewTestHandler("handler-ovn", npOVNKubernetes)
+			generic = NewTestHandler("handler-kubeproxy", npGenericKubeproxyIptables)
+			wildcard = NewTestHandler("wildcard-handler", event.AnyNetworkPlugin)
+			err := registry.AddHandlers(logger.NewHandler(), ovn, generic, wildcard)
+			Expect(err).NotTo(HaveOccurred())
+			cleanupTestEvents()
+		})
+
+		It("should only initialize the handlers whose network plugin matches that of the registry", func() {
+			Expect(ovn.Initialized).To(BeFalse())
+			Expect(generic.Initialized).To(BeTrue())
+			Expect(wildcard.Initialized).To(BeTrue())
+		})
+
+		It("should only invoke handlers whose network plugin matches that of the registry", func() {
+			_ = registry.TransitionToGateway()
+			Expect(ovn.Events).ShouldNot(Receive())
+			Expect(generic.Events).Should(Receive())
+			Expect(wildcard.Events).Should(Receive())
+		})
+	})
+
+	When("handlers with the same network plugin are added to the registry", func() {
+		var (
+			handler1, handler2 *TestHandler
+			registry           event.Registry
+		)
+
+		BeforeEach(func() {
+			registry = event.NewRegistry("test-registry", npGenericKubeproxyIptables)
+			handler1 = NewTestHandler("handler1", npGenericKubeproxyIptables)
+			handler2 = NewTestHandler("handler2", npGenericKubeproxyIptables)
+			err := registry.AddHandlers(logger.NewHandler(), handler1, handler2)
+			Expect(err).NotTo(HaveOccurred())
+			cleanupTestEvents()
+		})
+
+		It("should initialize all the handlers", func() {
+			Expect(handler1.Initialized).To(BeTrue())
+			Expect(handler2.Initialized).To(BeTrue())
+		})
+
+		It("should invoke all handlers for all events", func() {
+			endpoint := &submV1.Endpoint{ObjectMeta: v1meta.ObjectMeta{Name: "endpoint1"}}
+			node := &k8sV1.Node{ObjectMeta: v1meta.ObjectMeta{Name: "node1"}}
+
+			events := map[TestEvent]func() error{
+				{Name: evStop, Parameter: false}:                     func() error { return registry.StopHandlers(false) },
+				{Name: evTransitionToGateway}:                        registry.TransitionToGateway,
+				{Name: evTransitionToNonGateway}:                     registry.TransitionToNonGateway,
+				{Name: evNodeCreated, Parameter: node}:               func() error { return registry.NodeCreated(node) },
+				{Name: evNodeUpdated, Parameter: node}:               func() error { return registry.NodeUpdated(node) },
+				{Name: evNodeRemoved, Parameter: node}:               func() error { return registry.NodeRemoved(node) },
+				{Name: evLocalEndpointCreated, Parameter: endpoint}:  func() error { return registry.LocalEndpointCreated(endpoint) },
+				{Name: evLocalEndpointUpdated, Parameter: endpoint}:  func() error { return registry.LocalEndpointUpdated(endpoint) },
+				{Name: evLocalEndpointRemoved, Parameter: endpoint}:  func() error { return registry.LocalEndpointRemoved(endpoint) },
+				{Name: evRemoteEndpointCreated, Parameter: endpoint}: func() error { return registry.RemoteEndpointCreated(endpoint) },
+				{Name: evRemoteEndpointUpdated, Parameter: endpoint}: func() error { return registry.RemoteEndpointUpdated(endpoint) },
+				{Name: evRemoteEndpointRemoved, Parameter: endpoint}: func() error { return registry.RemoteEndpointRemoved(endpoint) },
+			}
+
+			for ev, f := range events {
+				err := f()
+				Expect(err).To(Succeed())
+				Expect(handler1.Events).Should(Receive(Equal(ev)))
+				Expect(handler2.Events).Should(Receive(Equal(ev)))
+
+				// Handlers should be handled invoked in order of registration
+				ev.Handler = handler1.Name
+				Expect(allTestEvents).Should(Receive(Equal(ev)))
+				ev.Handler = handler2.Name
+				Expect(allTestEvents).Should(Receive(Equal(ev)))
+			}
+		})
+
+		It("one handler returns error subsequent handlers should still execute", func() {
+			handler1.FailOnEvent = errors.New("I shall fail!")
+			err := registry.TransitionToGateway()
+			Expect(handler1.Events).ShouldNot(Receive())
+			Expect(handler2.Events).Should(Receive())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This registry will be used later by the networkplugin-syncer or the route-agent.
    
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
