### PR TITLE
Add CODE-OF-CONDUCT.md, point to website

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,1 @@
+Please see the [Code of Conduct docs on Submariner's website](https://submariner.io/contributing/code-of-conduct/).


### PR DESCRIPTION
It seems most CNCF projects provide a CODE-OF-CONDUCT.md file at the
root of their repositories, even if they have their Code of Conduct on
their website. To better fit into the CNCF ecosystem and be a more
welcoming project, follow that pattern.

Relates-to: #804
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>