### PR TITLE
Add CI for CODEOWNERS generation

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Run gen-codeowners to rebuild CODEOWNERS file
         run: make CODEOWNERS
       - name: Validate new CODEOWNERS file is the same as tracked by Git
-        run: git diff --exit-code
+        run: git diff --exit-code CODEOWNERS

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,0 +1,22 @@
+---
+name: CODEOWNERS
+
+on:
+  pull_request:
+    paths:
+      - 'CODEOWNERS'
+      - 'CODEOWNERS.in'
+
+jobs:
+  updated:
+    name: Up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Delete current CODEOWNERS file
+        run: rm CODEOWNERS
+      - name: Run gen-codeowners to rebuild CODEOWNERS file
+        run: make CODEOWNERS
+      - name: Validate new CODEOWNERS file is the same as tracked by Git
+        run: git diff --exit-code


### PR DESCRIPTION
Validate that changes to CODEOWNERS/CODEOWNERS.in are the same generated
by the gen-codeowners script.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>