### PR TITLE
Use single space vs tab alignment in CODEOWNERS.in

### DIFF
--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,6 +1,6 @@
-@mangelajo	*
-@Oats87		*
-@skitt		*
-@tpantelis	*
-@mkolesnik	/.github/workflows/ /scripts/ Makefile* Dockerfile.dapper /package/*
-@sridhargaddam	/pkg/globalnet/* /pkg/routeagent/* /pkg/cable/strongswan/*
+@mangelajo *
+@Oats87 *
+@skitt *
+@tpantelis *
+@mkolesnik /.github/workflows/ /scripts/ Makefile* Dockerfile.dapper /package/*
+@sridhargaddam /pkg/globalnet/* /pkg/routeagent/* /pkg/cable/strongswan/*


### PR DESCRIPTION
Trying to line up rows of files with a number of tabs varying by the
length of the code owner's GitHub username is difficult to maintain and
consistently achieve readable rendering.

Instead, use a single space after each code owner handle.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>