### PR TITLE
Wait for ClusterCRD in Globalnet during initialization

### DIFF
--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -50,17 +50,17 @@ func main() {
 
 	var localCluster *submarinerv1.Cluster
 	// During installation, sometimes creation of clusterCRD by submariner-gateway-pod would take few secs.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 100; i++ {
 		localCluster, err = submarinerClient.SubmarinerV1().Clusters(ipamSpec.Namespace).Get(ipamSpec.ClusterID, metav1.GetOptions{})
 		if err == nil {
 			break
 		}
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(3 * time.Second)
 	}
 
 	if err != nil {
-		klog.Fatalf("error while retrieving the local cluster %q info: %v", ipamSpec.ClusterID, err)
+		klog.Fatalf("error while retrieving the local cluster %q info even after waiting for 5 mins: %v", ipamSpec.ClusterID, err)
 	}
 
 	if localCluster.Spec.GlobalCIDR != nil && len(localCluster.Spec.GlobalCIDR) > 0 {


### PR DESCRIPTION
When Submariner is installed in a Cluster, the local ClusterCRD is
created by the submariner-gateway pod. While the submariner-gateway
pod is in the process of initializing itself if Globalnet pod tries
to read the ClusterCRD it will be missing. In this PR, we modify
Globalnet code to retry for 5 mins before giving up.

Fixes issue: https://github.com/submariner-io/submariner/issues/903

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>