### PR TITLE
Fix intermittent event controller test failures

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -119,23 +119,25 @@ func New(config *Config) (*Controller, error) {
 	return &ctl, nil
 }
 
-// Start will start the controller, and wait until stopCh receives a message
+// Start starts the controller.
 func (c *Controller) Start(stopCh <-chan struct{}) error {
-	klog.Info("Starting Controller")
+	klog.Info("Starting the Event controller...")
 
 	err := c.resourceWatcher.Start(stopCh)
 	if err != nil {
 		return err
 	}
 
-	klog.Info("Event Controller workers started")
-	<-stopCh
-	klog.Info("Event Controller stopping")
+	klog.Info("Event controller started")
+
+	return nil
+}
+
+func (c *Controller) Stop() {
+	klog.Info("Event controller stopping")
 
 	// TODO: Detect if it's an uninstall and invoke StopHandlers with uninstall=true if it's the case
 	if err := c.handlers.StopHandlers(false); err != nil {
 		klog.Warningf("In Event Controller, StopHandlers returned error: %v", err)
 	}
-
-	return nil
 }

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -45,6 +45,9 @@ func main() {
 		klog.Fatalf("Error starting controller: %v", err)
 	}
 
+	<-stopCh
+	ctl.Stop()
+
 	klog.Info("All controllers stopped or exited. Stopping submariner-networkplugin-syncer")
 }
 


### PR DESCRIPTION
A race condition with the `registry` field:

```
Write at 0x00c0003a3fa0 by goroutine 9:
  github.com/submariner-io/submariner/pkg/event/controller_test...
    /go/src/github.com/submariner-io/submariner/pkg/event/
       controller/controller_test.go:43


Previous read at 0x00c0003a3fa0 by goroutine 21:
  github.com/submariner-io/submariner/pkg/event.(*Registry).invokeHandlers()
      /go/src/github.com/submariner-io/submariner/pkg/event/registry.go:141
  github.com/submariner-io/submariner/pkg/event.(*Registry).StopHandlers()
      /go/src/github.com/submariner-io/submariner/pkg/event/registry.go:67
```

This is due to the test starting the controller in a Go routine but not waiting for it to complete. There's another intermittent failure related to fake client sets/informers that is also due to the async Start.

To fix both I changed `Start` to not wait on the stopCh. This also aligns with the semantics of Start vs Run.
