### PR TITLE
Reduce the logger event handler log footprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40
-	github.com/submariner-io/admiral v0.7.1-0.20201105164647-156433d6fe3e
+	github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf
 	github.com/submariner-io/shipyard v0.7.2
 	github.com/vishvananda/netlink v1.1.0
 	go.uber.org/zap v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ebay/go-ovn v0.1.0 h1:IxmpGJsp0SrsBrabCUCV1/xbQRNGUR5LeRbgkDcpIAs=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20200426045556-49ad98f6dac1 h1:TEmChtx8+IeOghiySC8kQIr0JZOdKUmRmmkuRDuYs3E=
 github.com/elazarl/goproxy v0.0.0-20200426045556-49ad98f6dac1/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
@@ -332,6 +333,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.7.1-0.20201105164647-156433d6fe3e h1:R26aMi94rSIkSpXBDvKPSfs6bwUbh1tFiw5CkFiB+z0=
 github.com/submariner-io/admiral v0.7.1-0.20201105164647-156433d6fe3e/go.mod h1:CB0bBubRoDoYYJTpjAww+VwloKfLRU4U0roevyXkrXk=
+github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf h1:GVvrpEx82lqv/gUV8vr8gVB6LUJKQqWJQ7isa7mz0Ec=
+github.com/submariner-io/admiral v0.7.1-0.20201113155402-50bbbbc388cf/go.mod h1:CB0bBubRoDoYYJTpjAww+VwloKfLRU4U0roevyXkrXk=
 github.com/submariner-io/shipyard v0.7.2 h1:jlg8AHfBkAqWKJXyby1VEBN1aCipDgwfCvBoWr5Qb6M=
 github.com/submariner-io/shipyard v0.7.2/go.mod h1:m4Qj1bHIgQBmp/CoPQOhsQDaQJvaF9YV3oyDLNfecRg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -36,35 +36,35 @@ func (l *Handler) TransitionToGateway() error {
 }
 
 func (l *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("A new Endpoint for the local cluster has been created: %#v", endpoint)
+	klog.V(log.DEBUG).Infof("A new Endpoint for the local cluster has been created: %#v", endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been updated: %#v", endpoint)
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been updated: %#v", endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been removed: %#v", endpoint)
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been removed: %#v", endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been created: %#v",
-		endpoint.Spec.ClusterID, endpoint)
+		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
-		endpoint.Spec.ClusterID, endpoint)
+		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
-		endpoint.Spec.ClusterID, endpoint)
+		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }
 


### PR DESCRIPTION
This becomes more useful by not printing the whole object blobs, we
just need small informative lines to understand that the events
are happening and when.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>