### PR TITLE
Change the statistics type from float64 to uint64

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -86,11 +86,11 @@ type GatewayStatus struct {
 // LatencySpec describes the round trip time information in miliseconds for a packet
 // between the gateway pods of two clusters.
 type LatencySpec struct {
-	LastRTT    float64 `json:"lastRTT"`
-	MinRTT     float64 `json:"minRTT"`
-	AverageRTT float64 `json:"averageRTT"`
-	MaxRTT     float64 `json:"maxRTT"`
-	StdDevRTT  float64 `json:"stddevRTT"`
+	LastRTT    *float64 `json:"lastRTT"`
+	MinRTT     *float64 `json:"minRTT"`
+	AverageRTT *float64 `json:"averageRTT"`
+	MaxRTT     *float64 `json:"maxRTT"`
+	StdDevRTT  *float64 `json:"stddevRTT"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -86,11 +86,11 @@ type GatewayStatus struct {
 // LatencySpec describes the round trip time information in miliseconds for a packet
 // between the gateway pods of two clusters.
 type LatencySpec struct {
-	LastRTT    *float64 `json:"lastRTT"`
-	MinRTT     *float64 `json:"minRTT"`
-	AverageRTT *float64 `json:"averageRTT"`
-	MaxRTT     *float64 `json:"maxRTT"`
-	StdDevRTT  *float64 `json:"stddevRTT"`
+	LastRTT    uint64 `json:"lastRTT"`
+	MinRTT     uint64 `json:"minRTT"`
+	AverageRTT uint64 `json:"averageRTT"`
+	MaxRTT     uint64 `json:"maxRTT"`
+	StdDevRTT  uint64 `json:"stddevRTT"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -83,7 +83,7 @@ type GatewayStatus struct {
 	Connections   []Connection `json:"connections"`
 }
 
-// LatencySpec describes the round trip time information in miliseconds for a packet
+// LatencySpec describes the round trip time information in nanoseconds for a packet
 // between the gateway pods of two clusters.
 type LatencySpec struct {
 	LastRTT    uint64 `json:"lastRTT"`


### PR DESCRIPTION
The code generator does not support float64 and hence updating
the API to use uint64

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>