### PR TITLE
Avoid deleting local endpoint when Engine pod is restarted

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, map[string]string{}, submSpec.NatEnabled,
+	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, nil, submSpec.NatEnabled,
 		localSubnets, util.GetLocalIP())
 
 	if err != nil {

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -116,11 +116,7 @@ func NewDriver(localEndpoint types.SubmarinerEndpoint, localCluster types.Submar
 
 	pub = priv.PublicKey()
 
-	if localEndpoint.Spec.BackendConfig == nil {
-		localEndpoint.Spec.BackendConfig = make(map[string]string)
-	}
-
-	localEndpoint.Spec.BackendConfig[PublicKey] = pub.String()
+	w.localEndpoint.Spec.BackendConfig[PublicKey] = pub.String()
 
 	// configure the device. still not up
 	port := w.spec.NATTPort

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -197,6 +197,23 @@ func testCompareEndpointSpec() {
 					BackendConfig: map[string]string{"key": "aaa"},
 				})).To(BeTrue())
 		})
+
+		It("should return true", func() {
+			Expect(util.CompareEndpointSpec(
+				subv1.EndpointSpec{
+					ClusterID:     "east",
+					CableName:     "submariner-cable-east-172-16-32-5",
+					Hostname:      "my-host",
+					Backend:       "strongswan",
+					BackendConfig: map[string]string{},
+				},
+				subv1.EndpointSpec{
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname:  "my-host",
+					Backend:   "strongswan",
+				})).To(BeTrue())
+		})
 	})
 
 	Context("with different cluster IDs", func() {


### PR DESCRIPTION
In datastoresyncer, ensureExclusiveEndpoint API when the local endpoints
are compared, they were not matching due to small mismatch in BackendConfig
and this was causing deletion of local endpoint followed by creation of
local endpoint.

Fixes issue: https://github.com/submariner-io/submariner/issues/960
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>