### PR TITLE
Extend the generic routeagent handler to the other drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ reload-images: build images
 bin/submariner-engine: vendor/modules.txt main.go $(shell find pkg -not \( -path 'pkg/globalnet*' -o -path 'pkg/routeagent*' \))
 	${SCRIPTS_DIR}/compile.sh $@ main.go $(BUILD_ARGS)
 
-bin/submariner-route-agent: vendor/modules.txt $(shell find pkg/routeagent)
-	${SCRIPTS_DIR}/compile.sh $@ ./pkg/routeagent/main.go $(BUILD_ARGS)
+bin/submariner-route-agent: vendor/modules.txt $(shell find pkg/routeagent-driver)
+	${SCRIPTS_DIR}/compile.sh $@ ./pkg/routeagent-driver/main.go $(BUILD_ARGS)
 
 bin/submariner-globalnet: vendor/modules.txt $(shell find pkg/globalnet)
 	${SCRIPTS_DIR}/compile.sh $@ ./pkg/globalnet/main.go $(BUILD_ARGS)

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -17,7 +17,7 @@ type Handler interface {
 	GetName() string
 
 	// GetNetworkPlugin returns the kubernetes network plugin that this handler supports.
-	GetNetworkPlugin() string
+	GetNetworkPlugins() []string
 
 	// Stop is called once during shutdown to let the handler perform any cleanup. The uninstall flag indicates
 	// whether or not Submariner is being completely uninstalled from the system.

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -21,8 +21,8 @@ func (l *Handler) GetName() string {
 	return "logger"
 }
 
-func (l *Handler) GetNetworkPlugin() string {
-	return event.AnyNetworkPlugin
+func (l *Handler) GetNetworkPlugins() []string {
+	return []string{event.AnyNetworkPlugin}
 }
 
 func (l *Handler) TransitionToNonGateway() error {

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 type Registry struct {
@@ -34,9 +35,13 @@ func (er *Registry) GetName() string {
 }
 
 func (er *Registry) addHandler(eventHandler Handler) error {
-	evNetworkPlugin := eventHandler.GetNetworkPlugin()
+	evNetworkPlugins := util.NewStringSet()
 
-	if evNetworkPlugin == AnyNetworkPlugin || evNetworkPlugin == er.networkPlugin {
+	for _, np := range eventHandler.GetNetworkPlugins() {
+		evNetworkPlugins.Add(np)
+	}
+
+	if evNetworkPlugins.Contains(AnyNetworkPlugin) || evNetworkPlugins.Contains(er.networkPlugin) {
 		if err := eventHandler.Init(); err != nil {
 			return errors.Wrapf(err, "Event handler %q failed to initialize", eventHandler.GetName())
 		}

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -52,8 +52,8 @@ func (t *TestHandler) GetName() string {
 	return t.Name
 }
 
-func (t *TestHandler) GetNetworkPlugin() string {
-	return t.NetworkPlugin
+func (t *TestHandler) GetNetworkPlugins() []string {
+	return []string{t.NetworkPlugin}
 }
 
 const EvTransitionToNonGateway = "TransitionToNonGateway"

--- a/pkg/globalnet/cleanup/gn_cleanup.go
+++ b/pkg/globalnet/cleanup/gn_cleanup.go
@@ -67,24 +67,28 @@ func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 
 	if gn.globalnetStatus == GN_Enabled {
 		klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
-
-		ipt, err := iptables.New()
-		if err != nil {
-			return fmt.Errorf("error initializing iptables: %v", err)
-		}
-
-		if err = ipt.ClearChain("nat", constants.SmGlobalnetIngressChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetIngressChain, err)
-		}
-
-		if err = ipt.ClearChain("nat", constants.SmGlobalnetEgressChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetEgressChain, err)
-		}
-
-		if err = ipt.ClearChain("nat", constants.SmGlobalnetMarkChain); err != nil {
-			klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetMarkChain, err)
-		}
+		ClearGlobalnetChains()
 	}
 
 	return nil
+}
+
+func ClearGlobalnetChains() {
+	ipt, err := iptables.New()
+	if err != nil {
+		klog.Errorf("error initializing iptables: %v", err)
+		return
+	}
+
+	if err = ipt.ClearChain("nat", constants.SmGlobalnetIngressChain); err != nil {
+		klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetIngressChain, err)
+	}
+
+	if err = ipt.ClearChain("nat", constants.SmGlobalnetEgressChain); err != nil {
+		klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetEgressChain, err)
+	}
+
+	if err = ipt.ClearChain("nat", constants.SmGlobalnetMarkChain); err != nil {
+		klog.Errorf("Error while flushing rules in %s chain: %v", constants.SmGlobalnetMarkChain, err)
+	}
 }

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
-	globalnetCleanup "github.com/submariner-io/submariner/pkg/globalnet/cleanup"
+
+	"github.com/submariner-io/submariner/pkg/globalnet/cleanup"
 	"github.com/submariner-io/submariner/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,8 +73,6 @@ func NewGatewayMonitor(spec *SubmarinerIpamControllerSpecification, cfg *rest.Co
 		DeleteFunc: gatewayMonitor.handleRemovedEndpoint,
 	}, handlerResync)
 
-	gatewayMonitor.cleanupHandlers = globalnetCleanup.GetGlobalnetCleanupHandlers(spec.ClusterID, spec.Namespace, submarinerClient)
-
 	submarinerInformerFactory.Start(stopCh)
 
 	return gatewayMonitor, nil
@@ -81,7 +80,7 @@ func NewGatewayMonitor(spec *SubmarinerIpamControllerSpecification, cfg *rest.Co
 
 func (i *GatewayMonitor) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
-	defer i.gatewayToNonGatewayTransitionCleanups()
+	defer cleanup.ClearGlobalnetChains()
 
 	klog.Info("Starting GatewayMonitor to monitor the active Gateway node in the cluster.")
 
@@ -302,13 +301,4 @@ func (i *GatewayMonitor) stopIpamController() {
 	}
 
 	klog.V(log.DEBUG).Infof("Notified ipamController to stop processing.")
-}
-
-func (i *GatewayMonitor) gatewayToNonGatewayTransitionCleanups() {
-	for _, handler := range i.cleanupHandlers {
-		if err := handler.GatewayToNonGatewayTransition(); err != nil {
-			klog.Errorf("Error handling GatewayToNonGateway cleanup in %q, %s",
-				handler.GetName(), err)
-		}
-	}
 }

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/globalnet/cleanup"
 	"github.com/submariner-io/submariner/pkg/routeagent/controllers/route"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -85,6 +86,7 @@ func NewController(spec *SubmarinerIpamControllerSpecification, config *Informer
 
 func (i *Controller) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
+	defer cleanup.ClearGlobalnetChains()
 
 	// Start the informer factories to begin populating the informer caches
 	klog.Info("Starting IPAM Controller")

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
-	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
 )
 
 type SubmarinerIpamControllerSpecification struct {
@@ -52,6 +51,5 @@ type GatewayMonitor struct {
 	ipt                 *iptables.IPTables
 	stopProcessing      chan struct{}
 	isGatewayNode       bool
-	cleanupHandlers     []cleanup.Handler
 	syncMutex           *sync.Mutex
 }

--- a/pkg/networkplugin-syncer/handlers/ovn/ovn.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn.go
@@ -14,6 +14,6 @@ func (ovn *SyncHandler) GetName() string {
 	return "ovn-sync-handler"
 }
 
-func (ovn *SyncHandler) GetNetworkPlugin() string {
-	return "OVNKubernetes"
+func (ovn *SyncHandler) GetNetworkPlugins() []string {
+	return []string{"OVNKubernetes"}
 }

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -26,7 +26,13 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	registry := event.NewRegistry("networkplugin-syncer", os.Getenv("NETWORK_PLUGIN"))
+	networkPlugin := os.Getenv("SUBMARINER_NETWORKPLUGIN")
+
+	if networkPlugin == "" {
+		networkPlugin = "generic"
+	}
+
+	registry := event.NewRegistry("networkplugin-syncer", networkPlugin)
 	if err := registry.AddHandlers(logger.NewHandler(), ovn.NewSyncHandler()); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}

--- a/pkg/routeagent-driver/cni_interface/cni_iface.go
+++ b/pkg/routeagent-driver/cni_interface/cni_iface.go
@@ -1,0 +1,67 @@
+package cni_interface
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+)
+
+type CniInterface struct {
+	Name      string
+	IPAddress string
+}
+
+func Discover(clusterCIDR string) (*CniInterface, error) {
+	_, clusterNetwork, err := net.ParseCIDR(clusterCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("unable to ParseCIDR %q : %v", clusterCIDR, err)
+	}
+
+	hostInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("net.Interfaces() returned error : %v", err)
+	}
+
+	for _, iface := range hostInterfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, fmt.Errorf("for interface %q, iface.Addrs returned error: %v", iface.Name, err)
+		}
+
+		for i := range addrs {
+			ipAddr, _, err := net.ParseCIDR(addrs[i].String())
+			if err != nil {
+				klog.Errorf("Unable to ParseCIDR : %q", addrs[i].String())
+			} else if ipAddr.To4() != nil {
+				klog.V(log.DEBUG).Infof("Interface %q has %q address", iface.Name, ipAddr)
+				address := net.ParseIP(ipAddr.String())
+
+				// Verify that interface has an address from cluster CIDR
+				if clusterNetwork.Contains(address) {
+					klog.V(log.DEBUG).Infof("Found CNI Interface %q that has IP %q from ClusterCIDR %q",
+						iface.Name, ipAddr.String(), clusterCIDR)
+					return &CniInterface{IPAddress: ipAddr.String(), Name: iface.Name}, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find CNI Interface on the host which has IP from %q", clusterCIDR)
+}
+
+func ConfigureRpFilter(iface string) error {
+	// We won't ever create rp_filter, and its permissions are 644
+	// #nosec G306
+	err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+iface+"/rp_filter", []byte("2"), 0644)
+	if err != nil {
+		return fmt.Errorf("unable to update rp_filter for cni_interface %q, err: %s", iface, err)
+	} else {
+		klog.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on cniInterface %q", iface)
+	}
+
+	return nil
+}

--- a/pkg/routeagent-driver/constants/constants.go
+++ b/pkg/routeagent-driver/constants/constants.go
@@ -1,0 +1,32 @@
+package constants
+
+const (
+	SmGlobalnetIngressChain = "SUBMARINER-GN-INGRESS"
+	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
+	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
+
+	// IPTable chains used by RouteAgent
+	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
+
+	// In order to support connectivity from HostNetwork to remoteCluster, route-agent tries
+	// to discover the CNIInterface[#] on the respective node and does SNAT of outgoing
+	// traffic from that node to the corresponding CNIInterfaceIP. It is to be noted that
+	// only traffic destined to the remoteClusters connected via Submariner is SNAT'ed and not
+	// any other traffic.
+	// At the same time, when Globalnet controller is deployed (i.e., clusters with overlapping
+	// Service/Cluster CIDRs) it needs this information so that it can map the CNIInterfaceIP
+	// with the corresponding globalIP assigned to the node. Since globalnet controller does
+	// not run on all the worker-nodes and there is no well defined mechanism to get the
+	// CNIInterfaceIP for each of the nodes, we annotate the node with CNIInterfaceIPInfo as
+	// part of route-agent and this will subsequently be used in globalnet controller for
+	// supporting connectivity from HostNetwork to remoteClusters.
+	// [#] interface on the node that has an IPAddress from the clusterCIDR
+	CniInterfaceIp = "submariner.io/cniIfaceIp"
+)
+
+type Specification struct {
+	ClusterID   string
+	Namespace   string
+	ClusterCidr []string
+	ServiceCidr []string
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/cleanup_handling.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/cleanup_handling.go
@@ -1,0 +1,38 @@
+package kp_iptables
+
+import (
+	"github.com/submariner-io/admiral/pkg/log"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+
+	"k8s.io/klog"
+)
+
+func (kp *SyncHandler) installCleanupHandlers(handlers []cleanup.Handler) {
+	kp.cleanupHandlers = append(kp.cleanupHandlers, handlers...)
+}
+
+func (kp *SyncHandler) nonGatewayCleanups() {
+	klog.V(log.DEBUG).Infof("Handling nonGatewayCleanups")
+
+	for _, handler := range kp.cleanupHandlers {
+		if err := handler.NonGatewayCleanup(); err != nil {
+			klog.Errorf("Error handling NonGatewayCleanup in %q, %s",
+				handler.GetName(), err)
+		}
+	}
+}
+
+func (kp *SyncHandler) gatewayToNonGatewayTransitionCleanups() {
+	klog.V(log.DEBUG).Infof("Handling gatewayToNonGatewayTransitionCleanups: wasGatewayPreviously %t ",
+		kp.wasGatewayPreviously)
+
+	if kp.wasGatewayPreviously {
+		kp.wasGatewayPreviously = false
+		for _, handler := range kp.cleanupHandlers {
+			if err := handler.GatewayToNonGatewayTransition(); err != nil {
+				klog.Errorf("Error handling GatewayToNonGateway cleanup in %q, %s", handler.GetName(), err)
+			}
+		}
+	}
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/constants.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/constants.go
@@ -53,7 +53,7 @@ const (
 type Operation int
 
 const (
-	AddRoute Operation = iota
-	DeleteRoute
-	FlushRouteTable
+	Add Operation = iota
+	Delete
+	Flush
 )

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/constants.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/constants.go
@@ -1,0 +1,59 @@
+package kp_iptables
+
+const (
+	VxLANIface         = "vx-submariner"
+	VxInterfaceWorker  = 0
+	VxInterfaceGateway = 1
+	VxLANPort          = 4800
+	VxLANOverhead      = 50
+
+	// Why VxLANVTepNetworkPrefix is 240?
+	// On VxLAN interfaces we need a unique IPAddress which does not collide with the
+	// host ip-address. This is going to be tricky as currently there is no specific
+	// CIDR in K8s that can be used for this purpose. One option is to take this as an
+	// input from the user (i.e., as a configuration parameter), but we want to avoid
+	// any additional inputs particularly if there is a way to automate it.
+
+	// So, the approach we are taking is to derive the VxLAN ip from the hostIPAddress
+	// as shown below.
+	// For example: Say, the host ipaddress is "192.168.1.100/16", we prepend 240 to the
+	// host-ip address, derive the vxlan vtepIP (i.e., 240.168.1.100/8) and configure it
+	// on the VxLAN interface.
+
+	// The reason behind choosing 240 is that "240.0.0.0/4" is a Reserved IPAddress [*]
+	// which normally will not be assigned on any of the hosts. Also, note that the VxLAN
+	// IPs are only used within the local cluster and traffic will not leave the cluster
+	// with the VxLAN ipaddress.
+	// [*] https://en.wikipedia.org/wiki/Reserved_IP_addresses
+
+	VxLANVTepNetworkPrefix = 240
+	SmRouteAgentFilter     = "app=submariner-routeagent"
+
+	// In order to support connectivity from HostNetwork to remoteCluster, route-agent tries
+	// to discover the CNIInterface[#] on the respective node and does SNAT of outgoing
+	// traffic from that node to the corresponding CNIInterfaceIP. It is to be noted that
+	// only traffic destined to the remoteClusters connected via Submariner is SNAT'ed and not
+	// any other traffic.
+	// At the same time, when Globalnet controller is deployed (i.e., clusters with overlapping
+	// Service/Cluster CIDRs) it needs this information so that it can map the CNIInterfaceIP
+	// with the corresponding globalIP assigned to the node. Since globalnet controller does
+	// not run on all the worker-nodes and there is no well defined mechanism to get the
+	// CNIInterfaceIP for each of the nodes, we annotate the node with CNIInterfaceIPInfo as
+	// part of route-agent and this will subsequently be used in globalnet controller for
+	// supporting connectivity from HostNetwork to remoteClusters.
+	// [#] interface on the node that has an IPAddress from the clusterCIDR
+	CniInterfaceIp = "submariner.io/cniIfaceIp"
+
+	// To support connectivity for Pods with HostNetworking on the GatewayNode, we program
+	// certain routing rules in table 150. As part of these routes, we set the source-ip of
+	// the egress traffic to the corresponding CNIInterfaceIP on that host.
+	RouteAgentHostNetworkTableID = 150
+)
+
+type Operation int
+
+const (
+	AddRoute Operation = iota
+	DeleteRoute
+	FlushRouteTable
+)

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
@@ -2,6 +2,7 @@ package kp_iptables
 
 import (
 	"fmt"
+	"net"
 
 	"k8s.io/klog"
 
@@ -10,7 +11,31 @@ import (
 )
 
 func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	kp.syncHandlerMutex.Lock()
+	defer kp.syncHandlerMutex.Unlock()
 	kp.localCableDriver = endpoint.Spec.Backend
+
+	// We are on nonGateway node
+	if endpoint.Spec.Hostname != kp.hostname {
+		kp.isGatewayNode = false
+		localClusterGwNodeIP := net.ParseIP(endpoint.Spec.PrivateIP)
+		remoteVtepIP, err := kp.getVxlanVtepIPAddress(localClusterGwNodeIP.String())
+		if err != nil {
+			return fmt.Errorf("failed to derive the remoteVtepIP %v", err)
+		}
+
+		klog.Infof("Creating the vxlan interface %s with gateway node IP %s", VxLANIface, localClusterGwNodeIP)
+		err = kp.createVxLANInterface(VxInterfaceWorker, localClusterGwNodeIP)
+		if err != nil {
+			klog.Fatalf("Unable to create VxLAN interface on non-GatewayNode (%s): %v", endpoint.Spec.Hostname, err)
+		}
+
+		kp.vxlanGwIP = &remoteVtepIP
+		err = kp.reconcileRoutes(remoteVtepIP)
+		if err != nil {
+			return fmt.Errorf("error while reconciling routes %v", err)
+		}
+	}
 
 	return nil
 }
@@ -22,12 +47,16 @@ func (kp *SyncHandler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
 func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
-	// Add routes to the new endpoint on the GatewayNode.
-	if kp.isGatewayNode {
-		kp.updateRoutingRulesForHostNetworkSupport(nil, FlushRouteTable)
-	}
-
 	kp.isGatewayNode = false
+
+	if kp.vxlanDevice != nil {
+		err := kp.vxlanDevice.deleteVxLanIface()
+		kp.vxlanDevice = nil
+		kp.vxlanGwIP = nil
+		if err != nil {
+			return fmt.Errorf("Failed to delete the the vxlan interface on Endpoint removal: %v", err)
+		}
+	}
 
 	return nil
 }
@@ -38,28 +67,46 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 		return err
 	}
 
-	kp.updateIptableRulesForInterclusterTraffic(endpoint.Spec.Subnets)
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
+	for _, inputCidrBlock := range endpoint.Spec.Subnets {
+		if !kp.remoteSubnets.Contains(inputCidrBlock) {
+			kp.remoteSubnets.Add(inputCidrBlock)
+		}
+	}
+
+	if err := kp.updateRoutingRulesForInterClusterSupport(endpoint.Spec.Subnets, Add); err != nil {
+		klog.Errorf("updateRoutingRulesForInterClusterSupport returned error: %+v", err)
+		return err
+	}
 	// Add routes to the new endpoint on the GatewayNode.
-	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, AddRoute)
+	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Add)
+	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Add)
 
 	return nil
 }
 
 func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
-	if err := kp.overlappingSubnets(endpoint.Spec.Subnets); err != nil {
-		// Skip processing the endpoint when CIDRs overlap
-		return err
-	}
-
 	return nil
 }
 
 func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
-	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, DeleteRoute)
+	for _, inputCidrBlock := range endpoint.Spec.Subnets {
+		if !kp.remoteSubnets.Contains(inputCidrBlock) {
+			kp.remoteSubnets.Delete(inputCidrBlock)
+		}
+	}
+	// TODO: Handle a remote endpoint removal use-case
+	//         - remove related iptable rules
+	if err := kp.updateRoutingRulesForInterClusterSupport(endpoint.Spec.Subnets, Delete); err != nil {
+		klog.Errorf("updateRoutingRulesForInterClusterSupport returned error: %+v", err)
+		return err
+	}
+
+	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Delete)
+	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Delete)
 
 	return nil
 }
@@ -97,4 +144,26 @@ func (kp *SyncHandler) overlappingSubnets(remoteSubnets []string) error {
 	}
 
 	return nil
+}
+
+func (kp *SyncHandler) getHostIfaceIPAddress() (net.IP, error) {
+	addrs, err := kp.defaultHostIface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(addrs) > 0 {
+		for i := range addrs {
+			ipAddr, _, err := net.ParseCIDR(addrs[i].String())
+			if err != nil {
+				klog.Errorf("Unable to ParseCIDR : %v\n", addrs)
+			}
+
+			if ipAddr.To4() != nil {
+				return ipAddr, nil
+			}
+		}
+	}
+
+	return nil, nil
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
@@ -1,0 +1,44 @@
+package kp_iptables
+
+import (
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+)
+
+func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for the local cluster has been created: %#v", endpoint)
+	// TODO: If subnets are overlapping, ignore that endpoint
+	return nil
+}
+
+func (kp *SyncHandler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been updated: %#v", endpoint)
+	// TODO: If subnets are overlapping, ignore that endpoint
+	return nil
+}
+
+func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been removed: %#v", endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been created: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/endpoint_handler.go
@@ -1,11 +1,14 @@
 package kp_iptables
 
 import (
+	"fmt"
+
 	"k8s.io/klog"
 
 	"github.com/submariner-io/admiral/pkg/log"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
@@ -28,17 +31,62 @@ func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been created: %#v",
 		endpoint.Spec.ClusterID, endpoint)
+	if err := kp.overlappingSubnets(endpoint.Spec.Subnets); err != nil {
+		// Skip processing the endpoint when CIDRs overlap
+		return err
+	}
+
 	return nil
 }
 
 func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
 		endpoint.Spec.ClusterID, endpoint)
+	if err := kp.overlappingSubnets(endpoint.Spec.Subnets); err != nil {
+		// Skip processing the endpoint when CIDRs overlap
+		return err
+	}
+
 	return nil
 }
 
 func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
 		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) overlappingSubnets(remoteSubnets []string) error {
+	// If the remoteSubnets [*] overlap with local cluster Pod/Service CIDRs we
+	// should not update the IPTable rules on the host, as it will disrupt the
+	// functionality of the local cluster. So, lets validate that subnets do not
+	// overlap before we program any IPTable rules on the host for inter-cluster
+	// traffic.
+	// [*] Note: In a non-GlobalNet deployment, remoteSubnets will be a list of
+	// Pod/Service CIDRs, whereas in a GlobalNet deployment, it will be a list of
+	// globalCIDRs allocated to the clusters.
+	for _, serviceCidr := range kp.localServiceCidr {
+		overlap, err := util.IsOverlappingCIDR(remoteSubnets, serviceCidr)
+		if err != nil {
+			// Ideally this case will never hit, as the subnets are valid CIDRs
+			klog.Warningf("unable to validate overlapping Service CIDR: %s", err)
+		}
+
+		if overlap {
+			return fmt.Errorf("Local Service CIDR %q, overlaps with remote cluster %s", serviceCidr, err)
+		}
+	}
+
+	for _, podCidr := range kp.localClusterCidr {
+		overlap, err := util.IsOverlappingCIDR(remoteSubnets, podCidr)
+		if err != nil {
+			klog.Warningf("unable to validate overlapping Pod CIDR: %s", err)
+		}
+
+		if overlap {
+			return fmt.Errorf("Local Pod CIDR %q, overlaps with remote cluster %s", podCidr, err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -11,24 +11,42 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
 	kp.isGatewayNode = false
-	kp.updateRoutingRulesForHostNetworkSupport(nil, FlushRouteTable)
+
+	kp.cleanVxSubmarinerRoutes()
+	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
+	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
+	err := kp.configureIPRule(Delete)
+	if err != nil {
+		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
+			RouteAgentHostNetworkTableID, kp.hostname, err)
+	}
 
 	return nil
 }
 
 func (kp *SyncHandler) TransitionToGateway() error {
 	klog.V(log.DEBUG).Info("The current node has become a Gateway")
+	kp.cleanVxSubmarinerRoutes()
+
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
 	kp.isGatewayNode = true
+
+	klog.Infof("Creating the vxlan interface: %s on the gateway node", VxLANIface)
+
+	err := kp.createVxLANInterface(VxInterfaceGateway, nil)
+	if err != nil {
+		klog.Fatalf("Unable to create VxLAN interface on gateway node (%s): %v", kp.hostname, err)
+	}
+
+	err = kp.configureIPRule(Add)
+	if err != nil {
+		klog.Errorf("Unable to add ip rule to table %d on Gateway node %s: %v",
+			RouteAgentHostNetworkTableID, kp.hostname, err)
+	}
+
 	// Add routes to the new endpoint on the GatewayNode.
-	kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.Elements(), AddRoute)
+	kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.Elements(), Add)
 
 	return nil
-}
-
-func (kp *SyncHandler) populateRemoteVtepIps(vtepIP string) {
-	if !kp.remoteVTEPs.Contains(vtepIP) {
-		kp.remoteVTEPs.Add(vtepIP)
-	}
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -1,0 +1,17 @@
+package kp_iptables
+
+import (
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+)
+
+func (kp *SyncHandler) TransitionToNonGateway() error {
+	klog.V(log.DEBUG).Info("The current node is no longer a Gateway")
+	return nil
+}
+
+func (kp *SyncHandler) TransitionToGateway() error {
+	klog.V(log.DEBUG).Info("The current node has become a Gateway")
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -8,11 +8,22 @@ import (
 
 func (kp *SyncHandler) TransitionToNonGateway() error {
 	klog.V(log.DEBUG).Info("The current node is no longer a Gateway")
+	kp.syncHandlerMutex.Lock()
+	defer kp.syncHandlerMutex.Unlock()
+	kp.isGatewayNode = false
+	kp.updateRoutingRulesForHostNetworkSupport(nil, FlushRouteTable)
+
 	return nil
 }
 
 func (kp *SyncHandler) TransitionToGateway() error {
 	klog.V(log.DEBUG).Info("The current node has become a Gateway")
+	kp.syncHandlerMutex.Lock()
+	defer kp.syncHandlerMutex.Unlock()
+	kp.isGatewayNode = true
+	// Add routes to the new endpoint on the GatewayNode.
+	kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.Elements(), AddRoute)
+
 	return nil
 }
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -34,7 +34,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 
 	klog.Infof("Creating the vxlan interface: %s on the gateway node", VxLANIface)
 
-	err := kp.createVxLANInterface(VxInterfaceGateway, nil)
+	err := kp.createVxLANInterface(kp.hostname, VxInterfaceGateway, nil)
 	if err != nil {
 		klog.Fatalf("Unable to create VxLAN interface on gateway node (%s): %v", kp.hostname, err)
 	}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -15,6 +15,8 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	kp.cleanVxSubmarinerRoutes()
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
 	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
+	kp.nonGatewayCleanups()
+	kp.gatewayToNonGatewayTransitionCleanups()
 	err := kp.configureIPRule(Delete)
 	if err != nil {
 		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
@@ -31,6 +33,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
 	kp.isGatewayNode = true
+	kp.wasGatewayPreviously = true
 
 	klog.Infof("Creating the vxlan interface: %s on the gateway node", VxLANIface)
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/gw_transition.go
@@ -15,3 +15,9 @@ func (kp *SyncHandler) TransitionToGateway() error {
 	klog.V(log.DEBUG).Info("The current node has become a Gateway")
 	return nil
 }
+
+func (kp *SyncHandler) populateRemoteVtepIps(vtepIP string) {
+	if !kp.remoteVTEPs.Contains(vtepIP) {
+		kp.remoteVTEPs.Add(vtepIP)
+	}
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/iptables-iface.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/iptables-iface.go
@@ -72,14 +72,16 @@ func (kp *SyncHandler) createIPTableChains() error {
 	return nil
 }
 
-func (kp *SyncHandler) updateIptableRulesForInterclusterTraffic(inputCidrBlocks []string) {
+func (kp *SyncHandler) updateIptableRulesForInterClusterTraffic(inputCidrBlocks []string, operation Operation) {
 	for _, inputCidrBlock := range inputCidrBlocks {
-		if !kp.remoteSubnets.Contains(inputCidrBlock) {
-			kp.remoteSubnets.Add(inputCidrBlock)
+		if operation == Add {
 			err := kp.programIptableRulesForInterClusterTraffic(inputCidrBlock)
 			if err != nil {
 				klog.Errorf("Failed to program iptable rule. %v", err)
 			}
+		} else if operation == Delete {
+			// TODO: Handle this use-case
+			klog.Warning("Handle the delete use-case")
 		}
 	}
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/iptables-iface.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/iptables-iface.go
@@ -1,0 +1,73 @@
+package kp_iptables
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/submariner-io/admiral/pkg/log"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent/constants"
+	"github.com/submariner-io/submariner/pkg/util"
+)
+
+func (kp *SyncHandler) createIPTableChains() error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("error initializing iptables: %v", err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
+
+	if err = util.CreateChainIfNotExists(ipt, "nat", constants.SmPostRoutingChain); err != nil {
+		return fmt.Errorf("unable to create %s chain in iptables: %v", constants.SmPostRoutingChain, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Insert %s rule that has rules for inter-cluster traffic", constants.SmPostRoutingChain)
+	forwardToSubPostroutingRuleSpec := []string{"-j", constants.SmPostRoutingChain}
+	if err = util.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
+		return fmt.Errorf("unable to insert iptable rule in NAT table, POSTROUTING chain: %v", err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure SUBMARINER-INPUT chain exists")
+
+	if err = util.CreateChainIfNotExists(ipt, "filter", "SUBMARINER-INPUT"); err != nil {
+		return fmt.Errorf("unable to create SUBMARINER-INPUT chain in iptables: %v", err)
+	}
+
+	forwardToSubInputRuleSpec := []string{"-p", "udp", "-m", "udp", "-j", "SUBMARINER-INPUT"}
+	if err = ipt.AppendUnique("filter", "INPUT", forwardToSubInputRuleSpec...); err != nil {
+		return fmt.Errorf("unable to append iptables rule %q: %v\n", strings.Join(forwardToSubInputRuleSpec, " "), err)
+	}
+
+	klog.V(log.DEBUG).Infof("Allow VxLAN incoming traffic in SUBMARINER-INPUT Chain")
+
+	ruleSpec := []string{"-p", "udp", "-m", "udp", "--dport", strconv.Itoa(VxLANPort), "-j", "ACCEPT"}
+
+	if err = ipt.AppendUnique("filter", "SUBMARINER-INPUT", ruleSpec...); err != nil {
+		return fmt.Errorf("unable to append iptables rule %q: %v\n", strings.Join(ruleSpec, " "), err)
+	}
+
+	klog.V(log.DEBUG).Infof("Insert rule to allow traffic over %s interface in FORWARDing Chain", VxLANIface)
+
+	ruleSpec = []string{"-o", VxLANIface, "-j", "ACCEPT"}
+
+	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
+		return fmt.Errorf("unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
+	}
+
+	if kp.cniIface != nil {
+		// Program rules to support communication from HostNetwork to remoteCluster
+		sourceAddress := strconv.Itoa(VxLANVTepNetworkPrefix) + ".0.0.0/8"
+		ruleSpec = []string{"-s", sourceAddress, "-o", VxLANIface, "-j", "SNAT", "--to", kp.cniIface.IPAddress}
+		klog.V(log.DEBUG).Infof("Installing rule for host network to remote cluster communication: %s", strings.Join(ruleSpec, " "))
+
+		if err = ipt.AppendUnique("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error appending iptables rule %q: %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -1,26 +1,34 @@
 package kp_iptables
 
 import (
+	"fmt"
+	"os"
+
 	"k8s.io/klog"
 
-	"github.com/submariner-io/admiral/pkg/log"
-	k8sV1 "k8s.io/api/core/v1"
-
-	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/routeagent-driver/cni_interface"
+	"github.com/submariner-io/submariner/pkg/routeagent-driver/constants"
 )
 
 type SyncHandler struct {
 	event.HandlerBase
 	clusterID        string
+	namespace        string
 	localClusterCidr []string
 	localServiceCidr []string
 
-	cniIface *cniInterface
+	hostname string
+	cniIface *cni_interface.CniInterface
 }
 
-func NewSyncHandler() *SyncHandler {
-	return &SyncHandler{}
+func NewSyncHandler(env constants.Specification) *SyncHandler {
+	return &SyncHandler{
+		clusterID:        env.ClusterID,
+		namespace:        env.Namespace,
+		localClusterCidr: env.ClusterCidr,
+		localServiceCidr: env.ServiceCidr,
+	}
 }
 
 func (kp *SyncHandler) GetName() string {
@@ -32,69 +40,29 @@ func (kp *SyncHandler) GetNetworkPlugin() string {
 }
 
 func (kp *SyncHandler) Init() error {
-	return nil
-}
+	var err error
+	kp.hostname, err = os.Hostname()
+	if err != nil {
+		klog.Fatalf("unable to determine hostname: %v", err)
+	}
 
-func (kp *SyncHandler) TransitionToNonGateway() error {
-	klog.V(log.DEBUG).Info("The current node is no longer a Gateway")
-	return nil
-}
+	cniIface, err := cni_interface.Discover(kp.localClusterCidr[0])
+	if err == nil {
+		// Configure CNI Specific changes
+		kp.cniIface = cniIface
+		err := cni_interface.ConfigureRpFilter(kp.cniIface.Name)
+		if err != nil {
+			return fmt.Errorf("ConfigureRpFilter returned error. %v", err)
+		}
+	} else {
+		klog.Errorf("DiscoverCNIInterface returned error %v", err)
+	}
 
-func (kp *SyncHandler) TransitionToGateway() error {
-	klog.V(log.DEBUG).Info("The current node has become a Gateway")
-	return nil
-}
+	// Create the necessary IPTable chains in the filter and nat tables.
+	err = kp.createIPTableChains()
+	if err != nil {
+		return fmt.Errorf("createIPTableChains returned error. %v", err)
+	}
 
-func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("A new Endpoint for the local cluster has been created: %#v", endpoint)
-	// TODO: If subnets are overlapping, ignore that endpoint
-	return nil
-}
-
-func (kp *SyncHandler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been updated: %#v", endpoint)
-	// TODO: If subnets are overlapping, ignore that endpoint
-	return nil
-}
-
-func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been removed: %#v", endpoint)
-	return nil
-}
-
-func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been created: %#v",
-		endpoint.Spec.ClusterID, endpoint)
-	return nil
-}
-
-func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
-		endpoint.Spec.ClusterID, endpoint)
-	return nil
-}
-
-func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
-	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
-		endpoint.Spec.ClusterID, endpoint)
-	return nil
-}
-
-func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
-	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
-		node.Name, node.Status.Addresses)
-	// TODO: Here we have to annotate node with cni-iface ip
-	return nil
-}
-
-func (kp *SyncHandler) NodeUpdated(node *k8sV1.Node) error {
-	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been updated",
-		node.Name, node.Status.Addresses)
-	return nil
-}
-
-func (kp *SyncHandler) NodeRemoved(node *k8sV1.Node) error {
-	klog.V(log.DEBUG).Infof("A Node with name %q has been removed",
-		node.Name)
 	return nil
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -1,0 +1,100 @@
+package kp_iptables
+
+import (
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	k8sV1 "k8s.io/api/core/v1"
+
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event"
+)
+
+type SyncHandler struct {
+	event.HandlerBase
+	clusterID        string
+	localClusterCidr []string
+	localServiceCidr []string
+
+	cniIface *cniInterface
+}
+
+func NewSyncHandler() *SyncHandler {
+	return &SyncHandler{}
+}
+
+func (kp *SyncHandler) GetName() string {
+	return "kubeproxy-iptables-handler"
+}
+
+func (kp *SyncHandler) GetNetworkPlugin() string {
+	return event.AnyNetworkPlugin
+}
+
+func (kp *SyncHandler) Init() error {
+	return nil
+}
+
+func (kp *SyncHandler) TransitionToNonGateway() error {
+	klog.V(log.DEBUG).Info("The current node is no longer a Gateway")
+	return nil
+}
+
+func (kp *SyncHandler) TransitionToGateway() error {
+	klog.V(log.DEBUG).Info("The current node has become a Gateway")
+	return nil
+}
+
+func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for the local cluster has been created: %#v", endpoint)
+	// TODO: If subnets are overlapping, ignore that endpoint
+	return nil
+}
+
+func (kp *SyncHandler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been updated: %#v", endpoint)
+	// TODO: If subnets are overlapping, ignore that endpoint
+	return nil
+}
+
+func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("The Endpoint for the local cluster has been removed: %#v", endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been created: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	klog.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
+		endpoint.Spec.ClusterID, endpoint)
+	return nil
+}
+
+func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
+		node.Name, node.Status.Addresses)
+	// TODO: Here we have to annotate node with cni-iface ip
+	return nil
+}
+
+func (kp *SyncHandler) NodeUpdated(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been updated",
+		node.Name, node.Status.Addresses)
+	return nil
+}
+
+func (kp *SyncHandler) NodeRemoved(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q has been removed",
+		node.Name)
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -9,14 +9,19 @@ import (
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/routeagent-driver/cni_interface"
 	"github.com/submariner-io/submariner/pkg/routeagent-driver/constants"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 type SyncHandler struct {
 	event.HandlerBase
 	clusterID        string
 	namespace        string
+	localCableDriver string
 	localClusterCidr []string
 	localServiceCidr []string
+
+	remoteSubnets *util.StringSet
+	remoteVTEPs   *util.StringSet
 
 	hostname string
 	cniIface *cni_interface.CniInterface
@@ -28,6 +33,9 @@ func NewSyncHandler(env constants.Specification) *SyncHandler {
 		namespace:        env.Namespace,
 		localClusterCidr: env.ClusterCidr,
 		localServiceCidr: env.ServiceCidr,
+		localCableDriver: "",
+		remoteSubnets:    util.NewStringSet(),
+		remoteVTEPs:      util.NewStringSet(),
 	}
 }
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -29,6 +29,8 @@ type SyncHandler struct {
 	syncHandlerMutex *sync.Mutex
 	isGatewayNode    bool
 
+	vxlanDevice      *vxLanIface
+	vxlanGwIP        *net.IP
 	hostname         string
 	cniIface         *cni_interface.CniInterface
 	defaultHostIface *net.Interface
@@ -46,6 +48,8 @@ func NewSyncHandler(env constants.Specification) *SyncHandler {
 		routeCacheGWNode: util.NewStringSet(),
 		syncHandlerMutex: &sync.Mutex{},
 		isGatewayNode:    false,
+		vxlanDevice:      nil,
+		vxlanGwIP:        nil,
 	}
 }
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -11,7 +11,6 @@ import (
 	cableCleanup "github.com/submariner-io/submariner/pkg/cable/cleanup"
 	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/event"
-	globalnetCleanup "github.com/submariner-io/submariner/pkg/globalnet/cleanup"
 	"github.com/submariner-io/submariner/pkg/routeagent-driver/cni_interface"
 	"github.com/submariner-io/submariner/pkg/routeagent-driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
@@ -103,7 +102,6 @@ func (kp *SyncHandler) Init() error {
 
 	// For now we get all the cleanups
 	kp.installCleanupHandlers(cableCleanup.GetCleanupHandlers())
-	kp.installCleanupHandlers(globalnetCleanup.GetGlobalnetCleanupHandlers(kp.clusterID, kp.namespace, kp.smClientSet))
 
 	return nil
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/kp-iptables.go
@@ -66,8 +66,8 @@ func (kp *SyncHandler) GetName() string {
 	return "kubeproxy-iptables-handler"
 }
 
-func (kp *SyncHandler) GetNetworkPlugin() string {
-	return event.AnyNetworkPlugin
+func (kp *SyncHandler) GetNetworkPlugins() []string {
+	return []string{"generic", "canal-flannel", "weave-net", "OpenShiftSDN"}
 }
 
 func (kp *SyncHandler) Init() error {

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
@@ -1,0 +1,27 @@
+package kp_iptables
+
+import (
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	k8sV1 "k8s.io/api/core/v1"
+)
+
+func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
+		node.Name, node.Status.Addresses)
+	// TODO: Here we have to annotate node with cni-iface ip
+	return nil
+}
+
+func (kp *SyncHandler) NodeUpdated(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been updated",
+		node.Name, node.Status.Addresses)
+	return nil
+}
+
+func (kp *SyncHandler) NodeRemoved(node *k8sV1.Node) error {
+	klog.V(log.DEBUG).Infof("A Node with name %q has been removed",
+		node.Name)
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
@@ -1,6 +1,8 @@
 package kp_iptables
 
 import (
+	"net"
+
 	"k8s.io/klog"
 
 	"github.com/submariner-io/admiral/pkg/log"
@@ -11,9 +13,12 @@ func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
 	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
 		node.Name, node.Status.Addresses)
 
+	kp.syncHandlerMutex.Lock()
+	defer kp.syncHandlerMutex.Unlock()
+
 	for i, addr := range node.Status.Addresses {
 		if addr.Type == k8sV1.NodeInternalIP {
-			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address)
+			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address, Add)
 			break
 		}
 	}
@@ -28,7 +33,39 @@ func (kp *SyncHandler) NodeUpdated(node *k8sV1.Node) error {
 }
 
 func (kp *SyncHandler) NodeRemoved(node *k8sV1.Node) error {
-	klog.V(log.DEBUG).Infof("A Node with name %q has been removed",
-		node.Name)
+	klog.V(log.DEBUG).Infof("A Node with name %q has been removed", node.Name)
+
+	for i, addr := range node.Status.Addresses {
+		if addr.Type == k8sV1.NodeInternalIP {
+			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address, Delete)
+			break
+		}
+	}
+
 	return nil
+}
+
+func (kp *SyncHandler) populateRemoteVtepIps(vtepIP string, operation Operation) {
+	// The remoteVTEP info is cached on all the routeAgent nodes and is used when there is a Gateway transition.
+	if operation == Add && !kp.remoteVTEPs.Contains(vtepIP) {
+		kp.remoteVTEPs.Add(vtepIP)
+	} else if operation == Delete {
+		kp.remoteVTEPs.Delete(vtepIP)
+	}
+
+	klog.V(log.DEBUG).Infof("populateRemoteVtepIps is called with vtepIP %s, isGatewayNode %t",
+		vtepIP, kp.isGatewayNode)
+
+	if kp.isGatewayNode {
+		switch operation {
+		case Add:
+			if err := kp.vxlanDevice.AddFDB(net.ParseIP(vtepIP), "00:00:00:00:00:00"); err != nil {
+				klog.Errorf("Failed to add FDB entry on the Gateway Node vxlan iface %v", err)
+			}
+		case Delete:
+			if err := kp.vxlanDevice.DelFDB(net.ParseIP(vtepIP), "00:00:00:00:00:00"); err != nil {
+				klog.Errorf("Failed to delete FDB entry on the Gateway Node vxlan iface %v", err)
+			}
+		}
+	}
 }

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/node_handler.go
@@ -10,7 +10,14 @@ import (
 func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
 	klog.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
 		node.Name, node.Status.Addresses)
-	// TODO: Here we have to annotate node with cni-iface ip
+
+	for i, addr := range node.Status.Addresses {
+		if addr.Type == k8sV1.NodeInternalIP {
+			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address)
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/routes-iface.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/routes-iface.go
@@ -1,0 +1,98 @@
+package kp_iptables
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+
+	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+)
+
+func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks []string, operation Operation) {
+	if operation == FlushRouteTable {
+		kp.routeCacheGWNode.DeleteAll()
+		// The conversion doesn't introduce a security problem
+		// #nosec G204
+		cmd := exec.Command("/sbin/ip", "r", "flush", "table", strconv.Itoa(RouteAgentHostNetworkTableID))
+		if err := cmd.Run(); err != nil {
+			// We can safely ignore this error, as this table will exist only on GW nodes
+			klog.V(log.TRACE).Infof("Flushing routing table %d returned error. Can be ignored on non-Gw node: %v",
+				RouteAgentHostNetworkTableID, err)
+			return
+		}
+	} else if kp.isGatewayNode && kp.cniIface != nil {
+		// These routing rules are required ONLY on the Gateway Node.
+		// On the non-Gateway nodes, we use iptable rules to support this use-case.
+		switch operation {
+		case AddRoute:
+			for _, inputCidrBlock := range inputCidrBlocks {
+				if kp.routeCacheGWNode.Add(inputCidrBlock) {
+					if err := kp.configureRoute(inputCidrBlock, operation); err != nil {
+						kp.routeCacheGWNode.Delete(inputCidrBlock)
+						klog.Errorf("Failed to add route %q for HostNetwork support on the Gateway node: %v",
+							inputCidrBlock, err)
+					}
+				}
+			}
+		case DeleteRoute:
+			for _, inputCidrBlock := range inputCidrBlocks {
+				if kp.routeCacheGWNode.Delete(inputCidrBlock) {
+					if err := kp.configureRoute(inputCidrBlock, operation); err != nil {
+						klog.Errorf("Failed to delete route %q for HostNetwork support on the Gateway node. %v",
+							inputCidrBlock, err)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation) error {
+	src := net.ParseIP(kp.cniIface.IPAddress)
+	_, dst, err := net.ParseCIDR(remoteSubnet)
+	if err != nil {
+		return fmt.Errorf("error parsing cidr block %s: %v", remoteSubnet, err)
+	}
+
+	ifaceIndex := kp.defaultHostIface.Index
+	// TODO: Add support for this in the CableDrivers themselves.
+	if kp.localCableDriver == "wireguard" {
+		if wg, err := net.InterfaceByName(wireguard.DefaultDeviceName); err == nil {
+			ifaceIndex = wg.Index
+		} else {
+			klog.Errorf("Wireguard interface %s not found on the node.", wireguard.DefaultDeviceName)
+		}
+	}
+
+	route := netlink.Route{
+		Dst:       dst,
+		Src:       src,
+		Scope:     unix.RT_SCOPE_LINK,
+		LinkIndex: ifaceIndex,
+		Protocol:  4,
+		Table:     RouteAgentHostNetworkTableID,
+	}
+
+	switch operation {
+	case AddRoute:
+		err = netlink.RouteAdd(&route)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("error adding the route %s: %v", route.String(), err)
+		}
+	case DeleteRoute:
+		err = netlink.RouteDel(&route)
+		if err != nil {
+			return fmt.Errorf("error deleting the route %s: %v", route.String(), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/routes-iface.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/routes-iface.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"syscall"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -17,7 +18,7 @@ import (
 )
 
 func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks []string, operation Operation) {
-	if operation == FlushRouteTable {
+	if operation == Flush {
 		kp.routeCacheGWNode.DeleteAll()
 		// The conversion doesn't introduce a security problem
 		// #nosec G204
@@ -32,7 +33,7 @@ func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks [
 		// These routing rules are required ONLY on the Gateway Node.
 		// On the non-Gateway nodes, we use iptable rules to support this use-case.
 		switch operation {
-		case AddRoute:
+		case Add:
 			for _, inputCidrBlock := range inputCidrBlocks {
 				if kp.routeCacheGWNode.Add(inputCidrBlock) {
 					if err := kp.configureRoute(inputCidrBlock, operation); err != nil {
@@ -42,7 +43,7 @@ func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks [
 					}
 				}
 			}
-		case DeleteRoute:
+		case Delete:
 			for _, inputCidrBlock := range inputCidrBlocks {
 				if kp.routeCacheGWNode.Delete(inputCidrBlock) {
 					if err := kp.configureRoute(inputCidrBlock, operation); err != nil {
@@ -82,15 +83,187 @@ func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation) 
 	}
 
 	switch operation {
-	case AddRoute:
+	case Add:
 		err = netlink.RouteAdd(&route)
 		if err != nil && !os.IsExist(err) {
 			return fmt.Errorf("error adding the route %s: %v", route.String(), err)
 		}
-	case DeleteRoute:
+	case Delete:
 		err = netlink.RouteDel(&route)
 		if err != nil {
 			return fmt.Errorf("error deleting the route %s: %v", route.String(), err)
+		}
+	}
+
+	return nil
+}
+
+func (kp *SyncHandler) cleanVxSubmarinerRoutes() {
+	link, err := netlink.LinkByName(VxLANIface)
+	if err != nil {
+		if _, ok := err.(netlink.LinkNotFoundError); !ok {
+			klog.Errorf("Error retrieving link by name %q: %v", VxLANIface, err)
+			return
+		}
+	}
+
+	currentRouteList, err := netlink.RouteList(link, syscall.AF_INET)
+	if err != nil {
+		klog.Errorf("Unable to cleanup routes, error retrieving routes on the link %s: %v", VxLANIface, err)
+		return
+	}
+
+	for i := range currentRouteList {
+		klog.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])
+
+		if currentRouteList[i].Dst == nil || currentRouteList[i].Gw == nil {
+			klog.V(log.DEBUG).Infof("Found nil gw or dst")
+		} else if kp.remoteSubnets.Contains(currentRouteList[i].Dst.String()) {
+			klog.V(log.DEBUG).Infof("Removing route %s", currentRouteList[i])
+			if err = netlink.RouteDel(&currentRouteList[i]); err != nil {
+				klog.Errorf("Error removing route %s: %v", currentRouteList[i], err)
+			}
+		}
+	}
+}
+
+// Reconcile the routes installed on this device using rtnetlink
+func (kp *SyncHandler) reconcileRoutes(vxlanGw net.IP) error {
+	klog.V(log.DEBUG).Infof("Reconciling routes to gw: %s", vxlanGw.String())
+
+	link, err := netlink.LinkByName(VxLANIface)
+	if err != nil {
+		return fmt.Errorf("error retrieving link by name %s: %v", VxLANIface, err)
+	}
+
+	currentRouteList, err := netlink.RouteList(link, syscall.AF_INET)
+
+	if err != nil {
+		return fmt.Errorf("error retrieving routes for link %s: %v", VxLANIface, err)
+	}
+
+	// First lets delete all of the routes that don't match
+	for i := range currentRouteList {
+		// contains(endpoint destinations, route destination string, and the route gateway is our actual destination
+		klog.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])
+
+		if currentRouteList[i].Dst == nil || currentRouteList[i].Gw == nil {
+			klog.V(log.DEBUG).Infof("Found nil gw or dst")
+		} else {
+			if kp.remoteSubnets.Contains(currentRouteList[i].Dst.String()) && currentRouteList[i].Gw.Equal(vxlanGw) {
+				klog.V(log.DEBUG).Infof("Found route %s with gw %s already installed", currentRouteList[i], currentRouteList[i].Gw)
+			} else {
+				klog.V(log.DEBUG).Infof("Removing route %s", currentRouteList[i])
+				if err = netlink.RouteDel(&currentRouteList[i]); err != nil {
+					klog.Errorf("Error removing route %s: %v", currentRouteList[i], err)
+				}
+			}
+		}
+	}
+
+	currentRouteList, err = netlink.RouteList(link, syscall.AF_INET)
+
+	if err != nil {
+		return fmt.Errorf("error retrieving routes for link %s: %v", VxLANIface, err)
+	}
+
+	// let's now add the routes that are missing
+	for _, cidrBlock := range kp.remoteSubnets.Elements() {
+		_, dst, err := net.ParseCIDR(cidrBlock)
+		if err != nil {
+			klog.Errorf("Error parsing cidr block %s: %v", cidrBlock, err)
+			break
+		}
+
+		route := netlink.Route{
+			Dst:       dst,
+			Gw:        vxlanGw,
+			Scope:     unix.RT_SCOPE_UNIVERSE,
+			LinkIndex: link.Attrs().Index,
+			Protocol:  4,
+		}
+		found := false
+		for _, curRoute := range currentRouteList {
+			if curRoute.Gw == nil || curRoute.Dst == nil {
+
+			} else if curRoute.Gw.Equal(route.Gw) && curRoute.Dst.String() == route.Dst.String() {
+				klog.V(log.DEBUG).Infof("Found equivalent route, not adding")
+				found = true
+			}
+		}
+
+		if !found {
+			err = netlink.RouteAdd(&route)
+			if err != nil {
+				klog.Errorf("Error adding route %s: %v", route.String(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (kp *SyncHandler) updateRoutingRulesForInterClusterSupport(remoteCIDRs []string, operation Operation) error {
+	if kp.isGatewayNode {
+		klog.V(log.DEBUG).Info("On GWNode, in updateRoutingRulesForInterClusterSupport ignoring")
+		// These rules are required only on the nonGatewayNode.
+		return nil
+	}
+
+	if kp.vxlanDevice != nil && kp.vxlanGwIP != nil {
+		link, err := netlink.LinkByName(VxLANIface)
+		if err != nil {
+			return fmt.Errorf("error retrieving link by name %s: %v", VxLANIface, err)
+		}
+
+		for _, cidrBlock := range remoteCIDRs {
+			_, dst, err := net.ParseCIDR(cidrBlock)
+			if err != nil {
+				return fmt.Errorf("error parsing cidr block %s: %v", cidrBlock, err)
+			}
+
+			route := netlink.Route{
+				Dst:       dst,
+				Gw:        *kp.vxlanGwIP,
+				Scope:     unix.RT_SCOPE_UNIVERSE,
+				LinkIndex: link.Attrs().Index,
+				Protocol:  4,
+			}
+
+			if operation == Add {
+				err = netlink.RouteAdd(&route)
+				if err != nil {
+					return fmt.Errorf("error adding route %s: %v", route.String(), err)
+				}
+			} else if operation == Delete {
+				err = netlink.RouteDel(&route)
+				if err != nil {
+					return fmt.Errorf("error deleting route %s: %v", route.String(), err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (kp *SyncHandler) configureIPRule(operation Operation) error {
+	if kp.cniIface != nil {
+		rule := netlink.NewRule()
+		rule.Table = RouteAgentHostNetworkTableID
+		rule.Priority = RouteAgentHostNetworkTableID
+
+		switch operation {
+		case Add:
+			err := netlink.RuleAdd(rule)
+			if err != nil && !os.IsExist(err) {
+				return fmt.Errorf("failed to add ip rule %s: %v", rule.String(), err)
+			}
+		case Delete:
+			err := netlink.RuleDel(rule)
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("failed to delete ip rule %s: %v", rule.String(), err)
+			}
 		}
 	}
 

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan.go
@@ -1,0 +1,274 @@
+package kp_iptables
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog"
+)
+
+type vxLanAttributes struct {
+	name     string
+	vxlanId  int
+	group    net.IP
+	srcAddr  net.IP
+	vtepPort int
+	mtu      int
+}
+
+type vxLanIface struct {
+	link *netlink.Vxlan
+}
+
+func newVxlanIface(attrs *vxLanAttributes) (*vxLanIface, error) {
+	iface := &netlink.Vxlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  attrs.name,
+			MTU:   attrs.mtu,
+			Flags: net.FlagUp,
+		},
+		VxlanId: attrs.vxlanId,
+		SrcAddr: attrs.srcAddr,
+		Group:   attrs.group,
+		Port:    attrs.vtepPort,
+	}
+
+	vxLANIface := &vxLanIface{
+		link: iface,
+	}
+
+	if err := createVxLanIface(vxLANIface); err != nil {
+		return nil, err
+	}
+
+	return vxLANIface, nil
+}
+
+func createVxLanIface(iface *vxLanIface) error {
+	err := netlink.LinkAdd(iface.link)
+	if err == syscall.EEXIST {
+		// Get the properties of existing vxlan interface
+		existing, err := netlink.LinkByName(iface.link.Name)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve link info: %v", err)
+		}
+
+		if isVxlanConfigTheSame(iface.link, existing) {
+			klog.V(log.DEBUG).Infof("VxLAN interface already exists with same configuration.")
+
+			iface.link = existing.(*netlink.Vxlan)
+
+			return nil
+		}
+
+		// Config does not match, delete the existing interface and re-create it.
+		if err = netlink.LinkDel(existing); err != nil {
+			return fmt.Errorf("failed to delete the existing vxlan interface: %v", err)
+		}
+
+		if err = netlink.LinkAdd(iface.link); err != nil {
+			return fmt.Errorf("failed to re-create the the vxlan interface: %v", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to create the the vxlan interface: %v", err)
+	}
+
+	return nil
+}
+
+func (iface *vxLanIface) deleteVxLanIface() error {
+	err := netlink.LinkDel(iface.link)
+	if err != nil {
+		return fmt.Errorf("failed to delete the the vxlan interface: %v", err)
+	}
+
+	return nil
+}
+
+func isVxlanConfigTheSame(newLink, currentLink netlink.Link) bool {
+	required := newLink.(*netlink.Vxlan)
+	existing := currentLink.(*netlink.Vxlan)
+
+	if required.VxlanId != existing.VxlanId {
+		klog.Errorf("VxlanId of existing interface (%d) does not match with required VxlanId (%d)", existing.VxlanId, required.VxlanId)
+		return false
+	}
+
+	if len(required.Group) > 0 && len(existing.Group) > 0 && !required.Group.Equal(existing.Group) {
+		klog.Errorf("Vxlan Group (%v) of existing interface does not match with required Group (%v)", existing.Group, required.Group)
+		return false
+	}
+
+	if len(required.SrcAddr) > 0 && len(existing.SrcAddr) > 0 && !required.SrcAddr.Equal(existing.SrcAddr) {
+		klog.Errorf("Vxlan SrcAddr (%v) of existing interface does not match with required SrcAddr (%v)", existing.SrcAddr, required.SrcAddr)
+		return false
+	}
+
+	if required.Port > 0 && existing.Port > 0 && required.Port != existing.Port {
+		klog.V(log.DEBUG).Infof("Vxlan Port (%d) of existing interface does not match with required Port (%d)", existing.Port, required.Port)
+		return false
+	}
+
+	return true
+}
+
+func (iface *vxLanIface) configureIPAddress(ipAddress net.IP, mask net.IPMask) error {
+	ipConfig := &netlink.Addr{IPNet: &net.IPNet{
+		IP:   ipAddress,
+		Mask: mask,
+	}}
+
+	err := netlink.AddrAdd(iface.link, ipConfig)
+	if err == syscall.EEXIST {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("unable to configure address (%s) on vxlan interface (%s). %v", ipAddress, iface.link.Name, err)
+	}
+
+	return nil
+}
+
+func (iface *vxLanIface) AddFDB(ipAddress net.IP, hwAddr string) error {
+	macAddr, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return fmt.Errorf("invalid MAC Address (%s) supplied. %v", hwAddr, err)
+	}
+
+	if ipAddress == nil {
+		return fmt.Errorf("invalid ipAddress (%v) supplied", ipAddress)
+	}
+
+	neigh := &netlink.Neigh{
+		LinkIndex:    iface.link.Index,
+		Family:       unix.AF_BRIDGE,
+		Flags:        netlink.NTF_SELF,
+		Type:         netlink.NDA_DST,
+		IP:           ipAddress,
+		State:        netlink.NUD_PERMANENT | netlink.NUD_NOARP,
+		HardwareAddr: macAddr,
+	}
+
+	err = netlink.NeighAppend(neigh)
+	if err != nil {
+		return fmt.Errorf("unable to add the bridge fdb entry %v, err: %s", neigh, err)
+	} else {
+		klog.V(log.DEBUG).Infof("Successfully added the bridge fdb entry %v", neigh)
+	}
+
+	return nil
+}
+
+func (iface *vxLanIface) DelFDB(ipAddress net.IP, hwAddr string) error {
+	macAddr, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return fmt.Errorf("invalid MAC Address (%s) supplied. %v", hwAddr, err)
+	}
+
+	neigh := &netlink.Neigh{
+		LinkIndex:    iface.link.Index,
+		Family:       unix.AF_BRIDGE,
+		Flags:        netlink.NTF_SELF,
+		Type:         netlink.NDA_DST,
+		IP:           ipAddress,
+		State:        netlink.NUD_PERMANENT | netlink.NUD_NOARP,
+		HardwareAddr: macAddr,
+	}
+
+	err = netlink.NeighDel(neigh)
+	if err != nil {
+		return fmt.Errorf("unable to delete the bridge fdb entry %v, err: %s", neigh, err)
+	} else {
+		klog.V(log.DEBUG).Infof("Successfully deleted the bridge fdb entry %v", neigh)
+	}
+
+	return nil
+}
+
+func (kp *SyncHandler) getVxlanVtepIPAddress(ipAddr string) (net.IP, error) {
+	ipSlice := strings.Split(ipAddr, ".")
+	if len(ipSlice) < 4 {
+		return nil, fmt.Errorf("invalid ipAddr [%s]", ipAddr)
+	}
+
+	ipSlice[0] = strconv.Itoa(VxLANVTepNetworkPrefix)
+	vxlanIP := net.ParseIP(strings.Join(ipSlice, "."))
+
+	return vxlanIP, nil
+}
+
+func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP) error {
+	ipAddr, err := kp.getHostIfaceIPAddress()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve the IPv4 address on the Host %v", err)
+	}
+
+	vtepIP, err := kp.getVxlanVtepIPAddress(ipAddr.String())
+	if err != nil {
+		return fmt.Errorf("failed to derive the vxlan vtepIP for %s, %v", ipAddr, err)
+	}
+
+	// Derive the MTU based on the default outgoing interface
+	vxlanMtu := kp.defaultHostIface.MTU - VxLANOverhead
+
+	if ifaceType == VxInterfaceGateway {
+		attrs := &vxLanAttributes{
+			name:     VxLANIface,
+			vxlanId:  100,
+			group:    nil,
+			srcAddr:  nil,
+			vtepPort: VxLANPort,
+			mtu:      vxlanMtu,
+		}
+
+		kp.vxlanDevice, err = newVxlanIface(attrs)
+		if err != nil {
+			return fmt.Errorf("failed to create vxlan interface on Gateway Node: %v", err)
+		}
+
+		for _, fdbAddress := range kp.remoteVTEPs.Elements() {
+			err = kp.vxlanDevice.AddFDB(net.ParseIP(fdbAddress), "00:00:00:00:00:00")
+			if err != nil {
+				return fmt.Errorf("failed to add FDB entry on the Gateway Node vxlan iface %v", err)
+			}
+		}
+
+		// Enable loose mode (rp_filter=2) reverse path filtering on the vxlan interface.
+		// We won't ever create rp_filter, and its permissions are 644
+		// #nosec G306
+		err = ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+VxLANIface+"/rp_filter", []byte("2"), 0644)
+		if err != nil {
+			return fmt.Errorf("unable to update vxlan rp_filter proc entry, err: %s", err)
+		} else {
+			klog.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on %s", VxLANIface)
+		}
+	} else if ifaceType == VxInterfaceWorker {
+		// non-Gateway/Worker Node
+		attrs := &vxLanAttributes{
+			name:     VxLANIface,
+			vxlanId:  100,
+			group:    gatewayNodeIP,
+			srcAddr:  nil,
+			vtepPort: VxLANPort,
+			mtu:      vxlanMtu,
+		}
+
+		kp.vxlanDevice, err = newVxlanIface(attrs)
+		if err != nil {
+			return fmt.Errorf("failed to create vxlan interface on non-Gateway Node: %v", err)
+		}
+	}
+
+	err = kp.vxlanDevice.configureIPAddress(vtepIP, net.CIDRMask(8, 32))
+	if err != nil {
+		return fmt.Errorf("failed to configure vxlan interface ipaddress on the Gateway Node %v", err)
+	}
+
+	return nil
+}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan.go
@@ -24,10 +24,11 @@ type vxLanAttributes struct {
 }
 
 type vxLanIface struct {
-	link *netlink.Vxlan
+	link                   *netlink.Vxlan
+	activeEndpointHostname string
 }
 
-func newVxlanIface(attrs *vxLanAttributes) (*vxLanIface, error) {
+func newVxlanIface(attrs *vxLanAttributes, activeEndPoint string) (*vxLanIface, error) {
 	iface := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
 			Name:  attrs.name,
@@ -41,7 +42,8 @@ func newVxlanIface(attrs *vxLanAttributes) (*vxLanIface, error) {
 	}
 
 	vxLANIface := &vxLanIface{
-		link: iface,
+		link:                   iface,
+		activeEndpointHostname: activeEndPoint,
 	}
 
 	if err := createVxLanIface(vxLANIface); err != nil {
@@ -203,7 +205,7 @@ func (kp *SyncHandler) getVxlanVtepIPAddress(ipAddr string) (net.IP, error) {
 	return vxlanIP, nil
 }
 
-func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP) error {
+func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int, gatewayNodeIP net.IP) error {
 	ipAddr, err := kp.getHostIfaceIPAddress()
 	if err != nil {
 		return fmt.Errorf("unable to retrieve the IPv4 address on the Host %v", err)
@@ -227,7 +229,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			mtu:      vxlanMtu,
 		}
 
-		kp.vxlanDevice, err = newVxlanIface(attrs)
+		kp.vxlanDevice, err = newVxlanIface(attrs, activeEndPoint)
 		if err != nil {
 			return fmt.Errorf("failed to create vxlan interface on Gateway Node: %v", err)
 		}
@@ -259,7 +261,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			mtu:      vxlanMtu,
 		}
 
-		kp.vxlanDevice, err = newVxlanIface(attrs)
+		kp.vxlanDevice, err = newVxlanIface(attrs, activeEndPoint)
 		if err != nil {
 			return fmt.Errorf("failed to create vxlan interface on non-Gateway Node: %v", err)
 		}

--- a/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan_test.go
+++ b/pkg/routeagent-driver/handlers/kubeproxy-iptables/vxlan_test.go
@@ -1,0 +1,34 @@
+package kp_iptables
+
+import (
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getVxlanVtepIPAddress", func() {
+	Describe("Unit tests for getVxlanVtepIPAddress", func() {
+		Context("When a valid ipaddress is provided to getVxlanVtepIPAddress", func() {
+			It("Should return the VxLAN VtepIP that can be configured", func() {
+				routeController := SyncHandler{}
+				vtepIP, _ := routeController.getVxlanVtepIPAddress("192.168.100.24")
+				Expect(vtepIP.String()).Should(Equal(strconv.Itoa(VxLANVTepNetworkPrefix) + ".168.100.24"))
+			})
+		})
+
+		Context("When an invalid ipaddress is provided to getVxlanVtepIPAddress", func() {
+			It("Should return an error", func() {
+				routeController := SyncHandler{}
+				_, err := routeController.getVxlanVtepIPAddress("10.0.0")
+				Expect(err).ShouldNot(Equal(nil))
+			})
+		})
+	})
+})
+
+func TestRoute(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Route Suite")
+}

--- a/pkg/routeagent-driver/main.go
+++ b/pkg/routeagent-driver/main.go
@@ -28,7 +28,7 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
-	klog.Info("SGM: Starting submariner-route-agent using the event framework")
+	klog.Info("SGM:: Starting submariner-route-agent using the event framework")
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
@@ -42,13 +42,13 @@ func main() {
 		klog.Errorf("Error while annotating the node: %s", err.Error())
 	}
 
-	eventHandlers := event.NewRegistry("routeagent-driver", os.Getenv("NETWORK_PLUGIN"))
-	if err := eventHandlers.AddHandlers(logger.NewHandler(), kp_iptables.NewSyncHandler(env)); err != nil {
+	registry := event.NewRegistry("routeagent-driver", os.Getenv("NETWORK_PLUGIN"))
+	if err := registry.AddHandlers(logger.NewHandler(), kp_iptables.NewSyncHandler(env)); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}
 
 	ctl, err := controller.New(&controller.Config{
-		Registry:   &eventHandlers,
+		Registry:   registry,
 		MasterURL:  masterURL,
 		Kubeconfig: kubeconfig})
 

--- a/pkg/routeagent-driver/main.go
+++ b/pkg/routeagent-driver/main.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
 	"github.com/submariner-io/submariner/pkg/event/logger"
+	"github.com/submariner-io/submariner/pkg/routeagent-driver/cni_interface"
 	"github.com/submariner-io/submariner/pkg/routeagent-driver/constants"
 	kp_iptables "github.com/submariner-io/submariner/pkg/routeagent-driver/handlers/kubeproxy-iptables"
 )
@@ -32,6 +36,10 @@ func main() {
 	err := envconfig.Process("submariner", &env)
 	if err != nil {
 		klog.Fatalf("Error reading the environment variables: %s", err.Error())
+	}
+
+	if err = annotateNode(env.ClusterCidr); err != nil {
+		klog.Errorf("Error while annotating the node: %s", err.Error())
 	}
 
 	eventHandlers := event.NewRegistry("routeagent-driver", os.Getenv("NETWORK_PLUGIN"))
@@ -63,4 +71,28 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+}
+
+func annotateNode(clusterCidr []string) error {
+	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	if err != nil {
+		klog.Fatalf("Error building kubeconfig: %s", err.Error())
+	}
+
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("Error building clientset: %s", err.Error())
+	}
+
+	nodeName, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		return fmt.Errorf("Error reading the NODE_NAME from the environment")
+	}
+
+	err = cni_interface.AnnotateNodeWithCNIInterfaceIP(nodeName, constants.CniInterfaceIp, clientSet, clusterCidr)
+	if err != nil {
+		return fmt.Errorf("AnnotateNodeWithCNIInterfaceIP returned error %v", err)
+	}
+
+	return nil
 }

--- a/pkg/routeagent-driver/main.go
+++ b/pkg/routeagent-driver/main.go
@@ -28,7 +28,7 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
-	klog.Info("SGM:: Starting submariner-route-agent using the event framework")
+	klog.Info("Starting submariner-route-agent using the event framework")
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 

--- a/pkg/routeagent-driver/main.go
+++ b/pkg/routeagent-driver/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/event/controller"
+	"github.com/submariner-io/submariner/pkg/event/logger"
+	kp "github.com/submariner-io/submariner/pkg/routeagent-driver/handlers/kubeproxy-iptables"
+)
+
+var (
+	masterURL  string
+	kubeconfig string
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	klog.Info("SGM: Starting submariner-route-agent using the event framework")
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
+
+	eventHandlers := event.NewRegistry("routeagent-driver", os.Getenv("NETWORK_PLUGIN"))
+	if err := eventHandlers.AddHandlers(logger.NewHandler(), kp.NewSyncHandler()); err != nil {
+		klog.Fatalf("Error registering the handlers: %s", err.Error())
+	}
+
+	ctl, err := controller.New(&controller.Config{
+		Registry:   &eventHandlers,
+		MasterURL:  masterURL,
+		Kubeconfig: kubeconfig})
+
+	if err != nil {
+		klog.Fatalf("Error creating controller for event handling %v", err)
+	}
+
+	err = ctl.Start(stopCh)
+	if err != nil {
+		klog.Fatalf("Error starting controller: %v", err)
+	}
+
+	<-stopCh
+	ctl.Stop()
+
+	klog.Info("All controllers stopped or exited. Stopping submariner-networkplugin-syncer")
+}
+
+func init() {
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "",
+		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+}

--- a/pkg/routeagent-driver/main.go
+++ b/pkg/routeagent-driver/main.go
@@ -54,7 +54,7 @@ func main() {
 		klog.Errorf("Error while annotating the node: %s", err.Error())
 	}
 
-	registry := event.NewRegistry("routeagent-driver", os.Getenv("NETWORK_PLUGIN"))
+	registry := event.NewRegistry("routeagent-driver", os.Getenv("SUBMARINER_NETWORKPLUGIN"))
 	if err := registry.AddHandlers(logger.NewHandler(), kp_iptables.NewSyncHandler(env, smClientset)); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}


### PR DESCRIPTION
This will allow for all those network plugins to be recognized with this same
route agent driver, and at the same time we could make specific modification
if this was ever required.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>