### PR TITLE
Ovn routeagent handler

### DIFF
--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -17,7 +17,7 @@ type Handler interface {
 	GetName() string
 
 	// GetNetworkPlugin returns the kubernetes network plugin that this handler supports.
-	GetNetworkPlugin() string
+	GetNetworkPlugins() []string
 
 	// Stop is called once during shutdown to let the handler perform any cleanup. The uninstall flag indicates
 	// whether or not Submariner is being completely uninstalled from the system.

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -21,8 +21,8 @@ func (l *Handler) GetName() string {
 	return "logger"
 }
 
-func (l *Handler) GetNetworkPlugin() string {
-	return event.AnyNetworkPlugin
+func (l *Handler) GetNetworkPlugins() []string {
+	return []string{event.AnyNetworkPlugin}
 }
 
 func (l *Handler) TransitionToNonGateway() error {

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 type Registry struct {
@@ -34,9 +35,13 @@ func (er *Registry) GetName() string {
 }
 
 func (er *Registry) addHandler(eventHandler Handler) error {
-	evNetworkPlugin := eventHandler.GetNetworkPlugin()
+	evNetworkPlugins := util.NewStringSet()
 
-	if evNetworkPlugin == AnyNetworkPlugin || evNetworkPlugin == er.networkPlugin {
+	for _, np := range eventHandler.GetNetworkPlugins() {
+		evNetworkPlugins.Add(np)
+	}
+
+	if evNetworkPlugins.Contains(AnyNetworkPlugin) || evNetworkPlugins.Contains(er.networkPlugin) {
 		if err := eventHandler.Init(); err != nil {
 			return errors.Wrapf(err, "Event handler %q failed to initialize", eventHandler.GetName())
 		}

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -52,8 +52,8 @@ func (t *TestHandler) GetName() string {
 	return t.Name
 }
 
-func (t *TestHandler) GetNetworkPlugin() string {
-	return t.NetworkPlugin
+func (t *TestHandler) GetNetworkPlugins() []string {
+	return []string{t.NetworkPlugin}
 }
 
 const EvTransitionToNonGateway = "TransitionToNonGateway"

--- a/pkg/networkplugin-syncer/handlers/ovn/handler.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/handler.go
@@ -31,11 +31,11 @@ func (ovn *SyncHandler) GetName() string {
 	return "ovn-sync-handler"
 }
 
-func (ovn *SyncHandler) GetNetworkPlugin() string {
-	return "OVNKubernetes"
+func (ovn *SyncHandler) GetNetworkPlugins() []string {
+	return []string{"OVNKubernetes"}
 }
 
-func NewSyncHandler(k8sClientset clientset.Interface) *SyncHandler {
+func NewSyncHandler(k8sClientset clientset.Interface) event.Handler {
 	return &SyncHandler{
 		remoteEndpoints: make(map[string]*submV1.Endpoint),
 		k8sClientset:    k8sClientset,

--- a/pkg/networkplugin-syncer/handlers/ovn/infrastructure.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/infrastructure.go
@@ -72,6 +72,10 @@ func (ovn *SyncHandler) ensureSubmarinerRouter() error {
 		[]string{submarinerDownstreamNET}, nil,
 	)
 
+	if err != nil {
+		return errors.Wrapf(err, "error link for port %q", submarinerDownstreamRPort)
+	}
+
 	err = ovn.nbdb.Execute(linkCmd)
 	if err != nil {
 		return errors.Wrapf(err, "error creating %q port %q", submarinerLogicalRouter, submarinerDownstreamRPort)

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
@@ -12,8 +12,8 @@ const (
 	submarinerUpstreamSwPort = "submariner_up_lsp"
 	submarinerUpstreamRPort  = "submariner_up_lrp"
 	submarinerUpstreamMAC    = "00:60:2f:10:01:01"
-	submarinerUpstreamNET    = submarinerUpstreamIP + "/24"
-	submarinerUpstreamIP     = "169.254.33.7"
+	submarinerUpstreamNET    = SubmarinerUpstreamIP + "/24"
+	SubmarinerUpstreamIP     = "169.254.33.7" // public constant, used in the route-agent handler
 	hostUpstreamIP           = "169.254.33.1"
 )
 

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -30,7 +30,13 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	registry := event.NewRegistry("networkplugin-syncer", os.Getenv("NETWORK_PLUGIN"))
+	networkPlugin := os.Getenv("SUBMARINER_NETWORKPLUGIN")
+
+	if networkPlugin == "" {
+		networkPlugin = "generic"
+	}
+
+	registry := event.NewRegistry("networkplugin-syncer", networkPlugin)
 	if err := registry.AddHandlers(logger.NewHandler(), ovn.NewSyncHandler(getK8sClient())); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -22,4 +22,6 @@ const (
 	// supporting connectivity from HostNetwork to remoteClusters.
 	// [#] interface on the node that has an IPAddress from the clusterCIDR
 	CniInterfaceIP = "submariner.io/cniIfaceIp"
+
+	RouteAgentHostNetworkTableID = 150
 )

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -1,0 +1,8 @@
+package environment
+
+type Specification struct {
+	ClusterID   string
+	Namespace   string
+	ClusterCidr []string
+	ServiceCidr []string
+}

--- a/pkg/routeagent_driver/handlers/kubeproxy_iptables/constants.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy_iptables/constants.go
@@ -32,7 +32,7 @@ const (
 	// To support connectivity for Pods with HostNetworking on the GatewayNode, we program
 	// certain routing rules in table 150. As part of these routes, we set the source-ip of
 	// the egress traffic to the corresponding CNIInterfaceIP on that host.
-	RouteAgentHostNetworkTableID = 150
+
 )
 
 type Operation int

--- a/pkg/routeagent_driver/handlers/kubeproxy_iptables/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy_iptables/gw_transition.go
@@ -4,6 +4,8 @@ import (
 	"k8s.io/klog"
 
 	"github.com/submariner-io/admiral/pkg/log"
+
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 )
 
 func (kp *SyncHandler) TransitionToNonGateway() error {
@@ -20,7 +22,7 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	err := kp.configureIPRule(Delete)
 	if err != nil {
 		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
-			RouteAgentHostNetworkTableID, kp.hostname, err)
+			constants.RouteAgentHostNetworkTableID, kp.hostname, err)
 	}
 
 	return nil
@@ -45,7 +47,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 	err = kp.configureIPRule(Add)
 	if err != nil {
 		klog.Errorf("Unable to add ip rule to table %d on Gateway node %s: %v",
-			RouteAgentHostNetworkTableID, kp.hostname, err)
+			constants.RouteAgentHostNetworkTableID, kp.hostname, err)
 	}
 
 	// Add routes to the new endpoint on the GatewayNode.

--- a/pkg/routeagent_driver/handlers/kubeproxy_iptables/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy_iptables/kp_iptables.go
@@ -60,8 +60,8 @@ func (kp *SyncHandler) GetName() string {
 	return "kubeproxy-iptables-handler"
 }
 
-func (kp *SyncHandler) GetNetworkPlugin() string {
-	return event.AnyNetworkPlugin
+func (kp *SyncHandler) GetNetworkPlugins() []string {
+	return []string{"generic", "canal-flannel", "weave-net", "OpenShiftSDN"}
 }
 
 func (kp *SyncHandler) Init() error {

--- a/pkg/routeagent_driver/handlers/kubeproxy_iptables/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy_iptables/routes_iface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 
 	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 )
 
 func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks []string, operation Operation) {
@@ -22,11 +23,11 @@ func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks [
 		kp.routeCacheGWNode.DeleteAll()
 		// The conversion doesn't introduce a security problem
 		// #nosec G204
-		cmd := exec.Command("/sbin/ip", "r", "flush", "table", strconv.Itoa(RouteAgentHostNetworkTableID))
+		cmd := exec.Command("/sbin/ip", "r", "flush", "table", strconv.Itoa(constants.RouteAgentHostNetworkTableID))
 		if err := cmd.Run(); err != nil {
 			// We can safely ignore this error, as this table will exist only on GW nodes
 			klog.V(log.TRACE).Infof("Flushing routing table %d returned error. Can be ignored on non-Gw node: %v",
-				RouteAgentHostNetworkTableID, err)
+				constants.RouteAgentHostNetworkTableID, err)
 			return
 		}
 	} else if kp.isGatewayNode && kp.cniIface != nil {
@@ -79,7 +80,7 @@ func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation) 
 		Scope:     unix.RT_SCOPE_LINK,
 		LinkIndex: ifaceIndex,
 		Protocol:  4,
-		Table:     RouteAgentHostNetworkTableID,
+		Table:     constants.RouteAgentHostNetworkTableID,
 	}
 
 	switch operation {
@@ -250,8 +251,8 @@ func (kp *SyncHandler) updateRoutingRulesForInterClusterSupport(remoteCIDRs []st
 func (kp *SyncHandler) configureIPRule(operation Operation) error {
 	if kp.cniIface != nil {
 		rule := netlink.NewRule()
-		rule.Table = RouteAgentHostNetworkTableID
-		rule.Priority = RouteAgentHostNetworkTableID
+		rule.Table = constants.RouteAgentHostNetworkTableID
+		rule.Priority = constants.RouteAgentHostNetworkTableID
 
 		switch operation {
 		case Add:

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -1,31 +1,46 @@
 package ovn
 
 import (
-	"fmt"
 	"net"
 	"os"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
 
+	npSyncerOvn "github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/util"
 )
 
 func (ovn *Handler) cleanupGatewayDataplane() error {
 	currentRemoteSubnets, err := ovn.getExistingRuleSubnets()
 	if err != nil {
-		return errors.Wrapf(err, "error reading ip rule list for IPv4 in TransitionToNonGateway")
+		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}
 
-	err = ovn.handleSubnets(currentRemoteSubnets.Elements(), netlink.RuleDel, os.IsNotExist, "TransitionToNonGateway")
+	err = ovn.handleSubnets(currentRemoteSubnets.Elements(), netlink.RuleDel, os.IsNotExist)
 	if err != nil {
 		return errors.Wrapf(err, "error removing routing rule")
 	}
 
 	err = netlink.RouteDel(getSubmDefaultRoute())
 	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "error deleting submariner default route during TransitionToNonGateway")
+		return errors.Wrap(err, "error deleting submariner default route")
+	}
+
+	for _, handler := range ovn.cleanupHandlers {
+		// TODO: Make those handlers have a single cleanup on GatewayToNonGateway transition,
+		//       we can make them a normal event handler, instead of a cleanup handler, but
+		//       we need to make sure that TransitionToNonGateway is fired at least one for
+		//       a controller which is started once and no endpoint is received on for current
+		//       host.
+		if err := handler.NonGatewayCleanup(); err != nil {
+			return errors.Wrap(err, "NonGatewayCleanup")
+		} else if err := handler.GatewayToNonGatewayTransition(); err != nil {
+			return errors.Wrap(err, "GatewayToNonGatewayTransition")
+		}
 	}
 
 	return ovn.cleanupForwardingIptables()
@@ -34,49 +49,60 @@ func (ovn *Handler) cleanupGatewayDataplane() error {
 func (ovn *Handler) updateGatewayDataplane() error {
 	currentRuleRemotes, err := ovn.getExistingRuleSubnets()
 	if err != nil {
-		return errors.Wrapf(err, "error reading ip rule list for IPv4 in TransitionToGateway")
+		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}
 
 	endpointSubnets := ovn.getRemoteSubnets()
 
 	toAdd := currentRuleRemotes.Difference(endpointSubnets)
 
-	err = ovn.handleSubnets(toAdd, netlink.RuleAdd, os.IsExist, "TransitionToGateway")
+	err = ovn.handleSubnets(toAdd, netlink.RuleAdd, os.IsExist)
 	if err != nil {
-		return errors.Wrapf(err, "error adding routing rule")
+		return errors.Wrap(err, "error adding routing rule")
 	}
 
 	toRemove := endpointSubnets.Difference(currentRuleRemotes)
 
-	err = ovn.handleSubnets(toRemove, netlink.RuleDel, os.IsNotExist, "TransitionToGateway")
+	err = ovn.handleSubnets(toRemove, netlink.RuleDel, os.IsNotExist)
 	if err != nil {
 		return errors.Wrapf(err, "error removing routing rule")
 	}
 
 	err = netlink.RouteAdd(getSubmDefaultRoute())
 	if err != nil && !os.IsExist(err) {
-		return errors.Wrap(err, "error adding submariner default route during TransitionToGateway")
+		return errors.Wrap(err, "error adding submariner default")
 	}
 
 	return ovn.setupForwardingIptables()
 }
 
+func (ovn *Handler) getForwardingRuleSpecs() ([][]string, error) {
+	if ovn.cableRoutingInterface == nil {
+		return nil, errors.New("error setting up forwarding iptables, the cable interface isn't discovered yet, " +
+			"this will be retried")
+	}
+
+	return [][]string{
+		{"-i", "ovn-k8s-gw0", "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"},
+		{"-i", ovn.cableRoutingInterface.Name, "-o", "ovn-k8s-gw0", "-j", "ACCEPT"},
+	}, nil
+}
+
 func (ovn *Handler) setupForwardingIptables() error {
 	ipt, err := iptables.New()
 	if err != nil {
-		return fmt.Errorf("error initializing iptables: %v", err)
+		return errors.Wrap(err, "error initializing iptables")
 	}
 
-	ruleSpec := []string{"-i", "ovn-k8s-gw0", "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"}
-
-	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
-		return fmt.Errorf("unable to insert iptable rule in filter table to forward submariner traffic: %v", err)
+	ruleSpecs, err := ovn.getForwardingRuleSpecs()
+	if err != nil {
+		return err
 	}
 
-	ruleSpec = []string{"-i", ovn.cableRoutingInterface.Name, "-o", "ovn-k8s-gw0", "-j", "ACCEPT"}
-
-	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
-		return fmt.Errorf("unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
+	for _, ruleSpec := range ruleSpecs {
+		if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
+			return errors.Wrap(err, "unable to insert iptable rule in filter table to forward submariner traffic")
+		}
 	}
 
 	return nil
@@ -85,21 +111,29 @@ func (ovn *Handler) setupForwardingIptables() error {
 func (ovn *Handler) cleanupForwardingIptables() error {
 	ipt, err := iptables.New()
 	if err != nil {
-		return fmt.Errorf("error initializing iptables: %v", err)
+		return errors.Wrap(err, "error initializing iptables")
 	}
 
-	_ = ipt.Delete("filter", "FORWARD", "-i", "ovn-k8s-gw0", "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT")
-	_ = ipt.Delete("filter", "FORWARD", "-i", ovn.cableRoutingInterface.Name, "-o", "ovn-k8s-gw0", "-j", "ACCEPT")
+	ruleSpecs, err := ovn.getForwardingRuleSpecs()
+	if err != nil {
+		return err
+	}
+
+	for _, ruleSpec := range ruleSpecs {
+		err = ipt.Delete("filter", "FORWARD", ruleSpec...)
+		if err != nil {
+			// We log, and don't return, because there could be some transient errors on delete if the
+			// rule didn't exist, we don't want to retry
+			klog.Errorf("error cleaning FORWARD tables: %s", err)
+		}
+	}
 
 	return nil
 }
 
-// TODO: Use the constant defined in networkplugin-syncer handler when that's merged.
-const submarinerUpstreamIP = "169.254.33.7"
-
 func getSubmDefaultRoute() *netlink.Route {
 	return &netlink.Route{
-		Gw:    net.ParseIP(submarinerUpstreamIP),
-		Table: ovnRoutingRulesTable,
+		Gw:    net.ParseIP(npSyncerOvn.SubmarinerUpstreamIP),
+		Table: constants.RouteAgentHostNetworkTableID,
 	}
 }

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -1,0 +1,105 @@
+package ovn
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+
+	"github.com/submariner-io/submariner/pkg/util"
+)
+
+func (ovn *Handler) cleanupGatewayDataplane() error {
+	currentRemoteSubnets, err := ovn.getExistingRuleSubnets()
+	if err != nil {
+		return errors.Wrapf(err, "error reading ip rule list for IPv4 in TransitionToNonGateway")
+	}
+
+	err = ovn.handleSubnets(currentRemoteSubnets.Elements(), netlink.RuleDel, os.IsNotExist, "TransitionToNonGateway")
+	if err != nil {
+		return errors.Wrapf(err, "error removing routing rule")
+	}
+
+	err = netlink.RouteDel(getSubmDefaultRoute())
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "error deleting submariner default route during TransitionToNonGateway")
+	}
+
+	return ovn.cleanupForwardingIptables()
+}
+
+func (ovn *Handler) updateGatewayDataplane() error {
+	currentRuleRemotes, err := ovn.getExistingRuleSubnets()
+	if err != nil {
+		return errors.Wrapf(err, "error reading ip rule list for IPv4 in TransitionToGateway")
+	}
+
+	endpointSubnets := ovn.getRemoteSubnets()
+
+	toAdd := currentRuleRemotes.Difference(endpointSubnets)
+
+	err = ovn.handleSubnets(toAdd, netlink.RuleAdd, os.IsExist, "TransitionToGateway")
+	if err != nil {
+		return errors.Wrapf(err, "error adding routing rule")
+	}
+
+	toRemove := endpointSubnets.Difference(currentRuleRemotes)
+
+	err = ovn.handleSubnets(toRemove, netlink.RuleDel, os.IsNotExist, "TransitionToGateway")
+	if err != nil {
+		return errors.Wrapf(err, "error removing routing rule")
+	}
+
+	err = netlink.RouteAdd(getSubmDefaultRoute())
+	if err != nil && !os.IsExist(err) {
+		return errors.Wrap(err, "error adding submariner default route during TransitionToGateway")
+	}
+
+	return ovn.setupForwardingIptables()
+}
+
+func (ovn *Handler) setupForwardingIptables() error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("error initializing iptables: %v", err)
+	}
+
+	ruleSpec := []string{"-i", "ovn-k8s-gw0", "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"}
+
+	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
+		return fmt.Errorf("unable to insert iptable rule in filter table to forward submariner traffic: %v", err)
+	}
+
+	ruleSpec = []string{"-i", ovn.cableRoutingInterface.Name, "-o", "ovn-k8s-gw0", "-j", "ACCEPT"}
+
+	if err = util.PrependUnique(ipt, "filter", "FORWARD", ruleSpec); err != nil {
+		return fmt.Errorf("unable to insert iptable rule in filter table to allow vxlan traffic: %v", err)
+	}
+
+	return nil
+}
+
+func (ovn *Handler) cleanupForwardingIptables() error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("error initializing iptables: %v", err)
+	}
+
+	_ = ipt.Delete("filter", "FORWARD", "-i", "ovn-k8s-gw0", "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT")
+	_ = ipt.Delete("filter", "FORWARD", "-i", ovn.cableRoutingInterface.Name, "-o", "ovn-k8s-gw0", "-j", "ACCEPT")
+
+	return nil
+}
+
+// TODO: Use the constant defined in networkplugin-syncer handler when that's merged.
+const submarinerUpstreamIP = "169.254.33.7"
+
+func getSubmDefaultRoute() *netlink.Route {
+	return &netlink.Route{
+		Gw:    net.ParseIP(submarinerUpstreamIP),
+		Table: ovnRoutingRulesTable,
+	}
+}

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (ovn *Handler) cleanupGatewayDataplane() error {
-	currentRemoteSubnets, err := ovn.getExistingRuleSubnets()
+	currentRemoteSubnets, err := ovn.getExistingIPv4RuleSubnets()
 	if err != nil {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}
@@ -47,7 +47,7 @@ func (ovn *Handler) cleanupGatewayDataplane() error {
 }
 
 func (ovn *Handler) updateGatewayDataplane() error {
-	currentRuleRemotes, err := ovn.getExistingRuleSubnets()
+	currentRuleRemotes, err := ovn.getExistingIPv4RuleSubnets()
 	if err != nil {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -1,0 +1,155 @@
+package ovn
+
+import (
+	"net"
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	cableCleanup "github.com/submariner-io/submariner/pkg/cable/cleanup"
+	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/routeagent/cleanup"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
+	"github.com/submariner-io/submariner/pkg/util"
+)
+
+type Handler struct {
+	event.HandlerBase
+	mutex                 sync.Mutex
+	config                *environment.Specification
+	smClient              clientset.Interface
+	cableRoutingInterface *net.Interface
+	cleanupHandlers       []cleanup.Handler
+	localEndpoint         *submV1.Endpoint
+	remoteEndpoints       map[string]*submV1.Endpoint
+	isGateway             bool
+}
+
+func NewHandler(env environment.Specification, smClientSet clientset.Interface) *Handler {
+	return &Handler{
+		config:   &env,
+		smClient: smClientSet,
+	}
+}
+
+func (ovn *Handler) GetName() string {
+	return "ovn-hostroutes-handler"
+}
+
+func (ovn *Handler) GetNetworkPlugins() []string {
+	return []string{"OVNKubernetes"}
+}
+
+func (ovn *Handler) Init() error {
+	var err error
+
+	ovn.cableRoutingInterface, err = util.GetDefaultGatewayInterface()
+	if err != nil {
+		klog.Fatalf("Unable to find the default interface on host: %s", err.Error())
+	}
+
+	// For now we get all the cleanups
+	ovn.cleanupHandlers = cableCleanup.GetCleanupHandlers()
+
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.localEndpoint = endpoint
+
+	// TODO: this logic belongs to the cabledrivers instead
+	if endpoint.Spec.Backend == "wireguard" {
+		//NOTE: This assumes that LocalEndpointCreated happens before than TransitionToGatewayNode
+		if wg, err := net.InterfaceByName(wireguard.DefaultDeviceName); err == nil {
+			ovn.cableRoutingInterface = wg
+		} else {
+			return errors.Wrapf(err, "Wireguard interface %s not found on the node.", wireguard.DefaultDeviceName)
+		}
+	}
+
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.localEndpoint = endpoint
+
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	if ovn.localEndpoint.Name == endpoint.Name {
+		ovn.localEndpoint = nil
+	}
+
+	return nil
+}
+
+func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.remoteEndpoints[endpoint.Name] = endpoint
+
+	if ovn.isGateway {
+		return ovn.updateGatewayDataplane()
+	}
+
+	return nil
+}
+
+func (ovn *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.remoteEndpoints[endpoint.Name] = endpoint
+
+	if ovn.isGateway {
+		return ovn.updateGatewayDataplane()
+	}
+
+	return nil
+}
+
+func (ovn *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	delete(ovn.remoteEndpoints, endpoint.Name)
+
+	if ovn.isGateway {
+		return ovn.updateGatewayDataplane()
+	}
+
+	return nil
+}
+
+func (ovn *Handler) TransitionToNonGateway() error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.isGateway = false
+
+	return ovn.cleanupGatewayDataplane()
+}
+
+func (ovn *Handler) TransitionToGateway() error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	ovn.isGateway = true
+
+	return ovn.updateGatewayDataplane()
+}

--- a/pkg/routeagent_driver/handlers/ovn/iptables.go
+++ b/pkg/routeagent_driver/handlers/ovn/iptables.go
@@ -1,0 +1,1 @@
+package ovn

--- a/pkg/routeagent_driver/handlers/ovn/iptables.go
+++ b/pkg/routeagent_driver/handlers/ovn/iptables.go
@@ -1,1 +1,0 @@
-package ovn

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -18,12 +18,12 @@ func (ovn *Handler) handleSubnets(subnets []string, ruleFunc func(rule *netlink.
 		for _, localSubnet := range ovn.localEndpoint.Spec.Subnets {
 			rule, err := ovn.ruleForSouthTraffic(localSubnet, subnetToHandle)
 			if err != nil {
-				return errors.Wrapf(err, "creating rule %#v", rule)
+				return errors.Wrapf(err, "error creating rule %#v", rule)
 			}
 
 			err = ruleFunc(rule)
 			if err != nil && !ignoredErrorFunc(err) {
-				return errors.Wrapf(err, "handling rule %#v with dst=%q src=%q", rule, rule.Dst.String(), rule.Src.String())
+				return errors.Wrapf(err, "error handling rule %#v", rule)
 			}
 		}
 	}
@@ -50,7 +50,7 @@ func (ovn *Handler) ruleForSouthTraffic(localSubnet, remoteSubnet string) (*netl
 	return rule, nil
 }
 
-func (ovn *Handler) getExistingRuleSubnets() (stringset.Interface, error) {
+func (ovn *Handler) getExistingIPv4RuleSubnets() (stringset.Interface, error) {
 	currentRuleRemotes := stringset.New()
 	rules, err := netlink.RuleList(netlink.FAMILY_V4)
 	if err != nil {

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -1,0 +1,65 @@
+package ovn
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/vishvananda/netlink"
+)
+
+const ovnRoutingRulesTable = 5
+
+// handleSubnets builds ip rules, and passes them to the specified netlink function
+//               for provided subnet list
+func (ovn *Handler) handleSubnets(subnets []string, ruleFunc func(rule *netlink.Rule) error,
+	ignoredErrorFunc func(error) bool, event string) error {
+	for _, subnetToHandle := range subnets {
+		for _, localSubnet := range ovn.localEndpoint.Spec.Subnets {
+			rule, err := ovn.ruleForSouthTraffic(localSubnet, subnetToHandle, event)
+			if err != nil {
+				return err
+			}
+
+			err = ruleFunc(rule)
+			if err != nil && !ignoredErrorFunc(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (ovn *Handler) ruleForSouthTraffic(localSubnet, remoteSubnet, event string) (*netlink.Rule, error) {
+	_, dstCIDR, err := net.ParseCIDR(localSubnet)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error trying to parse local subnet %q on %q", localSubnet, event)
+	}
+
+	_, srcCIDR, err := net.ParseCIDR(remoteSubnet)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error trying to parse remote subnet %q on %q", remoteSubnet, event)
+	}
+
+	return &netlink.Rule{
+		Dst:   dstCIDR,
+		Src:   srcCIDR,
+		Table: ovnRoutingRulesTable}, nil
+}
+
+func (ovn *Handler) getExistingRuleSubnets() (stringset.Interface, error) {
+	currentRuleRemotes := stringset.New()
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range rules {
+		if rule.Table == ovnRoutingRulesTable && rule.Src != nil {
+			currentRuleRemotes.Add(rule.Src.String())
+		}
+	}
+
+	return currentRuleRemotes, nil
+}

--- a/pkg/routeagent_driver/handlers/ovn/subnets.go
+++ b/pkg/routeagent_driver/handlers/ovn/subnets.go
@@ -1,0 +1,15 @@
+package ovn
+
+import "github.com/submariner-io/admiral/pkg/stringset"
+
+func (ovn *Handler) getRemoteSubnets() stringset.Interface {
+	endpointSubnets := stringset.New()
+
+	for _, endpoint := range ovn.remoteEndpoints {
+		for _, subnet := range endpoint.Spec.Subnets {
+			endpointSubnets.Add(subnet)
+		}
+	}
+
+	return endpointSubnets
+}

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -60,9 +60,16 @@ func main() {
 		klog.Errorf("Error while annotating the node: %s", err.Error())
 	}
 
-	registry := event.NewRegistry("routeagent_driver", os.Getenv("NETWORK_PLUGIN"))
-	if err := registry.AddHandlers(logger.NewHandler(),
-		kp_iptables.NewSyncHandler(env.ClusterCidr, env.ServiceCidr, smClientset)); err != nil {
+	np := os.Getenv("SUBMARINER_NETWORKPLUGIN")
+	if np == "" {
+		np = "generic"
+	}
+
+	registry := event.NewRegistry("routeagent_driver", np)
+	if err := registry.AddHandlers(
+		logger.NewHandler(),
+		kp_iptables.NewSyncHandler(env.ClusterCidr, env.ServiceCidr, smClientset),
+	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}
 

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -17,20 +17,15 @@ import (
 	"github.com/submariner-io/submariner/pkg/event/controller"
 	"github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni_interface"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	kp_iptables "github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy_iptables"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
 )
 
 var (
 	masterURL  string
 	kubeconfig string
 )
-
-type specification struct {
-	ClusterID   string
-	Namespace   string
-	ClusterCidr []string
-	ServiceCidr []string
-}
 
 func main() {
 	klog.InitFlags(nil)
@@ -40,7 +35,7 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	var env specification
+	var env environment.Specification
 	err := envconfig.Process("submariner", &env)
 	if err != nil {
 		klog.Fatalf("Error reading the environment variables: %s", err.Error())
@@ -69,6 +64,7 @@ func main() {
 	if err := registry.AddHandlers(
 		logger.NewHandler(),
 		kp_iptables.NewSyncHandler(env.ClusterCidr, env.ServiceCidr, smClientset),
+		ovn.NewHandler(env, smClientset),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}


### PR DESCRIPTION
OVN route-agent handler
    
This handler manages the ip routing rules & routes on the submariner gateway,
as well as the necessary FORWARD iptables.
   
Extend the generic routeagent handler to the other drivers
     
This will allow for all those network plugins to be recognized with this same
route agent driver, and at the same time we could make specific modification
if this was ever required.
    
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
