### PR TITLE
Make Healthchecker ping continuous

### DIFF
--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -11,7 +11,6 @@ import (
 var waitTime = 15 * time.Second
 
 const threshold = 5
-const allpackets = 100
 
 // The RTT will be stored and will be used to calculate the statistics until
 // the size is reached. Once the size is reached the array will be reset and
@@ -65,12 +64,11 @@ func (p *pingerInfo) sendPing() {
 	pinger.RecordRtts = false
 
 	pinger.OnSend = func(packet *ping.Packet) {
-		// Pinger will be stopped once the packet loss reaches threshold and
-		// if packet loss is not 100% recreates the Pinger without marking an error
-		if pinger.Statistics().PacketsSent-pinger.Statistics().PacketsRecv > threshold {
-			klog.Infof("Packet loss reached a threshold of %d and hence stopping the pinger for HealthCheckIP: %q",
-				threshold, p.healthCheckIP)
-			pinger.Stop()
+		// Pinger will mark a connection as an error if the packet loss reaches the threshold
+		if pinger.PacketsSent-pinger.PacketsRecv > threshold {
+			p.failureMsg = fmt.Sprintf("Failed to successfully ping the remote endpoint IP %q", p.healthCheckIP)
+			pinger.PacketsSent = 0
+			pinger.PacketsRecv = 0
 		}
 	}
 
@@ -79,13 +77,6 @@ func (p *pingerInfo) sendPing() {
 		p.statistics.update(uint64(packet.Rtt.Nanoseconds()))
 	}
 
-	pinger.OnFinish = func(stats *ping.Statistics) {
-		// Since we are setting a timeout and not a count, it will be an endless ping.
-		// If the timeout is reached with no successful packets, onFinish will be called and it is a failed ping.
-		if stats.PacketLoss == allpackets {
-			p.failureMsg = fmt.Sprintf("Failed to successfully ping the remote endpoint IP %q", p.healthCheckIP)
-		}
-	}
 	err = pinger.Run()
 	if err != nil {
 		klog.Errorf("Error running ping for the remote endpoint IP %q: %v", p.healthCheckIP, err)

--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -10,7 +10,7 @@ import (
 
 var waitTime = 15 * time.Second
 
-const threshold = 5
+const maxLosablePackets = 5
 
 // The RTT will be stored and will be used to calculate the statistics until
 // the size is reached. Once the size is reached the array will be reset and
@@ -65,7 +65,7 @@ func (p *pingerInfo) sendPing() {
 
 	pinger.OnSend = func(packet *ping.Packet) {
 		// Pinger will mark a connection as an error if the packet loss reaches the threshold
-		if pinger.PacketsSent-pinger.PacketsRecv > threshold {
+		if pinger.PacketsSent-pinger.PacketsRecv > maxLosablePackets {
 			p.failureMsg = fmt.Sprintf("Failed to successfully ping the remote endpoint IP %q", p.healthCheckIP)
 			pinger.PacketsSent = 0
 			pinger.PacketsRecv = 0


### PR DESCRIPTION
When the Timeout value is set in the pinger, it is calcuated from the
time pinger starts and not the time interval between send and receive.
So now we are now using a threshold of packet count after which the connection
will be marked as an error, if the packet loss continues to be 100%.

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>