### PR TITLE
Fix OVNKubernetes PMTU discovery bug

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -42,6 +42,11 @@ func (ovn *SyncHandler) updateGatewayNode() error {
 		return err
 	}
 
+	// Update ovn-kubernetes host management ACL to allow return of fragmentation ICMP for PMTU discovery
+	if err := ovn.changeMgmtAllowRelatedACL(chassis.Hostname); err != nil {
+		return err
+	}
+
 	// Associate the port to an specific chassis (=host) on OVN so the traffic flows out/in through that host
 	// the active submariner-gateway in our case
 	if err := ovn.associateSubmarinerExternalPortToChassis(chassis); err != nil {


### PR DESCRIPTION
This toggles an ACL generated by default in ovn-kubernetes, that allows
traffic from the k8s-host port (a virtual port that exist on each host)
so that fragment ICMP packets will also get back to pods in the gateway nodes.

Without this change, if a packet needs to be fragmented while traversing the
IPSEC tunnel the sender pod won't be properly notified, and the packet will
never be fragmented in the origin, as we use the DNF flag all around
for performance purposes.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>