### PR TITLE
Reset gateway connection status when health checker reports connected

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,8 +125,13 @@ func main() {
 
 	var cableHealthchecker healthchecker.Interface
 	if len(submSpec.GlobalCidr) == 0 && submSpec.HealthCheckEnabled {
-		cableHealthchecker, err = healthchecker.New(&watcher.Config{RestConfig: cfg}, submSpec.Namespace,
-			submSpec.ClusterID, submSpec.HealthCheckInterval, submSpec.HealthCheckMaxPacketLossCount)
+		cableHealthchecker, err = healthchecker.New(&healthchecker.Config{
+			WatcherConfig:      &watcher.Config{RestConfig: cfg},
+			EndpointNamespace:  submSpec.Namespace,
+			ClusterID:          submSpec.ClusterID,
+			PingInterval:       submSpec.HealthCheckInterval,
+			MaxPacketLossCount: submSpec.HealthCheckMaxPacketLossCount,
+		})
 		if err != nil {
 			klog.Errorf("Error creating healthChecker: %v", err)
 		}

--- a/pkg/cableengine/healthchecker/fake/pinger.go
+++ b/pkg/cableengine/healthchecker/fake/pinger.go
@@ -1,0 +1,62 @@
+package fake
+
+import (
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
+)
+
+type Pinger struct {
+	ip          string
+	latencyInfo atomic.Value
+	start       chan struct{}
+	stop        chan struct{}
+}
+
+func NewPinger(ip string) *Pinger {
+	return &Pinger{
+		ip:    ip,
+		start: make(chan struct{}),
+		stop:  make(chan struct{}),
+	}
+}
+
+func (p *Pinger) Start() {
+	defer GinkgoRecover()
+	Expect(p.start).ToNot(BeClosed())
+	close(p.start)
+}
+
+func (p *Pinger) Stop() {
+	defer GinkgoRecover()
+	Expect(p.stop).ToNot(BeClosed())
+	close(p.stop)
+}
+
+func (p *Pinger) GetLatencyInfo() *healthchecker.LatencyInfo {
+	o := p.latencyInfo.Load()
+	if o != nil {
+		info := o.(healthchecker.LatencyInfo)
+		return &info
+	}
+
+	return nil
+}
+
+func (p *Pinger) SetLatencyInfo(info *healthchecker.LatencyInfo) {
+	p.latencyInfo.Store(*info)
+}
+
+func (p *Pinger) GetIP() string {
+	return p.ip
+}
+
+func (p *Pinger) AwaitStart() {
+	Eventually(p.start).Should(BeClosed(), "Start was not called")
+}
+
+func (p *Pinger) AwaitStop() {
+	Eventually(p.stop).Should(BeClosed(), "Stop was not called")
+}

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -218,6 +218,9 @@ func (i *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 							connection.Status = v1.ConnectionError
 							connection.StatusMessage = latencyInfo.ConnectionError
 						}
+					} else if connection.Status == v1.ConnectionError && latencyInfo.ConnectionError == "" {
+						connection.Status = v1.Connected
+						connection.StatusMessage = ""
 					}
 				}
 			}


### PR DESCRIPTION
When the health checker reports a connection error, the gateway syncer sets the gateway connection status to error. When the health checker subsequently reports connected, the gateway syncer needs to set the status back to connected.

The rest of the changes were related to adding unit tests for the health checker's interaction with the gateway syncer. This entailed creating a PingerInterface and a fake implementation that can be hooked into the health checker.

