### PR TITLE
Support latest ovn-kubernetes architecture

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -28,7 +28,7 @@ func (ovn *SyncHandler) initClients() error {
 		return err
 	}
 
-	ovn.nbctl = nbctl.New(defaultOVNNBDB, pkFile, certFile, caFile)
+	ovn.nbctl = nbctl.New(getOVNNBDBAddress(), pkFile, certFile, caFile)
 
 	tlsConfig, err := getOVNTLSConfig(pkFile, certFile, caFile)
 	if err != nil {

--- a/pkg/networkplugin-syncer/handlers/ovn/handler.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/handler.go
@@ -17,14 +17,18 @@ var WaitingForLocalEndpoint = errors.New("Waiting for the local endpoint details
 
 type SyncHandler struct {
 	event.HandlerBase
-	syncMutex        sync.Mutex
-	k8sClientset     clientset.Interface
-	nbctl            *nbctl.NbCtl
-	nbdb             goovn.Client
-	sbdb             goovn.Client
-	localEndpoint    *submV1.Endpoint
-	remoteEndpoints  map[string]*submV1.Endpoint
-	lastOvnGwChassis string
+	syncMutex             sync.Mutex
+	k8sClientset          clientset.Interface
+	nbctl                 *nbctl.NbCtl
+	nbdb                  goovn.Client
+	sbdb                  goovn.Client
+	localEndpoint         *submV1.Endpoint
+	remoteEndpoints       map[string]*submV1.Endpoint
+	lastOvnGwChassis      string
+	submarinerUpstreamIP  string
+	submarinerUpstreamNet string
+	hostUpstreamIP        string
+	hasNodeLocalSwitch    bool
 }
 
 func (ovn *SyncHandler) GetName() string {
@@ -44,6 +48,10 @@ func NewSyncHandler(k8sClientset clientset.Interface) event.Handler {
 
 func (ovn *SyncHandler) Init() error {
 	if err := ovn.initClients(); err != nil {
+		return err
+	}
+
+	if err := ovn.detectOvnKubernetesImplementation(); err != nil {
 		return err
 	}
 

--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl_suite_test.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl_suite_test.go
@@ -1,0 +1,36 @@
+package nbctl
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	ip1   = "1.1.1.1"
+	ip2   = "2.2.2.2"
+	ip3   = "3.3.3.3"
+	port  = "1234"
+	proto = "ssl"
+)
+
+func fakeResolver(host string) ([]net.IP, error) {
+	return []net.IP{net.ParseIP(ip1), net.ParseIP(ip2), net.ParseIP(ip3)}, nil
+}
+
+var _ = Describe("expandConnectionStringIPs", func() {
+	It("should expand correctly", func() {
+		connection, err := expandConnectionStringIPsDetail(proto+":some-host:"+port, fakeResolver)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(connection).To(Equal(fmt.Sprintf("%s:%s:%s,%s:%s:%s,%s:%s:%s",
+			proto, ip1, port, proto, ip2, port, proto, ip3, port)))
+	})
+})
+
+func TestNbctl(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NBCTL Test Suite")
+}

--- a/pkg/networkplugin-syncer/handlers/ovn/ovn_kubernetes_versions.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn_kubernetes_versions.go
@@ -1,0 +1,34 @@
+package ovn
+
+import (
+	"github.com/pkg/errors"
+
+	goovn "github.com/ebay/go-ovn"
+	"k8s.io/klog"
+)
+
+const nodeLocalSwitch = "node_local_switch"
+
+func (ovn *SyncHandler) detectOvnKubernetesImplementation() error {
+	ls, err := ovn.nbdb.LSGet(nodeLocalSwitch)
+
+	switch {
+	case ls != nil && err == nil:
+		klog.Infof("New ovn-kubernetes implementation detected, using %q", submarinerUpstreamNETv2)
+
+		ovn.submarinerUpstreamIP = SubmarinerUpstreamIPv2
+		ovn.submarinerUpstreamNet = submarinerUpstreamNETv2
+		ovn.hostUpstreamIP = hostUpstreamIPv2
+		ovn.hasNodeLocalSwitch = true
+	case ls == nil && errors.Is(err, goovn.ErrorNotFound):
+		klog.Infof("Old ovn-kubernetes implementation detected, using %q", submarinerUpstreamNET)
+
+		ovn.submarinerUpstreamIP = SubmarinerUpstreamIP
+		ovn.submarinerUpstreamNet = submarinerUpstreamNET
+		ovn.hostUpstreamIP = hostUpstreamIP
+	default:
+		return errors.Wrapf(err, "error trying to find %q switch to detect ovn version details", nodeLocalSwitch)
+	}
+
+	return nil
+}

--- a/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
@@ -16,8 +16,8 @@ const (
 	ovnClusterSubmarinerSwPort = "ovn_cluster_subm_lsp"
 	ovnClusterSubmarinerMAC    = "00:60:2f:10:01:02"
 	ovnClusterSubmarinerNET    = ovnClusterSubmarinerIP + "/29"
-	ovnClusterSubmarinerIP     = "169.254.34.2"
-	ovnRoutePoliciesPrio       = 10
+	ovnClusterSubmarinerIP     = "169.254.254.2"
+	ovnRoutePoliciesPrio       = 20000
 )
 
 func (ovn *SyncHandler) connectOvnClusterRouterToSubm() error {

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
@@ -15,6 +15,11 @@ const (
 	submarinerUpstreamNET    = SubmarinerUpstreamIP + "/24"
 	SubmarinerUpstreamIP     = "169.254.33.7" // public constant, used in the route-agent handler
 	hostUpstreamIP           = "169.254.33.1"
+	// the implementation IPs changed at some point
+	// https://github.com/ovn-org/ovn-kubernetes/blob/master/go-controller/pkg/types/const.go#L50
+	hostUpstreamIPv2        = "169.254.0.1"
+	submarinerUpstreamNETv2 = SubmarinerUpstreamIPv2 + "/20"
+	SubmarinerUpstreamIPv2  = "169.254.0.7"
 )
 
 func (ovn *SyncHandler) createOrUpdateSubmarinerExternalPort(extLogicalSwitch string) error {
@@ -28,7 +33,7 @@ func (ovn *SyncHandler) createOrUpdateSubmarinerExternalPort(extLogicalSwitch st
 		extLogicalSwitch, submarinerUpstreamSwPort,
 		submarinerLogicalRouter, submarinerUpstreamRPort,
 		submarinerUpstreamMAC,
-		[]string{submarinerUpstreamNET}, nil,
+		[]string{ovn.submarinerUpstreamNet}, nil,
 	)
 
 	if err == nil {
@@ -57,7 +62,7 @@ func (ovn *SyncHandler) updateSubmarinerRouterRemoteRoutes() error {
 
 	ovn.logRoutingChanges("north routes", submarinerLogicalRouter, toAdd, toRemove)
 
-	ovnCommands, err := ovn.addSubmRoutesToSubnets(toAdd, submarinerUpstreamRPort, hostUpstreamIP, []*goovn.OvnCommand{})
+	ovnCommands, err := ovn.addSubmRoutesToSubnets(toAdd, submarinerUpstreamRPort, ovn.hostUpstreamIP, []*goovn.OvnCommand{})
 	if err != nil {
 		return err
 	}

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -16,7 +16,7 @@ const (
 	submarinerDownstreamSwPort = "submariner_j_lsp"
 	submarinerDownstreamMAC    = "00:60:2f:10:01:03"
 	submarinerDownstreamNET    = submarinerDownstreamIP + "/29"
-	submarinerDownstreamIP     = "169.254.34.1"
+	submarinerDownstreamIP     = "169.254.254.1"
 )
 
 func (ovn *SyncHandler) updateGatewayNode() error {
@@ -37,8 +37,15 @@ func (ovn *SyncHandler) updateGatewayNode() error {
 
 	klog.V(log.DEBUG).Infof("Chassis for gw %q is %q, host: %q", gwHostname, chassis.Name, chassis.Hostname)
 
+	var submExternalPortSwitch string
+	if ovn.hasNodeLocalSwitch {
+		submExternalPortSwitch = nodeLocalSwitch
+	} else {
+		submExternalPortSwitch = "ext_" + chassis.Hostname
+	}
+
 	// Create/update the submariner external port associated to one of the external switches
-	if err := ovn.createOrUpdateSubmarinerExternalPort("ext_" + chassis.Hostname); err != nil && !errors.Is(err, goovn.ErrorExist) {
+	if err := ovn.createOrUpdateSubmarinerExternalPort(submExternalPortSwitch); err != nil && !errors.Is(err, goovn.ErrorExist) {
 		return err
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -1,0 +1,3 @@
+package ovn
+
+const ovnK8sGatewayInterface = "ovn-k8s-gw0"

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -133,7 +133,8 @@ func (ovn *Handler) cleanupForwardingIptables() error {
 
 func getSubmDefaultRoute() *netlink.Route {
 	return &netlink.Route{
-		Gw:    net.ParseIP(npSyncerOvn.SubmarinerUpstreamIP),
+		// TODO WIP: detect as we have now two options
+		Gw:    net.ParseIP(npSyncerOvn.SubmarinerUpstreamIPv2),
 		Table: constants.RouteAgentHostNetworkTableID,
 	}
 }

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -27,6 +27,7 @@ type Handler struct {
 	localEndpoint         *submV1.Endpoint
 	remoteEndpoints       map[string]*submV1.Endpoint
 	isGateway             bool
+	submarinerUpstreamIP  string
 }
 
 func NewHandler(env environment.Specification, smClientSet clientset.Interface) *Handler {

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -50,7 +50,7 @@ func (ovn *Handler) Init() error {
 	// For now we get all the cleanups
 	ovn.cleanupHandlers = cableCleanup.GetCleanupHandlers()
 
-	return nil
+	return ovn.initIPtablesChains()
 }
 
 func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {

--- a/pkg/routeagent_driver/iptables/iptables.go
+++ b/pkg/routeagent_driver/iptables/iptables.go
@@ -1,0 +1,29 @@
+package iptables
+
+import (
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/util"
+)
+
+func InitSubmarinerPostRoutingChain(ipt *iptables.IPTables) error {
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
+
+	if err := util.CreateChainIfNotExists(ipt, "nat", constants.SmPostRoutingChain); err != nil {
+		return errors.Wrapf(err, "unable to create %q chain in iptables", constants.SmPostRoutingChain)
+	}
+
+	klog.V(log.DEBUG).Infof("Insert %s rule that has rules for inter-cluster traffic", constants.SmPostRoutingChain)
+
+	forwardToSubPostroutingRuleSpec := []string{"-j", constants.SmPostRoutingChain}
+
+	if err := util.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
+		return errors.Wrapf(err, "unable to insert iptable rule in NAT table, POSTROUTING chain")
+	}
+
+	return nil
+}


### PR DESCRIPTION
In separate commits:

Avoid src ip masquerade of pods:
Fixes-Issue: #1016

Auto detect submariner-router upstream leg ip
Related-Issue: #994

Expands ovn database address IPs when calling ovn-nbctl  
Fixes-Issue: #1018

Supports new ovn-kubernetes architecture as well as the old one   
Fixes-Issue: #994

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>