### PR TITLE
Add check for GW latency info in E2E

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,12 @@ func main() {
 	}
 
 	var cableHealthchecker healthchecker.Interface
-	if len(submSpec.GlobalCidr) == 0 && submSpec.HealthCheckEnabled {
+
+	if !submSpec.HealthCheckEnabled {
+		klog.Info("The CableEngine HealthChecker is disabled")
+	} else if len(submSpec.GlobalCidr) > 0 {
+		klog.Info("Globalnet is enabled - not running the CableEngine HealthChecker")
+	} else {
 		cableHealthchecker, err = healthchecker.New(&healthchecker.Config{
 			WatcherConfig:      &watcher.Config{RestConfig: cfg},
 			EndpointNamespace:  submSpec.Namespace,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,7 +25,7 @@ type SubmarinerSpecification struct {
 	Token                         string
 	Debug                         bool
 	NatEnabled                    bool
-	HealthCheckEnabled            bool
+	HealthCheckEnabled            bool `default:"true"`
 	HealthCheckInterval           uint
 	HealthCheckMaxPacketLossCount uint
 }

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -1,0 +1,98 @@
+package dataplane
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[dataplane] Gateway status reporting", func() {
+	f := subFramework.NewFramework("dataplane-gateway-status")
+
+	When("a gateway node is configured", func() {
+		It("should correctly report its status and connection information", func() {
+			clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+			By(fmt.Sprintf("Ensuring that only one gateway reports as active on %q", clusterAName))
+
+			activeGateways := f.AwaitGatewaysWithStatus(framework.ClusterA, submarinerv1.HAStatusActive)
+			Expect(activeGateways).To(HaveLen(1))
+
+			name := activeGateways[0].Name
+			otherCluster := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+			By(fmt.Sprintf("Ensuring that gateway %q reports connection information for cluster %q", name, otherCluster))
+
+			gwClient := subFramework.SubmarinerClients[framework.ClusterA].SubmarinerV1().Gateways(
+				framework.TestContext.SubmarinerNamespace)
+			framework.AwaitUntil(fmt.Sprintf("await active connection on Gateway %q", name),
+				func() (interface{}, error) {
+					resGw, err := gwClient.Get(name, metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						return nil, nil
+					}
+					return resGw, err
+				},
+				func(result interface{}) (bool, string, error) {
+					if result == nil {
+						return false, "gateway not found", nil
+					}
+
+					return verifyGateway(result.(*submarinerv1.Gateway), otherCluster)
+				})
+		})
+	})
+})
+
+func verifyGateway(gw *submarinerv1.Gateway, otherCluster string) (bool, string, error) {
+	if len(gw.Status.Connections) == 0 {
+		return false, "Gateway has no connections", nil
+	}
+
+	for _, conn := range gw.Status.Connections {
+		if conn.Endpoint.ClusterID != otherCluster {
+			continue
+		}
+
+		if conn.Status != submarinerv1.Connected {
+			return false, fmt.Sprintf("Cluster %q is not connected: Status: %q, Message: %q",
+				conn.Endpoint.ClusterID, conn.Status, conn.StatusMessage), nil
+		}
+
+		if !framework.TestContext.GlobalnetEnabled {
+			if conn.LatencyRTT == nil {
+				return false, fmt.Sprintf("Connection for cluster %q has no LatencyRTT information", otherCluster), nil
+			}
+
+			if conn.LatencyRTT.Average == "" {
+				return false, fmt.Sprintf("Connection for cluster %q is missing Average RTT data", otherCluster), nil
+			}
+
+			if conn.LatencyRTT.Last == "" {
+				return false, fmt.Sprintf("Connection for cluster %q is missing Last RTT data", otherCluster), nil
+			}
+
+			if conn.LatencyRTT.Min == "" {
+				return false, fmt.Sprintf("Connection for cluster %q is missing Min RTT data", otherCluster), nil
+			}
+
+			if conn.LatencyRTT.Max == "" {
+				return false, fmt.Sprintf("Connection for cluster %q is missing Max RTT data", otherCluster), nil
+			}
+
+			if conn.LatencyRTT.StdDev == "" {
+				return false, fmt.Sprintf("Connection for cluster %q is missing StdDev RTT data", otherCluster), nil
+			}
+		}
+
+		return true, "", nil
+	}
+
+	return false, fmt.Sprintf("Connection for cluster %q was not found", otherCluster), nil
+}

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -21,12 +21,6 @@ var _ = Describe("[redundancy] Gateway fail-over tests", func() {
 	// After each test, we make sure that the system again has a single gateway, the active one
 	AfterEach(f.GatewayCleanup)
 
-	When("any gateway node is configured", func() {
-		It("should be reported to the Gateway API", func() {
-			testBasicGatewayReporting(f)
-		})
-	})
-
 	When("one gateway node is configured and the submariner engine pod fails", func() {
 		It("should start a new submariner engine pod and be able to connect from another cluster", func() {
 			testEnginePodRestartScenario(f)
@@ -39,19 +33,6 @@ var _ = Describe("[redundancy] Gateway fail-over tests", func() {
 		})
 	})
 })
-
-func testBasicGatewayReporting(f *subFramework.Framework) {
-	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
-
-	By(fmt.Sprintf("Ensuring that only one gateway reports as active %q", clusterAName))
-
-	activeGateways := f.AwaitGatewaysWithStatus(framework.ClusterA, subv1.HAStatusActive)
-
-	Expect(activeGateways).To(HaveLen(1))
-
-	By(fmt.Sprintf("Ensuring that the gateway %q is reporting connections", activeGateways[0].Name))
-	f.AwaitGatewayFullyConnected(framework.ClusterA, activeGateways[0].Name)
-}
 
 func testEnginePodRestartScenario(f *subFramework.Framework) {
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]


### PR DESCRIPTION
Added verification that the GW LatemcyRTT info is present and non-empty for the remote cluster connection. This is coupled with the basic GW status reporting test that was in the redundancy suite and moved to the dataplane suite which seemed more appropriate.
