### PR TITLE
Give access to the gateway metrics port on AWS

### DIFF
--- a/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
+++ b/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
@@ -61,6 +61,28 @@ resource "aws_security_group_rule" "worker_to_master_sg_vxlan_rule" {
 
 
 
+# Add a rule for metrics traffic for all workers.
+resource "aws_security_group_rule" "worker_sg_metrics_rule" {
+  security_group_id        = data.aws_security_group.worker_sg.id
+  source_security_group_id = data.aws_security_group.worker_sg.id
+  from_port                = 8080
+  protocol                 = "tcp"
+  to_port                  = 8080
+  type                     = "ingress"
+}
+
+# Add a rule for metrics traffic from master nodes to worker nodes.
+resource "aws_security_group_rule" "master_to_worker_sg_metrics_rule" {
+  security_group_id        = data.aws_security_group.worker_sg.id
+  source_security_group_id = data.aws_security_group.master_sg.id
+  from_port                = 8080
+  protocol                 = "tcp"
+  to_port                  = 8080
+  type                     = "ingress"
+}
+
+
+
 # Create a submariner gateway security group.
 resource "aws_security_group" "submariner_gw_sg" {
   name   = "${var.cluster_id}-submariner-gw-sg"


### PR DESCRIPTION
Since the gateway runs on the host network, we need to give access to
its metrics port (8080) if we want Prometheus to be able to scrape its
metrics.

Fixes: #999
Signed-off-by: Stephen Kitt <skitt@redhat.com>