### PR TITLE
Stop trying to install wireguard-dkms

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install WireGuard kernel module (only in WireGuard jobs)
         if: matrix.cable_driver == 'wireguard'
         run: |
-          sudo apt install -y linux-headers-$(uname -r) wireguard wireguard-dkms
+          sudo apt install -y linux-headers-$(uname -r) wireguard
           sudo modprobe wireguard
 
       - name: Reclaim free space

--- a/.github/workflows/periodic_e2e.yml
+++ b/.github/workflows/periodic_e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install WireGuard kernel module (only in WireGuard jobs)
         if: matrix.cable_driver == 'wireguard'
         run: |
-          sudo apt install -y linux-headers-$(uname -r) wireguard wireguard-dkms
+          sudo apt install -y linux-headers-$(uname -r) wireguard
           sudo modprobe wireguard
 
       - name: Reclaim free space


### PR DESCRIPTION
The WireGuard module is shipped with the kernel, so wireguard-dkms
hasn't been needed for a little while; the latest point-releases of
Ubuntu drop it entirely, which causes our builds to fail.

Signed-off-by: Stephen Kitt <skitt@redhat.com>