### PR TITLE
Fix testing Libreswan twice and strongSwan none

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         deploytool: ['operator', 'helm']
         globalnet: ['', 'globalnet']
-        cable_driver: ['', 'wireguard', 'libreswan']
+        cable_driver: ['libreswan', 'strongswan', 'wireguard']
         exclude:
           # Our Helm setup doesn’t know how to deploy other cable drivers
           - deploytool: 'helm'

--- a/.github/workflows/periodic_e2e.yml
+++ b/.github/workflows/periodic_e2e.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         deploytool: ['operator', 'helm']
         globalnet: ['', 'globalnet']
-        cable_driver: ['', 'wireguard', 'libreswan']
+        cable_driver: ['libreswan', 'strongswan', 'wireguard']
         exclude:
           # Our Helm setup doesn’t know how to deploy other cable drivers
           - deploytool: 'helm'


### PR DESCRIPTION
After the default changed from Strongswan to Libreswan, Libreswan is
being tested twice and strongSwan not at all.

Instead of relying on an implicit default, explicitly list all of the
cable drivers.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>