### PR TITLE
Associate submariner_router to chassis via options

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/handler.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/handler.go
@@ -24,7 +24,6 @@ type SyncHandler struct {
 	sbdb                  goovn.Client
 	localEndpoint         *submV1.Endpoint
 	remoteEndpoints       map[string]*submV1.Endpoint
-	lastOvnGwChassis      string
 	submarinerUpstreamIP  string
 	submarinerUpstreamNet string
 	hostUpstreamIP        string

--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
@@ -62,6 +62,11 @@ func (n *NbCtl) nbctl(parameters ...string) (output string, err error) {
 	return strOut, err
 }
 
+func (n *NbCtl) SetRouterChassis(router, chassis string) error {
+	_, err := n.nbctl("set", "Logical_Router", router, "options:chassis="+chassis)
+	return err
+}
+
 func (n *NbCtl) SetGatewayChassis(lrp, chassis string, prio int) error {
 	_, err := n.nbctl("lrp-set-gateway-chassis", lrp, chassis, strconv.Itoa(prio))
 	return err

--- a/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
@@ -122,24 +122,8 @@ func (ovn *SyncHandler) getMgmtPortIP(chassisSwitch string) (string, error) {
 	return macIP[1], nil
 }
 
-func (ovn *SyncHandler) associateSubmarinerExternalPortToChassis(chassis *goovn.Chassis) error {
-	if ovn.lastOvnGwChassis != chassis.Name {
-		// TODO: make this less stateful, by listing the existing gateway chassis entries, and leaving only
-		//       the desired state
-		if ovn.lastOvnGwChassis != "" {
-			err := ovn.nbctl.DelGatewayChassis(submarinerUpstreamRPort, chassis.Name, 0)
-			if err != nil {
-				return errors.Wrapf(err, "error deleting the gateway chassis for %q", submarinerUpstreamRPort)
-			}
-		}
-
-		err := ovn.nbctl.SetGatewayChassis(submarinerUpstreamRPort, chassis.Name, 0)
-		if err != nil {
-			return errors.Wrapf(err, "error setting the new gateway chassis for %q", submarinerUpstreamRPort)
-		}
-	}
-
-	return nil
+func (ovn *SyncHandler) associateSubmarinerRouterToChassis(chassis *goovn.Chassis) error {
+	return ovn.nbctl.SetRouterChassis(submarinerLogicalRouter, chassis.Name)
 }
 
 func (ovn *SyncHandler) setupOvnClusterRouterRemoteRules() error {

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -56,7 +56,7 @@ func (ovn *SyncHandler) updateGatewayNode() error {
 
 	// Associate the port to an specific chassis (=host) on OVN so the traffic flows out/in through that host
 	// the active submariner-gateway in our case
-	if err := ovn.associateSubmarinerExternalPortToChassis(chassis); err != nil {
+	if err := ovn.associateSubmarinerRouterToChassis(chassis); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In OVN, you can provide a list of "gateway_chassis" for a router port along
with priorities,  or you can simply attach the router to a chassis.

The former works more reliably in our case. And we don't need the extra features
of "Gateway_Chassis" so this flips the implementation to the router
options field.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>