### PR TITLE
Increase upgrade test timeout 30->45 mins

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   upgrade-e2e:
     name: Latest Release to Latest Version
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The upgrade tests have recently started being frequently canceled by
their 30min job timeouts.

github.com/submariner-io/submariner/actions?query=workflow%3AUpgrade

"The job running on runner GitHub Actions 2 has exceeded the maximum
execution time of 30 minutes."

It seems they are hitting a failure described by #1031 and then being
canceled before they have time to run their post mortem.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>