### PR TITLE
Support non non ssl connections for ovn-kubernetes database

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
@@ -37,11 +37,18 @@ func (n *NbCtl) nbctl(parameters ...string) (output string, err error) {
 		return "", err
 	}
 
-	allParameters := []string{
-		fmt.Sprintf("--db=%s", dbConnection),
-		"-c", n.clientCert,
-		"-p", n.clientKey,
-		"-C", n.ca,
+	allParameters := []string{fmt.Sprintf("--db=%s", dbConnection)}
+
+	if n.clientCert != "" {
+		allParameters = append(allParameters, []string{"-c", n.clientCert}...)
+	}
+
+	if n.clientKey != "" {
+		allParameters = append(allParameters, []string{"-p", n.clientKey}...)
+	}
+
+	if n.ca != "" {
+		allParameters = append(allParameters, []string{"-C", n.ca}...)
 	}
 
 	allParameters = append(allParameters, parameters...)


### PR DESCRIPTION
This will enable ovn-kubernetes without SSL, which is the default
mode for kind testing, which also simplifies debuggability.

Depends-On: https://github.com/submariner-io/submariner-operator/pull/1001

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>