### PR TITLE
Switch the submariner-networkplugin-syncer to fedora:32

### DIFF
--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,4 +1,4 @@
-FROM fedora:33 
+FROM fedora:32
 
 WORKDIR /var/submariner
 


### PR DESCRIPTION
We use fedora to get ovn-nbctl, but fedora:33 now ships an ovn-nbctl
version which is incompatible with previous versions of the database.

The version in fedora:32 should be fine, and this ovn-nbctl functionality
should be migrated into go-ovn during 0.9.0.

Fixes-Issue: #1063

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>