### PR TITLE
Install ovn 20.06 to match ovn-kubernetes

### DIFF
--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -3,7 +3,7 @@ FROM fedora:33
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           ovn && \
+           https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/x86_64/ovn-20.06.2-4.fc33.x86_64.rpm && \
     dnf -y clean all
 
 # install the networkpluginc-sync


### PR DESCRIPTION
To ensure that ovn-nbctl uses the expected schema, explicitly install
the last available package of ovn 20.06 for Fedora 33.

This is a somewhat brittle workaround, the real fix will come in
go-ovn.

Fixes: #1063
Signed-off-by: Stephen Kitt <skitt@redhat.com>