### PR TITLE
Update Endpoint HealthcheckIP to globalIP in Globalnet Deployments

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,8 +111,11 @@ func main() {
 
 	localCluster := submarinerClusterFrom(&submSpec)
 
+	globalnetEnabled := false
+
 	if len(submSpec.GlobalCidr) > 0 {
 		localSubnets = submSpec.GlobalCidr
+		globalnetEnabled = true
 	} else {
 		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
 		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
@@ -124,8 +127,8 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, nil, submSpec.NatEnabled,
-		localSubnets, util.GetLocalIP(), submSpec.ClusterCidr)
+	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, nil,
+		globalnetEnabled, submSpec.NatEnabled, localSubnets, util.GetLocalIP(), submSpec.ClusterCidr)
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)
@@ -142,8 +145,6 @@ func main() {
 
 	if !submSpec.HealthCheckEnabled {
 		klog.Info("The CableEngine HealthChecker is disabled")
-	} else if len(submSpec.GlobalCidr) > 0 {
-		klog.Info("Globalnet is enabled - not running the CableEngine HealthChecker")
 	} else {
 		cableHealthchecker, err = healthchecker.New(&healthchecker.Config{
 			WatcherConfig:      &watcher.Config{RestConfig: cfg},

--- a/main.go
+++ b/main.go
@@ -105,21 +105,9 @@ func main() {
 		klog.Fatalf("Error creating submariner clientset: %s", err.Error())
 	}
 
-	var localSubnets []string
-
 	klog.Info("Creating the cable engine")
 
 	localCluster := submarinerClusterFrom(&submSpec)
-
-	globalnetEnabled := false
-
-	if len(submSpec.GlobalCidr) > 0 {
-		localSubnets = submSpec.GlobalCidr
-		globalnetEnabled = true
-	} else {
-		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
-		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
-	}
 
 	if submSpec.CableDriver == "" {
 		submSpec.CableDriver = cable.GetDefaultCableDriver()
@@ -127,8 +115,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, nil,
-		globalnetEnabled, submSpec.NatEnabled, localSubnets, util.GetLocalIP(), submSpec.ClusterCidr)
+	localEndpoint, err := util.GetLocalEndpoint(submSpec, nil, util.GetLocalIP())
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -112,12 +112,6 @@ func (d *DatastoreSyncer) Run(stopCh <-chan struct{}) error {
 
 	d.localFederator = syncer.GetLocalFederator()
 
-	if len(d.localCluster.Spec.GlobalCIDR) > 0 {
-		if err := d.startNodeWatcher(stopCh); err != nil {
-			return fmt.Errorf("startNodeWatcher returned error: %v", err)
-		}
-	}
-
 	if err := d.ensureExclusiveEndpoint(syncer); err != nil {
 		return fmt.Errorf("could not ensure exclusive submariner Endpoint: %v", err)
 	}
@@ -128,6 +122,12 @@ func (d *DatastoreSyncer) Run(stopCh <-chan struct{}) error {
 
 	if err := d.createOrUpdateLocalEndpoint(); err != nil {
 		return fmt.Errorf("error creating the local submariner Endpoint: %v", err)
+	}
+
+	if len(d.localCluster.Spec.GlobalCIDR) > 0 {
+		if err := d.startNodeWatcher(stopCh); err != nil {
+			return fmt.Errorf("startNodeWatcher returned error: %v", err)
+		}
 	}
 
 	klog.Info("Datastore syncer started")

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -1,0 +1,54 @@
+package datastoresyncer
+
+import (
+	"github.com/submariner-io/admiral/pkg/log"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+)
+
+func (d *DatastoreSyncer) handleCreateOrUpdateNode(obj runtime.Object) bool {
+	node := obj.(*k8sv1.Node)
+	if node.Name != d.localNodeName {
+		return false
+	}
+
+	globalIpOfNode := node.GetAnnotations()[constants.SubmarinerIpamGlobalIp]
+
+	return d.updateLocalEndpointIfNecessary(globalIpOfNode)
+}
+
+func (d *DatastoreSyncer) isNodeEquivalent(obj1, obj2 *unstructured.Unstructured) bool {
+	if obj1.GetName() != d.localNodeName {
+		// Ignore this event. We are only interested in active GatewayNode events.
+		return true
+	}
+
+	existingGlobalIP := obj1.GetAnnotations()[constants.SubmarinerIpamGlobalIp]
+	newGlobalIP := obj2.GetAnnotations()[constants.SubmarinerIpamGlobalIp]
+
+	if existingGlobalIP == newGlobalIP {
+		klog.V(log.DEBUG).Infof("isNodeEquivalent called for %q, existingGlobalIP %q, newGlobalIP %q",
+			obj1.GetName(), existingGlobalIP, newGlobalIP)
+		return true
+	}
+
+	return false
+}
+
+func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIpOfNode string) bool {
+	if globalIpOfNode != "" && d.localFederator != nil && d.localEndpoint.Spec.HealthCheckIP != globalIpOfNode {
+		klog.Infof("Updating the endpoint HealthCheckIP to globalIP %q", globalIpOfNode)
+
+		d.localEndpoint.Spec.HealthCheckIP = globalIpOfNode
+		if err := d.createOrUpdateLocalEndpoint(d.localFederator); err != nil {
+			klog.Warningf("error updating the local submariner Endpoint with HealthcheckIP: %v", err)
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -55,9 +55,13 @@ func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIPOfNode string) 
 	if globalIPOfNode != "" && d.localEndpoint.Spec.HealthCheckIP != globalIPOfNode {
 		klog.Infof("Updating the endpoint HealthCheckIP to globalIP %q", globalIPOfNode)
 
+		prevHealthCheckIP := d.localEndpoint.Spec.HealthCheckIP
 		d.localEndpoint.Spec.HealthCheckIP = globalIPOfNode
 		if err := d.createOrUpdateLocalEndpoint(); err != nil {
 			klog.Warningf("Error updating the local submariner Endpoint with HealthcheckIP: %v", err)
+
+			d.localEndpoint.Spec.HealthCheckIP = prevHealthCheckIP
+
 			return true
 		}
 	}

--- a/pkg/globalnet/cleanup/gn_cleanup.go
+++ b/pkg/globalnet/cleanup/gn_cleanup.go
@@ -81,7 +81,6 @@ func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 	}
 
 	if gn.globalnetStatus == GN_Enabled {
-		klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
 		ClearGlobalnetChains()
 	}
 
@@ -89,6 +88,8 @@ func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 }
 
 func ClearGlobalnetChains() {
+	klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
+
 	ipt, err := iptables.New()
 	if err != nil {
 		klog.Errorf("error initializing iptables: %v", err)

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -38,6 +38,9 @@ const (
 	// [#] interface on the node that has an IPAddress from the clusterCIDR
 	CniInterfaceIP = "submariner.io/cniIfaceIp"
 
+	// TODO (revisit): Unify this constant across different components
+	SubmarinerIpamGlobalIp = "submariner.io/globalIp"
+
 	RouteAgentInterClusterNetworkTableID = 149
 
 	// To support connectivity for Pods with HostNetworking on the GatewayNode, we program

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -39,7 +39,7 @@ const (
 	CniInterfaceIP = "submariner.io/cniIfaceIp"
 
 	// TODO (revisit): Unify this constant across different components
-	SubmarinerIpamGlobalIp = "submariner.io/globalIp"
+	SmGlobalIP = "submariner.io/globalIp"
 
 	RouteAgentInterClusterNetworkTableID = 149
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -100,8 +100,8 @@ func FlattenColors(colorCodes []string) string {
 	return flattenedColors
 }
 
-func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string, globalnetEnabled, natEnabled bool,
-	subnets []string, privateIP string, clusterCIDR []string) (types.SubmarinerEndpoint, error) {
+func GetLocalEndpoint(submSpec types.SubmarinerSpecification, backendConfig map[string]string,
+	privateIP string) (types.SubmarinerEndpoint, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return types.SubmarinerEndpoint{}, fmt.Errorf("Error getting hostname: %v", err)
@@ -111,20 +111,32 @@ func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string
 		backendConfig = make(map[string]string)
 	}
 
+	var localSubnets []string
+
+	globalnetEnabled := false
+
+	if len(submSpec.GlobalCidr) > 0 {
+		localSubnets = submSpec.GlobalCidr
+		globalnetEnabled = true
+	} else {
+		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
+		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
+	}
+
 	endpoint := types.SubmarinerEndpoint{
 		Spec: subv1.EndpointSpec{
-			CableName:     fmt.Sprintf("submariner-cable-%s-%s", clusterID, strings.ReplaceAll(privateIP, ".", "-")),
-			ClusterID:     clusterID,
+			CableName:     fmt.Sprintf("submariner-cable-%s-%s", submSpec.ClusterID, strings.ReplaceAll(privateIP, ".", "-")),
+			ClusterID:     submSpec.ClusterID,
 			Hostname:      hostname,
 			PrivateIP:     privateIP,
-			NATEnabled:    natEnabled,
-			Subnets:       subnets,
-			Backend:       backend,
+			NATEnabled:    submSpec.NatEnabled,
+			Subnets:       localSubnets,
+			Backend:       submSpec.CableDriver,
 			BackendConfig: backendConfig,
 		},
 	}
 
-	if natEnabled {
+	if submSpec.NatEnabled {
 		publicIP, err := ipify.GetIp()
 		if err != nil {
 			return types.SubmarinerEndpoint{}, fmt.Errorf("Could not determine public IP: %v", err)
@@ -138,7 +150,7 @@ func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string
 		// In a fresh deployment, globalIP annotation for the node might take few seconds. So we listen on NodeEvents
 		// and update the endpoint HealthCheckIP (to globalIP) in datastoreSyncer at a later stage. This will trigger
 		// the HealthCheck between the clusters.
-		endpoint.Spec.HealthCheckIP, err = getCNIInterfaceIPAddress(clusterCIDR)
+		endpoint.Spec.HealthCheckIP, err = getCNIInterfaceIPAddress(submSpec.ClusterCidr)
 		if err != nil {
 			return types.SubmarinerEndpoint{}, fmt.Errorf("Error getting CNI Interface IP address: %v", err)
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -85,7 +85,7 @@ func testGetLocalEndpoint() {
 	It("should return a valid SubmarinerEndpoint object", func() {
 		subnets := []string{"127.0.0.1/16"}
 		privateIP := "127.0.0.1"
-		endpoint, err := util.GetLocalEndpoint("east", "backend", map[string]string{}, false, subnets, privateIP, subnets)
+		endpoint, err := util.GetLocalEndpoint("east", "backend", map[string]string{}, false, false, subnets, privateIP, subnets)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(endpoint.Spec.ClusterID).To(Equal("east"))

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -85,7 +85,12 @@ func testGetLocalEndpoint() {
 	It("should return a valid SubmarinerEndpoint object", func() {
 		subnets := []string{"127.0.0.1/16"}
 		privateIP := "127.0.0.1"
-		endpoint, err := util.GetLocalEndpoint("east", "backend", map[string]string{}, false, false, subnets, privateIP, subnets)
+		submSpec := types.SubmarinerSpecification{
+			ClusterID:   "east",
+			ClusterCidr: subnets,
+			CableDriver: "backend",
+		}
+		endpoint, err := util.GetLocalEndpoint(submSpec, map[string]string{}, privateIP)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(endpoint.Spec.ClusterID).To(Equal("east"))


### PR DESCRIPTION
This PR implements the following changes.
1. When Globalnet is enabled, datastoreSyncer registers for NodeListeners
   and will update the localEndpoint with the globalIP of the node.
2. Enables pinger/HealthCheck to work even with Globalnet Deployments.

Depends on: https://github.com/submariner-io/submariner-operator/pull/1019

Fixes Issue: https://github.com/submariner-io/submariner/issues/1068
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>