### PR TITLE
Change GetActiveConnections to return []Connection

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -32,7 +32,7 @@ type Driver interface {
 	Init() error
 
 	// GetActiveConnections returns an array of all the active connections for the given cluster.
-	GetActiveConnections(clusterID string) ([]string, error)
+	GetActiveConnections(clusterID string) ([]v1.Connection, error)
 
 	// GetConnections() returns an array of the existing connections, including status and endpoint info
 	GetConnections() ([]v1.Connection, error)

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -216,15 +216,8 @@ func (i *libreswan) refreshConnectionStatus() error {
 }
 
 // GetActiveConnections returns an array of all the active connections for the given cluster.
-func (i *libreswan) GetActiveConnections(clusterID string) ([]string, error) {
-	connections := []string{}
-	for j := range i.connections {
-		connections = append(connections, i.connections[j].Endpoint.CableName)
-	}
-
-	klog.Infof("Active connections: %v", connections)
-
-	return connections, nil
+func (i *libreswan) GetActiveConnections(clusterID string) ([]subv1.Connection, error) {
+	return i.connections, nil
 }
 
 // GetConnections() returns an array of the existing connections, including status and endpoint info

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -329,9 +329,9 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint types.SubmarinerEndpoi
 	return nil
 }
 
-func (w *wireguard) GetActiveConnections(clusterID string) ([]string, error) {
+func (w *wireguard) GetActiveConnections(clusterID string) ([]v1.Connection, error) {
 	// force caller to skip duplicate handling
-	return make([]string, 0), nil
+	return make([]v1.Connection, 0), nil
 }
 
 // Create new wg link and assign addr from local subnets


### PR DESCRIPTION
Previously it returned `[]string` of cable IDs and `InstallCable` used `GetConnections` to find the associated `Connection` instances. So having `GetActiveConnections` return a `[]Connection` simplifies `InstallCable` and also simplifies the libreswan driver - avoiding translation from `Connection` to cable ID then back to `Connection`. It complicates the strongswan driver a bit which now has to do the cable ID to `Connection` but that seems reasonable (plus the strongswan driver is on the chopping block anyway).
