### PR TITLE
Fix bug in findChassisByHostname matching

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -88,9 +88,17 @@ func (ovn *SyncHandler) findChassisByHostname(hostname string) (*goovn.Chassis, 
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get chassis list from OVN")
 	}
+	// Attempt matching by the exact hostname
 	for _, chassis := range chassisList {
-		if chassis.Hostname == hostname || strings.HasPrefix(chassis.Hostname, hostname) ||
-			strings.HasPrefix(hostname, chassis.Hostname) {
+		if chassis.Hostname == hostname {
+			return chassis, nil
+		}
+	}
+
+	// In a second round try to match expecting a higher level domain after the hostname
+	for _, chassis := range chassisList {
+		if strings.HasPrefix(chassis.Hostname, hostname+".") ||
+			strings.HasPrefix(hostname, chassis.Hostname+".") {
 			return chassis, nil
 		}
 	}


### PR DESCRIPTION
findChassisByHostname was erroneusly matching cluster-worker with
cluster-worker2 as part of the support for non exact hostnames
(looking for higher level dns names in the hostname at any of
the sides).

Now we first attempt exact host matching, aftewards we try unbalanced
hostnames, but including a dot after the hostname.

Fixes-Issue: #1074

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>