### PR TITLE
Release 0.8 backports

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown

--- a/main.go
+++ b/main.go
@@ -90,18 +90,9 @@ func main() {
 		klog.Fatalf("Error creating submariner clientset: %s", err.Error())
 	}
 
-	var localSubnets []string
-
 	klog.Info("Creating the cable engine")
 
 	localCluster := submarinerClusterFrom(&submSpec)
-
-	if len(submSpec.GlobalCidr) > 0 {
-		localSubnets = submSpec.GlobalCidr
-	} else {
-		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
-		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
-	}
 
 	if submSpec.CableDriver == "" {
 		submSpec.CableDriver = cable.GetDefaultCableDriver()
@@ -109,8 +100,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, submSpec.CableDriver, nil, submSpec.NatEnabled,
-		localSubnets, util.GetLocalIP(), submSpec.ClusterCidr)
+	localEndpoint, err := util.GetLocalEndpoint(submSpec, nil, util.GetLocalIP())
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)
@@ -127,8 +117,6 @@ func main() {
 
 	if !submSpec.HealthCheckEnabled {
 		klog.Info("The CableEngine HealthChecker is disabled")
-	} else if len(submSpec.GlobalCidr) > 0 {
-		klog.Info("Globalnet is enabled - not running the CableEngine HealthChecker")
 	} else {
 		cableHealthchecker, err = healthchecker.New(&healthchecker.Config{
 			WatcherConfig:      &watcher.Config{RestConfig: cfg},

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -3,7 +3,7 @@ FROM fedora:33
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           ovn && \
+           https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/x86_64/ovn-20.06.2-4.fc33.x86_64.rpm && \
     dnf -y clean all
 
 # install the networkpluginc-sync

--- a/pkg/cable/metrics.go
+++ b/pkg/cable/metrics.go
@@ -151,7 +151,7 @@ func RecordConnection(cableDriverName string, localEndpoint, remoteEndpoint *sub
 	}
 
 	labels[connectionsStatusLabel] = status
-	connectionsGauge.With(labels).Inc()
+	connectionsGauge.With(labels).Set(1)
 }
 
 func RecordDisconnected(cableDriverName string, localEndpoint, remoteEndpoint *submv1.EndpointSpec) {
@@ -161,6 +161,7 @@ func RecordDisconnected(cableDriverName string, localEndpoint, remoteEndpoint *s
 	connectionEstablishedTimestampGauge.Delete(labels)
 	rxGauge.Delete(labels)
 	txGauge.Delete(labels)
+	connectionsGauge.Delete(labels)
 }
 
 func RecordNoConnections() {

--- a/pkg/cable/wireguard/README.md
+++ b/pkg/cable/wireguard/README.md
@@ -40,7 +40,8 @@ Currently assuming Linux Kernel WireGuard (`wgtypes.LinuxKernel`).
   bin/subctl join --cable-driver wireguard --disable-nat broker-info.subm
   ```
 
-- The default UDP listen port for WireGuard is `5871`. It can be changed by setting the env var `CE_IPSEC_NATTPORT`
+- The default UDP listen port for submariner WireGuard driver is `4500`. It can be changed by setting the env var `CE_IPSEC_NATTPORT`
+- It is assumed that the wireguard network device named `submariner` is exclusively used by submariner-gateway and should not be edited manually.
 
 ## Troubleshooting, limitations
 
@@ -61,3 +62,12 @@ Currently assuming Linux Kernel WireGuard (`wgtypes.LinuxKernel`).
 - No new `iptables` rules were added, although source NAT needs to be disabled for cross cluster communication. This is similar to disabling
   SNAT when sending cross-cluster traffic between nodes to `submariner-gateway`, so the existing rules should be enough.  **The driver will
 fail if the CNI does SNAT before routing to Wireguard** (e.g., failed with Calico, works with Flannel).
+
+## Monitoring
+
+The following metrics are exposed per gateway:
+
+- `connection_status`: indicates whether or not the connection is established where the value 1 means connected and 0 means disconnected.
+- `connection_established_timestamp` the Unix timestamp at which the connection established.
+- `gateway_tx_bytes` Bytes transmitted for the connection.
+- `gateway_rx_bytes` Bytes received for the connection.

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -9,18 +9,15 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-
-	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-
-	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/submariner/pkg/cable"
-	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/vishvananda/netlink"
-
-	"k8s.io/klog"
-
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/types"
 )
 
 const (
@@ -264,6 +261,8 @@ func (w *wireguard) ConnectToEndpoint(remoteEndpoint types.SubmarinerEndpoint) (
 
 	klog.V(log.DEBUG).Infof("Done connecting endpoint peer %s@%s", *remoteKey, remoteIP)
 
+	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
+
 	return ip, nil
 }
 
@@ -310,6 +309,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint types.SubmarinerEndpoi
 	delete(w.connections, remoteEndpoint.Spec.ClusterID)
 
 	klog.V(log.DEBUG).Infof("Done removing endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
+	cable.RecordDisconnected(cableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
 
 	return nil
 }

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -168,6 +168,11 @@ func (i *engine) getEndpointInfo(cableName string, connections *[]v1.Connection)
 }
 
 func (i *engine) RemoveCable(endpoint types.SubmarinerEndpoint) error {
+	if endpoint.Spec.ClusterID == i.localCluster.ID {
+		klog.V(log.DEBUG).Infof("Cables are not added/removed for the local cluster, skipping removal")
+		return nil
+	}
+
 	klog.Infof("Removing Endpoint cable %q", endpoint.Spec.CableName)
 
 	i.Lock()

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -2,29 +2,36 @@ package datastoresyncer
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	resourceSyncer "github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
-	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/submariner-io/submariner/pkg/util"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
 )
 
 type NewSyncer func(*broker.SyncerConfig) (*broker.Syncer, error)
 
 type DatastoreSyncer struct {
-	colorCodes    []string
-	localCluster  types.SubmarinerCluster
-	localEndpoint types.SubmarinerEndpoint
-	syncerConfig  broker.SyncerConfig
-	newSyncer     NewSyncer
+	colorCodes     []string
+	localCluster   types.SubmarinerCluster
+	localEndpoint  types.SubmarinerEndpoint
+	localNodeName  string
+	syncerConfig   broker.SyncerConfig
+	newSyncer      NewSyncer
+	localFederator federate.Federator
 }
 
 func New(restConfig *rest.Config, namespace string, localCluster types.SubmarinerCluster,
@@ -88,16 +95,24 @@ func (d *DatastoreSyncer) Run(stopCh <-chan struct{}) error {
 		return err
 	}
 
+	d.localFederator = syncer.GetLocalFederator()
+
 	if err := d.ensureExclusiveEndpoint(syncer); err != nil {
 		return fmt.Errorf("could not ensure exclusive submariner Endpoint: %v", err)
 	}
 
-	if err := d.createLocalCluster(syncer.GetLocalFederator()); err != nil {
+	if err := d.createLocalCluster(); err != nil {
 		return fmt.Errorf("error creating the local submariner Cluster: %v", err)
 	}
 
-	if err := d.createLocalEndpoint(syncer.GetLocalFederator()); err != nil {
+	if err := d.createOrUpdateLocalEndpoint(); err != nil {
 		return fmt.Errorf("error creating the local submariner Endpoint: %v", err)
+	}
+
+	if len(d.localCluster.Spec.GlobalCIDR) > 0 {
+		if err := d.startNodeWatcher(stopCh); err != nil {
+			return fmt.Errorf("startNodeWatcher returned error: %v", err)
+		}
 	}
 
 	klog.Info("Datastore syncer started")
@@ -163,7 +178,49 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint(syncer *broker.Syncer) error {
 	return nil
 }
 
-func (d *DatastoreSyncer) createLocalCluster(federator federate.Federator) error {
+func (d *DatastoreSyncer) startNodeWatcher(stopCh <-chan struct{}) error {
+	nodeName, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		// Healthcheck in globalnet deployments will not work because of missing NODE_NAME.
+		klog.Error("Error reading the NODE_NAME from the env, healthChecker functionality will not work.")
+	} else {
+		d.localNodeName = nodeName
+		return d.createNodeWatcher(stopCh)
+	}
+
+	return nil
+}
+
+func (d *DatastoreSyncer) createNodeWatcher(stopCh <-chan struct{}) error {
+	resourceWatcher, err := watcher.New(&watcher.Config{
+		Scheme:     scheme.Scheme,
+		RestConfig: d.syncerConfig.LocalRestConfig,
+		ResourceConfigs: []watcher.ResourceConfig{
+			{
+				Name:                "Node watcher for datastoresyncer",
+				ResourceType:        &k8sv1.Node{},
+				ResourcesEquivalent: d.isNodeEquivalent,
+				Handler: watcher.EventHandlerFuncs{
+					OnCreateFunc: d.handleCreateOrUpdateNode,
+					OnUpdateFunc: d.handleCreateOrUpdateNode,
+					OnDeleteFunc: nil,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating resource watcher for Nodes %v", err)
+	}
+
+	err = resourceWatcher.Start(stopCh)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DatastoreSyncer) createLocalCluster() error {
 	klog.Infof("Creating local submariner Cluster: %#v ", d.localCluster)
 
 	cluster := &submarinerv1.Cluster{
@@ -173,10 +230,10 @@ func (d *DatastoreSyncer) createLocalCluster(federator federate.Federator) error
 		Spec: d.localCluster.Spec,
 	}
 
-	return federator.Distribute(cluster)
+	return d.localFederator.Distribute(cluster)
 }
 
-func (d *DatastoreSyncer) createLocalEndpoint(federator federate.Federator) error {
+func (d *DatastoreSyncer) createOrUpdateLocalEndpoint() error {
 	klog.Infof("Creating local submariner Endpoint: %#v ", d.localEndpoint)
 
 	endpointName, err := util.GetEndpointCRDName(&d.localEndpoint)
@@ -191,5 +248,5 @@ func (d *DatastoreSyncer) createLocalEndpoint(federator federate.Federator) erro
 		Spec: d.localEndpoint.Spec,
 	}
 
-	return federator.Distribute(endpoint)
+	return d.localFederator.Distribute(endpoint)
 }

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -1,0 +1,70 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package datastoresyncer
+
+import (
+	"github.com/submariner-io/admiral/pkg/log"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+)
+
+func (d *DatastoreSyncer) handleCreateOrUpdateNode(obj runtime.Object) bool {
+	node := obj.(*k8sv1.Node)
+	if node.Name != d.localNodeName {
+		return false
+	}
+
+	globalIPOfNode := node.GetAnnotations()[constants.SmGlobalIP]
+
+	return d.updateLocalEndpointIfNecessary(globalIPOfNode)
+}
+
+func (d *DatastoreSyncer) isNodeEquivalent(obj1, obj2 *unstructured.Unstructured) bool {
+	if obj1.GetName() != d.localNodeName {
+		// Ignore this event. We are only interested in active GatewayNode events.
+		return true
+	}
+
+	existingGlobalIP := obj1.GetAnnotations()[constants.SmGlobalIP]
+	newGlobalIP := obj2.GetAnnotations()[constants.SmGlobalIP]
+
+	klog.V(log.DEBUG).Infof("isNodeEquivalent called for %q, existingGlobalIP %q, newGlobalIP %q",
+		obj1.GetName(), existingGlobalIP, newGlobalIP)
+
+	return existingGlobalIP == newGlobalIP
+}
+
+func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIPOfNode string) bool {
+	if globalIPOfNode != "" && d.localEndpoint.Spec.HealthCheckIP != globalIPOfNode {
+		klog.Infof("Updating the endpoint HealthCheckIP to globalIP %q", globalIPOfNode)
+
+		prevHealthCheckIP := d.localEndpoint.Spec.HealthCheckIP
+		d.localEndpoint.Spec.HealthCheckIP = globalIPOfNode
+		if err := d.createOrUpdateLocalEndpoint(); err != nil {
+			klog.Warningf("Error updating the local submariner Endpoint with HealthcheckIP: %v", err)
+
+			d.localEndpoint.Spec.HealthCheckIP = prevHealthCheckIP
+
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/globalnet/cleanup/gn_cleanup.go
+++ b/pkg/globalnet/cleanup/gn_cleanup.go
@@ -66,7 +66,6 @@ func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 	}
 
 	if gn.globalnetStatus == GN_Enabled {
-		klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
 		ClearGlobalnetChains()
 	}
 
@@ -74,6 +73,8 @@ func (gn *cleanupGlobalnetRules) GatewayToNonGatewayTransition() error {
 }
 
 func ClearGlobalnetChains() {
+	klog.Info("Globalnet is enabled and active gateway migrated, flushing Globalnet chains.")
+
 	ipt, err := iptables.New()
 	if err != nil {
 		klog.Errorf("error initializing iptables: %v", err)

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -73,10 +73,19 @@ func (i *Controller) syncServiceRules(service *k8sv1.Service, globalIP string, a
 	return nil
 }
 
-func (i *Controller) syncNodeRules(cniIfaceIP, globalIP string, addRules bool) error {
+func (i *Controller) syncNodeRules(nodeName, cniIfaceIP, globalIP string, addRules bool) error {
 	err := i.updateEgressRulesForResource("Node", cniIfaceIP, globalIP, addRules)
 	if err != nil {
 		return fmt.Errorf("error updating egress rules for Node %s: %v", cniIfaceIP, err)
+	}
+
+	// On the active Gateway Node where this code gets executed, we program icmp ingress rules
+	// to support health-check use-case.
+	if i.gwNodeName == nodeName {
+		err = i.updateIngressRulesForHealthCheck("Node", cniIfaceIP, globalIP, addRules)
+		if err != nil {
+			return fmt.Errorf("error updating healthcheck ingress rules for Node %q: %v", nodeName, err)
+		}
 	}
 
 	return nil

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -60,3 +60,22 @@ func (i *Controller) doesIPTablesChainExist(table, chain string) (bool, error) {
 
 	return false, nil
 }
+
+func (i *Controller) updateIngressRulesForHealthCheck(resourceName, cniIfaceIP, globalIP string, addRules bool) error {
+	ruleSpec := []string{"-p", "icmp", "-d", globalIP, "-j", "DNAT", "--to", cniIfaceIP}
+
+	if addRules {
+		klog.V(log.DEBUG).Infof("Installing iptable ingress rules for %s: %s", resourceName, strings.Join(ruleSpec, " "))
+
+		if err := i.ipt.AppendUnique("nat", constants.SmGlobalnetIngressChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error appending iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	} else {
+		klog.V(log.DEBUG).Infof("Deleting iptable ingress rules for %s : %s", resourceName, strings.Join(ruleSpec, " "))
+		if err := i.ipt.Delete("nat", constants.SmGlobalnetIngressChain, ruleSpec...); err != nil {
+			return fmt.Errorf("error deleting iptables rule \"%s\": %v\n", strings.Join(ruleSpec, " "), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/globalnet/controllers/ipam/ipam.go
+++ b/pkg/globalnet/controllers/ipam/ipam.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/submariner-io/admiral/pkg/log"
+
 	"github.com/submariner-io/submariner/pkg/globalnet/cleanup"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 
@@ -21,7 +22,8 @@ import (
 	"k8s.io/klog"
 )
 
-func NewController(spec *SubmarinerIpamControllerSpecification, config *InformerConfigStruct, globalCIDR string) (*Controller, error) {
+func NewController(spec *SubmarinerIpamControllerSpecification, config *InformerConfigStruct,
+	globalCIDR, gwNodeName string) (*Controller, error) {
 	exclusionMap := make(map[string]bool)
 	for _, v := range spec.ExcludeNS {
 		exclusionMap[v] = true
@@ -46,6 +48,7 @@ func NewController(spec *SubmarinerIpamControllerSpecification, config *Informer
 		podsSynced:       config.PodInformer.Informer().HasSynced,
 		nodeWorkqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Nodes"),
 		nodesSynced:      config.NodeInformer.Informer().HasSynced,
+		gwNodeName:       gwNodeName,
 
 		excludeNamespaces: exclusionMap,
 		pool:              pool,
@@ -451,46 +454,6 @@ func (i *Controller) handleRemovedPod(obj interface{}) {
 	}
 }
 
-func (i *Controller) handleRemovedNode(obj interface{}) {
-	// TODO: further minimize duplication between this and handleRemovedPod
-	var node *k8sv1.Node
-	var ok bool
-	var key string
-	var err error
-	if node, ok = obj.(*k8sv1.Node); !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Could not convert object %v to Node", obj)
-			return
-		}
-
-		node, ok = tombstone.Obj.(*k8sv1.Node)
-		if !ok {
-			klog.Errorf("Could not convert object tombstone %v to Node", tombstone.Obj)
-			return
-		}
-	}
-
-	globalIp := node.Annotations[submarinerIpamGlobalIp]
-	cniIfaceIp := node.Annotations[constants.CniInterfaceIP]
-	if globalIp != "" && cniIfaceIp != "" {
-		if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
-			utilruntime.HandleError(err)
-			return
-		}
-
-		i.pool.Release(key)
-		klog.V(log.DEBUG).Infof("Released ip %s for Node %s", globalIp, key)
-
-		err = i.syncNodeRules(cniIfaceIp, globalIp, DeleteRules)
-		if err != nil {
-			klog.Errorf("Error while cleaning up HostNetwork egress rules. %v", err)
-		}
-	} else {
-		klog.V(log.DEBUG).Infof("handleRemovedNode called for %q, that has globalIp %s and cniIfaceIp %s", key, globalIp, cniIfaceIp)
-	}
-}
-
 func (i *Controller) annotateGlobalIp(key, globalIp string) (string, error) {
 	var ip string
 	var err error
@@ -622,57 +585,6 @@ func (i *Controller) podUpdater(obj runtime.Object, key string) error {
 		err = i.syncPodRules(pod.Status.PodIP, existingGlobalIp, AddRules)
 		if err != nil {
 			logAndRequeue(key, i.podWorkqueue)
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (i *Controller) nodeUpdater(obj runtime.Object, key string) error {
-	node := obj.(*k8sv1.Node)
-	cniIfaceIP := node.GetAnnotations()[constants.CniInterfaceIP]
-	existingGlobalIp := node.GetAnnotations()[submarinerIpamGlobalIp]
-	allocatedIp, err := i.annotateGlobalIp(key, existingGlobalIp)
-	if err != nil { // failed to get globalIp or failed to update, we want to retry
-		logAndRequeue(key, i.nodeWorkqueue)
-		return fmt.Errorf("failed to annotate globalIp to node %q: %+v", key, err)
-	}
-
-	// This case is hit in one of the two situations
-	// 1. when the Worker Node does not have the globalIp annotation and a new globalIp is allocated
-	// 2. when the current globalIp annotation on the Node does not match with the info maintained by ipPool
-	if allocatedIp != "" {
-		klog.V(log.DEBUG).Infof("Allocating globalIp %s to Node %q ", allocatedIp, key)
-		err = i.syncNodeRules(cniIfaceIP, allocatedIp, AddRules)
-		if err != nil {
-			logAndRequeue(key, i.nodeWorkqueue)
-			return err
-		}
-
-		annotations := node.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-
-		annotations[submarinerIpamGlobalIp] = allocatedIp
-
-		node.SetAnnotations(annotations)
-
-		_, err := i.kubeClientSet.CoreV1().Nodes().Update(node)
-		if err != nil {
-			logAndRequeue(key, i.nodeWorkqueue)
-			return err
-		}
-	} else if existingGlobalIp != "" {
-		klog.V(log.DEBUG).Infof("Node %q already has globalIp %s annotation, syncing rules", key, existingGlobalIp)
-		// When Globalnet Controller is migrated, we get notification for all the existing Nodes.
-		// For Worker Nodes that already have the annotation, we update the local ipPool cache and sync
-		// the iptable rules on the new GatewayNode.
-		// Note: This case will also be hit when Globalnet Pod is restarted
-		err = i.syncNodeRules(cniIfaceIP, existingGlobalIp, AddRules)
-		if err != nil {
-			logAndRequeue(key, i.nodeWorkqueue)
 			return err
 		}
 	}

--- a/pkg/globalnet/controllers/ipam/node_handler.go
+++ b/pkg/globalnet/controllers/ipam/node_handler.go
@@ -1,0 +1,105 @@
+package ipam
+
+import (
+	"fmt"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+)
+
+func (i *Controller) nodeUpdater(obj runtime.Object, key string) error {
+	node := obj.(*k8sv1.Node)
+	cniIfaceIP := node.GetAnnotations()[constants.CniInterfaceIP]
+	existingGlobalIp := node.GetAnnotations()[submarinerIpamGlobalIp]
+	allocatedIp, err := i.annotateGlobalIp(key, existingGlobalIp)
+	if err != nil { // failed to get globalIp or failed to update, we want to retry
+		logAndRequeue(key, i.nodeWorkqueue)
+		return fmt.Errorf("failed to annotate globalIp to node %q: %+v", key, err)
+	}
+
+	// This case is hit in one of the two situations
+	// 1. when the Worker Node does not have the globalIp annotation and a new globalIp is allocated
+	// 2. when the current globalIp annotation on the Node does not match with the info maintained by ipPool
+	if allocatedIp != "" {
+		klog.V(log.DEBUG).Infof("Allocating globalIp %s to Node %q ", allocatedIp, key)
+		err = i.syncNodeRules(node.Name, cniIfaceIP, allocatedIp, AddRules)
+		if err != nil {
+			logAndRequeue(key, i.nodeWorkqueue)
+			return err
+		}
+
+		annotations := node.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		annotations[submarinerIpamGlobalIp] = allocatedIp
+
+		node.SetAnnotations(annotations)
+
+		_, err := i.kubeClientSet.CoreV1().Nodes().Update(node)
+		if err != nil {
+			logAndRequeue(key, i.nodeWorkqueue)
+			return err
+		}
+	} else if existingGlobalIp != "" {
+		klog.V(log.DEBUG).Infof("Node %q already has globalIp %s annotation, syncing rules", key, existingGlobalIp)
+		// When Globalnet Controller is migrated, we get notification for all the existing Nodes.
+		// For Worker Nodes that already have the annotation, we update the local ipPool cache and sync
+		// the iptable rules on the new GatewayNode.
+		// Note: This case will also be hit when Globalnet Pod is restarted
+		err = i.syncNodeRules(node.Name, cniIfaceIP, existingGlobalIp, AddRules)
+		if err != nil {
+			logAndRequeue(key, i.nodeWorkqueue)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (i *Controller) handleRemovedNode(obj interface{}) {
+	// TODO: further minimize duplication between this and handleRemovedPod
+	var node *k8sv1.Node
+	var ok bool
+	var key string
+	var err error
+	if node, ok = obj.(*k8sv1.Node); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Could not convert object %v to Node", obj)
+			return
+		}
+
+		node, ok = tombstone.Obj.(*k8sv1.Node)
+		if !ok {
+			klog.Errorf("Could not convert object tombstone %v to Node", tombstone.Obj)
+			return
+		}
+	}
+
+	globalIp := node.Annotations[submarinerIpamGlobalIp]
+	cniIfaceIp := node.Annotations[constants.CniInterfaceIP]
+	if globalIp != "" && cniIfaceIp != "" {
+		if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+
+		i.pool.Release(key)
+		klog.V(log.DEBUG).Infof("Released ip %s for Node %s", globalIp, key)
+
+		err = i.syncNodeRules(node.Name, cniIfaceIp, globalIp, DeleteRules)
+		if err != nil {
+			klog.Errorf("Error while cleaning up HostNetwork egress rules. %v", err)
+		}
+	} else {
+		klog.V(log.DEBUG).Infof("handleRemovedNode called for %q, that has globalIp %s and cniIfaceIp %s", key, globalIp, cniIfaceIp)
+	}
+}

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -34,6 +34,7 @@ type Controller struct {
 	podsSynced       cache.InformerSynced
 	nodeWorkqueue    workqueue.RateLimitingInterface
 	nodesSynced      cache.InformerSynced
+	gwNodeName       string
 
 	excludeNamespaces map[string]bool
 	pool              *IpPool
@@ -51,5 +52,6 @@ type GatewayMonitor struct {
 	ipt                 *iptables.IPTables
 	stopProcessing      chan struct{}
 	isGatewayNode       bool
+	nodeName            string
 	syncMutex           *sync.Mutex
 }

--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -8,6 +8,7 @@ import (
 
 	goovn "github.com/ebay/go-ovn"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	"github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn/nbctl"
 	"github.com/submariner-io/submariner/pkg/util/cluster_files"
@@ -16,7 +17,9 @@ import (
 func (ovn *SyncHandler) initClients() error {
 	var tlsConfig *tls.Config
 
-	if strings.HasPrefix(getOVNNBDBAddress(), "ssl://") || strings.HasPrefix(getOVNSBDBAddress(), "ssl://") {
+	if strings.HasPrefix(getOVNNBDBAddress(), "ssl:") || strings.HasPrefix(getOVNSBDBAddress(), "ssl:") {
+		klog.Infof("OVN connection using SSL, loading certificates")
+
 		certFile, err := cluster_files.Get(ovn.k8sClientset, getOVNCertPath())
 		if err != nil {
 			return err
@@ -39,6 +42,8 @@ func (ovn *SyncHandler) initClients() error {
 
 		ovn.nbctl = nbctl.New(getOVNNBDBAddress(), pkFile, certFile, caFile)
 	} else {
+		klog.Infof("OVN connection using plaintext TCP")
+
 		ovn.nbctl = nbctl.New(getOVNNBDBAddress(), "", "", "")
 	}
 

--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
@@ -37,11 +37,18 @@ func (n *NbCtl) nbctl(parameters ...string) (output string, err error) {
 		return "", err
 	}
 
-	allParameters := []string{
-		fmt.Sprintf("--db=%s", dbConnection),
-		"-c", n.clientCert,
-		"-p", n.clientKey,
-		"-C", n.ca,
+	allParameters := []string{fmt.Sprintf("--db=%s", dbConnection)}
+
+	if n.clientCert != "" {
+		allParameters = append(allParameters, []string{"-c", n.clientCert}...)
+	}
+
+	if n.clientKey != "" {
+		allParameters = append(allParameters, []string{"-p", n.clientKey}...)
+	}
+
+	if n.ca != "" {
+		allParameters = append(allParameters, []string{"-C", n.ca}...)
 	}
 
 	allParameters = append(allParameters, parameters...)

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -73,9 +73,17 @@ func (ovn *SyncHandler) findChassisByHostname(hostname string) (*goovn.Chassis, 
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get chassis list from OVN")
 	}
+	// Attempt matching by the exact hostname
 	for _, chassis := range chassisList {
-		if chassis.Hostname == hostname || strings.HasPrefix(chassis.Hostname, hostname) ||
-			strings.HasPrefix(hostname, chassis.Hostname) {
+		if chassis.Hostname == hostname {
+			return chassis, nil
+		}
+	}
+
+	// In a second round try to match expecting a higher level domain after the hostname
+	for _, chassis := range chassisList {
+		if strings.HasPrefix(chassis.Hostname, hostname+".") ||
+			strings.HasPrefix(hostname, chassis.Hostname+".") {
 			return chassis, nil
 		}
 	}

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -23,6 +23,9 @@ const (
 	// [#] interface on the node that has an IPAddress from the clusterCIDR
 	CniInterfaceIP = "submariner.io/cniIfaceIp"
 
+	// TODO (revisit): Unify this constant across different components
+	SmGlobalIP = "submariner.io/globalIp"
+
 	RouteAgentInterClusterNetworkTableID = 149
 
 	// To support connectivity for Pods with HostNetworking on the GatewayNode, we program

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -85,8 +85,8 @@ func FlattenColors(colorCodes []string) string {
 	return flattenedColors
 }
 
-func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string, natEnabled bool,
-	subnets []string, privateIP string, clusterCIDR []string) (types.SubmarinerEndpoint, error) {
+func GetLocalEndpoint(submSpec types.SubmarinerSpecification, backendConfig map[string]string,
+	privateIP string) (types.SubmarinerEndpoint, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return types.SubmarinerEndpoint{}, fmt.Errorf("Error getting hostname: %v", err)
@@ -96,20 +96,32 @@ func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string
 		backendConfig = make(map[string]string)
 	}
 
+	var localSubnets []string
+
+	globalnetEnabled := false
+
+	if len(submSpec.GlobalCidr) > 0 {
+		localSubnets = submSpec.GlobalCidr
+		globalnetEnabled = true
+	} else {
+		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
+		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
+	}
+
 	endpoint := types.SubmarinerEndpoint{
 		Spec: subv1.EndpointSpec{
-			CableName:     fmt.Sprintf("submariner-cable-%s-%s", clusterID, strings.ReplaceAll(privateIP, ".", "-")),
-			ClusterID:     clusterID,
+			CableName:     fmt.Sprintf("submariner-cable-%s-%s", submSpec.ClusterID, strings.ReplaceAll(privateIP, ".", "-")),
+			ClusterID:     submSpec.ClusterID,
 			Hostname:      hostname,
 			PrivateIP:     privateIP,
-			NATEnabled:    natEnabled,
-			Subnets:       subnets,
-			Backend:       backend,
+			NATEnabled:    submSpec.NatEnabled,
+			Subnets:       localSubnets,
+			Backend:       submSpec.CableDriver,
 			BackendConfig: backendConfig,
 		},
 	}
 
-	if natEnabled {
+	if submSpec.NatEnabled {
 		publicIP, err := ipify.GetIp()
 		if err != nil {
 			return types.SubmarinerEndpoint{}, fmt.Errorf("Could not determine public IP: %v", err)
@@ -118,10 +130,15 @@ func GetLocalEndpoint(clusterID, backend string, backendConfig map[string]string
 		endpoint.Spec.PublicIP = publicIP
 	}
 
-	endpoint.Spec.HealthCheckIP, err = getCNIInterfaceIPAddress(clusterCIDR)
-
-	if err != nil {
-		return types.SubmarinerEndpoint{}, fmt.Errorf("Error getting CNI Interface IP address: %v", err)
+	if !globalnetEnabled {
+		// When globalnet is enabled, HealthCheckIP will be the globalIP assigned to the Active GatewayNode.
+		// In a fresh deployment, globalIP annotation for the node might take few seconds. So we listen on NodeEvents
+		// and update the endpoint HealthCheckIP (to globalIP) in datastoreSyncer at a later stage. This will trigger
+		// the HealthCheck between the clusters.
+		endpoint.Spec.HealthCheckIP, err = getCNIInterfaceIPAddress(submSpec.ClusterCidr)
+		if err != nil {
+			return types.SubmarinerEndpoint{}, fmt.Errorf("Error getting CNI Interface IP address: %v", err)
+		}
 	}
 
 	return endpoint, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -70,7 +70,12 @@ func testGetLocalEndpoint() {
 	It("should return a valid SubmarinerEndpoint object", func() {
 		subnets := []string{"127.0.0.1/16"}
 		privateIP := "127.0.0.1"
-		endpoint, err := util.GetLocalEndpoint("east", "backend", map[string]string{}, false, subnets, privateIP, subnets)
+		submSpec := types.SubmarinerSpecification{
+			ClusterID:   "east",
+			ClusterCidr: subnets,
+			CableDriver: "backend",
+		}
+		endpoint, err := util.GetLocalEndpoint(submSpec, map[string]string{}, privateIP)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(endpoint.Spec.ClusterID).To(Equal("east"))


### PR DESCRIPTION
Includes the following patches:

7f481f7 Fix SSL detection in OVN connection string
92dc605 Use the PR base branch as reference when linting
ec721f5 Update Endpoint HealthcheckIP to globalIP in Globalnet Deployments
10adc6d Don't try to remove local cable
c126c22 Fix bug in findChassisByHostname matching
d255f6a Install ovn 20.06 to match ovn-kubernetes
78b9b8a Globalnet Healthcheck support
30aac0f Adding wireguard prometheus metrics
73ce104 Support non non ssl connections for ovn-kubernetes database
