### PR TITLE
Configure the base branch for Markdown linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: "release-0.8"
 
   markdownlint:
     name: Markdown


### PR DESCRIPTION
When checking only changed files, the checker needs to know what the
reference branch is; this sets it to release-0.8 for the 0.8 branch.

Signed-off-by: Stephen Kitt <skitt@redhat.com>