### PR TITLE
Fix SSL detection in OVN connection string

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -23,6 +23,7 @@ import (
 
 	goovn "github.com/ebay/go-ovn"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	"github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn/nbctl"
 	"github.com/submariner-io/submariner/pkg/util/cluster_files"
@@ -31,7 +32,9 @@ import (
 func (ovn *SyncHandler) initClients() error {
 	var tlsConfig *tls.Config
 
-	if strings.HasPrefix(getOVNNBDBAddress(), "ssl://") || strings.HasPrefix(getOVNSBDBAddress(), "ssl://") {
+	if strings.HasPrefix(getOVNNBDBAddress(), "ssl:") || strings.HasPrefix(getOVNSBDBAddress(), "ssl:") {
+		klog.Infof("OVN connection using SSL, loading certificates")
+
 		certFile, err := cluster_files.Get(ovn.k8sClientset, getOVNCertPath())
 		if err != nil {
 			return err
@@ -54,6 +57,8 @@ func (ovn *SyncHandler) initClients() error {
 
 		ovn.nbctl = nbctl.New(getOVNNBDBAddress(), pkFile, certFile, caFile)
 	} else {
+		klog.Infof("OVN connection using plaintext TCP")
+
 		ovn.nbctl = nbctl.New(getOVNNBDBAddress(), "", "", "")
 	}
 


### PR DESCRIPTION
OVSDB prefixes connections by ssl: and not ssl://

Fixes-Issue: #1088

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>