### PR TITLE
Support debugging in Libreswan cabledriver

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -406,6 +406,10 @@ func (i *libreswan) runPluto() error {
 
 	args := []string{}
 
+	if i.debug {
+		args = append(args, "--stderrlog")
+	}
+
 	cmd := exec.Command("/usr/local/bin/pluto", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -451,6 +455,12 @@ func (i *libreswan) runPluto() error {
 		}
 
 		time.Sleep(1 * time.Second)
+	}
+
+	if i.debug {
+		if err := whack("--debug", "base"); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR enables running pluto process with debug when enabled.
Debugging is controlled via CE_IPSEC_DEBUG env flag. By default
pluto logs are dumped in stdout unless CE_IPSEC_LOGFILE is
explicitly specified.

Fixes issue: https://github.com/submariner-io/submariner/issues/1099
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 71fdbfd1ce9720355ab0f049f9ea9af4ac458ba4)