### PR TITLE
Specify the minimum TLS version for OVN

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -107,5 +107,6 @@ func getOVNTLSConfig(pkFile, certFile, caFile string) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      rootCAs,
 		ServerName:   "ovn",
+		MinVersion:   tls.VersionTLS12,
 	}, nil
 }


### PR DESCRIPTION
This is flagged by gosec: tls.Config should specify the minimum TLS
version, which should be 1.2.

Signed-off-by: Stephen Kitt <skitt@redhat.com>