### PR TITLE
Update OCP AWS scripts for master->devel rename

### DIFF
--- a/tools/openshift/ocp-ipi-aws/README.md
+++ b/tools/openshift/ocp-ipi-aws/README.md
@@ -13,7 +13,7 @@ You can use the `prep_for_subm.sh` script on your OpenShift install directory wi
 
 ```bash
 cd my-cluster-openshift-install-dir
-curl https://raw.githubusercontent.com/submariner-io/submariner/master/tools/openshift/ocp-ipi-aws/prep_for_subm.sh -L -O
+curl https://raw.githubusercontent.com/submariner-io/submariner/devel/tools/openshift/ocp-ipi-aws/prep_for_subm.sh -L -O
 chmod a+x ./prep_for_subm.sh
 ./prep_for_subm.sh
 ```

--- a/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
+++ b/tools/openshift/ocp-ipi-aws/prep_for_subm.sh
@@ -16,7 +16,7 @@ if (( $# > 1 )) ; then
 fi
 
 # Set Github parameters
-GITHUB_BRANCH="${GITHUB_BRANCH:-master}"
+GITHUB_BRANCH="${GITHUB_BRANCH:-devel}"
 GITHUB_USERFORK="${GITHUB_USERFORK:-submariner-io}"
 GITHUB_ARCHIVE="https://github.com/$GITHUB_USERFORK/submariner/archive/$GITHUB_BRANCH.tar.gz"
 


### PR DESCRIPTION
Update the prep_for_subm.sh OCP AWS install script and docs to reflect
the rename of the "master" branch to "devel" for all Submariner repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>