### PR TITLE
Prefix all metrics with "submariner_"

### DIFF
--- a/pkg/cable/metrics.go
+++ b/pkg/cable/metrics.go
@@ -39,7 +39,7 @@ var (
 	// RX/TX metrics
 	rxGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "gateway_rx_bytes",
+			Name: "submariner_gateway_rx_bytes",
 			Help: "Count of bytes received (by cable driver and cable)",
 		},
 		[]string{
@@ -54,7 +54,7 @@ var (
 	)
 	txGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "gateway_tx_bytes",
+			Name: "submariner_gateway_tx_bytes",
 			Help: "Count of bytes transmitted (by cable driver and cable)",
 		},
 		[]string{
@@ -69,7 +69,7 @@ var (
 	)
 	connectionsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "connections",
+			Name: "submariner_connections",
 			Help: "Number of connections and corresponding status (by cable driver and cable)",
 		},
 		[]string{
@@ -85,7 +85,7 @@ var (
 	)
 	connectionEstablishedTimestampGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "connection_established_timestamp",
+			Name: "submariner_connection_established_timestamp",
 			Help: "Timestamp of last successful connection established (by cable driver and cable)",
 		},
 		[]string{
@@ -100,7 +100,7 @@ var (
 	)
 	connectionLatencySecondsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "connection_latency_seconds",
+			Name: "submariner_connection_latency_seconds",
 			Help: "Connection latency in seconds (last RTT, by cable driver and cable)",
 		},
 		[]string{

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -49,7 +49,7 @@ var GatewayUpdateInterval = 5 * time.Second
 var GatewayStaleTimeout = GatewayUpdateInterval * 3
 
 var gatewaySyncIterations = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "gateway_sync_iterations",
+	Name: "submariner_gateway_sync_iterations",
 	Help: "Gateway synchronization iterations",
 })
 

--- a/pkg/globalnet/controllers/ipam/metrics.go
+++ b/pkg/globalnet/controllers/ipam/metrics.go
@@ -25,7 +25,7 @@ const (
 var (
 	globalIPsAvailabilityGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "global_IP_availability",
+			Name: "submariner_global_IP_availability",
 			Help: "Count of available global IPs per CIDR",
 		},
 		[]string{
@@ -34,7 +34,7 @@ var (
 	)
 	globalIPsAllocatedGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "global_IP_allocated",
+			Name: "submariner_global_IP_allocated",
 			Help: "Count of global IPs allocated for Pods/Services per CIDR",
 		},
 		[]string{


### PR DESCRIPTION
This makes them simpler to find in the sea of metrics on an OpenShift
system.

Signed-off-by: Stephen Kitt <skitt@redhat.com>