### PR TITLE
Add dependabot ignore for submariner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,4 @@ updates:
       - dependency-name: sigs.k8s.io/controller-runtime
         versions:
           - "> 0.3.0"
+      - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
Updates to submariner dependencies is done via our release process.
