### PR TITLE
Enable PLPMTUD on the active gateway node when using Globalnet

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -37,6 +37,9 @@ const (
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
 	kubeProxyServiceChainName   = "KUBE-SERVICES"
 
+	tcpMtuProbingProcEntry = "/proc/sys/net/ipv4/tcp_mtu_probing"
+	tcpBaseMssProcEntry    = "/proc/sys/net/ipv4/tcp_base_mss"
+
 	maxServiceRequeues = 20
 
 	AddRules    = true

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -68,6 +68,12 @@ type Controller struct {
 	ipt iptables.Interface
 }
 
+type MTUConfig struct {
+	successfullyRead          bool
+	default_mtu_probing       []byte
+	default_tcp_base_mss      []byte
+}
+
 type GatewayMonitor struct {
 	clusterID                 string
 	kubeClientSet             kubernetes.Interface
@@ -81,5 +87,6 @@ type GatewayMonitor struct {
 	stopProcessing            chan struct{}
 	isGatewayNode             bool
 	nodeName                  string
+	mtuConfig                 MTUConfig
 	syncMutex                 sync.Mutex
 }

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -68,12 +68,6 @@ type Controller struct {
 	ipt iptables.Interface
 }
 
-type MTUConfig struct {
-	successfullyRead          bool
-	default_mtu_probing       []byte
-	default_tcp_base_mss      []byte
-}
-
 type GatewayMonitor struct {
 	clusterID                 string
 	kubeClientSet             kubernetes.Interface
@@ -87,6 +81,5 @@ type GatewayMonitor struct {
 	stopProcessing            chan struct{}
 	isGatewayNode             bool
 	nodeName                  string
-	mtuConfig                 MTUConfig
 	syncMutex                 sync.Mutex
 }


### PR DESCRIPTION
On some platforms like AWS when using Globalnet, it was seen
that Path MTU discovery was not happening properly. Because of
this, one of the e2e test is failing when the sourcePod is on
Gateway Node with HostNetworking enabled. This PR enables TCP
Packetization-Layer Path MTU discovery when an ICMP black hole
is detected by configuring the appropriate proc entry.

Also, we update the base mss value to RFC4821 recommended value
of 1024. This change is done only on the active Gateway node of
the cluster.

Fixes issue: https://github.com/submariner-io/submariner/issues/995
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>