### PR TITLE
Remove reliance on `version` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ images: build
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e / -e reload-images)
-override BUILD_ARGS += $(shell source ${SCRIPTS_DIR}/lib/version; echo --ldflags \'-X main.VERSION=$${VERSION}\')
+override BUILD_ARGS += --ldflags '-X main.VERSION=$(VERSION)'
 
 ifneq (,$(filter ovn,$(_using)))
 override CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings.ovn

--- a/scripts/reload-images
+++ b/scripts/reload-images
@@ -14,7 +14,6 @@ echo "Running with: restart=${restart}"
 set -em
 
 source ${SCRIPTS_DIR}/lib/debug_functions
-source ${SCRIPTS_DIR}/lib/version
 source ${SCRIPTS_DIR}/lib/deploy_funcs
 source ${SCRIPTS_DIR}/lib/utils
 source ${SCRIPTS_DIR}/lib/cluster_settings


### PR DESCRIPTION
The script has been migrated to `Makefile.versions` so we can just rely
on the `$VERSION` from there.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>