### PR TITLE
Enable PLPMTUD on the active gateway node when using Globalnet

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -22,6 +22,9 @@ const (
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
 	kubeProxyServiceChainName   = "KUBE-SERVICES"
 
+	tcpMtuProbingProcEntry = "/proc/sys/net/ipv4/tcp_mtu_probing"
+	tcpBaseMssProcEntry    = "/proc/sys/net/ipv4/tcp_base_mss"
+
 	maxServiceRequeues = 20
 
 	AddRules    = true

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -190,6 +190,10 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 		if endpoint.Spec.Hostname == hostname {
 			klog.V(log.DEBUG).Infof("We are now on GatewayNode %s", endpoint.Spec.PrivateIP)
 
+			// mtuProbe value of 1 enables PLPMTUD when an ICMP blackhole is detected.
+			// RFC4821 recommends using base mss value of 1024
+			ConfigureTCPMTUProbeValue([]byte("1"), []byte("1024"))
+
 			i.syncMutex.Lock()
 			if !i.isGatewayNode {
 				i.isGatewayNode = true
@@ -198,6 +202,7 @@ func (i *GatewayMonitor) processNextEndpoint() bool {
 			i.syncMutex.Unlock()
 		} else {
 			klog.V(log.DEBUG).Infof("We are on non-gatewayNode. GatewayNode ip is %s", endpoint.Spec.PrivateIP)
+
 			i.syncMutex.Lock()
 			if i.isGatewayNode {
 				i.stopIpamController()
@@ -311,10 +316,14 @@ func (i *GatewayMonitor) stopIpamController() {
 	klog.V(log.DEBUG).Infof("Notified ipamController to stop processing.")
 }
 
-func ConfigureTcpMTUProbeValue(mtuProbe, mssValue []byte) {
-	// If we are unable to update the values, just log a warning, Globalnet functionality works fine except
-	// for one use-case where Pod with HostNetworking on Gateway node has mtu issues connecting to remoteServices.
+func ConfigureTCPMTUProbeValue(mtuProbe, mssValue []byte) {
+	// If we are unable to update the values, just log a warning. Most of the Globalnet
+	// functionality works fine except for one use-case where Pod with HostNetworking
+	// on Gateway node has mtu issues connecting to remoteServices.
+	// We won't ever create tcpMtuProbingProcEntry/tcpBaseMssProcEntry, and its permissions are 644
+	// #nosec G306
 	if err := ioutil.WriteFile(tcpMtuProbingProcEntry, mtuProbe, 0644); err == nil {
+		// #nosec G306
 		err = ioutil.WriteFile(tcpBaseMssProcEntry, mssValue, 0644)
 		if err != nil {
 			klog.Warningf("unable to update value of tcp_base_mss to %s, err: %s", mssValue, err)
@@ -322,29 +331,4 @@ func ConfigureTcpMTUProbeValue(mtuProbe, mssValue []byte) {
 	} else {
 		klog.Warningf("unable to update value of tcp_mtu_probing to %s, err: %s", mtuProbe, err)
 	}
-}
-
-func (gm *GatewayMonitor)ReadTcpMTUConfigurationOnNode() {
-	var err error
-
-	// If we are unable to read the values, just log a warning, Globalnet functionality works fine except
-	// for one use-case where Pod with HostNetworking on Gateway node has mtu issues connecting to remoteServices.
-	if gm.mtuConfig.default_mtu_probing, err = ioutil.ReadFile(tcpMtuProbingProcEntry); err == nil {
-		gm.mtuConfig.default_tcp_base_mss, err = ioutil.ReadFile(tcpBaseMssProcEntry)
-		if err != nil {
-			klog.Warningf("unable to read default value of tcp_base_mss, err: %s", err)
-		}
-	} else {
-		klog.Warningf("unable to read default value of tcp_mtu_probing, err: %s", err)
-	}
-
-	if err != nil {
-		gm.mtuConfig.successfullyRead = false
-		return
-	}
-
-	klog.Infof("Default_mtu_probing is %s and tcp_base_mss is %s", gm.mtuConfig.default_mtu_probing,
-		gm.mtuConfig.default_tcp_base_mss)
-	gm.mtuConfig.successfullyRead = true
-	return
 }

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -308,4 +309,42 @@ func (i *GatewayMonitor) stopIpamController() {
 	}
 
 	klog.V(log.DEBUG).Infof("Notified ipamController to stop processing.")
+}
+
+func ConfigureTcpMTUProbeValue(mtuProbe, mssValue []byte) {
+	// If we are unable to update the values, just log a warning, Globalnet functionality works fine except
+	// for one use-case where Pod with HostNetworking on Gateway node has mtu issues connecting to remoteServices.
+	if err := ioutil.WriteFile(tcpMtuProbingProcEntry, mtuProbe, 0644); err == nil {
+		err = ioutil.WriteFile(tcpBaseMssProcEntry, mssValue, 0644)
+		if err != nil {
+			klog.Warningf("unable to update value of tcp_base_mss to %s, err: %s", mssValue, err)
+		}
+	} else {
+		klog.Warningf("unable to update value of tcp_mtu_probing to %s, err: %s", mtuProbe, err)
+	}
+}
+
+func (gm *GatewayMonitor)ReadTcpMTUConfigurationOnNode() {
+	var err error
+
+	// If we are unable to read the values, just log a warning, Globalnet functionality works fine except
+	// for one use-case where Pod with HostNetworking on Gateway node has mtu issues connecting to remoteServices.
+	if gm.mtuConfig.default_mtu_probing, err = ioutil.ReadFile(tcpMtuProbingProcEntry); err == nil {
+		gm.mtuConfig.default_tcp_base_mss, err = ioutil.ReadFile(tcpBaseMssProcEntry)
+		if err != nil {
+			klog.Warningf("unable to read default value of tcp_base_mss, err: %s", err)
+		}
+	} else {
+		klog.Warningf("unable to read default value of tcp_mtu_probing, err: %s", err)
+	}
+
+	if err != nil {
+		gm.mtuConfig.successfullyRead = false
+		return
+	}
+
+	klog.Infof("Default_mtu_probing is %s and tcp_base_mss is %s", gm.mtuConfig.default_mtu_probing,
+		gm.mtuConfig.default_tcp_base_mss)
+	gm.mtuConfig.successfullyRead = true
+	return
 }

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -42,6 +42,12 @@ type Controller struct {
 	ipt *iptables.IPTables
 }
 
+type MTUConfig struct {
+	successfullyRead          bool
+	default_mtu_probing       []byte
+	default_tcp_base_mss      []byte
+}
+
 type GatewayMonitor struct {
 	clusterID           string
 	kubeClientSet       kubernetes.Interface

--- a/pkg/globalnet/controllers/ipam/types.go
+++ b/pkg/globalnet/controllers/ipam/types.go
@@ -42,12 +42,6 @@ type Controller struct {
 	ipt *iptables.IPTables
 }
 
-type MTUConfig struct {
-	successfullyRead          bool
-	default_mtu_probing       []byte
-	default_tcp_base_mss      []byte
-}
-
 type GatewayMonitor struct {
 	clusterID           string
 	kubeClientSet       kubernetes.Interface


### PR DESCRIPTION
On some platforms like AWS when using Globalnet, it was seen
that Path MTU discovery was not happening properly. Because of
this, one of the e2e test is failing when the sourcePod is on
Gateway Node with HostNetworking enabled. This PR enables TCP
Packetization-Layer Path MTU discovery when an ICMP black hole
is detected by configuring the appropriate proc entry.

Also, we update the base mss value to RFC4821 recommended value
of 1024. This change is done only on the active Gateway node of
the cluster.

Fixes issue: #995
Signed-Off-by: Sridhar Gaddam sgaddam@redhat.com