### PR TITLE
Enable PL-PMTUD on the active gateway node by default

### DIFF
--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -201,9 +201,9 @@ func (gm *GatewayMonitor) processNextEndpoint() bool {
 		// If the endpoint hostname matches with our hostname, it implies we are on gateway node
 		if endpoint.Spec.Hostname == hostname {
 			klog.V(log.DEBUG).Infof("We are now on GatewayNode %s", endpoint.Spec.PrivateIP)
-			// mtuProbe value of 1 enables PLPMTUD when an ICMP blackhole is detected.
-			// RFC4821 recommends using base mss value of 1024
-			ConfigureTCPMTUProbeValue([]byte("1"), []byte("1024"))
+			// An mtuProbe value of 2 enables PLPMTUD. Along with this change, we also configure
+			// base mss to 1024 as per RFC4821 recommendation.
+			ConfigureTCPMTUProbeValue([]byte("2"), []byte("1024"))
 
 			gm.syncMutex.Lock()
 			if !gm.isGatewayNode {


### PR DESCRIPTION
In the previous fix to this issue, we enabled PL-PMTUD only when an
ICMP blackhole is detected (aka tcp_mtu_probing value of 1), but
during testing it was seen that it sometimes takes time for MTU
discovery and e2e fails occasionally.
In this PR, we enable PL-PMTUD always (aka tcp_mtu_probing value of
2) after which the e2e tests pass consistently.

Fixes issue: https://github.com/submariner-io/submariner/issues/995
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>