### PR TITLE
Use the K8s iptables wrapper everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
 
-IMAGES ?= submariner submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
+IMAGES ?= submariner-iptables-base submariner submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
 images: build
 
 include $(SHIPYARD_DIR)/Makefile.inc

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,20 +1,13 @@
-FROM fedora:33
+FROM quay.io/submariner/submariner-iptables-base:devel
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
-# iproute and iptables are used internally
 # libreswan provides IKE
-# procps-ng is needed for sysctl
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft libreswan procps-ng && \
+           libreswan && \
     dnf -y clean all
 
 COPY package/submariner.sh package/pluto bin/${TARGETPLATFORM}/submariner-engine /usr/local/bin/
-
-# Wrapper scripts to choose the appropriate iptables
-# https://github.com/kubernetes-sigs/iptables-wrappers
-COPY package/iptables-wrapper-installer.sh /usr/sbin/
-RUN /usr/sbin/iptables-wrapper-installer.sh
 
 ENTRYPOINT submariner.sh

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,15 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM quay.io/submariner/submariner-iptables-base:devel
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
-# These are all available in the UBI8 base OS repository
-RUN microdnf -y install --nodocs iproute iptables && \
-    microdnf clean all
+RUN dnf -y clean all
 
 COPY package/submariner-globalnet.sh bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/
-
-# Wrapper scripts to use iptables from the host when that's available
-COPY package/iptables-wrapper.in /usr/sbin/
 
 ENTRYPOINT submariner-globalnet.sh

--- a/package/Dockerfile.submariner-iptables-base
+++ b/package/Dockerfile.submariner-iptables-base
@@ -1,0 +1,17 @@
+# Base Submariner image for containers using iptables
+
+FROM fedora:33
+ARG TARGETPLATFORM
+
+WORKDIR /var/submariner
+
+# iproute and iptables are used internally
+# procps-ng is needed for sysctl
+RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
+           iproute iptables iptables-nft procps-ng
+# Child containers are expected to add packages, so we don’t clean here
+
+# Wrapper scripts to choose the appropriate iptables
+# https://github.com/kubernetes-sigs/iptables-wrappers
+COPY package/iptables-wrapper-installer.sh /usr/sbin/
+RUN /usr/sbin/iptables-wrapper-installer.sh

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,15 +1,10 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM quay.io/submariner/submariner-iptables-base:devel
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
-# These are all available in the UBI8 base OS repository
-RUN microdnf -y install --nodocs iproute iptables && \
-    microdnf clean all
+RUN dnf -y clean all
 
 COPY package/submariner-route-agent.sh bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/
-
-# Wrapper scripts to use iptables from the host when that's available
-COPY package/iptables-wrapper.in /usr/sbin/
 
 ENTRYPOINT submariner-route-agent.sh

--- a/package/iptables-wrapper.in
+++ b/package/iptables-wrapper.in
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host @@PATH@@/${0##*/} "$@"

--- a/package/submariner-globalnet.sh
+++ b/package/submariner-globalnet.sh
@@ -11,34 +11,4 @@ else
     DEBUG="-v=${SUBMARINER_VERBOSITY}"
 fi
 
-function find_iptables_on_host() {
-    chroot /host test -x /usr/sbin/$1 && { echo "/usr/sbin"; return; }
-    chroot /host test -x /sbin/$1 && { echo "/sbin"; return; }
-    echo "unknown"
-}
-
-
-# If host is mounted on /host and host has its own iptables version
-# use that one instead via the shipped iptables wrapper, we do this
-# to avoid configuring iptables and nftables on the host which
-# could lead to functional failures because some hosts use an iptables
-# and iptables-save which program nftables under the hood.
-# Since we're using UBI8, we only have nftables in the container so we
-# can't use the Kubernetes approach (see
-# https://github.com/kubernetes/kubernetes/pull/82966 and
-# https://github.com/kubernetes/website/pull/16271 for details).
-
-for f in iptables-save iptables; do
-  location=$(find_iptables_on_host $f)
-  if [ "${location}" != "unknown" ]; then
-    echo "$f is present on the host at ${location}/$f"
-	sed "s!@@PATH@@!${location}!" /usr/sbin/iptables-wrapper.in > /usr/sbin/$f
-  else
-    echo "WARNING: not using iptables wrapper because iptables was not detected on the"
-    echo "host at the following paths [/usr/sbin, /sbin]."
-    echo "Either the host file system isn't mounted or the host does not have iptables"
-    echo "installed. The pod will use the image installed iptables version."
-  fi
-done
-
 exec submariner-globalnet ${DEBUG} -alsologtostderr

--- a/package/submariner-route-agent.sh
+++ b/package/submariner-route-agent.sh
@@ -11,34 +11,4 @@ else
     DEBUG="-v=${SUBMARINER_VERBOSITY}"
 fi
 
-function find_iptables_on_host() {
-    chroot /host test -x /usr/sbin/$1 && { echo "/usr/sbin"; return; }
-    chroot /host test -x /sbin/$1 && { echo "/sbin"; return; }
-    echo "unknown"
-}
-
-
-# If host is mounted on /host and host has its own iptables version
-# use that one instead via the shipped iptables wrapper, we do this
-# to avoid configuring iptables and nftables on the host which
-# could lead to functional failures because some hosts use an iptables
-# and iptables-save which program nftables under the hood.
-# Since we're using UBI8, we only have nftables in the container so we
-# can't use the Kubernetes approach (see
-# https://github.com/kubernetes/kubernetes/pull/82966 and
-# https://github.com/kubernetes/website/pull/16271 for details).
-
-for f in iptables-save iptables; do
-  location=$(find_iptables_on_host $f)
-  if [ "${location}" != "unknown" ]; then
-    echo "$f is present on the host at ${location}/$f"
-	sed "s!@@PATH@@!${location}!" /usr/sbin/iptables-wrapper.in > /usr/sbin/$f
-  else
-    echo "WARNING: not using iptables wrapper because iptables was not detected on the"
-    echo "host at the following paths [/usr/sbin, /sbin]."
-    echo "Either the host file system isn't mounted or the host does not have iptables"
-    echo "installed. The pod will use the image installed iptables version."
-  fi
-done
-
 exec submariner-route-agent ${DEBUG} -alsologtostderr


### PR DESCRIPTION
This will allow us to drop the host mount requirement on all pods.
An iptables-equipped base image is used to reduce the time spent
building the images.

This requires using Fedora; UBI images don’t carry both iptables
variants. We’ll need to resolve this at some point, but for now
dropping the host mount seems more useful.

Signed-off-by: Stephen Kitt <skitt@redhat.com>