### PR TITLE
Define a nat-discovery protocol for selecting public or private IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ scripts/broker-info.subm*
 Dockerfile.dapper[0-9]*
 .shflags
 Makefile.dapper
+pkg/natdiscovery/proto/*.pb.go

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,6 +5,14 @@ ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_REF CLUSTERS_ARGS DE
     DAPPER_SOURCE=/go/src/github.com/submariner-io/submariner DAPPER_DOCKER_SOCKET=true
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
+ENV PROTOC_VERSION=3.15.5
+
+# alternative: dnf install -y --nodocs --setopt=install_weak_deps=False golang-google-protobuf protobuf-compiler && dnf -y clean all
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.5/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local && \
+    rm -f protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    GO111MODULE=off go get google.golang.org/protobuf/cmd/protoc-gen-go
+
 WORKDIR ${DAPPER_SOURCE}
 
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ deploy: images
 reload-images: build images
 	./scripts/$@ --restart $(restart)
 
-bin/%/submariner-gateway: vendor/modules.txt main.go $(shell find pkg -not \( -path 'pkg/globalnet*' -o -path 'pkg/routeagent*' \))
+%.pb.go: %.proto
+	protoc --go_out=/go/src $<
+
+bin/%/submariner-gateway: vendor/modules.txt main.go $(shell find pkg -not \( -path 'pkg/globalnet*' -o -path 'pkg/routeagent*' \)) pkg/natdiscovery/proto/natdiscovery.pb.go
 	GOARCH=$(call dockertogoarch,$(patsubst bin/linux/%/,%,$(dir $@))) ${SCRIPTS_DIR}/compile.sh $@ main.go $(BUILD_ARGS)
 
 bin/%/submariner-route-agent: vendor/modules.txt $(shell find pkg/routeagent_driver)

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ dockertogoarch = $(patsubst arm/v7,arm,$(1))
 
 deploy: images
 
+golangci-lint: pkg/natdiscovery/proto/natdiscovery.pb.go
+
+unit: pkg/natdiscovery/proto/natdiscovery.pb.go
+
 reload-images: build images
 	./scripts/$@ --restart $(restart)
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
 	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/gopacket v1.1.19
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
@@ -19,7 +20,7 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210112080510-489259a85091
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf
-	google.golang.org/protobuf v1.25.0 // indirect
+	google.golang.org/protobuf v1.25.0
 	k8s.io/api v0.18.4
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v0.18.4

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
+	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
@@ -18,6 +19,7 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210112080510-489259a85091
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf
+	google.golang.org/protobuf v1.25.0 // indirect
 	k8s.io/api v0.18.4
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -568,6 +570,7 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -691,6 +694,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -224,6 +225,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -718,6 +721,7 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
@@ -727,13 +731,18 @@ google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
+google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -70,14 +70,15 @@ type EndpointSpec struct {
 	ClusterID string `json:"cluster_id"`
 	CableName string `json:"cable_name"`
 	// +optional
-	HealthCheckIP string            `json:"healthCheckIP,omitempty"`
-	Hostname      string            `json:"hostname"`
-	Subnets       []string          `json:"subnets"`
-	PrivateIP     string            `json:"private_ip"`
-	PublicIP      string            `json:"public_ip"`
-	NATEnabled    bool              `json:"nat_enabled"`
-	Backend       string            `json:"backend"`
-	BackendConfig map[string]string `json:"backend_config,omitempty"`
+	HealthCheckIP    string            `json:"healthCheckIP,omitempty"`
+	Hostname         string            `json:"hostname"`
+	Subnets          []string          `json:"subnets"`
+	PrivateIP        string            `json:"private_ip"`
+	PublicIP         string            `json:"public_ip"`
+	NATEnabled       bool              `json:"nat_enabled"`
+	Backend          string            `json:"backend"`
+	BackendConfig    map[string]string `json:"backend_config,omitempty"`
+	NATDiscoveryPort *int32            `json:"natDiscoveryPort,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *EndpointSpec) DeepCopyInto(out *EndpointSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NATDiscoveryPort != nil {
+		in, out := &in.NATDiscoveryPort, &out.NATDiscoveryPort
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/natdiscovery/listener.go
+++ b/pkg/natdiscovery/listener.go
@@ -1,0 +1,73 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natdiscovery
+
+import (
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+
+	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+func (nd *natDiscovery) runListener(stopCh <-chan struct{}) error {
+	serverAddress, err := net.ResolveUDPAddr("udp4", ":"+strconv.Itoa(natproto.DefaultPort))
+	if err != nil {
+		return errors.Wrap(err, "Error resolving UDP address")
+	}
+
+	serverConnection, err := net.ListenUDP("udp", serverAddress)
+	if err != nil {
+		return errors.Wrapf(err, "Error listening on udp port %d", natproto.DefaultPort)
+	}
+
+	// Instead of storing the server connection I save the reference to the WriteToUDP
+	// of our server connection instance, in a way that we can use this for unit testing
+	// later too.
+	nd.serverUDPWrite = serverConnection.WriteToUDP
+
+	go wait.Until(func() {
+		buf := make([]byte, 2048)
+		if _, addr, err := serverConnection.ReadFromUDP(buf); err != nil {
+			klog.Errorf("Error receiving from udp: %s", err)
+		} else if err := nd.parseAndHandleMessageFromAddress(buf, addr); err != nil {
+			klog.Errorf("Error handling message from address %#v: %s", addr, err)
+		}
+	}, time.Second, stopCh)
+
+	return nil
+}
+
+func (nd *natDiscovery) parseAndHandleMessageFromAddress(buf []byte, addr *net.UDPAddr) error {
+	msg := natproto.SubmarinerNatDiscoveryMessage{}
+	if err := proto.Unmarshal(buf, &msg); err != nil {
+		return errors.Wrapf(err, "Error unmarshaling message received on UDP port %d", natproto.DefaultPort)
+	}
+
+	if request := msg.GetRequest(); request != nil {
+		return nd.handleRequestFromAddress(request, addr)
+	} else if response := msg.GetResponse(); response != nil {
+		return nd.handleResponseFromAddress(response, addr)
+	}
+
+	return errors.Errorf("Message without response or request received from %#v", addr)
+}

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -1,0 +1,1 @@
+package natdiscovery

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -1,1 +1,156 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package natdiscovery
+
+import (
+	"crypto/rand"
+	"math/big"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+type Interface interface {
+	Run(stopCh <-chan struct{}) error
+	AddEndpoint(endpoint *types.SubmarinerEndpoint)
+	RemoveEndpoint(endpointName string)
+	SetReadyChannel(readyChannel chan *NATEndpointInfo)
+}
+
+type udpWriteFunction func(b []byte, addr *net.UDPAddr) (int, error)
+type findSrcIPFunction func(destinationIP string) (string, error)
+
+type natDiscovery struct {
+	sync.Mutex
+	localEndpoint   *types.SubmarinerEndpoint
+	remoteEndpoints map[string]*remoteEndpointNAT
+	requestCounter  uint64
+	serverUDPWrite  udpWriteFunction
+	findSrcIP       findSrcIPFunction
+	serverPort      int32
+	readyChannel    chan *NATEndpointInfo
+}
+
+func (nd *natDiscovery) SetReadyChannel(readyChannel chan *NATEndpointInfo) {
+	nd.readyChannel = readyChannel
+}
+
+func New(localEndpoint *types.SubmarinerEndpoint) (Interface, error) {
+	return newNatDiscovery(localEndpoint)
+}
+
+func newNatDiscovery(localEndpoint *types.SubmarinerEndpoint) (*natDiscovery, error) {
+	port, err := extractNATDiscoveryPort(localEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	requestCounter, err := randomRequestCounter()
+	if err != nil {
+		return nil, err
+	}
+
+	return &natDiscovery{
+		localEndpoint:   localEndpoint,
+		serverPort:      port,
+		remoteEndpoints: map[string]*remoteEndpointNAT{},
+		findSrcIP:       findPreferredSourceIP,
+		requestCounter:  requestCounter,
+	}, nil
+}
+
+func randomRequestCounter() (uint64, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000))
+	if err != nil {
+		return 0, errors.Wrapf(err, "generating random request counter")
+	}
+
+	return n.Uint64(), nil
+}
+
+var errorNoNatDiscoveryPort = errors.New("nat discovery port missing in endpoint")
+
+func extractNATDiscoveryPort(endpoint *types.SubmarinerEndpoint) (int32, error) {
+	if endpoint.Spec.NATDiscoveryPort == nil {
+		return 0, errorNoNatDiscoveryPort
+	}
+
+	return *endpoint.Spec.NATDiscoveryPort, nil
+}
+
+func (nd *natDiscovery) Run(stopCh <-chan struct{}) error {
+	err := nd.runListener(stopCh)
+	if err != nil {
+		return err
+	}
+
+	go wait.Until(func() {
+		nd.checkEndpointList()
+	}, time.Second, stopCh)
+
+	return nil
+}
+
+func (nd *natDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
+	nd.Lock()
+	defer nd.Unlock()
+
+	if ep, exists := nd.remoteEndpoints[endpoint.Spec.CableName]; exists {
+		if reflect.DeepEqual(ep.endpoint.Spec, endpoint.Spec) {
+			return
+		} else {
+			delete(nd.remoteEndpoints, endpoint.Spec.CableName)
+		}
+	}
+
+	remoteNAT := newRemoteEndpointNAT(endpoint)
+
+	// support a remote cluster endpoint which still hasn't implemented this protocol
+	if _, err := extractNATDiscoveryPort(endpoint); err == errorNoNatDiscoveryPort {
+		remoteNAT.useLegacyNATSettings()
+	}
+
+	nd.remoteEndpoints[endpoint.Spec.CableName] = remoteNAT
+}
+
+func (nd *natDiscovery) RemoveEndpoint(endpointName string) {
+	nd.Lock()
+	defer nd.Unlock()
+	delete(nd.remoteEndpoints, endpointName)
+}
+
+func (nd *natDiscovery) checkEndpointList() {
+	nd.Lock()
+	defer nd.Unlock()
+
+	for _, endpointNAT := range nd.remoteEndpoints {
+		if endpointNAT.shouldCheck() {
+			if endpointNAT.hasTimedOut() {
+				endpointNAT.useLegacyNATSettings()
+			} else if err := nd.sendCheckRequest(endpointNAT); err != nil {
+				klog.Errorf("Error sending check request to %q: %s", endpointNAT.endpoint.Spec.CableName, err)
+			}
+		}
+	}
+}

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -1,0 +1,1 @@
+package natdiscovery

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -1,1 +1,131 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package natdiscovery
+
+import (
+	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/klog"
+
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+func TestNATDiscovery(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NAT Discovery Suite")
+}
+
+const (
+	testLocalEndpointName = "cluster-a-ep-1"
+	testLocalClusterID    = "cluster-a"
+	testLocalPublicIP     = "10.1.1.1"
+	testLocalPrivateIP    = "2.2.2.2"
+
+	testRemoteEndpointName        = "cluster-b-ep-1"
+	testRemoteUnknownEndpointName = "cluster-b-ep-unknown"
+	testRemoteClusterID           = "cluster-b"
+	testRemotePublicIP            = "10.3.3.3"
+	testRemotePrivateIP           = "4.4.4.4"
+)
+
+var (
+	testLocalNATPort  int32 = 1234
+	testRemoteNATPort int32 = 4321
+)
+
+func parseProtocolRequest(buf []byte) *natproto.SubmarinerNatDiscoveryRequest {
+	msg := natproto.SubmarinerNatDiscoveryMessage{}
+	if err := proto.Unmarshal(buf, &msg); err != nil {
+		klog.Errorf("error unmarshaling message received on UDP port %d: %s", natproto.DefaultPort, err)
+	}
+
+	request := msg.GetRequest()
+	Expect(request).NotTo(BeNil())
+
+	return request
+}
+
+func parseProtocolResponse(buf []byte) *natproto.SubmarinerNatDiscoveryResponse {
+	msg := natproto.SubmarinerNatDiscoveryMessage{}
+	if err := proto.Unmarshal(buf, &msg); err != nil {
+		klog.Errorf("error unmarshaling message received on UDP port %d: %s", natproto.DefaultPort, err)
+	}
+
+	response := msg.GetResponse()
+	Expect(response).NotTo(BeNil())
+
+	return response
+}
+
+func createTestListener(endpoint *types.SubmarinerEndpoint) (*natDiscovery, chan []byte) {
+	listener, err := newNatDiscovery(endpoint)
+	readyChannel := make(chan *NATEndpointInfo, 100)
+	listener.SetReadyChannel(readyChannel)
+	Expect(err).NotTo(HaveOccurred())
+
+	udpSentChannel := make(chan []byte, 10)
+	listener.serverUDPWrite = func(b []byte, addr *net.UDPAddr) (int, error) {
+		udpSentChannel <- b
+		return len(b), nil
+	}
+
+	return listener, udpSentChannel
+}
+func createTestLocalEndpoint() types.SubmarinerEndpoint {
+	return types.SubmarinerEndpoint{
+		Spec: submarinerv1.EndpointSpec{
+			CableName:        testLocalEndpointName,
+			ClusterID:        testLocalClusterID,
+			PublicIP:         testLocalPublicIP,
+			PrivateIP:        testLocalPrivateIP,
+			NATDiscoveryPort: &testLocalNATPort,
+		},
+	}
+}
+
+func createTestRemoteEndpoint() types.SubmarinerEndpoint {
+	return types.SubmarinerEndpoint{
+		Spec: submarinerv1.EndpointSpec{
+			CableName:        testRemoteEndpointName,
+			ClusterID:        testRemoteClusterID,
+			PublicIP:         testRemotePublicIP,
+			PrivateIP:        testRemotePrivateIP,
+			NATDiscoveryPort: &testRemoteNATPort,
+		},
+	}
+}
+
+func createTestUnknownRemoteEndpoint() types.SubmarinerEndpoint {
+	return types.SubmarinerEndpoint{
+		Spec: submarinerv1.EndpointSpec{
+			CableName:        testRemoteUnknownEndpointName,
+			ClusterID:        testRemoteClusterID,
+			PublicIP:         testRemotePublicIP,
+			PrivateIP:        testRemotePrivateIP,
+			NATDiscoveryPort: &testRemoteNATPort,
+		},
+	}
+}

--- a/pkg/natdiscovery/proto/consts.go
+++ b/pkg/natdiscovery/proto/consts.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 package proto
 
-const Port = 4499
+const DefaultPort = 4490
+const Version = 1

--- a/pkg/natdiscovery/proto/consts.go
+++ b/pkg/natdiscovery/proto/consts.go
@@ -1,0 +1,19 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proto
+
+const Port = 4499

--- a/pkg/natdiscovery/proto/natdiscovery.proto
+++ b/pkg/natdiscovery/proto/natdiscovery.proto
@@ -44,9 +44,8 @@ enum ResponseType {
   SRC_MODIFIED = 1;
   UNKNOWN_DST_CLUSTER = 2;
   UNKNOWN_DST_ENDPOINT = 3;
-  UNKNOWN_SRC_CLUSTER = 4;
-  UNKNOWN_SRC_ENDPOINT = 5;
-  MALFORMED = 6;
+  UNKNOWN_SRC_ENDPOINT = 4;
+  MALFORMED = 5;
 }
 
 message SubmarinerNatDiscoveryResponse {

--- a/pkg/natdiscovery/proto/natdiscovery.proto
+++ b/pkg/natdiscovery/proto/natdiscovery.proto
@@ -1,0 +1,73 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+syntax = "proto3";
+option go_package = "github.com/submariner-io/submariner/pkg/natdiscovery/proto";
+
+message SubmarinerNatDiscoveryMessage {
+  int32 version = 1;
+
+  oneof message {
+    SubmarinerNatDiscoveryRequest request = 2;
+    SubmarinerNatDiscoveryResponse response = 3;
+  }
+}
+
+message SubmarinerNatDiscoveryRequest {
+  uint64 request_number = 1;
+
+  EndpointDetails sender = 2;
+  EndpointDetails receiver = 3;
+
+  // The following information would allow the receiver to identify
+  // and log if any form of NAT traversal is happening on the path
+  IPPortPair using_src = 4;
+  IPPortPair using_dst = 5;
+}
+
+enum ResponseType {
+  OK = 0;
+  SRC_MODIFIED = 1;
+  UNKNOWN_DST_CLUSTER = 2;
+  UNKNOWN_DST_ENDPOINT = 3;
+  UNKNOWN_SRC_CLUSTER = 4;
+  UNKNOWN_SRC_ENDPOINT = 5;
+  MALFORMED = 6;
+}
+
+message SubmarinerNatDiscoveryResponse {
+  uint64 request_number = 1;
+
+  ResponseType response = 2;
+  EndpointDetails sender = 3;
+  EndpointDetails receiver = 4;
+
+  // The received SRC IP / SRC port is reported, which will be useful for
+  // diagnosing corner cases
+  IPPortPair received_src = 5;
+}
+
+message IPPortPair {
+  string IP = 1;
+  uint32 port = 2;
+}
+
+message EndpointDetails {
+  // should we hash this for privacy? a hash can be checked against a known list, but can't be decoded
+  string cluster_id = 1;
+  string endpoint_id = 2;
+}

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -1,0 +1,153 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package natdiscovery
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+type endpointState int
+
+const (
+	testingPrivateAndPublicIPs endpointState = iota
+	waitingForResponse
+	selectedPublicIP
+	selectedPrivateIP
+	recheckTime                    = 2 * time.Second
+	totalTimeout                   = 60 * time.Second
+	publicToPrivateFailoverTimeout = 1 * time.Second
+)
+
+type remoteEndpointNAT struct {
+	endpoint               *types.SubmarinerEndpoint
+	state                  endpointState
+	lastCheck              time.Time
+	lastTransition         time.Time
+	started                time.Time
+	useNAT                 bool
+	useIP                  string
+	lastPublicIPRequestID  uint64
+	lastPrivateIPRequestID uint64
+}
+
+type NATEndpointInfo struct {
+	Endpoint subv1.EndpointSpec
+	UseNAT   bool
+	UseIP    string
+}
+
+func (rn *remoteEndpointNAT) toNATEndpointInfo() *NATEndpointInfo {
+	return &NATEndpointInfo{
+		Endpoint: rn.endpoint.Spec,
+		UseNAT:   rn.useNAT,
+		UseIP:    rn.useIP,
+	}
+}
+
+func newRemoteEndpointNAT(endpoint *types.SubmarinerEndpoint) *remoteEndpointNAT {
+	return &remoteEndpointNAT{
+		endpoint:       endpoint,
+		state:          testingPrivateAndPublicIPs,
+		started:        time.Now(),
+		lastTransition: time.Now(),
+	}
+}
+
+func (rn *remoteEndpointNAT) transitionToState(newState endpointState) {
+	rn.lastTransition = time.Now()
+	rn.state = newState
+}
+
+func (rn *remoteEndpointNAT) sinceLastTransition() time.Duration {
+	return time.Since(rn.lastTransition)
+}
+
+func (rn *remoteEndpointNAT) hasTimedOut() bool {
+	return time.Since(rn.started) > totalTimeout
+}
+
+func (rn *remoteEndpointNAT) useLegacyNATSettings() {
+	rn.useNAT = rn.endpoint.Spec.NATEnabled
+	if rn.endpoint.Spec.NATEnabled {
+		rn.useIP = rn.endpoint.Spec.PublicIP
+		rn.transitionToState(selectedPublicIP)
+	} else {
+		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.transitionToState(selectedPrivateIP)
+	}
+}
+
+func (rn *remoteEndpointNAT) shouldCheck() bool {
+	switch rn.state {
+	case testingPrivateAndPublicIPs:
+		return true
+	case waitingForResponse:
+		return time.Since(rn.lastCheck) > recheckTime
+	default:
+		return false
+	}
+}
+
+func (rn *remoteEndpointNAT) checkSent() {
+	if rn.state == testingPrivateAndPublicIPs {
+		rn.state = waitingForResponse
+	}
+
+	rn.lastCheck = time.Now()
+}
+
+func (rn *remoteEndpointNAT) transitionToPublicIP(remoteEndpointID string, useNAT bool) error {
+	if rn.state == waitingForResponse {
+		rn.useIP = rn.endpoint.Spec.PublicIP
+		rn.useNAT = useNAT
+		rn.transitionToState(selectedPublicIP)
+	} else {
+		return errors.Errorf("received unexpected transition to public IP from endpoint %q", remoteEndpointID)
+	}
+
+	return nil
+}
+
+func (rn *remoteEndpointNAT) transitionToPrivateIP(remoteEndpointID string, useNAT bool) error {
+	switch rn.state {
+	case waitingForResponse:
+		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.useNAT = useNAT
+		rn.transitionToState(selectedPrivateIP)
+
+	case selectedPublicIP:
+		// If a PublicIP was selected, we still allow some time for the privateIP response to arrive, and we always
+		// prefer PrivateIP with no NAT connection, as it will be more likely to work, and more efficient
+		if rn.sinceLastTransition() > publicToPrivateFailoverTimeout {
+			return errors.Errorf("response on private address received too late after response on public address for endpoint %q",
+				remoteEndpointID)
+		}
+
+		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.useNAT = useNAT
+		rn.transitionToState(selectedPrivateIP)
+
+	default:
+		return errors.Errorf("received unexpected transition to private IP from endpoint %q", remoteEndpointID)
+	}
+
+	return nil
+}

--- a/pkg/natdiscovery/remote_endpoint_test.go
+++ b/pkg/natdiscovery/remote_endpoint_test.go
@@ -1,0 +1,188 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natdiscovery
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("remoteEndpointNAT", func() {
+
+	var rnat *remoteEndpointNAT
+
+	BeforeEach(func() {
+		remoteEndpoint := createTestRemoteEndpoint()
+		rnat = newRemoteEndpointNAT(&remoteEndpoint)
+	})
+
+	When("first created", func() {
+		It("shouldCheck should return true", func() {
+			Expect(rnat.shouldCheck()).To(BeTrue())
+		})
+	})
+
+	When("right after a check has been sent", func() {
+		It("shouldCheck should return false", func() {
+			rnat.checkSent()
+			Expect(rnat.shouldCheck()).To(BeFalse())
+		})
+	})
+
+	When("the total timeout has elapsed", func() {
+		It("should report as timed out", func() {
+			rnat.started = time.Now().Add(-totalTimeout)
+			Expect(rnat.hasTimedOut()).To(BeTrue())
+		})
+	})
+
+	When("using legacy settings", func() {
+		Context("and NAT is not enabled", func() {
+			It("should select the private IP", func() {
+				rnat.endpoint.Spec.NATEnabled = false
+				rnat.useLegacyNATSettings()
+				Expect(rnat.state).To(Equal(selectedPrivateIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+			})
+		})
+		Context("and NAT is enabled", func() {
+			It("should select the public IP", func() {
+				rnat.endpoint.Spec.NATEnabled = true
+				rnat.useLegacyNATSettings()
+				Expect(rnat.state).To(Equal(selectedPublicIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+			})
+		})
+	})
+
+	When("the public IP is selected but no check was sent", func() {
+		It("it should fail", func() {
+			err := rnat.transitionToPublicIP(testRemoteEndpointName, false)
+			Expect(err).To(HaveOccurred())
+			Expect(rnat.useIP).To(Equal(""))
+		})
+	})
+
+	When("the private IP is selected but no check was sent", func() {
+		It("it should fail", func() {
+			err := rnat.transitionToPrivateIP(testRemoteEndpointName, false)
+			Expect(err).To(HaveOccurred())
+			Expect(rnat.useIP).To(Equal(""))
+		})
+	})
+
+	When("the private IP is selected", func() {
+		var useNAT bool
+
+		JustBeforeEach(func() {
+			rnat.checkSent()
+			err := rnat.transitionToPrivateIP(testRemoteEndpointName, useNAT)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rnat.state).To(Equal(selectedPrivateIP))
+		})
+
+		It("should use the private IP", func() {
+			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+		})
+
+		Context("with NAT discovered", func() {
+			BeforeEach(func() {
+				useNAT = true
+			})
+
+			It("should set useNAT to true", func() {
+				Expect(rnat.useNAT).To(BeTrue())
+			})
+		})
+
+		Context("with no NAT discovered", func() {
+			BeforeEach(func() {
+				useNAT = false
+			})
+
+			It("should set useNAT to false", func() {
+				Expect(rnat.useNAT).To(BeFalse())
+			})
+		})
+	})
+
+	When("the public IP is selected", func() {
+		var useNAT bool
+
+		JustBeforeEach(func() {
+			rnat.checkSent()
+			err := rnat.transitionToPublicIP(testRemoteEndpointName, useNAT)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rnat.state).To(Equal(selectedPublicIP))
+		})
+
+		It("should use the public IP", func() {
+			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+		})
+
+		Context("with NAT discovered", func() {
+			BeforeEach(func() {
+				useNAT = true
+			})
+
+			It("should set useNAT to true", func() {
+				Expect(rnat.useNAT).To(BeTrue())
+			})
+		})
+
+		Context("with no NAT discovered", func() {
+			BeforeEach(func() {
+				useNAT = false
+			})
+
+			It("should set useNAT to false", func() {
+				Expect(rnat.useNAT).To(BeFalse())
+			})
+		})
+	})
+
+	When("private IP is selected right after publicIP ", func() {
+		Context("and the grace period has not elapsed", func() {
+			It("should use the private IP", func() {
+				rnat.checkSent()
+				err := rnat.transitionToPublicIP(testRemoteEndpointName, true)
+				Expect(err).NotTo(HaveOccurred())
+				err = rnat.transitionToPrivateIP(testRemoteEndpointName, false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rnat.state).To(Equal(selectedPrivateIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+				Expect(rnat.useNAT).To(BeFalse())
+			})
+		})
+
+		Context("and the grace period has elapsed", func() {
+			It("should still use the public IP", func() {
+				rnat.checkSent()
+				err := rnat.transitionToPublicIP(testRemoteEndpointName, true)
+				Expect(err).NotTo(HaveOccurred())
+				rnat.lastTransition = rnat.lastTransition.Add(-publicToPrivateFailoverTimeout)
+				err = rnat.transitionToPrivateIP(testRemoteEndpointName, false)
+				Expect(err).To(HaveOccurred())
+				Expect(rnat.state).To(Equal(selectedPublicIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+				Expect(rnat.useNAT).To(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/natdiscovery/request_handle.go
+++ b/pkg/natdiscovery/request_handle.go
@@ -1,0 +1,133 @@
+/*
+© 2021 Red Hat, Inc. and others.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natdiscovery
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	proto2 "google.golang.org/protobuf/proto"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+func (nd *natDiscovery) handleRequestFromAddress(req *proto.SubmarinerNatDiscoveryRequest, addr *net.UDPAddr) error {
+	response := proto.SubmarinerNatDiscoveryResponse{
+		RequestNumber: req.RequestNumber,
+		Sender: &proto.EndpointDetails{
+			ClusterId:  nd.localEndpoint.Spec.ClusterID,
+			EndpointId: nd.localEndpoint.Spec.CableName,
+		},
+		Receiver: req.Sender,
+		ReceivedSrc: &proto.IPPortPair{
+			Port: uint32(addr.Port),
+			IP:   addr.IP.String(),
+		},
+	}
+
+	if req.Receiver == nil || req.Sender == nil || req.UsingDst == nil || req.UsingSrc == nil {
+		klog.Warningf("Received NAT discovery packet %#v from %#v which seems to be malformed ", req, addr)
+
+		response.Response = proto.ResponseType_MALFORMED
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	if req.Receiver.GetClusterId() != nd.localEndpoint.Spec.ClusterID {
+		klog.Warningf("Received NAT discovery packet for cluster %q, but we are cluster %q", req.Receiver.GetClusterId(),
+			nd.localEndpoint.Spec.ClusterID)
+
+		response.Response = proto.ResponseType_UNKNOWN_DST_CLUSTER
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	if req.Receiver.GetEndpointId() != nd.localEndpoint.Spec.CableName {
+		klog.Warningf("Received NAT discovery packet for endpoint %q, but we are endpoint %q "+
+			"if the port for NAT discovery has been mapped somewhere an error may exist", req.Receiver.GetEndpointId(),
+			nd.localEndpoint.Spec.CableName)
+
+		response.Response = proto.ResponseType_UNKNOWN_DST_ENDPOINT
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	if !nd.isKnownEndpoint(req.Sender.GetEndpointId(), req.Sender.GetClusterId()) {
+		// This can be ok for some time, because one cluster could discover an endpoint earlier on the broker than the
+		// the other endpoint has discovered him
+		klog.V(log.DEBUG).Infof("Received a NAT discovery packet from an endpoint %q on cluster %q we don't know about yet",
+			req.Receiver.GetEndpointId(), req.Receiver.GetClusterId())
+
+		response.Response = proto.ResponseType_UNKNOWN_SRC_ENDPOINT
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	if req.UsingSrc.GetIP() != "" && req.UsingSrc.GetIP() != addr.IP.String() {
+		klog.V(log.DEBUG).Infof("Received NAT packet from endpoint %q, cluster %q, where NAT has been detected, "+
+			"source IP changed",
+			req.Sender.GetEndpointId(), req.Sender.GetClusterId())
+		klog.V(log.DEBUG).Infof("Original src IP was %q, received src IP is %q", req.UsingSrc.IP, addr.IP.String())
+
+		response.Response = proto.ResponseType_SRC_MODIFIED
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	if int(req.UsingSrc.Port) != addr.Port {
+		klog.V(log.DEBUG).Infof("Received NAT packet from endpoint %q, cluster %q, where NAT on the source has been detected, "+
+			"src port changed",
+			req.Sender.GetEndpointId(), req.Sender.GetClusterId())
+		klog.V(log.DEBUG).Infof("Original src IP was %q, received src IP is %q", req.UsingSrc.IP, addr.IP.String())
+
+		response.Response = proto.ResponseType_SRC_MODIFIED
+
+		return nd.sendResponseToAddress(&response, addr)
+	}
+
+	response.Response = proto.ResponseType_OK
+
+	return nd.sendResponseToAddress(&response, addr)
+}
+
+func (nd *natDiscovery) isKnownEndpoint(endpointID, clusterID string) bool {
+	nd.Lock()
+	defer nd.Unlock()
+
+	ep, ok := nd.remoteEndpoints[endpointID]
+
+	return ok && ep.endpoint.Spec.ClusterID == clusterID
+}
+
+func (nd *natDiscovery) sendResponseToAddress(response *proto.SubmarinerNatDiscoveryResponse, addr *net.UDPAddr) error {
+	msgResponse := proto.SubmarinerNatDiscoveryMessage_Response{Response: response}
+	message := proto.SubmarinerNatDiscoveryMessage{Message: &msgResponse}
+	buf, err := proto2.Marshal(&message)
+	if err != nil {
+		return errors.Wrapf(err, "error marshaling response %#v", response)
+	}
+
+	if length, err := nd.serverUDPWrite(buf, addr); err != nil {
+		return errors.Wrapf(err, "error sending response packet %#v", response)
+	} else if length != len(buf) {
+		return errors.Errorf("the sent UDP packet was smaller than requested, sent=%d, expected=%d", length, len(buf))
+	}
+
+	return nil
+}

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -1,0 +1,186 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package natdiscovery
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+
+	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+var _ = Describe("natdiscovery listener", func() {
+
+	var localListener *natDiscovery
+	var localUDPSent chan []byte
+	var remoteListener *natDiscovery
+	var remoteUDPSent chan []byte
+
+	localEndpoint := createTestLocalEndpoint()
+	remoteEndpoint := createTestRemoteEndpoint()
+	remoteUnknownEndpoint := createTestUnknownRemoteEndpoint()
+
+	remoteUDPAddr := net.UDPAddr{
+		IP:   net.ParseIP(testRemotePrivateIP),
+		Port: int(testRemoteNATPort),
+	}
+
+	BeforeEach(func() {
+		localListener, localUDPSent = createTestListener(&localEndpoint)
+		localListener.findSrcIP = func(_ string) (string, error) { return testLocalPrivateIP, nil }
+		remoteListener, remoteUDPSent = createTestListener(&remoteEndpoint)
+		remoteListener.findSrcIP = func(_ string) (string, error) { return testRemotePrivateIP, nil }
+	})
+
+	parseResponseInLocalListener := func(udpPacket []byte, remoteAddr *net.UDPAddr) *natproto.SubmarinerNatDiscoveryResponse {
+		err := localListener.parseAndHandleMessageFromAddress(udpPacket, remoteAddr)
+		Expect(err).NotTo(HaveOccurred())
+		return parseProtocolResponse(<-localUDPSent)
+	}
+	requestResponseFromRemoteToLocal := func(remoteAddr *net.UDPAddr) []*natproto.SubmarinerNatDiscoveryResponse {
+		err := remoteListener.sendCheckRequestByRemoteID(testLocalEndpointName)
+		Expect(err).NotTo(HaveOccurred())
+		return []*natproto.SubmarinerNatDiscoveryResponse{
+			parseResponseInLocalListener(<-remoteUDPSent, remoteAddr), /* Private IP request */
+			parseResponseInLocalListener(<-remoteUDPSent, remoteAddr), /* Public IP request */
+		}
+	}
+
+	When("receiving a request from an unknown endpoint on a known cluster", func() {
+		It("it should respond unknown endpoint", func() {
+			remoteListener.AddEndpoint(&localEndpoint)
+			localListener.AddEndpoint(&remoteUnknownEndpoint)
+			response := requestResponseFromRemoteToLocal(&remoteUDPAddr)
+			Expect(response[0].Response).To(Equal(natproto.ResponseType_UNKNOWN_SRC_ENDPOINT))
+		})
+	})
+
+	When("receiving a request from an known cluster", func() {
+		It("it should respond OK", func() {
+			remoteListener.AddEndpoint(&localEndpoint)
+			localListener.AddEndpoint(&remoteEndpoint)
+			response := requestResponseFromRemoteToLocal(&remoteUDPAddr)
+			Expect(response[0].Response).To(Equal(natproto.ResponseType_OK))
+		})
+	})
+
+	When("receiving a request from an known cluster, but IP is modified", func() {
+		It("it should respond OK", func() {
+			remoteUDPAddrOtherIP := net.UDPAddr{
+				IP:   net.ParseIP(testRemotePublicIP),
+				Port: int(testRemoteNATPort),
+			}
+			remoteListener.AddEndpoint(&localEndpoint)
+			localListener.AddEndpoint(&remoteEndpoint)
+			response := requestResponseFromRemoteToLocal(&remoteUDPAddrOtherIP)
+			Expect(response[0].Response).To(Equal(natproto.ResponseType_SRC_MODIFIED))
+		})
+	})
+
+	When("receiving a request from an known cluster, but port is modified", func() {
+		It("it should respond OK", func() {
+			remoteUDPAddrOtherPort := net.UDPAddr{
+				IP:   net.ParseIP(testRemotePrivateIP),
+				Port: int(testRemoteNATPort + 1),
+			}
+			remoteListener.AddEndpoint(&localEndpoint)
+			localListener.AddEndpoint(&remoteEndpoint)
+			response := requestResponseFromRemoteToLocal(&remoteUDPAddrOtherPort)
+			Expect(response[0].Response).To(Equal(natproto.ResponseType_SRC_MODIFIED))
+		})
+	})
+
+	When("receiving a malformed request", func() {
+		It("it should respond MALFORMED for a missing Sender", func() {
+			request := createMalformedRequest(func(msg *natproto.SubmarinerNatDiscoveryMessage) {
+				msg.GetRequest().Sender = nil
+			})
+			response := parseResponseInLocalListener(request, &remoteUDPAddr)
+			Expect(response.Response).To(Equal(natproto.ResponseType_MALFORMED))
+		})
+	})
+
+	When("receiving a malformed request", func() {
+		It("it should respond MALFORMED for a missing Receiver", func() {
+			request := createMalformedRequest(func(msg *natproto.SubmarinerNatDiscoveryMessage) {
+				msg.GetRequest().Receiver = nil
+			})
+			response := parseResponseInLocalListener(request, &remoteUDPAddr)
+			Expect(response.Response).To(Equal(natproto.ResponseType_MALFORMED))
+		})
+	})
+
+	When("receiving a malformed request", func() {
+		It("it should respond MALFORMED for a missing UsingDst", func() {
+			request := createMalformedRequest(func(msg *natproto.SubmarinerNatDiscoveryMessage) {
+				msg.GetRequest().UsingDst = nil
+			})
+			response := parseResponseInLocalListener(request, &remoteUDPAddr)
+			Expect(response.Response).To(Equal(natproto.ResponseType_MALFORMED))
+		})
+	})
+
+	When("receiving a malformed request", func() {
+		It("it should respond MALFORMED for a missing UsingSrc", func() {
+			request := createMalformedRequest(func(msg *natproto.SubmarinerNatDiscoveryMessage) {
+				msg.GetRequest().UsingSrc = nil
+			})
+			response := parseResponseInLocalListener(request, &remoteUDPAddr)
+			Expect(response.Response).To(Equal(natproto.ResponseType_MALFORMED))
+		})
+	})
+})
+
+func createMalformedRequest(mangleFunction func(*natproto.SubmarinerNatDiscoveryMessage)) []byte {
+	request := natproto.SubmarinerNatDiscoveryRequest{
+		RequestNumber: 1,
+		Sender: &natproto.EndpointDetails{
+			EndpointId: testRemoteEndpointName,
+			ClusterId:  testRemoteClusterID,
+		},
+		Receiver: &natproto.EndpointDetails{
+			EndpointId: testLocalEndpointName,
+			ClusterId:  testLocalClusterID,
+		},
+		UsingSrc: &natproto.IPPortPair{
+			IP:   testRemotePrivateIP,
+			Port: uint32(natproto.DefaultPort),
+		},
+		UsingDst: &natproto.IPPortPair{
+			IP:   testLocalPrivateIP,
+			Port: uint32(natproto.DefaultPort),
+		},
+	}
+
+	msgRequest := &natproto.SubmarinerNatDiscoveryMessage_Request{
+		Request: &request,
+	}
+
+	message := natproto.SubmarinerNatDiscoveryMessage{
+		Version: natproto.Version,
+		Message: msgRequest,
+	}
+
+	mangleFunction(&message)
+
+	buf, err := proto.Marshal(&message)
+	Expect(err).NotTo(HaveOccurred())
+
+	return buf
+}

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -1,0 +1,152 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package natdiscovery
+
+import (
+	"net"
+
+	"github.com/google/gopacket/routing"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/klog"
+
+	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+func (nd *natDiscovery) sendCheckRequestByRemoteID(id string) error {
+	remoteNAT := nd.remoteEndpoints[id]
+	return nd.sendCheckRequest(remoteNAT)
+}
+
+func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
+	var errPrivate, errPublic error
+	var reqID uint64
+	if remoteNAT.endpoint.Spec.PrivateIP != "" {
+		reqID, errPrivate = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.PrivateIP)
+		if errPrivate == nil {
+			remoteNAT.lastPrivateIPRequestID = reqID
+		}
+	}
+
+	if remoteNAT.endpoint.Spec.PublicIP != "" {
+		reqID, errPublic = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.PublicIP)
+		if errPublic == nil {
+			remoteNAT.lastPublicIPRequestID = reqID
+		}
+	}
+
+	if errPrivate != nil && errPublic != nil {
+		return errors.Errorf("error while trying to discover both public & private IPs of endpoint %q, [%s, %s]",
+			remoteNAT.endpoint.Spec.CableName, errPublic, errPrivate)
+	}
+
+	if errPrivate != nil {
+		return errors.Wrapf(errPrivate, "error while trying to NAT-discover private IP of endpoint %q",
+			remoteNAT.endpoint.Spec.CableName)
+	}
+
+	if errPublic != nil {
+		return errors.Wrapf(errPublic, "error while trying to NAT-discover public IP of endpoint %q",
+			remoteNAT.endpoint.Spec.CableName)
+	}
+
+	return nil
+}
+
+func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT, targetIP string) (uint64, error) {
+	targetPort, err := extractNATDiscoveryPort(remoteNAT.endpoint)
+
+	if err != nil {
+		return 0, err
+	}
+
+	sourceIP, err := nd.findSrcIP(targetIP)
+	if err != nil {
+		klog.Warningf("unable to determine source IP while preparing NAT discovery request to endpoint %q: %s",
+			remoteNAT.endpoint.Spec.CableName, err)
+	}
+
+	nd.requestCounter++
+
+	request := &natproto.SubmarinerNatDiscoveryRequest{
+		RequestNumber: nd.requestCounter,
+		Sender: &natproto.EndpointDetails{
+			EndpointId: nd.localEndpoint.Spec.CableName,
+			ClusterId:  nd.localEndpoint.Spec.ClusterID,
+		},
+		Receiver: &natproto.EndpointDetails{
+			EndpointId: remoteNAT.endpoint.Spec.CableName,
+			ClusterId:  remoteNAT.endpoint.Spec.ClusterID,
+		},
+		UsingSrc: &natproto.IPPortPair{
+			IP:   sourceIP,
+			Port: uint32(nd.serverPort),
+		},
+		UsingDst: &natproto.IPPortPair{
+			IP:   targetIP,
+			Port: uint32(targetPort),
+		},
+	}
+
+	msgRequest := &natproto.SubmarinerNatDiscoveryMessage_Request{
+		Request: request,
+	}
+
+	message := natproto.SubmarinerNatDiscoveryMessage{
+		Version: natproto.Version,
+		Message: msgRequest,
+	}
+
+	buf, err := proto.Marshal(&message)
+	if err != nil {
+		return request.RequestNumber, errors.Wrapf(err, "error marshaling request %#v", request)
+	}
+
+	addr := net.UDPAddr{
+		IP:   net.ParseIP(targetIP),
+		Port: int(targetPort),
+	}
+
+	if length, err := nd.serverUDPWrite(buf, &addr); err != nil {
+		return request.RequestNumber, errors.Wrapf(err, "error sending request packet %#v", request)
+	} else if length != len(buf) {
+		return request.RequestNumber, errors.Errorf("the sent UDP packet was smaller than requested, sent=%d, expected=%d", length,
+			len(buf))
+	}
+
+	remoteNAT.checkSent()
+
+	return request.RequestNumber, nil
+}
+
+func findPreferredSourceIP(destinationIP string) (string, error) {
+	var ip net.IP
+	if ip = net.ParseIP(destinationIP); ip == nil {
+		return "", errors.Errorf("error parsing destination IP %q while trying to figure out preferred source IP", destinationIP)
+	}
+
+	router, err := routing.New()
+	if err != nil {
+		return "", errors.Wrap(err, "error while creating gopacket routing object")
+	}
+
+	_, _, preferredSourceIP, err := router.Route(ip)
+	if err != nil {
+		return "", errors.Wrapf(err, "error finding src IP in route to IP %q", ip.String())
+	}
+
+	return preferredSourceIP.String(), nil
+}

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -1,0 +1,73 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package natdiscovery
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+var _ = Describe("natdiscovery requests", func() {
+
+	var ndInstance *natDiscovery
+	var udpSent chan []byte
+
+	localEndpoint := createTestLocalEndpoint()
+	remoteEndpoint := createTestRemoteEndpoint()
+
+	BeforeEach(func() {
+		ndInstance, udpSent = createTestListener(&localEndpoint)
+		ndInstance.AddEndpoint(&remoteEndpoint)
+	})
+
+	makeRequestToRemote := func() *natproto.SubmarinerNatDiscoveryRequest {
+		err := ndInstance.sendCheckRequestByRemoteID(testRemoteEndpointName)
+		Expect(err).NotTo(HaveOccurred())
+		return parseProtocolRequest(<-udpSent)
+	}
+
+	When("sending a request", func() {
+		It("should fill up the sender fields correctly", func() {
+			request := makeRequestToRemote()
+			Expect(request.Sender).NotTo(BeNil())
+			Expect(request.Sender.ClusterId).To(Equal(testLocalClusterID))
+			Expect(request.Sender.EndpointId).To(Equal(testLocalEndpointName))
+		})
+
+		It("should fill up the receiver fields correctly", func() {
+			request := makeRequestToRemote()
+			Expect(request.Receiver).NotTo(BeNil())
+			Expect(request.Receiver.ClusterId).To(Equal(testRemoteClusterID))
+			Expect(request.Receiver.EndpointId).To(Equal(testRemoteEndpointName))
+		})
+
+		It("should fill up the using-src fields correctly", func() {
+			request := makeRequestToRemote()
+			Expect(request.UsingSrc).NotTo(BeNil())
+			Expect(request.UsingSrc.Port).To(Equal(uint32(testLocalNATPort)))
+		})
+
+		It("should fill up the using-dst fields correctly", func() {
+			request := makeRequestToRemote()
+			Expect(request.UsingDst).NotTo(BeNil())
+			Expect(request.UsingDst.Port).To(Equal(uint32(testRemoteNATPort)))
+			Expect(request.UsingDst.IP).To(Equal(testRemotePrivateIP))
+		})
+
+	})
+})

--- a/pkg/natdiscovery/response_handle.go
+++ b/pkg/natdiscovery/response_handle.go
@@ -1,0 +1,88 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natdiscovery
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+)
+
+func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscoveryResponse, addr *net.UDPAddr) error {
+	if req.GetSender() == nil || req.GetReceiver() == nil || req.GetReceivedSrc() == nil {
+		return errors.Errorf("received malformed response %#v", req)
+	}
+
+	if req.Response != proto.ResponseType_OK && req.Response != proto.ResponseType_SRC_MODIFIED {
+		var ok bool
+		var name string
+
+		if name, ok = proto.ResponseType_name[int32(req.Response)]; !ok {
+			name = fmt.Sprintf("%d", req.Response)
+		}
+
+		return errors.Errorf("remote endpoint %q responded with %q : %#v", req.Sender.EndpointId, name, req)
+	}
+
+	nd.Lock()
+	remoteNat, ok := nd.remoteEndpoints[req.GetSender().EndpointId]
+	defer nd.Unlock()
+
+	if !ok {
+		return errors.Errorf("received response from unknown endpoint %q", req.GetSender().EndpointId)
+	}
+
+	// response to a PublicIP request
+	if remoteNat.lastPublicIPRequestID == req.RequestNumber {
+		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
+		if err := remoteNat.transitionToPublicIP(req.GetSender().EndpointId, useNAT); err != nil {
+			return err
+		}
+
+		nd.readyChannel <- remoteNat.toNATEndpointInfo()
+
+		return nil
+	}
+
+	// response to a PrivateIP request
+	if remoteNat.lastPrivateIPRequestID == req.RequestNumber {
+		if addr.IP.String() != remoteNat.endpoint.Spec.PrivateIP {
+			return errors.Errorf("response for NAT discovery on endpoint %q private IP %q comes from different IP %q, "+
+				"NAT on private IPs is unlikely and filtered for security reasons",
+				req.GetSender().EndpointId, remoteNat.endpoint.Spec.PrivateIP, addr.IP)
+		}
+
+		if req.Response == proto.ResponseType_SRC_MODIFIED {
+			klog.Warningf("response for NAT discovery on endpoint %q private IP %q says src was modified which is unexpected",
+				req.GetSender().EndpointId, remoteNat.endpoint.Spec.PrivateIP)
+		}
+
+		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
+
+		if err := remoteNat.transitionToPrivateIP(req.GetSender().EndpointId, useNAT); err != nil {
+			return err
+		}
+
+		nd.readyChannel <- remoteNat.toNATEndpointInfo()
+	}
+
+	return errors.Errorf("received response for unknown request id %d", req.RequestNumber)
+}


### PR DESCRIPTION
This protocol is defined for the discovery 1:1 of the IP to be used. between private or public, and expected to be used
over an UDP port.

I have been thinking about the usability/security consequences. One important fact is that the implementation should only rely on the queries made, never on the queries received. So a gateway cannot be tricked into changing the IP being used (DoS)

We could use mTLS over TCP for this discovery if we wanted using the same proto definition, but I was talking about this with @nyechiel  and may be at this point it's more reasonable to keep it simple, unless we believe we'd be sharing anything that should not be on plain text.

I suggest the cluster / endpoint ids to, may be, be hashed.


Related-Issue: https://github.com/submariner-io/submariner/issues/1174
Closes-Issue: https://github.com/submariner-io/submariner/issues/1175
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>