### PR TITLE
Fix e2e failures due to missing fdb entries on Gateway node

### DIFF
--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -82,7 +82,7 @@ func (n *netlinkType) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
 }
 
 func (n *netlinkType) NeighAppend(neigh *netlink.Neigh) error {
-	return netlink.NeighAdd(neigh)
+	return netlink.NeighAppend(neigh)
 }
 
 func (n *netlinkType) NeighDel(neigh *netlink.Neigh) error {


### PR DESCRIPTION
Recently, while creating the netlink interface as part of
[commit](https://github.com/submariner-io/submariner/commit/499f0373f11dd5f6682be5f97a928f13f68a1bfd),
instead of netlink.NeighAppend, netlink.NeighAdd was accidentally
used and because of this, FDB entries were not updated on the
Gateway node causing failures in e2e tests. This PR fixes this issue.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>