### PR TITLE
Abstract GatewayMonitor ConfigureTCPMTUProbe for unit tests

### DIFF
--- a/pkg/globalnet/controllers/ipam/constants.go
+++ b/pkg/globalnet/controllers/ipam/constants.go
@@ -37,9 +37,6 @@ const (
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
 	kubeProxyServiceChainName   = "KUBE-SERVICES"
 
-	tcpMtuProbingProcEntry = "/proc/sys/net/ipv4/tcp_mtu_probing"
-	tcpBaseMssProcEntry    = "/proc/sys/net/ipv4/tcp_base_mss"
-
 	maxServiceRequeues = 20
 
 	AddRules    = true

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -224,6 +224,10 @@ func (n *NetLink) EnableLooseModeReversePathFilter(interfaceName string) error {
 	return nil
 }
 
+func (n *NetLink) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
+	return nil
+}
+
 func (n *NetLink) AwaitLink(name string) (link netlink.Link) {
 	Eventually(func() netlink.Link {
 		link, _ = n.LinkByName(name)


### PR DESCRIPTION
This causes a warning in unit tests due to file permissions but it would be ideal not to even try to update system files. So this function was abstracted behind the netlink interface.

This is not important for 0.9.0 so I added it to the 0.10.0 board. 

