### PR TITLE
Stop producing the submariner-io/submariner image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
 
-IMAGES ?= submariner submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
+IMAGES ?= submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
 images: build
 
 include $(SHIPYARD_DIR)/Makefile.inc

--- a/package/Dockerfile.submariner
+++ b/package/Dockerfile.submariner
@@ -1,1 +1,0 @@
-Dockerfile.submariner-gateway


### PR DESCRIPTION
We now use the submariner-gateway image, and submariner image
was being produced in devel while the rename changes were still
being handled in submariner-operator.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
