### PR TITLE
Bump E2E timeout time to 45m

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   e2e:
     name: E2E
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -9,7 +9,7 @@ jobs:
   e2e:
     name: E2E
     if: github.repository_owner == 'submariner-io'
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
We have seen an slow down in the github CI due to network being slow
which results in many jobs timing out near "pass" completion.

This slows down our ability to merge patches which are ready.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
