### PR TITLE
Mods to NAT discovery unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
-	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/gopacket v1.1.19
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.15.0

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -26,11 +26,6 @@ import (
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
 )
 
-func (nd *natDiscovery) sendCheckRequestByRemoteID(id string) error {
-	remoteNAT := nd.remoteEndpoints[id]
-	return nd.sendCheckRequest(remoteNAT)
-}
-
 func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 	var errPrivate, errPublic error
 	var reqID uint64


### PR DESCRIPTION
- the tests intercept writes to the UDP port and put on a channel however
  they wait indefinitely to receive from the channel so, if the production
  code doesn't perform the write, the test will hang. Added a timeout for
  the wait.

- removed the sendCheckRequestByRemoteID function which was only used by
  the tests. Tests now call sendCheckRequest directly.

- added new test cases to request_handle_test.go and request_send_test.go.
