### PR TITLE
Add round trip NAT discovery unit tests

### DIFF
--- a/pkg/natdiscovery/natdiscovery_test.go
+++ b/pkg/natdiscovery/natdiscovery_test.go
@@ -1,0 +1,336 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package natdiscovery
+
+import (
+	"net"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+var _ = When("a remote Endpoint is added", func() {
+	var forwardHowManyFromLocal int
+
+	t := newDiscoveryTestDriver()
+
+	BeforeEach(func() {
+		atomic.StoreInt64(&recheckTime, 0)
+		atomic.StoreInt64(&totalTimeout, time.Hour.Nanoseconds())
+		atomic.StoreInt64(&publicToPrivateFailoverTimeout, time.Hour.Nanoseconds())
+		forwardHowManyFromLocal = 1
+		t.remoteEndpoint.Spec.PublicIP = ""
+	})
+
+	JustBeforeEach(func() {
+		forwardFromUDPChan(t.localUDPSent, t.localUDPAddr, t.remoteND, forwardHowManyFromLocal)
+		t.localND.AddEndpoint(&t.remoteEndpoint)
+		t.localND.checkEndpointList()
+	})
+
+	Context("with only the private IP set", func() {
+		t.testRemoteEndpointAdded(testRemotePrivateIP)
+	})
+
+	Context("with only the public IP set", func() {
+		BeforeEach(func() {
+			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteEndpoint.Spec.PrivateIP = ""
+		})
+
+		t.testRemoteEndpointAdded(testRemotePublicIP)
+	})
+
+	Context("with both the public IP and private IP set", func() {
+		var privateIPReq []byte
+		var publicIPReq []byte
+
+		BeforeEach(func() {
+			forwardHowManyFromLocal = 0
+			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteND.AddEndpoint(&t.localEndpoint)
+		})
+
+		JustBeforeEach(func() {
+			privateIPReq = awaitChan(t.localUDPSent)
+			publicIPReq = awaitChan(t.localUDPSent)
+		})
+
+		Context("and the private IP responds after the public IP within the grace period", func() {
+			It("should notify with the private IP NATEndpointInfo settings", func() {
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+
+				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+					Endpoint: t.remoteEndpoint.Spec,
+					UseNAT:   false,
+					UseIP:    t.remoteEndpoint.Spec.PublicIP,
+				})))
+
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+
+				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+					Endpoint: t.remoteEndpoint.Spec,
+					UseNAT:   false,
+					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+				})))
+			})
+		})
+
+		Context("and the private IP responds after the public IP but after the grace period has elapsed", func() {
+			It("should notify with the public IP NATEndpointInfo settings", func() {
+				atomic.StoreInt64(&publicToPrivateFailoverTimeout, 0)
+
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+
+				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+					Endpoint: t.remoteEndpoint.Spec,
+					UseNAT:   false,
+					UseIP:    t.remoteEndpoint.Spec.PublicIP,
+				})))
+
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+
+				Consistently(t.readyChannel).ShouldNot(Receive())
+			})
+		})
+
+		Context("and the private IP responds first", func() {
+			It("should notify with the private IP NATEndpointInfo settings", func() {
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+
+				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+					Endpoint: t.remoteEndpoint.Spec,
+					UseNAT:   false,
+					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+				})))
+
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+
+				Consistently(t.readyChannel).ShouldNot(Receive())
+			})
+		})
+	})
+
+	Context("and the local Endpoint is not initially known to the remote process", func() {
+		It("should eventually notify with the correct NATEndpointInfo settings", func() {
+			Consistently(t.readyChannel).ShouldNot(Receive())
+
+			t.remoteND.AddEndpoint(&t.localEndpoint)
+			forwardFromUDPChan(t.localUDPSent, t.localUDPAddr, t.remoteND, -1)
+
+			// Verify it doesn't send out the next request until the recheck time period has elapsed
+
+			atomic.StoreInt64(&recheckTime, time.Hour.Nanoseconds())
+			t.localND.checkEndpointList()
+			Expect(t.localUDPSent).ToNot(Receive())
+
+			atomic.StoreInt64(&recheckTime, 0)
+			t.localND.checkEndpointList()
+
+			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+				Endpoint: t.remoteEndpoint.Spec,
+				UseNAT:   false,
+				UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+			})))
+		})
+	})
+
+	Context("and then re-added after discovery is complete", func() {
+		var newRemoteEndpoint types.SubmarinerEndpoint
+
+		BeforeEach(func() {
+			t.remoteND.AddEndpoint(&t.localEndpoint)
+			newRemoteEndpoint = t.remoteEndpoint
+		})
+
+		JustBeforeEach(func() {
+			Eventually(t.readyChannel, 5).Should(Receive())
+
+			t.remoteUDPAddr.IP = net.ParseIP(newRemoteEndpoint.Spec.PrivateIP)
+			forwardFromUDPChan(t.localUDPSent, t.localUDPAddr, t.remoteND, 1)
+
+			t.localND.AddEndpoint(&newRemoteEndpoint)
+			t.localND.checkEndpointList()
+		})
+
+		Context("with no change to the Endpoint", func() {
+			It("should not restart discovery", func() {
+				Consistently(t.readyChannel).ShouldNot(Receive())
+			})
+		})
+
+		Context("with the Endpoint's private IP changed", func() {
+			BeforeEach(func() {
+				newRemoteEndpoint.Spec.PrivateIP = testRemotePrivateIP2
+			})
+
+			It("should notify with new NATEndpointInfo settings", func() {
+				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+					Endpoint: newRemoteEndpoint.Spec,
+					UseNAT:   false,
+					UseIP:    newRemoteEndpoint.Spec.PrivateIP,
+				})))
+			})
+		})
+	})
+
+	Context("and then removed while discovery is in progress", func() {
+		BeforeEach(func() {
+			forwardHowManyFromLocal = 0
+		})
+
+		It("should stop the discovery", func() {
+			Expect(t.localUDPSent).To(Receive())
+			Consistently(t.readyChannel).ShouldNot(Receive())
+
+			t.localND.RemoveEndpoint(t.remoteEndpoint.Spec.CableName)
+
+			t.localND.checkEndpointList()
+			Expect(t.localUDPSent).ToNot(Receive())
+		})
+	})
+
+	Context("with no NAT discovery port set", func() {
+		BeforeEach(func() {
+			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteEndpoint.Spec.PrivateIP = ""
+			t.remoteEndpoint.Spec.NATDiscoveryPort = nil
+		})
+
+		It("should notify with the legacy NATEndpointInfo settings", func() {
+			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+				Endpoint: t.remoteEndpoint.Spec,
+				UseNAT:   true,
+				UseIP:    t.remoteEndpoint.Spec.PublicIP,
+			})))
+		})
+	})
+
+	Context("and the remote process doesn't respond", func() {
+		BeforeEach(func() {
+			forwardHowManyFromLocal = 0
+			atomic.StoreInt64(&totalTimeout, (100 * time.Millisecond).Nanoseconds())
+		})
+
+		It("should eventually time out and notify with the legacy NATEndpointInfo settings", func() {
+			// Drop the request sent out
+			Expect(t.localUDPSent).Should(Receive())
+
+			Consistently(t.readyChannel, toDuration(&totalTimeout)).ShouldNot(Receive())
+			time.Sleep(50 * time.Millisecond)
+
+			t.localND.checkEndpointList()
+			Expect(t.localUDPSent).ToNot(Receive())
+
+			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+				Endpoint: t.remoteEndpoint.Spec,
+				UseNAT:   true,
+				UseIP:    t.remoteEndpoint.Spec.PublicIP,
+			})))
+		})
+	})
+})
+
+type discoveryTestDriver struct {
+	localND                           *natDiscovery
+	localUDPSent                      chan []byte
+	localEndpoint                     types.SubmarinerEndpoint
+	localUDPAddr                      *net.UDPAddr
+	remoteND                          *natDiscovery
+	remoteUDPSent                     chan []byte
+	remoteEndpoint                    types.SubmarinerEndpoint
+	remoteUDPAddr                     *net.UDPAddr
+	readyChannel                      chan *NATEndpointInfo
+	oldRecheckTime                    int64
+	oldTotalTimeout                   int64
+	oldPublicToPrivateFailoverTimeout int64
+}
+
+func newDiscoveryTestDriver() *discoveryTestDriver {
+	t := &discoveryTestDriver{}
+
+	BeforeEach(func() {
+		t.oldRecheckTime = atomic.LoadInt64(&recheckTime)
+		t.oldTotalTimeout = atomic.LoadInt64(&totalTimeout)
+		t.oldPublicToPrivateFailoverTimeout = atomic.LoadInt64(&publicToPrivateFailoverTimeout)
+
+		t.localUDPAddr = &net.UDPAddr{
+			IP:   net.ParseIP(testLocalPrivateIP),
+			Port: int(testLocalNATPort),
+		}
+
+		t.remoteUDPAddr = &net.UDPAddr{
+			IP:   net.ParseIP(testRemotePrivateIP),
+			Port: int(testRemoteNATPort),
+		}
+
+		t.remoteEndpoint = createTestRemoteEndpoint()
+		t.localEndpoint = createTestLocalEndpoint()
+
+		t.localND, t.localUDPSent, t.readyChannel = createTestListener(&t.localEndpoint)
+		t.localND.findSrcIP = func(_ string) (string, error) { return testLocalPrivateIP, nil }
+
+		t.remoteND, t.remoteUDPSent, _ = createTestListener(&t.remoteEndpoint)
+		t.remoteND.findSrcIP = func(_ string) (string, error) { return testRemotePrivateIP, nil }
+
+		forwardFromUDPChan(t.remoteUDPSent, t.remoteUDPAddr, t.localND, -1)
+	})
+
+	AfterEach(func() {
+		close(t.localUDPSent)
+		close(t.remoteUDPSent)
+
+		atomic.StoreInt64(&recheckTime, t.oldRecheckTime)
+		atomic.StoreInt64(&totalTimeout, t.oldTotalTimeout)
+		atomic.StoreInt64(&publicToPrivateFailoverTimeout, t.oldPublicToPrivateFailoverTimeout)
+	})
+
+	return t
+}
+
+func (t *discoveryTestDriver) testRemoteEndpointAdded(expIP string) {
+	BeforeEach(func() {
+		t.remoteND.AddEndpoint(&t.localEndpoint)
+	})
+
+	It("should notify with the correct NATEndpointInfo settings and stop the discovery", func() {
+		Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
+			Endpoint: t.remoteEndpoint.Spec,
+			UseNAT:   false,
+			UseIP:    expIP,
+		})))
+
+		// Verify it doesn't time out and try to notify of the legacy settings
+
+		atomic.StoreInt64(&totalTimeout, (100 * time.Millisecond).Nanoseconds())
+		time.Sleep(toDuration(&totalTimeout) + 20)
+
+		t.localND.checkEndpointList()
+		Expect(t.localUDPSent).ToNot(Receive())
+		Consistently(t.readyChannel).ShouldNot(Receive())
+
+		// Verify it doesn't try to send another request after the recheck time period has elapsed
+
+		atomic.StoreInt64(&totalTimeout, time.Hour.Nanoseconds())
+
+		t.localND.checkEndpointList()
+		Expect(t.localUDPSent).ToNot(Receive())
+		Consistently(t.readyChannel).ShouldNot(Receive())
+	})
+}

--- a/pkg/natdiscovery/remote_endpoint_test.go
+++ b/pkg/natdiscovery/remote_endpoint_test.go
@@ -47,7 +47,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 
 	When("the total timeout has elapsed", func() {
 		It("should report as timed out", func() {
-			rnat.started = time.Now().Add(-totalTimeout)
+			rnat.started = time.Now().Add(-toDuration(&totalTimeout))
 			Expect(rnat.hasTimedOut()).To(BeTrue())
 		})
 	})
@@ -176,7 +176,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				rnat.checkSent()
 				err := rnat.transitionToPublicIP(testRemoteEndpointName, true)
 				Expect(err).NotTo(HaveOccurred())
-				rnat.lastTransition = rnat.lastTransition.Add(-publicToPrivateFailoverTimeout)
+				rnat.lastTransition = rnat.lastTransition.Add(-time.Duration(publicToPrivateFailoverTimeout))
 				err = rnat.transitionToPrivateIP(testRemoteEndpointName, false)
 				Expect(err).To(HaveOccurred())
 				Expect(rnat.state).To(Equal(selectedPublicIP))

--- a/pkg/natdiscovery/request_handle.go
+++ b/pkg/natdiscovery/request_handle.go
@@ -123,6 +123,9 @@ func (nd *natDiscovery) sendResponseToAddress(response *proto.SubmarinerNatDisco
 		return errors.Wrapf(err, "error marshaling response %#v", response)
 	}
 
+	klog.V(log.TRACE).Infof("Sending response - REQUEST_NUMBER: %v, RESPONSE: %v, SENDER: %#v, RECEIVER: %#v",
+		response.RequestNumber, response.Response, response.Sender, response.Receiver)
+
 	if length, err := nd.serverUDPWrite(buf, addr); err != nil {
 		return errors.Wrapf(err, "error sending response packet %#v", response)
 	} else if length != len(buf) {

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -41,9 +41,9 @@ var _ = Describe("Request handling", func() {
 		localEndpoint = createTestLocalEndpoint()
 		remoteEndpoint = createTestRemoteEndpoint()
 
-		localListener, localUDPSent = createTestListener(&localEndpoint)
+		localListener, localUDPSent, _ = createTestListener(&localEndpoint)
 		localListener.findSrcIP = func(_ string) (string, error) { return testLocalPrivateIP, nil }
-		remoteListener, remoteUDPSent = createTestListener(&remoteEndpoint)
+		remoteListener, remoteUDPSent, _ = createTestListener(&remoteEndpoint)
 		remoteListener.findSrcIP = func(_ string) (string, error) { return testRemotePrivateIP, nil }
 
 		remoteUDPAddr = net.UDPAddr{

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/gopacket/routing"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/klog"
 
@@ -62,7 +63,7 @@ func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 }
 
 func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT, targetIP string) (uint64, error) {
-	targetPort, err := extractNATDiscoveryPort(remoteNAT.endpoint)
+	targetPort, err := extractNATDiscoveryPort(&remoteNAT.endpoint)
 
 	if err != nil {
 		return 0, err
@@ -114,6 +115,9 @@ func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT,
 		IP:   net.ParseIP(targetIP),
 		Port: int(targetPort),
 	}
+
+	klog.V(log.TRACE).Infof("Sending request - REQUEST_NUMBER: %v, SENDER: %#v, RECEIVER: %#v, USING_SRC: %#v, USING_DST: %#v",
+		request.RequestNumber, request.Sender, request.Receiver, request.UsingSrc, request.UsingDst)
 
 	if length, err := nd.serverUDPWrite(buf, &addr); err != nil {
 		return request.RequestNumber, errors.Wrapf(err, "error sending request packet %#v", request)

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -40,7 +40,7 @@ var _ = When("a request is sent", func() {
 	})
 
 	JustBeforeEach(func() {
-		ndInstance, udpSent = createTestListener(&localEndpoint)
+		ndInstance, udpSent, _ = createTestListener(&localEndpoint)
 		ndInstance.findSrcIP = func(_ string) (string, error) { return testLocalPrivateIP, nil }
 
 		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: remoteEndpoint.Spec}))


### PR DESCRIPTION
Tests from `AddEndpoint` to ready channel notified.

Transition to `useLegacyNATSettings` now notifies the ready channel.

The tests required changing the duration constants like `recheckTime` to vars of type int64 and using atomic operations to access them as they can be accessed by multiple threads which can cause intermittent race errors.

Also change the endpoint field in `remoteEndpointNAT` to a non-pointer to avoid race errors.

