### PR TITLE
Loosen remoteEndpointNAT transitionTo*IP strictness

### DIFF
--- a/pkg/natdiscovery/response_handle.go
+++ b/pkg/natdiscovery/response_handle.go
@@ -57,8 +57,8 @@ func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscov
 	// response to a PublicIP request
 	if remoteNat.lastPublicIPRequestID == req.RequestNumber {
 		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
-		if err := remoteNat.transitionToPublicIP(req.GetSender().EndpointId, useNAT); err != nil {
-			return err
+		if !remoteNat.transitionToPublicIP(req.GetSender().EndpointId, useNAT) {
+			return nil
 		}
 
 		nd.readyChannel <- remoteNat.toNATEndpointInfo()
@@ -81,8 +81,8 @@ func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscov
 
 		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
 
-		if err := remoteNat.transitionToPrivateIP(req.GetSender().EndpointId, useNAT); err != nil {
-			return err
+		if !remoteNat.transitionToPrivateIP(req.GetSender().EndpointId, useNAT) {
+			return nil
 		}
 
 		nd.readyChannel <- remoteNat.toNATEndpointInfo()


### PR DESCRIPTION
`transitionToPublicIP` and `transitionToPrivateIP` return an error for an unexpected transition including from `selectedPublicIP` -> `selectedPrivateIP` and `selectedPrivateIP` -> `selectedPublicIP`. The latter two will naturally happen
as one response will be received later than the other so we shouldn't log an error. However we still want the caller to know the transition didn't occur so return a bool instead and log errors internally where necessary.

