### PR TITLE
Mods to public IP to private IP transition

### DIFF
--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -123,7 +123,7 @@ func (nd *natDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
 		}
 	}
 
-	remoteNAT := newRemoteEndpointNAT(endpoint)
+	remoteNAT := newRemoteEndpointNAT(endpoint, nd.readyChannel)
 
 	// support a remote cluster endpoint which still hasn't implemented this protocol
 	if _, err := extractNATDiscoveryPort(endpoint); err == errorNoNatDiscoveryPort {

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Request handling", func() {
 	}
 
 	requestResponseFromRemoteToLocal := func(remoteAddr *net.UDPAddr) []*natproto.SubmarinerNatDiscoveryResponse {
-		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: localEndpoint.Spec}))
+		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: localEndpoint.Spec}, nil))
 		Expect(err).NotTo(HaveOccurred())
 		return []*natproto.SubmarinerNatDiscoveryResponse{
 			parseResponseInLocalListener(awaitChan(remoteUDPSent), remoteAddr), /* Private IP request */

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -43,7 +43,7 @@ var _ = When("a request is sent", func() {
 		ndInstance, udpSent, _ = createTestListener(&localEndpoint)
 		ndInstance.findSrcIP = func(_ string) (string, error) { return testLocalPrivateIP, nil }
 
-		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: remoteEndpoint.Spec}))
+		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: remoteEndpoint.Spec}, nil))
 		Expect(err).NotTo(HaveOccurred())
 
 		request = parseProtocolRequest(awaitChan(udpSent))

--- a/pkg/natdiscovery/response_handle.go
+++ b/pkg/natdiscovery/response_handle.go
@@ -57,11 +57,7 @@ func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscov
 	// response to a PublicIP request
 	if remoteNat.lastPublicIPRequestID == req.RequestNumber {
 		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
-		if !remoteNat.transitionToPublicIP(req.GetSender().EndpointId, useNAT) {
-			return nil
-		}
-
-		nd.readyChannel <- remoteNat.toNATEndpointInfo()
+		remoteNat.transitionToPublicIP(req.GetSender().EndpointId, useNAT)
 
 		return nil
 	}
@@ -80,12 +76,7 @@ func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscov
 		}
 
 		useNAT := req.Response == proto.ResponseType_SRC_MODIFIED
-
-		if !remoteNat.transitionToPrivateIP(req.GetSender().EndpointId, useNAT) {
-			return nil
-		}
-
-		nd.readyChannel <- remoteNat.toNATEndpointInfo()
+		_ = remoteNat.transitionToPrivateIP(req.GetSender().EndpointId, useNAT)
 
 		return nil
 	}


### PR DESCRIPTION
If the public IP respond first, the ready channel is immediately notified even if the private IP is still pending. If the private
IP responds within  the grace period, it will also notify the ready channel. It seems we should only notify the ready channel once, ie delay the selection of the public IP until the grace period elapses.

Added a new state, `selectPublicIPPending`, for the transient period until either the private IP responds or the grace period elapses. The check for the latter is part of `shouldCheck`. Since the `remoteEndpointNAT` now controls notification, the `readyChannel` is also stored in each `remoteEndpointNAT`.

