### PR TITLE
Enable Helm+cable driver test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,11 +17,6 @@ jobs:
         cable_driver: ['libreswan', 'wireguard']
         ovn: ['', 'ovn']
         exclude:
-          # Our Helm setup doesn’t know how to deploy other cable drivers
-          - deploytool: 'helm'
-            cable_driver: 'wireguard'
-          - deploytool: 'helm'
-            cable_driver: 'libreswan'
           - ovn: 'ovn'
             deploytool: 'helm'
           - ovn: 'ovn'

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -17,12 +17,6 @@ jobs:
         deploytool: ['operator', 'helm']
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'wireguard']
-        exclude:
-          # Our Helm setup doesn’t know how to deploy other cable drivers
-          - deploytool: 'helm'
-            cable_driver: 'wireguard'
-          - deploytool: 'helm'
-            cable_driver: 'libreswan'
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The Helm charts now support setting the cable driver, so the exclude
here is out-of-date and can be removed.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>