### PR TITLE
Use NAT discovery port specified as label in the gateway

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -107,6 +108,11 @@ func main() {
 		klog.Fatalf("Error creating submariner clientset: %s", err.Error())
 	}
 
+	localNode, err := node.GetLocalNode(cfg)
+	if err != nil {
+		klog.Fatalf("Error getting information on the local node: %s", err.Error())
+	}
+
 	klog.Info("Creating the cable engine")
 
 	localCluster := submarinerClusterFrom(&submSpec)
@@ -117,7 +123,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec, nil, util.GetLocalIP())
+	localEndpoint, err := util.GetLocalEndpoint(submSpec, nil, util.GetLocalIP(), localNode)
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1,0 +1,50 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	NATDiscoveryPortLabel = "submariner.io/nat-discovery-port"
+)
+
+func GetLocalNode(cfg *rest.Config) (*v1.Node, error) {
+	nodeName, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		return nil, errors.New("error reading the NODE_NAME from the environment")
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating Kubernetes clientset")
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to find local node %q", nodeName)
+	}
+
+	return node, nil
+}


### PR DESCRIPTION
The label submariner.io/nat-discovery-port can now be applied
to the gateway nodes to specify the nat-discovery-port to be used
and to enable the feature until it's enabled by default.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>