### PR TITLE
Verify NAT info in cable engine tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
-	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.15.0

--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
 
 	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/klog"
@@ -39,7 +40,7 @@ type Driver interface {
 
 	// ConnectToEndpoint establishes a connection to the given endpoint and returns a string
 	// representation of the IP address of the target endpoint.
-	ConnectToEndpoint(endpoint types.SubmarinerEndpoint, useIP string, useNAT bool) (string, error)
+	ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error)
 
 	// DisconnectFromEndpoint disconnects from the connection to the given endpoint.
 	DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -164,7 +164,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 		}
 	}
 
-	remoteEndpointIP, err := i.driver.ConnectToEndpoint(endpoint, rnat.UseIP, rnat.UseNAT)
+	remoteEndpointIP, err := i.driver.ConnectToEndpoint(rnat)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On `driver.ConnectToEndpoint`, verify the passed NAT info as well to be complete. The params to `ConnectToEndpoint` are the same as the `NATEndpointInfo` struct so might as well just pass that.
