### PR TITLE
Allow also ESP/AH encapsulation on AWS

### DIFF
--- a/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
+++ b/tools/openshift/ocp-ipi-aws/ocp-ipi-aws-prep/ec2-resources.tf
@@ -109,6 +109,22 @@ resource "aws_security_group" "submariner_gw_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # ESP encapsulation protocol
+  ingress {
+    protocol    = 50
+    cidr_blocks = ["0.0.0.0/0"]
+    to_port     = 0
+    from_port   = 0
+  }
+
+  # AH protocol
+  ingress {
+    protocol    = 51
+    cidr_blocks = ["0.0.0.0/0"]
+    to_port     = 0
+    from_port   = 0
+  }
+
   tags = merge(map(
     "Name", "${var.cluster_id}-submariner-gw-sg",
   ))


### PR DESCRIPTION
The new nat discovery protocol can detect connectivity over private IPs
and that means that nat traversal is disabled by default, triggering ESP
protocol which is expected to be more performant than UDP encap.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
