### PR TITLE
Custom backend config ports and single-udp-port

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -107,6 +108,11 @@ func main() {
 		klog.Fatalf("Error creating submariner clientset: %s", err.Error())
 	}
 
+	localNode, err := node.GetLocalNode(cfg)
+	if err != nil {
+		klog.Fatalf("Error getting information on the local node: %s", err.Error())
+	}
+
 	klog.Info("Creating the cable engine")
 
 	localCluster := submarinerClusterFrom(&submSpec)
@@ -117,7 +123,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := util.GetLocalEndpoint(submSpec, nil, util.GetLocalIP())
+	localEndpoint, err := util.GetLocalEndpoint(submSpec, util.GetLocalIP(), localNode)
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)

--- a/pkg/apis/submariner.io/v1/endpoint.go
+++ b/pkg/apis/submariner.io/v1/endpoint.go
@@ -1,0 +1,47 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+func (ep *EndpointSpec) GetBackendPort(configName string, defaultValue int32) (int32, error) {
+	if portStr := ep.BackendConfig[configName]; portStr != "" {
+		port, err := parsePort(portStr)
+		if err != nil {
+			return defaultValue, errors.Wrapf(err, "error parsing backend config %s", configName)
+		}
+
+		return port, nil
+	}
+
+	return defaultValue, nil
+}
+
+func parsePort(port string) (int32, error) {
+	if portInt, err := strconv.ParseUint(port, 10, 16); err != nil {
+		return -1, errors.Wrapf(err, "error parsing port %s", port)
+	} else if portInt < 1 {
+		return -1, errors.Errorf("port %s is < 1", port)
+	} else if portInt > 65535 {
+		return -1, errors.Errorf("port %s is > 65535", port)
+	} else {
+		return int32(portInt), nil
+	}
+}

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -70,15 +70,26 @@ type EndpointSpec struct {
 	ClusterID string `json:"cluster_id"`
 	CableName string `json:"cable_name"`
 	// +optional
-	HealthCheckIP    string            `json:"healthCheckIP,omitempty"`
-	Hostname         string            `json:"hostname"`
-	Subnets          []string          `json:"subnets"`
-	PrivateIP        string            `json:"private_ip"`
-	PublicIP         string            `json:"public_ip"`
-	NATEnabled       bool              `json:"nat_enabled"`
-	Backend          string            `json:"backend"`
-	BackendConfig    map[string]string `json:"backend_config,omitempty"`
-	NATDiscoveryPort *int32            `json:"natDiscoveryPort,omitempty"`
+	HealthCheckIP string            `json:"healthCheckIP,omitempty"`
+	Hostname      string            `json:"hostname"`
+	Subnets       []string          `json:"subnets"`
+	PrivateIP     string            `json:"private_ip"`
+	PublicIP      string            `json:"public_ip"`
+	NATEnabled    bool              `json:"nat_enabled"`
+	Backend       string            `json:"backend"`
+	BackendConfig map[string]string `json:"backend_config,omitempty"`
+}
+
+const (
+	GatewayConfigLabelPrefix = "gateway.submariner.io/"
+	UDPPortConfig            = "udp-port"
+	NATTDiscoveryPortConfig  = "natt-discovery-port"
+)
+
+// ValidGatewayNodeConfig list should contain only keys that configure node specific settings via labels
+var ValidGatewayNodeConfig = []string{
+	UDPPortConfig,
+	NATTDiscoveryPortConfig,
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/submariner.io/v1/zz_generated.deepcopy.go
@@ -217,11 +217,6 @@ func (in *EndpointSpec) DeepCopyInto(out *EndpointSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.NATDiscoveryPort != nil {
-		in, out := &in.NATDiscoveryPort, &out.NATDiscoveryPort
-		*out = new(int32)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -31,30 +31,26 @@ var _ = Describe("Libreswan", func() {
 func testIPsecPortConfiguration() {
 	When("NewLibreswan is called with no port environment variables set", func() {
 		It("should set the port fields from the defaults in the specification definition", func() {
-			checkLibreswanPorts(defaultIKEPort, defaultNATTPort)
+			checkLibreswanPort(defaultNATTPort)
 		})
 	})
 
 	When("NewLibreswan is called with port environment variables set", func() {
 		const (
-			ikePort        = "555"
 			nattPort       = "4555"
-			ikePortEnvVar  = "CE_IPSEC_IKEPORT"
 			nattPortEnvVar = "CE_IPSEC_NATTPORT"
 		)
 
 		BeforeEach(func() {
-			os.Setenv(ikePortEnvVar, ikePort)
 			os.Setenv(nattPortEnvVar, nattPort)
 		})
 
 		AfterEach(func() {
-			os.Unsetenv(ikePortEnvVar)
 			os.Unsetenv(nattPortEnvVar)
 		})
 
 		It("should set the port fields from the environment variables", func() {
-			checkLibreswanPorts(ikePort, nattPort)
+			checkLibreswanPort(nattPort)
 		})
 	})
 }
@@ -66,8 +62,7 @@ func createLibreswan() *libreswan {
 	return ls.(*libreswan)
 }
 
-func checkLibreswanPorts(ikePort, nattPort string) {
+func checkLibreswanPort(nattPort string) {
 	ls := createLibreswan()
-	Expect(ls.ipSecIKEPort).To(Equal(ikePort))
 	Expect(ls.ipSecNATTPort).To(Equal(nattPort))
 }

--- a/pkg/natdiscovery/listener.go
+++ b/pkg/natdiscovery/listener.go
@@ -29,12 +29,12 @@ import (
 )
 
 func (nd *natDiscovery) runListener(stopCh <-chan struct{}) error {
-	if nd.localEndpoint.Spec.NATDiscoveryPort == nil {
+	if nd.serverPort == 0 {
 		klog.Infof("NAT discovery protocol port not set for this gateway")
 		return nil
 	}
 
-	serverConnection, err := createServerConnection(int(*nd.localEndpoint.Spec.NATDiscoveryPort))
+	serverConnection, err := createServerConnection(nd.serverPort)
 	if err != nil {
 		return err
 	}
@@ -54,8 +54,8 @@ func (nd *natDiscovery) runListener(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func createServerConnection(port int) (*net.UDPConn, error) {
-	serverAddress, err := net.ResolveUDPAddr("udp4", ":"+strconv.Itoa(port))
+func createServerConnection(port int32) (*net.UDPConn, error) {
+	serverAddress, err := net.ResolveUDPAddr("udp4", ":"+strconv.Itoa(int(port)))
 	if err != nil {
 		return nil, errors.Wrap(err, "Error resolving UDP address")
 	}

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -17,6 +17,7 @@ package natdiscovery
 
 import (
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -123,12 +124,14 @@ func forwardFromUDPChan(from chan []byte, addr *net.UDPAddr, to *natDiscovery, h
 func createTestLocalEndpoint() types.SubmarinerEndpoint {
 	return types.SubmarinerEndpoint{
 		Spec: submarinerv1.EndpointSpec{
-			CableName:        testLocalEndpointName,
-			ClusterID:        testLocalClusterID,
-			PublicIP:         testLocalPublicIP,
-			PrivateIP:        testLocalPrivateIP,
-			NATEnabled:       true,
-			NATDiscoveryPort: &testLocalNATPort,
+			CableName:  testLocalEndpointName,
+			ClusterID:  testLocalClusterID,
+			PublicIP:   testLocalPublicIP,
+			PrivateIP:  testLocalPrivateIP,
+			NATEnabled: true,
+			BackendConfig: map[string]string{
+				submarinerv1.NATTDiscoveryPortConfig: strconv.Itoa(int(testLocalNATPort)),
+			},
 		},
 	}
 }
@@ -136,12 +139,14 @@ func createTestLocalEndpoint() types.SubmarinerEndpoint {
 func createTestRemoteEndpoint() types.SubmarinerEndpoint {
 	return types.SubmarinerEndpoint{
 		Spec: submarinerv1.EndpointSpec{
-			CableName:        testRemoteEndpointName,
-			ClusterID:        testRemoteClusterID,
-			PublicIP:         testRemotePublicIP,
-			PrivateIP:        testRemotePrivateIP,
-			NATEnabled:       true,
-			NATDiscoveryPort: &testRemoteNATPort,
+			CableName:  testRemoteEndpointName,
+			ClusterID:  testRemoteClusterID,
+			PublicIP:   testRemotePublicIP,
+			PrivateIP:  testRemotePrivateIP,
+			NATEnabled: true,
+			BackendConfig: map[string]string{
+				submarinerv1.NATTDiscoveryPortConfig: strconv.Itoa(int(testRemoteNATPort)),
+			},
 		},
 	}
 }

--- a/pkg/natdiscovery/natdiscovery_test.go
+++ b/pkg/natdiscovery/natdiscovery_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
 )
 
@@ -210,7 +211,7 @@ var _ = When("a remote Endpoint is added", func() {
 		BeforeEach(func() {
 			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
 			t.remoteEndpoint.Spec.PrivateIP = ""
-			t.remoteEndpoint.Spec.NATDiscoveryPort = nil
+			delete(t.remoteEndpoint.Spec.BackendConfig, submarinerv1.NATTDiscoveryPortConfig)
 		})
 
 		It("should notify with the legacy NATEndpointInfo settings", func() {

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -73,7 +73,6 @@ func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT,
 
 	nd.requestCounter++
 
-	serverPort := *nd.serverPort
 	request := &natproto.SubmarinerNatDiscoveryRequest{
 		RequestNumber: nd.requestCounter,
 		Sender: &natproto.EndpointDetails{
@@ -86,7 +85,7 @@ func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT,
 		},
 		UsingSrc: &natproto.IPPortPair{
 			IP:   sourceIP,
-			Port: uint32(serverPort),
+			Port: uint32(nd.serverPort),
 		},
 		UsingDst: &natproto.IPPortPair{
 			IP:   targetIP,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -1,0 +1,46 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func GetLocalNode(cfg *rest.Config) (*v1.Node, error) {
+	nodeName, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		return nil, errors.New("error reading the NODE_NAME from the environment")
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating Kubernetes clientset")
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to find local node %q", nodeName)
+	}
+
+	return node, nil
+}


### PR DESCRIPTION
Local node gateway configuration can be applied using the following labels on
the gateway node:

 - gateway.submariner.io/udp-port=<port>
 - gateway.submariner.io/natt-discovery-port=<port>

This commit also moves the UDP implementation into single-port to
simplify the picture, as our two-port IPSEC doesn't make sense anymore
with the use of IKEv2 and manual port selection.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>

Fixes: #1178
