### PR TITLE
Use indirect build images and dnf roots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
 
-IMAGES ?= submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
+IMAGES ?= submariner-buildenv submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
 images: build
 
 include $(SHIPYARD_DIR)/Makefile.inc

--- a/package/Dockerfile.submariner-buildenv
+++ b/package/Dockerfile.submariner-buildenv
@@ -1,0 +1,33 @@
+ARG FEDORA_VERSION=33
+FROM fedora:${FEDORA_VERSION}
+ARG FEDORA_VERSION
+ARG TARGETPLATFORM
+
+COPY package/dnf_install /
+
+# dnf cache and base packages, shared across all build sub-directories
+RUN /dnf_install -k -v ${FEDORA_VERSION} \
+    glibc bash glibc-minimal-langpack coreutils-single
+
+# gateway
+
+# iproute and iptables are used internally
+# libreswan provides IKE
+# procps-ng is needed for libreswan (pidof)
+RUN /dnf_install -v ${FEDORA_VERSION} -r /output/gateway \
+    libcurl-minimal iproute iptables iptables-nft libreswan procps-ng
+
+# globalnet
+
+RUN /dnf_install -v ${FEDORA_VERSION} -r /output/globalnet \
+    iproute iptables iptables-nft ipset
+
+# networkplugin-syncer
+
+RUN /dnf_install -v ${FEDORA_VERSION} -r /output/networkplugin-syncer \
+    https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/x86_64/ovn-20.06.2-4.fc33.x86_64.rpm
+
+# route-agent
+
+RUN /dnf_install -v ${FEDORA_VERSION} -r /output/route-agent \
+    iproute iptables iptables-nft openvswitch procps-ng

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,13 +1,13 @@
-FROM fedora:33
+ARG BASE_BRANCH
+FROM quay.io/submariner/submariner-buildenv:${BASE_BRANCH} AS build-env
 ARG TARGETPLATFORM
 
-WORKDIR /var/submariner
+FROM scratch
+ARG TARGETPLATFORM
 
-# iproute and iptables are used internally
-# libreswan provides IKE
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft libreswan && \
-    dnf -y clean all
+COPY --from=build-env /output/gateway /
+
+WORKDIR /var/submariner
 
 COPY package/submariner.sh package/pluto bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/
 

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,11 +1,13 @@
-FROM fedora:33
+ARG BASE_BRANCH
+FROM quay.io/submariner/submariner-buildenv:${BASE_BRANCH} AS build-env
 ARG TARGETPLATFORM
 
-WORKDIR /var/submariner
+FROM scratch
+ARG TARGETPLATFORM
 
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft ipset && \
-    dnf -y clean all
+COPY --from=build-env /output/globalnet /
+
+WORKDIR /var/submariner
 
 COPY package/submariner-globalnet.sh bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/
 

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,11 +1,13 @@
-FROM fedora:33 
+ARG BASE_BRANCH
+FROM quay.io/submariner/submariner-buildenv:${BASE_BRANCH} AS build-env
 ARG TARGETPLATFORM
 
-WORKDIR /var/submariner
+FROM scratch
+ARG TARGETPLATFORM
 
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/x86_64/ovn-20.06.2-4.fc33.x86_64.rpm && \
-    dnf -y clean all
+COPY --from=build-env /output/networkplugin-syncer /
+
+WORKDIR /var/submariner
 
 # install the networkpluginc-sync
 COPY package/submariner-networkplugin-syncer.sh bin/${TARGETPLATFORM}/submariner-networkplugin-syncer /usr/local/bin/

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,11 +1,13 @@
-FROM fedora:33
+ARG BASE_BRANCH
+FROM quay.io/submariner/submariner-buildenv:${BASE_BRANCH} AS build-env
 ARG TARGETPLATFORM
 
-WORKDIR /var/submariner
+FROM scratch
+ARG TARGETPLATFORM
 
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft openvswitch procps-ng && \
-    dnf -y clean all
+COPY --from=build-env /output/route-agent /
+
+WORKDIR /var/submariner
 
 COPY package/submariner-route-agent.sh bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/
 

--- a/package/dnf_install
+++ b/package/dnf_install
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+params="$(getopt -o kv:r: --name "$0" -- "$@")"
+eval set -- "$params"
+
+INSTALL_ROOT=/output/base
+
+while true
+do
+    case "$1" in
+	-k)
+	    KEEP_CACHE=true
+	    shift
+	    ;;
+	-v)
+	    FEDORA_VERSION="$2"
+	    shift 2
+	    ;;
+	-r)
+	    INSTALL_ROOT="$2"
+	    shift 2
+	    ;;
+	--)
+	    shift
+	    break
+	    ;;
+	*)
+	    echo "$0 doesn't support $1" >&2
+	    exit 1
+	    ;;
+    esac
+done
+
+[[ -z "${FEDORA_VERSION}" ]] && echo I need to know which version of Fedora to install, specify it with -v >&2 && exit 1
+
+if [[ "${INSTALL_ROOT}" != /output/base ]] && [[ ! -d "${INSTALL_ROOT}" ]]; then
+    cp -a /output/base "${INSTALL_ROOT}"
+fi
+
+dnf -y --setopt=install_weak_deps=0 --nodocs \
+    --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" \
+    install "$@"
+
+[[ "${KEEP_CACHE}" == true ]] || dnf -y --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" clean all


### PR DESCRIPTION
This reduces the images as follows:

* gateway: 243MiB → 174MiB
* globalnet: 213MiB → 81MiB
* networkplugin-syncer: 255MiB → 189MiB
* route-agent: 212MiB → 80.7MiB

We use minimal dependencies and a separate build environment with a
dedicated installation root to reduce the number of required packages
and remove the support infrastructure from the target images.

See https://www.youtube.com/watch?v=HuE2Lrf5mRg for details.

Depends on https://github.com/submariner-io/shipyard/pull/536
Signed-off-by: Stephen Kitt <skitt@redhat.com>