### PR TITLE
Move IsOverlappingCIDR to separate package

### DIFF
--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -1,0 +1,40 @@
+/*
+© 2021 Red Hat, Inc. and others
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cidr
+
+import (
+	"net"
+)
+
+func IsOverlapping(cidrList []string, cidr string) (bool, error) {
+	_, newNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range cidrList {
+		_, baseNet, err := net.ParseCIDR(v)
+		if err != nil {
+			return false, err
+		}
+
+		if baseNet.Contains(newNet.IP) || newNet.Contains(baseNet.IP) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -24,13 +24,13 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/submariner-io/submariner/pkg/globalnet/cleanup"
-	"github.com/submariner-io/submariner/pkg/iptables"
-	"github.com/submariner-io/submariner/pkg/netlink"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 
-	"github.com/submariner-io/submariner/pkg/util"
+	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/globalnet/cleanup"
+	"github.com/submariner-io/submariner/pkg/iptables"
+	"github.com/submariner-io/submariner/pkg/netlink"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -154,7 +154,7 @@ func (gm *GatewayMonitor) processNextEndpoint() bool {
 		if endpoint.Spec.ClusterID != gm.clusterID {
 			klog.V(log.DEBUG).Infof("Endpoint %s belongs to a remote cluster", endpoint.Spec.Hostname)
 
-			overlap, err := util.IsOverlappingCIDR(endpoint.Spec.Subnets, gm.ipamSpec.GlobalCIDR[0])
+			overlap, err := cidr.IsOverlapping(endpoint.Spec.Subnets, gm.ipamSpec.GlobalCIDR[0])
 			if err != nil {
 				// Ideally this case will never hit, as the subnets are valid CIDRs
 				klog.Warningf("unable to validate overlapping Service CIDR: %s", err)

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/klog"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/util"
+	"github.com/submariner-io/submariner/pkg/cidr"
 )
 
 func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
@@ -154,7 +154,7 @@ func (kp *SyncHandler) overlappingSubnets(remoteSubnets []string) error {
 	// Pod/Service CIDRs, whereas in a GlobalNet deployment, it will be a list of
 	// globalCIDRs allocated to the clusters.
 	for _, serviceCidr := range kp.localServiceCidr {
-		overlap, err := util.IsOverlappingCIDR(remoteSubnets, serviceCidr)
+		overlap, err := cidr.IsOverlapping(remoteSubnets, serviceCidr)
 		if err != nil {
 			// Ideally this case will never hit, as the subnets are valid CIDRs
 			klog.Warningf("unable to validate overlapping Service CIDR: %s", err)
@@ -167,7 +167,7 @@ func (kp *SyncHandler) overlappingSubnets(remoteSubnets []string) error {
 	}
 
 	for _, podCidr := range kp.localClusterCidr {
-		overlap, err := util.IsOverlappingCIDR(remoteSubnets, podCidr)
+		overlap, err := cidr.IsOverlapping(remoteSubnets, podCidr)
 		if err != nil {
 			klog.Warningf("unable to validate overlapping Pod CIDR: %s", err)
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -335,23 +335,3 @@ func PrependUnique(ipt iptables.Interface, table, chain string, ruleSpec []strin
 
 	return nil
 }
-
-func IsOverlappingCIDR(cidrList []string, cidr string) (bool, error) {
-	_, newNet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return false, err
-	}
-
-	for _, v := range cidrList {
-		_, baseNet, err := net.ParseCIDR(v)
-		if err != nil {
-			return false, err
-		}
-
-		if baseNet.Contains(newNet.IP) || newNet.Contains(baseNet.IP) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}


### PR DESCRIPTION
IsOverlappingCIDR is used in couple of Submariner components like
route-agent and globalnet. Recently, when it was used in subctl,
we started to notice issues while building subctl on Windows
platforms as the util package was importing iptables as well.
To fix this issue, moving the API to a separate package in
Submariner.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>