### PR TITLE
Remove ineffective Helm CI config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,18 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator', 'helm']
+        deploytool: ['operator']
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'wireguard']
         ovn: ['', 'ovn']
         exclude:
-          # Our Helm setup doesn’t know how to deploy other cable drivers
-          - deploytool: 'helm'
-            cable_driver: 'wireguard'
-          - deploytool: 'helm'
-            cable_driver: 'libreswan'
-          - ovn: 'ovn'
-            deploytool: 'helm'
           - ovn: 'ovn'
             globalnet: 'globalnet'
           - ovn: 'ovn'

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -14,15 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator', 'helm']
+        deploytool: ['operator']
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'wireguard']
-        exclude:
-          # Our Helm setup doesn’t know how to deploy other cable drivers
-          - deploytool: 'helm'
-            cable_driver: 'wireguard'
-          - deploytool: 'helm'
-            cable_driver: 'libreswan'
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
We currently don't run any Helm jobs in this repository, but we have GHA
configuration to define jobs and then exclude all off them.

This is the artifact of removing the non-excluded cable driver option
"strongswan" Submariner-wide. It left only cable drivers excluded by
the Helm jobs.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>