### PR TITLE
build: add the protoc-gen-go cmd to pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
+	github.com/golang/protobuf v1.4.3
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.15.0

--- a/pkg/protoc-gen-go/main.go
+++ b/pkg/protoc-gen-go/main.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The protoc-gen-go binary is a protoc plugin to generate Go code for
+// both proto2 and proto3 versions of the protocol buffer language.
+//
+// For more information about the usage of this plugin, see:
+//	https://developers.google.com/protocol-buffers/docs/reference/go-generated
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	gengo "google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo"
+	"google.golang.org/protobuf/compiler/protogen"
+)
+
+const version = "v1.26.0"
+const genGoDocURL = "https://developers.google.com/protocol-buffers/docs/reference/go-generated"
+const grpcDocURL = "https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code"
+
+func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Fprintf(os.Stdout, "%v %v\n", filepath.Base(os.Args[0]), version)
+		os.Exit(0)
+	}
+	if len(os.Args) == 2 && os.Args[1] == "--help" {
+		fmt.Fprintf(os.Stdout, "See "+genGoDocURL+" for usage information.\n")
+		os.Exit(0)
+	}
+
+	var (
+		flags   flag.FlagSet
+		plugins = flags.String("plugins", "", "deprecated option")
+	)
+	protogen.Options{
+		ParamFunc: flags.Set,
+	}.Run(func(gen *protogen.Plugin) error {
+		if *plugins != "" {
+			return errors.New("protoc-gen-go: plugins are not supported; use 'protoc --go-grpc_out=...' to generate gRPC\n\n" +
+				"See " + grpcDocURL + " for more information.")
+		}
+		for _, f := range gen.Files {
+			if f.Generate {
+				gengo.GenerateFile(gen, f)
+			}
+		}
+		gen.SupportedFeatures = gengo.SupportedFeatures
+		return nil
+	})
+}


### PR DESCRIPTION
This plugin is missing while building downstream images.

Signed-off-by: Steve Mattar <smattar@redhat.com>