### PR TITLE
Update K8s default to 1.20, also test 1.17

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,11 +16,15 @@ jobs:
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'wireguard']
         ovn: ['', 'ovn']
+        k8s_version: ['1.20.2']
         exclude:
           - ovn: 'ovn'
             globalnet: 'globalnet'
           - ovn: 'ovn'
             cable_driver: 'wireguard'
+        include:
+          # This is the oldest K8s version we try to support
+          - k8s_version: 1.17.17
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
@@ -28,6 +32,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
+          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.ovn }}
 
       - name: Post mortem


### PR DESCRIPTION
Use the new ability of the shared E2E GHA to configure the Kubernetes
version to add a CI matrix dimension for K8s versions.

Change the default K8s version tested in E2E to be the latest K8s
version, providing good coverage for minimal additional jobs.

Test 1.17 as it is the version we currently build with, and doing so
provides default-E2E coverage for the oldest version we support.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>