### PR TITLE
Make the API additions in 0.9 optional to fix upgrades

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -153,8 +153,8 @@ type Connection struct {
 	Status        ConnectionStatus `json:"status"`
 	StatusMessage string           `json:"statusMessage"`
 	Endpoint      EndpointSpec     `json:"endpoint"`
-	UsingIP       string           `json:"usingIP"`
-	UsingNAT      bool             `json:"usingNAT"`
+	UsingIP       string           `json:"usingIP,omitempty"`
+	UsingNAT      bool             `json:"usingNAT,omitempty"`
 	// +optional
 	LatencyRTT *LatencyRTTSpec `json:"latencyRTT,omitempty"`
 }


### PR DESCRIPTION
Otherwise, when we delete the Submariner operator object
from subctl it will never finish waiting on the orphan objects,
being Gateway an orphan object that cannot be deleted
because API checking fails with:
```
   "submariner" is invalid: [
    status.gateways.connections.usingIP: Required value,
    status.gateways.connections.usingNAT: Required value]
```
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
