### PR TITLE
Handle retries on install cable failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/coreos/go-iptables v0.5.0
 	github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0
 	github.com/go-ping/ping v0.0.0-20201022122018-3977ed72668a
-	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.0
 	github.com/onsi/gomega v1.11.0

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Cable Engine", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(engine.RemoveCable(*remoteEndpoint)).To(ContainErrorSubstring(fakeDriver.ErrOnDisconnectFromEndpoint))
+				Expect(engine.RemoveCable(*remoteEndpoint)).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -16,6 +16,8 @@ limitations under the License.
 package tunnel
 
 import (
+	"time"
+
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -47,6 +49,10 @@ func StartController(engine cableengine.Engine, namespace string, config *watche
 		},
 	}
 
+	if config.ResyncPeriod == 0 {
+		config.ResyncPeriod = time.Second * 30
+	}
+
 	endpointWatcher, err := watcher.New(config)
 	if err != nil {
 		return err
@@ -74,8 +80,6 @@ func (c *controller) handleCreatedOrUpdatedEndpoint(obj runtime.Object, numReque
 		klog.Errorf("error installing cable for Endpoint %#v, %v", myEndpoint, err)
 		return true
 	}
-
-	klog.V(log.DEBUG).Infof("Tunnel controller successfully installed Endpoint cable %s in the engine", endpoint.Spec.CableName)
 
 	return false
 }

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -131,6 +131,10 @@ func (nd *natDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
 
 	if ep, exists := nd.remoteEndpoints[endpoint.Spec.CableName]; exists {
 		if reflect.DeepEqual(ep.endpoint.Spec, endpoint.Spec) {
+			if ep.isDiscoveryComplete() {
+				nd.readyChannel <- ep.toNATEndpointInfo()
+			}
+
 			return
 		} else {
 			klog.V(log.DEBUG).Infof("NAT discovery updated endpoint %q", endpoint.Spec.CableName)
@@ -148,6 +152,8 @@ func (nd *natDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
 
 		remoteNAT.useLegacyNATSettings()
 		nd.readyChannel <- remoteNAT.toNATEndpointInfo()
+	} else {
+		klog.Infof("Starting NAT discovery for endpoint %q", endpoint.Spec.CableName)
 	}
 
 	nd.remoteEndpoints[endpoint.Spec.CableName] = remoteNAT

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -103,6 +103,10 @@ func (rn *remoteEndpointNAT) useLegacyNATSettings() {
 	}
 }
 
+func (rn *remoteEndpointNAT) isDiscoveryComplete() bool {
+	return rn.state == selectedPublicIP || rn.state == selectedPrivateIP
+}
+
 func (rn *remoteEndpointNAT) shouldCheck() bool {
 	switch rn.state {
 	case testingPrivateAndPublicIPs:

--- a/pkg/natdiscovery/response_handle.go
+++ b/pkg/natdiscovery/response_handle.go
@@ -90,6 +90,6 @@ func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscov
 		return nil
 	}
 
-	return errors.Errorf("received response for unknown request id %d, lastPublicIPRequestID: %d, lastPrivateIPRequestID: %d",
+	return errors.Errorf("received response for unknown request id 0x%x, lastPublicIPRequestID: %d, lastPrivateIPRequestID: %d",
 		req.RequestNumber, remoteNat.lastPublicIPRequestID, remoteNat.lastPrivateIPRequestID)
 }


### PR DESCRIPTION
Fixes #1243

The simple solution implemented is to set a resync interval in the tunnel controller. 30 sec was chosen as a reasonable interval as we don't expect failures to be common. This also means that every endpoint will be resynced every 30 sec but it should essentially be a no-op if the endpoint was already successfully installed. Prior to the change to use the resource
watcher, we had a resync interval set anyway (60 sec).

Modified `natDiscovery.AddEndpoint` to notify the ready channel if discovery had already completed. This enables retries to immediately  proceed again to the install cable phase.

The tunnel controller tests were changed to use the real cable engine and NAT discovery to more effectively test the retries round trip.
