### PR TITLE
Fix the default SKIP regex for E2E ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 restart ?= all
 FOCUS ?=
-SKIP ?= "\[external-dataplane\]"
+SKIP ?= "\\[external-dataplane\\]"
 PLUGIN ?=
 BASE_BRANCH ?= devel
 export BASE_BRANCH


### PR DESCRIPTION
This should fix the upgrade job tests.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>