### PR TITLE
Stop creating /etc/ipsec

### DIFF
--- a/package/submariner.sh
+++ b/package/submariner.sh
@@ -14,8 +14,6 @@ else
     DEBUG="-v=${SUBMARINER_VERBOSITY}"
 fi
 
-mkdir -p /etc/ipsec
-
 sysctl -w net.ipv4.conf.all.send_redirects=0
 
 exec submariner-gateway ${DEBUG} -alsologtostderr


### PR DESCRIPTION
This isn't used, and prevents us from using a read-only root.

Signed-off-by: Stephen Kitt <skitt@redhat.com>