### PR TITLE
Compare Endpoint timestamps when deciding to replace previous cable

### DIFF
--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -128,8 +128,8 @@ func (d *Driver) AwaitNoConnectToEndpoint() {
 	Consistently(d.connectToEndpoint, 500*time.Millisecond).ShouldNot(Receive(), "ConnectToEndpoint was unexpectedly called")
 }
 
-func (d *Driver) AwaitDisconnectFromEndpoint(expected *types.SubmarinerEndpoint) {
-	Eventually(d.disconnectFromEndpoint, 5).Should(Receive(Equal(expected)))
+func (d *Driver) AwaitDisconnectFromEndpoint(expected *v1.EndpointSpec) {
+	Eventually(d.disconnectFromEndpoint, 5).Should(Receive(Equal(&types.SubmarinerEndpoint{Spec: *expected})))
 }
 
 func (d *Driver) AwaitNoDisconnectFromEndpoint() {

--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -92,6 +92,9 @@ func (d *Driver) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (
 		return "", err
 	}
 
+	d.ActiveConnections[endpointInfo.Endpoint.Spec.ClusterID] = []v1.Connection{
+		{Endpoint: endpointInfo.Endpoint.Spec, UsingIP: endpointInfo.Endpoint.Spec.PublicIP, UsingNAT: true}}
+
 	d.connectToEndpoint <- endpointInfo
 
 	return endpointInfo.UseIP, nil
@@ -106,6 +109,8 @@ func (d *Driver) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error
 		d.ErrOnDisconnectFromEndpoint = nil
 		return err
 	}
+
+	delete(d.ActiveConnections, endpoint.Spec.ClusterID)
 
 	d.disconnectFromEndpoint <- &endpoint
 

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -302,7 +302,7 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 		return "", fmt.Errorf("error listening: %v", err)
 	}
 
-	connectionMode := i.calculateOperationMode(endpoint)
+	connectionMode := i.calculateOperationMode(&endpoint.Spec)
 
 	klog.Infof("Creating connection(s) for %v in %s mode", endpoint, connectionMode)
 

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -17,8 +17,6 @@ package libreswan
 
 import (
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/types"
-
 	"k8s.io/klog"
 )
 
@@ -30,16 +28,16 @@ const (
 	operationModeClient
 )
 
-func (i *libreswan) calculateOperationMode(remoteEndpoint *types.SubmarinerEndpoint) operationMode {
+func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) operationMode {
 	defaultValue := false
 	leftPreferred, err := i.localEndpoint.Spec.GetBackendBool(v1.PreferredServerConfig, &defaultValue)
 	if err != nil {
 		klog.Errorf("Error parsing local endpoint config: %s", err)
 	}
 
-	rightPreferred, err := remoteEndpoint.Spec.GetBackendBool(v1.PreferredServerConfig, nil)
+	rightPreferred, err := remoteEndpoint.GetBackendBool(v1.PreferredServerConfig, nil)
 	if err != nil {
-		klog.Errorf("Error parsing remote endpoint config %q: %s", remoteEndpoint.Spec.CableName, err)
+		klog.Errorf("Error parsing remote endpoint config %q: %s", remoteEndpoint.CableName, err)
 	}
 
 	if rightPreferred == nil || !*leftPreferred && !*rightPreferred {
@@ -55,7 +53,7 @@ func (i *libreswan) calculateOperationMode(remoteEndpoint *types.SubmarinerEndpo
 	}
 
 	// At this point both would like to be server, so we decide based on the cable name
-	if i.localEndpoint.Spec.CableName > remoteEndpoint.Spec.CableName {
+	if i.localEndpoint.Spec.CableName > remoteEndpoint.CableName {
 		return operationModeServer
 	}
 

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -52,7 +52,7 @@ func (e *Engine) StartEngine() error {
 	return nil
 }
 
-func (e *Engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
+func (e *Engine) InstallCable(endpoint *v1.Endpoint) error {
 	err := e.ErrOnInstallCable
 	if err != nil {
 		e.ErrOnInstallCable = nil
@@ -64,7 +64,7 @@ func (e *Engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 	return nil
 }
 
-func (e *Engine) RemoveCable(endpoint types.SubmarinerEndpoint) error {
+func (e *Engine) RemoveCable(endpoint *v1.Endpoint) error {
 	err := e.ErrOnRemoveCable
 	if err != nil {
 		e.ErrOnRemoveCable = nil

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -22,7 +22,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine"
-	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 )
@@ -71,13 +70,9 @@ func (c *controller) handleCreatedOrUpdatedEndpoint(obj runtime.Object, numReque
 
 	klog.V(log.DEBUG).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
 
-	myEndpoint := types.SubmarinerEndpoint{
-		Spec: endpoint.Spec,
-	}
-
-	err := c.engine.InstallCable(myEndpoint)
+	err := c.engine.InstallCable(endpoint)
 	if err != nil {
-		klog.Errorf("error installing cable for Endpoint %#v, %v", myEndpoint, err)
+		klog.Errorf("error installing cable for Endpoint %#v, %v", endpoint, err)
 		return true
 	}
 
@@ -89,12 +84,8 @@ func (c *controller) handleRemovedEndpoint(obj runtime.Object, numRequeues int) 
 
 	klog.V(log.DEBUG).Infof("Tunnel controller processing removed submariner Endpoint object: %#v", endpoint)
 
-	myEndpoint := types.SubmarinerEndpoint{
-		Spec: endpoint.Spec,
-	}
-
-	if err := c.engine.RemoveCable(myEndpoint); err != nil {
-		klog.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v", myEndpoint, err)
+	if err := c.engine.RemoveCable(endpoint); err != nil {
+		klog.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v", endpoint, err)
 		return true
 	}
 

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -124,12 +124,12 @@ var _ = Describe("Managing tunnels", func() {
 		fakeDriver.AwaitConnectToEndpoint(&natdiscovery.NATEndpointInfo{
 			UseIP:    endpoint.Spec.PrivateIP,
 			UseNAT:   false,
-			Endpoint: types.SubmarinerEndpoint{Spec: endpoint.Spec},
+			Endpoint: *endpoint,
 		})
 	}
 
 	verifyDisconnectFromEndpoint := func() {
-		fakeDriver.AwaitDisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: endpoint.Spec})
+		fakeDriver.AwaitDisconnectFromEndpoint(&endpoint.Spec)
 	}
 
 	When("an Endpoint is created", func() {

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -82,7 +82,7 @@ func parseProtocolResponse(buf []byte) *natproto.SubmarinerNatDiscoveryResponse 
 	return response
 }
 
-func createTestListener(endpoint *types.SubmarinerEndpoint) (*natDiscovery, chan []byte, chan *NATEndpointInfo) {
+func createTestListener(endpoint *submarinerv1.Endpoint) (*natDiscovery, chan []byte, chan *NATEndpointInfo) {
 	listener, err := newNatDiscovery(&types.SubmarinerEndpoint{Spec: endpoint.Spec})
 	Expect(err).To(Succeed())
 
@@ -119,8 +119,8 @@ func forwardFromUDPChan(from chan []byte, addr *net.UDPAddr, to *natDiscovery, h
 	}()
 }
 
-func createTestLocalEndpoint() types.SubmarinerEndpoint {
-	return types.SubmarinerEndpoint{
+func createTestLocalEndpoint() submarinerv1.Endpoint {
+	return submarinerv1.Endpoint{
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testLocalEndpointName,
 			ClusterID:  testLocalClusterID,
@@ -134,8 +134,8 @@ func createTestLocalEndpoint() types.SubmarinerEndpoint {
 	}
 }
 
-func createTestRemoteEndpoint() types.SubmarinerEndpoint {
-	return types.SubmarinerEndpoint{
+func createTestRemoteEndpoint() submarinerv1.Endpoint {
+	return submarinerv1.Endpoint{
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testRemoteEndpointName,
 			ClusterID:  testRemoteClusterID,

--- a/pkg/natdiscovery/natdiscovery_test.go
+++ b/pkg/natdiscovery/natdiscovery_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/types"
 )
 
 var _ = When("a remote Endpoint is added", func() {
@@ -139,7 +138,7 @@ var _ = When("a remote Endpoint is added", func() {
 	})
 
 	Context("and then re-added after discovery is complete", func() {
-		var newRemoteEndpoint types.SubmarinerEndpoint
+		var newRemoteEndpoint submarinerv1.Endpoint
 
 		BeforeEach(func() {
 			t.remoteND.AddEndpoint(&t.localEndpoint)
@@ -182,7 +181,7 @@ var _ = When("a remote Endpoint is added", func() {
 	})
 
 	Context("and then re-added while discovery is in progress", func() {
-		var newRemoteEndpoint types.SubmarinerEndpoint
+		var newRemoteEndpoint submarinerv1.Endpoint
 
 		BeforeEach(func() {
 			forwardHowManyFromLocal = 0
@@ -281,11 +280,11 @@ var _ = When("a remote Endpoint is added", func() {
 type discoveryTestDriver struct {
 	localND                           *natDiscovery
 	localUDPSent                      chan []byte
-	localEndpoint                     types.SubmarinerEndpoint
+	localEndpoint                     submarinerv1.Endpoint
 	localUDPAddr                      *net.UDPAddr
 	remoteND                          *natDiscovery
 	remoteUDPSent                     chan []byte
-	remoteEndpoint                    types.SubmarinerEndpoint
+	remoteEndpoint                    submarinerv1.Endpoint
 	remoteUDPAddr                     *net.UDPAddr
 	readyChannel                      chan *NATEndpointInfo
 	oldRecheckTime                    int64

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -20,9 +20,8 @@ import (
 	"time"
 
 	"github.com/submariner-io/admiral/pkg/log"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"k8s.io/klog"
-
-	"github.com/submariner-io/submariner/pkg/types"
 )
 
 type endpointState int
@@ -41,7 +40,7 @@ var (
 )
 
 type remoteEndpointNAT struct {
-	endpoint               types.SubmarinerEndpoint
+	endpoint               v1.Endpoint
 	state                  endpointState
 	lastCheck              time.Time
 	lastTransition         time.Time
@@ -53,7 +52,7 @@ type remoteEndpointNAT struct {
 }
 
 type NATEndpointInfo struct {
-	Endpoint types.SubmarinerEndpoint
+	Endpoint v1.Endpoint
 	UseNAT   bool
 	UseIP    string
 }
@@ -66,7 +65,7 @@ func (rn *remoteEndpointNAT) toNATEndpointInfo() *NATEndpointInfo {
 	}
 }
 
-func newRemoteEndpointNAT(endpoint *types.SubmarinerEndpoint) *remoteEndpointNAT {
+func newRemoteEndpointNAT(endpoint *v1.Endpoint) *remoteEndpointNAT {
 	return &remoteEndpointNAT{
 		endpoint:       *endpoint,
 		state:          testingPrivateAndPublicIPs,

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -20,9 +20,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/submariner-io/submariner/pkg/types"
 	"google.golang.org/protobuf/proto"
 
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
 )
 
@@ -32,8 +32,8 @@ var _ = Describe("Request handling", func() {
 	var localUDPSent chan []byte
 	var remoteListener *natDiscovery
 	var remoteUDPSent chan []byte
-	var localEndpoint types.SubmarinerEndpoint
-	var remoteEndpoint types.SubmarinerEndpoint
+	var localEndpoint submarinerv1.Endpoint
+	var remoteEndpoint submarinerv1.Endpoint
 
 	var remoteUDPAddr net.UDPAddr
 
@@ -59,7 +59,7 @@ var _ = Describe("Request handling", func() {
 	}
 
 	requestResponseFromRemoteToLocal := func(remoteAddr *net.UDPAddr) []*natproto.SubmarinerNatDiscoveryResponse {
-		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: localEndpoint.Spec}))
+		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&localEndpoint))
 		Expect(err).NotTo(HaveOccurred())
 		return []*natproto.SubmarinerNatDiscoveryResponse{
 			parseResponseInLocalListener(awaitChan(remoteUDPSent), remoteAddr), /* Private IP request */

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -63,7 +63,7 @@ func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 }
 
 func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT, targetIP string) (uint64, error) {
-	targetPort, err := extractNATDiscoveryPort(&remoteNAT.endpoint)
+	targetPort, err := extractNATDiscoveryPort(&remoteNAT.endpoint.Spec)
 
 	if err != nil {
 		return 0, err

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -19,14 +19,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
-	"github.com/submariner-io/submariner/pkg/types"
 )
 
 var _ = When("a request is sent", func() {
 	var (
 		request        *natproto.SubmarinerNatDiscoveryRequest
-		remoteEndpoint types.SubmarinerEndpoint
+		remoteEndpoint submarinerv1.Endpoint
 		udpSent        chan []byte
 		ndInstance     *natDiscovery
 	)
@@ -43,7 +43,7 @@ var _ = When("a request is sent", func() {
 		ndInstance, udpSent, _ = createTestListener(&localEndpoint)
 		ndInstance.findSrcIP = func(_ string) string { return testLocalPrivateIP }
 
-		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: remoteEndpoint.Spec}))
+		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&remoteEndpoint))
 		Expect(err).NotTo(HaveOccurred())
 
 		request = parseProtocolRequest(awaitChan(udpSent))


### PR DESCRIPTION
An `Endpoint` can become stale if a delete event is somehow missed or delayed. To protect against a stale `Endpoint` replacing a current one, cable installation now compares the `Endpoint` creation timestamps, favoring the newer one.

This also entailed refactoring `InstallCable` to take an `Endpoint` in order to access the `CreationTimestamp`.  `RemoveCable` was also changed for consistency.

Related to #1244