### PR TITLE
Revert "Compare Endpoint timestamps when deciding to replace previous cable"

### DIFF
--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -128,8 +128,8 @@ func (d *Driver) AwaitNoConnectToEndpoint() {
 	Consistently(d.connectToEndpoint, 500*time.Millisecond).ShouldNot(Receive(), "ConnectToEndpoint was unexpectedly called")
 }
 
-func (d *Driver) AwaitDisconnectFromEndpoint(expected *v1.EndpointSpec) {
-	Eventually(d.disconnectFromEndpoint, 5).Should(Receive(Equal(&types.SubmarinerEndpoint{Spec: *expected})))
+func (d *Driver) AwaitDisconnectFromEndpoint(expected *types.SubmarinerEndpoint) {
+	Eventually(d.disconnectFromEndpoint, 5).Should(Receive(Equal(expected)))
 }
 
 func (d *Driver) AwaitNoDisconnectFromEndpoint() {

--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -92,9 +92,6 @@ func (d *Driver) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (
 		return "", err
 	}
 
-	d.ActiveConnections[endpointInfo.Endpoint.Spec.ClusterID] = []v1.Connection{
-		{Endpoint: endpointInfo.Endpoint.Spec, UsingIP: endpointInfo.Endpoint.Spec.PublicIP, UsingNAT: true}}
-
 	d.connectToEndpoint <- endpointInfo
 
 	return endpointInfo.UseIP, nil
@@ -109,8 +106,6 @@ func (d *Driver) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error
 		d.ErrOnDisconnectFromEndpoint = nil
 		return err
 	}
-
-	delete(d.ActiveConnections, endpoint.Spec.ClusterID)
 
 	d.disconnectFromEndpoint <- &endpoint
 

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -302,7 +302,7 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 		return "", fmt.Errorf("error listening: %v", err)
 	}
 
-	connectionMode := i.calculateOperationMode(&endpoint.Spec)
+	connectionMode := i.calculateOperationMode(endpoint)
 
 	klog.Infof("Creating connection(s) for %v in %s mode", endpoint, connectionMode)
 

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -17,6 +17,8 @@ package libreswan
 
 import (
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
+
 	"k8s.io/klog"
 )
 
@@ -28,16 +30,16 @@ const (
 	operationModeClient
 )
 
-func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) operationMode {
+func (i *libreswan) calculateOperationMode(remoteEndpoint *types.SubmarinerEndpoint) operationMode {
 	defaultValue := false
 	leftPreferred, err := i.localEndpoint.Spec.GetBackendBool(v1.PreferredServerConfig, &defaultValue)
 	if err != nil {
 		klog.Errorf("Error parsing local endpoint config: %s", err)
 	}
 
-	rightPreferred, err := remoteEndpoint.GetBackendBool(v1.PreferredServerConfig, nil)
+	rightPreferred, err := remoteEndpoint.Spec.GetBackendBool(v1.PreferredServerConfig, nil)
 	if err != nil {
-		klog.Errorf("Error parsing remote endpoint config %q: %s", remoteEndpoint.CableName, err)
+		klog.Errorf("Error parsing remote endpoint config %q: %s", remoteEndpoint.Spec.CableName, err)
 	}
 
 	if rightPreferred == nil || !*leftPreferred && !*rightPreferred {
@@ -53,7 +55,7 @@ func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) oper
 	}
 
 	// At this point both would like to be server, so we decide based on the cable name
-	if i.localEndpoint.Spec.CableName > remoteEndpoint.CableName {
+	if i.localEndpoint.Spec.CableName > remoteEndpoint.Spec.CableName {
 		return operationModeServer
 	}
 

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -44,10 +44,10 @@ type Engine interface {
 	// InstallCable performs any set up work needed for connecting to given remote endpoint.
 	// Once InstallCable completes, it should be possible to connect to remote
 	// Pods or Services behind the given endpoint.
-	InstallCable(remote *v1.Endpoint) error
+	InstallCable(remote types.SubmarinerEndpoint) error
 	// RemoveCable disconnects the Engine from the given remote endpoint. Upon completion.
 	// remote Pods and Service may not be accessible any more.
-	RemoveCable(remote *v1.Endpoint) error
+	RemoveCable(remote types.SubmarinerEndpoint) error
 	// ListCableConnections returns a list of cable connection, and the related status
 	ListCableConnections() ([]v1.Connection, error)
 	// GetLocalEndpoint returns the local endpoint for this cable engine
@@ -187,7 +187,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 	return nil
 }
 
-func (i *engine) InstallCable(endpoint *v1.Endpoint) error {
+func (i *engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 	if endpoint.Spec.ClusterID == i.localCluster.ID {
 		klog.V(log.DEBUG).Infof("Not installing cable for local cluster")
 		return nil
@@ -202,12 +202,12 @@ func (i *engine) InstallCable(endpoint *v1.Endpoint) error {
 	i.natDiscoveryPending[endpoint.Spec.CableName]++
 	i.Unlock()
 
-	i.natDiscovery.AddEndpoint(endpoint)
+	i.natDiscovery.AddEndpoint(&endpoint)
 
 	return nil
 }
 
-func (i *engine) RemoveCable(endpoint *v1.Endpoint) error {
+func (i *engine) RemoveCable(endpoint types.SubmarinerEndpoint) error {
 	if endpoint.Spec.ClusterID == i.localCluster.ID {
 		klog.V(log.DEBUG).Infof("Cables are not added/removed for the local cluster, skipping removal")
 		return nil
@@ -226,7 +226,7 @@ func (i *engine) RemoveCable(endpoint *v1.Endpoint) error {
 		return nil
 	}
 
-	err := i.driver.DisconnectFromEndpoint(types.SubmarinerEndpoint{Spec: endpoint.Spec})
+	err := i.driver.DisconnectFromEndpoint(endpoint)
 	if err != nil {
 		return err
 	}

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -51,15 +51,15 @@ var _ = Describe("Cable Engine", func() {
 	var (
 		engine         cableengine.Engine
 		natDiscovery   *fakeNatDiscovery
-		localEndpoint  *subv1.Endpoint
-		remoteEndpoint *subv1.Endpoint
+		localEndpoint  *types.SubmarinerEndpoint
+		remoteEndpoint *types.SubmarinerEndpoint
 		skipStart      bool
 	)
 
 	BeforeEach(func() {
 		skipStart = false
 
-		localEndpoint = &subv1.Endpoint{
+		localEndpoint = &types.SubmarinerEndpoint{
 			Spec: subv1.EndpointSpec{
 				ClusterID: localClusterID,
 				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", localClusterID),
@@ -69,7 +69,7 @@ var _ = Describe("Cable Engine", func() {
 			},
 		}
 
-		remoteEndpoint = &subv1.Endpoint{
+		remoteEndpoint = &types.SubmarinerEndpoint{
 			Spec: subv1.EndpointSpec{
 				ClusterID: remoteClusterID,
 				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", remoteClusterID),
@@ -84,7 +84,7 @@ var _ = Describe("Cable Engine", func() {
 			Spec: subv1.ClusterSpec{
 				ClusterID: localClusterID,
 			},
-		}, types.SubmarinerEndpoint{Spec: localEndpoint.Spec})
+		}, *localEndpoint)
 
 		natDiscovery = &fakeNatDiscovery{removeEndpoint: make(chan string, 20), readyChannel: make(chan *natdiscovery.NATEndpointInfo, 100)}
 		engine.SetupNATDiscovery(natDiscovery)
@@ -106,20 +106,20 @@ var _ = Describe("Cable Engine", func() {
 	})
 
 	It("should return the local endpoint when queried", func() {
-		Expect(engine.GetLocalEndpoint()).To(Equal(&types.SubmarinerEndpoint{Spec: localEndpoint.Spec}))
+		Expect(engine.GetLocalEndpoint()).To(Equal(localEndpoint))
 	})
 
 	When("install cable for a remote endpoint", func() {
 		Context("and no endpoint was previously installed for the cluster", func() {
 			It("should connect to the endpoint", func() {
-				Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+				Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 			})
 		})
 
 		Context("and an endpoint was previously installed for the cluster", func() {
 			JustBeforeEach(func() {
-				Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+				Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 
 				fakeDriver.ActiveConnections[remoteClusterID] = []subv1.Connection{
@@ -131,15 +131,15 @@ var _ = Describe("Cable Engine", func() {
 					newEndpoint := *remoteEndpoint
 					newEndpoint.Spec.CableName = "new cable"
 
-					Expect(engine.InstallCable(&newEndpoint)).To(Succeed())
-					fakeDriver.AwaitDisconnectFromEndpoint(&remoteEndpoint.Spec)
+					Expect(engine.InstallCable(newEndpoint)).To(Succeed())
+					fakeDriver.AwaitDisconnectFromEndpoint(remoteEndpoint)
 					fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(&newEndpoint))
 				})
 			})
 
 			Context("and it's the same endpoint", func() {
 				It("should not connect to the endpoint again", func() {
-					Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+					Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 					fakeDriver.AwaitNoConnectToEndpoint()
 				})
 			})
@@ -149,8 +149,8 @@ var _ = Describe("Cable Engine", func() {
 					prevEndpoint := *remoteEndpoint
 					remoteEndpoint.Spec.PublicIP = "3.3.3.3"
 
-					Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
-					fakeDriver.AwaitDisconnectFromEndpoint(&prevEndpoint.Spec)
+					Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
+					fakeDriver.AwaitDisconnectFromEndpoint(&prevEndpoint)
 					fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 				})
 			})
@@ -158,14 +158,14 @@ var _ = Describe("Cable Engine", func() {
 
 		Context("followed by remove cable before NAT discovery is complete", func() {
 			BeforeEach(func() {
-				natDiscovery.captureAddEndpoint = make(chan *subv1.Endpoint, 10)
+				natDiscovery.captureAddEndpoint = make(chan *types.SubmarinerEndpoint, 10)
 			})
 
 			It("should not connect to the endpoint", func() {
-				Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+				Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 				Eventually(natDiscovery.captureAddEndpoint).Should(Receive())
 
-				Expect(engine.RemoveCable(remoteEndpoint)).To(Succeed())
+				Expect(engine.RemoveCable(*remoteEndpoint)).To(Succeed())
 				Eventually(natDiscovery.removeEndpoint).Should(Receive(Equal(remoteEndpoint.Spec.CableName)))
 				fakeDriver.AwaitNoDisconnectFromEndpoint()
 
@@ -177,20 +177,20 @@ var _ = Describe("Cable Engine", func() {
 
 	When("install cable for a local endpoint", func() {
 		It("should not connect to the endpoint", func() {
-			Expect(engine.InstallCable(localEndpoint)).To(Succeed())
+			Expect(engine.InstallCable(*localEndpoint)).To(Succeed())
 			fakeDriver.AwaitNoConnectToEndpoint()
 		})
 	})
 
 	When("remove cable for a remote endpoint", func() {
 		JustBeforeEach(func() {
-			Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+			Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 			fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 		})
 
 		It("should disconnect from the endpoint", func() {
-			Expect(engine.RemoveCable(remoteEndpoint)).To(Succeed())
-			fakeDriver.AwaitDisconnectFromEndpoint(&remoteEndpoint.Spec)
+			Expect(engine.RemoveCable(*remoteEndpoint)).To(Succeed())
+			fakeDriver.AwaitDisconnectFromEndpoint(remoteEndpoint)
 			Eventually(natDiscovery.removeEndpoint).Should(Receive(Equal(remoteEndpoint.Spec.CableName)))
 		})
 
@@ -200,19 +200,19 @@ var _ = Describe("Cable Engine", func() {
 			})
 
 			It("should return an error", func() {
-				Expect(engine.RemoveCable(remoteEndpoint)).To(HaveOccurred())
+				Expect(engine.RemoveCable(*remoteEndpoint)).To(HaveOccurred())
 			})
 		})
 	})
 
 	When("remove cable for a local endpoint", func() {
 		JustBeforeEach(func() {
-			Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+			Expect(engine.InstallCable(*remoteEndpoint)).To(Succeed())
 			fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 		})
 
 		It("should not disconnect from the endpoint", func() {
-			Expect(engine.RemoveCable(localEndpoint)).To(Succeed())
+			Expect(engine.RemoveCable(*localEndpoint)).To(Succeed())
 			fakeDriver.AwaitNoDisconnectFromEndpoint()
 			Consistently(natDiscovery.removeEndpoint).ShouldNot(Receive())
 		})
@@ -280,7 +280,7 @@ func TestCableEngine(t *testing.T) {
 
 type fakeNatDiscovery struct {
 	removeEndpoint     chan string
-	captureAddEndpoint chan *subv1.Endpoint
+	captureAddEndpoint chan *types.SubmarinerEndpoint
 	readyChannel       chan *natdiscovery.NATEndpointInfo
 }
 
@@ -288,7 +288,7 @@ func (n *fakeNatDiscovery) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (n *fakeNatDiscovery) AddEndpoint(endpoint *subv1.Endpoint) {
+func (n *fakeNatDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
 	if n.captureAddEndpoint != nil {
 		n.captureAddEndpoint <- endpoint
 		return
@@ -305,11 +305,11 @@ func (n *fakeNatDiscovery) GetReadyChannel() chan *natdiscovery.NATEndpointInfo 
 	return n.readyChannel
 }
 
-func (n *fakeNatDiscovery) notifyReady(endpoint *subv1.Endpoint) {
+func (n *fakeNatDiscovery) notifyReady(endpoint *types.SubmarinerEndpoint) {
 	n.readyChannel <- natEndpointInfoFor(endpoint)
 }
 
-func natEndpointInfoFor(endpoint *subv1.Endpoint) *natdiscovery.NATEndpointInfo {
+func natEndpointInfoFor(endpoint *types.SubmarinerEndpoint) *natdiscovery.NATEndpointInfo {
 	return &natdiscovery.NATEndpointInfo{
 		UseIP:    endpoint.Spec.PublicIP,
 		UseNAT:   true,

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,7 +29,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
@@ -62,9 +60,6 @@ var _ = Describe("Cable Engine", func() {
 		skipStart = false
 
 		localEndpoint = &subv1.Endpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Now(),
-			},
 			Spec: subv1.EndpointSpec{
 				ClusterID: localClusterID,
 				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", localClusterID),
@@ -75,9 +70,6 @@ var _ = Describe("Cable Engine", func() {
 		}
 
 		remoteEndpoint = &subv1.Endpoint{
-			ObjectMeta: metav1.ObjectMeta{
-				CreationTimestamp: metav1.Now(),
-			},
 			Spec: subv1.EndpointSpec{
 				ClusterID: remoteClusterID,
 				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", remoteClusterID),
@@ -126,85 +118,41 @@ var _ = Describe("Cable Engine", func() {
 		})
 
 		Context("and an endpoint was previously installed for the cluster", func() {
-			var prevEndpoint *subv1.Endpoint
-			var newEndpoint *subv1.Endpoint
-
-			BeforeEach(func() {
-				copy := *remoteEndpoint
-				newEndpoint = &copy
-				prevEndpoint = remoteEndpoint
-			})
-
 			JustBeforeEach(func() {
-				Expect(engine.InstallCable(prevEndpoint)).To(Succeed())
-				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(prevEndpoint))
+				Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
+				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 
-				Expect(engine.InstallCable(newEndpoint)).To(Succeed())
+				fakeDriver.ActiveConnections[remoteClusterID] = []subv1.Connection{
+					{Endpoint: remoteEndpoint.Spec, UsingIP: remoteEndpoint.Spec.PublicIP, UsingNAT: true}}
 			})
 
 			Context("and it's a different endpoint", func() {
-				BeforeEach(func() {
+				It("should disconnect from the previous endpoint and connect to the new one", func() {
+					newEndpoint := *remoteEndpoint
 					newEndpoint.Spec.CableName = "new cable"
-				})
 
-				Context("with an older creation timestamp", func() {
-					BeforeEach(func() {
-						time.Sleep(100 * time.Millisecond)
-						newEndpoint.CreationTimestamp = metav1.Now()
-					})
-
-					It("should disconnect from the previous endpoint and connect to the new one", func() {
-						fakeDriver.AwaitDisconnectFromEndpoint(&prevEndpoint.Spec)
-						fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(newEndpoint))
-					})
-				})
-
-				Context("with a newer creation timestamp", func() {
-					BeforeEach(func() {
-						newEndpoint.CreationTimestamp = metav1.Now()
-						time.Sleep(100 * time.Millisecond)
-						prevEndpoint.CreationTimestamp = metav1.Now()
-					})
-
-					It("should not disconnect from the previous endpoint nor connect to the new one", func() {
-						fakeDriver.AwaitNoDisconnectFromEndpoint()
-						fakeDriver.AwaitNoConnectToEndpoint()
-					})
+					Expect(engine.InstallCable(&newEndpoint)).To(Succeed())
+					fakeDriver.AwaitDisconnectFromEndpoint(&remoteEndpoint.Spec)
+					fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(&newEndpoint))
 				})
 			})
 
 			Context("and it's the same endpoint", func() {
 				It("should not connect to the endpoint again", func() {
+					Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
 					fakeDriver.AwaitNoConnectToEndpoint()
 				})
 			})
 
 			Context("and it's the same endpoint but with a different public IP", func() {
-				BeforeEach(func() {
-					newEndpoint.Spec.PublicIP = "3.3.3.3"
-				})
-
 				It("should disconnect from the previous endpoint and connect to the new one", func() {
+					prevEndpoint := *remoteEndpoint
+					remoteEndpoint.Spec.PublicIP = "3.3.3.3"
+
+					Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
 					fakeDriver.AwaitDisconnectFromEndpoint(&prevEndpoint.Spec)
-					fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(newEndpoint))
+					fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
 				})
-			})
-		})
-
-		Context("and an endpoint was previously installed for another cluster", func() {
-			It("should connect to the new endpoint and not disconnect from the previous one", func() {
-				otherEndpoint := subv1.Endpoint{Spec: subv1.EndpointSpec{
-					ClusterID: "other",
-					CableName: "submariner-cable-other-1.1.1.1",
-				},
-				}
-
-				Expect(engine.InstallCable(&otherEndpoint)).To(Succeed())
-				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(&otherEndpoint))
-
-				Expect(engine.InstallCable(remoteEndpoint)).To(Succeed())
-				fakeDriver.AwaitConnectToEndpoint(natEndpointInfoFor(remoteEndpoint))
-				fakeDriver.AwaitNoDisconnectFromEndpoint()
 			})
 		})
 

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -52,7 +52,7 @@ func (e *Engine) StartEngine() error {
 	return nil
 }
 
-func (e *Engine) InstallCable(endpoint *v1.Endpoint) error {
+func (e *Engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 	err := e.ErrOnInstallCable
 	if err != nil {
 		e.ErrOnInstallCable = nil
@@ -64,7 +64,7 @@ func (e *Engine) InstallCable(endpoint *v1.Endpoint) error {
 	return nil
 }
 
-func (e *Engine) RemoveCable(endpoint *v1.Endpoint) error {
+func (e *Engine) RemoveCable(endpoint types.SubmarinerEndpoint) error {
 	err := e.ErrOnRemoveCable
 	if err != nil {
 		e.ErrOnRemoveCable = nil

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -22,6 +22,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine"
+	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 )
@@ -70,9 +71,13 @@ func (c *controller) handleCreatedOrUpdatedEndpoint(obj runtime.Object, numReque
 
 	klog.V(log.DEBUG).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
 
-	err := c.engine.InstallCable(endpoint)
+	myEndpoint := types.SubmarinerEndpoint{
+		Spec: endpoint.Spec,
+	}
+
+	err := c.engine.InstallCable(myEndpoint)
 	if err != nil {
-		klog.Errorf("error installing cable for Endpoint %#v, %v", endpoint, err)
+		klog.Errorf("error installing cable for Endpoint %#v, %v", myEndpoint, err)
 		return true
 	}
 
@@ -84,8 +89,12 @@ func (c *controller) handleRemovedEndpoint(obj runtime.Object, numRequeues int) 
 
 	klog.V(log.DEBUG).Infof("Tunnel controller processing removed submariner Endpoint object: %#v", endpoint)
 
-	if err := c.engine.RemoveCable(endpoint); err != nil {
-		klog.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v", endpoint, err)
+	myEndpoint := types.SubmarinerEndpoint{
+		Spec: endpoint.Spec,
+	}
+
+	if err := c.engine.RemoveCable(myEndpoint); err != nil {
+		klog.Errorf("Tunnel controller failed to remove Endpoint cable %#v from the engine: %v", myEndpoint, err)
 		return true
 	}
 

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -124,12 +124,12 @@ var _ = Describe("Managing tunnels", func() {
 		fakeDriver.AwaitConnectToEndpoint(&natdiscovery.NATEndpointInfo{
 			UseIP:    endpoint.Spec.PrivateIP,
 			UseNAT:   false,
-			Endpoint: *endpoint,
+			Endpoint: types.SubmarinerEndpoint{Spec: endpoint.Spec},
 		})
 	}
 
 	verifyDisconnectFromEndpoint := func() {
-		fakeDriver.AwaitDisconnectFromEndpoint(&endpoint.Spec)
+		fakeDriver.AwaitDisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: endpoint.Spec})
 	}
 
 	When("an Endpoint is created", func() {

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -36,7 +36,7 @@ import (
 
 type Interface interface {
 	Run(stopCh <-chan struct{}) error
-	AddEndpoint(endpoint *v1.Endpoint)
+	AddEndpoint(endpoint *types.SubmarinerEndpoint)
 	RemoveEndpoint(endpointName string)
 	GetReadyChannel() chan *NATEndpointInfo
 }
@@ -93,8 +93,8 @@ func randomRequestCounter() (uint64, error) {
 
 var errorNoNatDiscoveryPort = errors.New("natt discovery port missing in endpoint")
 
-func extractNATDiscoveryPort(endpoint *v1.EndpointSpec) (int32, error) {
-	natDiscoveryPort, err := endpoint.GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
+func extractNATDiscoveryPort(endpoint *types.SubmarinerEndpoint) (int32, error) {
+	natDiscoveryPort, err := endpoint.Spec.GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
 	if err != nil {
 		return natDiscoveryPort, err
 	}
@@ -125,7 +125,7 @@ func (nd *natDiscovery) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (nd *natDiscovery) AddEndpoint(endpoint *v1.Endpoint) {
+func (nd *natDiscovery) AddEndpoint(endpoint *types.SubmarinerEndpoint) {
 	nd.Lock()
 	defer nd.Unlock()
 
@@ -145,7 +145,7 @@ func (nd *natDiscovery) AddEndpoint(endpoint *v1.Endpoint) {
 	remoteNAT := newRemoteEndpointNAT(endpoint)
 
 	// support nat discovery disabled or a remote cluster endpoint which still hasn't implemented this protocol
-	if _, err := extractNATDiscoveryPort(&endpoint.Spec); err != nil || nd.serverPort == 0 {
+	if _, err := extractNATDiscoveryPort(endpoint); err != nil || nd.serverPort == 0 {
 		if err != errorNoNatDiscoveryPort {
 			klog.Errorf("Error extracting NATT discovery port from endpoint %q: %v", endpoint.Spec.CableName, err)
 		}

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -82,7 +82,7 @@ func parseProtocolResponse(buf []byte) *natproto.SubmarinerNatDiscoveryResponse 
 	return response
 }
 
-func createTestListener(endpoint *submarinerv1.Endpoint) (*natDiscovery, chan []byte, chan *NATEndpointInfo) {
+func createTestListener(endpoint *types.SubmarinerEndpoint) (*natDiscovery, chan []byte, chan *NATEndpointInfo) {
 	listener, err := newNatDiscovery(&types.SubmarinerEndpoint{Spec: endpoint.Spec})
 	Expect(err).To(Succeed())
 
@@ -119,8 +119,8 @@ func forwardFromUDPChan(from chan []byte, addr *net.UDPAddr, to *natDiscovery, h
 	}()
 }
 
-func createTestLocalEndpoint() submarinerv1.Endpoint {
-	return submarinerv1.Endpoint{
+func createTestLocalEndpoint() types.SubmarinerEndpoint {
+	return types.SubmarinerEndpoint{
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testLocalEndpointName,
 			ClusterID:  testLocalClusterID,
@@ -134,8 +134,8 @@ func createTestLocalEndpoint() submarinerv1.Endpoint {
 	}
 }
 
-func createTestRemoteEndpoint() submarinerv1.Endpoint {
-	return submarinerv1.Endpoint{
+func createTestRemoteEndpoint() types.SubmarinerEndpoint {
+	return types.SubmarinerEndpoint{
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testRemoteEndpointName,
 			ClusterID:  testRemoteClusterID,

--- a/pkg/natdiscovery/natdiscovery_test.go
+++ b/pkg/natdiscovery/natdiscovery_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
 )
 
 var _ = When("a remote Endpoint is added", func() {
@@ -138,7 +139,7 @@ var _ = When("a remote Endpoint is added", func() {
 	})
 
 	Context("and then re-added after discovery is complete", func() {
-		var newRemoteEndpoint submarinerv1.Endpoint
+		var newRemoteEndpoint types.SubmarinerEndpoint
 
 		BeforeEach(func() {
 			t.remoteND.AddEndpoint(&t.localEndpoint)
@@ -181,7 +182,7 @@ var _ = When("a remote Endpoint is added", func() {
 	})
 
 	Context("and then re-added while discovery is in progress", func() {
-		var newRemoteEndpoint submarinerv1.Endpoint
+		var newRemoteEndpoint types.SubmarinerEndpoint
 
 		BeforeEach(func() {
 			forwardHowManyFromLocal = 0
@@ -280,11 +281,11 @@ var _ = When("a remote Endpoint is added", func() {
 type discoveryTestDriver struct {
 	localND                           *natDiscovery
 	localUDPSent                      chan []byte
-	localEndpoint                     submarinerv1.Endpoint
+	localEndpoint                     types.SubmarinerEndpoint
 	localUDPAddr                      *net.UDPAddr
 	remoteND                          *natDiscovery
 	remoteUDPSent                     chan []byte
-	remoteEndpoint                    submarinerv1.Endpoint
+	remoteEndpoint                    types.SubmarinerEndpoint
 	remoteUDPAddr                     *net.UDPAddr
 	readyChannel                      chan *NATEndpointInfo
 	oldRecheckTime                    int64

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -20,8 +20,9 @@ import (
 	"time"
 
 	"github.com/submariner-io/admiral/pkg/log"
-	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/types"
 )
 
 type endpointState int
@@ -40,7 +41,7 @@ var (
 )
 
 type remoteEndpointNAT struct {
-	endpoint               v1.Endpoint
+	endpoint               types.SubmarinerEndpoint
 	state                  endpointState
 	lastCheck              time.Time
 	lastTransition         time.Time
@@ -52,7 +53,7 @@ type remoteEndpointNAT struct {
 }
 
 type NATEndpointInfo struct {
-	Endpoint v1.Endpoint
+	Endpoint types.SubmarinerEndpoint
 	UseNAT   bool
 	UseIP    string
 }
@@ -65,7 +66,7 @@ func (rn *remoteEndpointNAT) toNATEndpointInfo() *NATEndpointInfo {
 	}
 }
 
-func newRemoteEndpointNAT(endpoint *v1.Endpoint) *remoteEndpointNAT {
+func newRemoteEndpointNAT(endpoint *types.SubmarinerEndpoint) *remoteEndpointNAT {
 	return &remoteEndpointNAT{
 		endpoint:       *endpoint,
 		state:          testingPrivateAndPublicIPs,

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -20,9 +20,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/types"
 	"google.golang.org/protobuf/proto"
 
-	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
 )
 
@@ -32,8 +32,8 @@ var _ = Describe("Request handling", func() {
 	var localUDPSent chan []byte
 	var remoteListener *natDiscovery
 	var remoteUDPSent chan []byte
-	var localEndpoint submarinerv1.Endpoint
-	var remoteEndpoint submarinerv1.Endpoint
+	var localEndpoint types.SubmarinerEndpoint
+	var remoteEndpoint types.SubmarinerEndpoint
 
 	var remoteUDPAddr net.UDPAddr
 
@@ -59,7 +59,7 @@ var _ = Describe("Request handling", func() {
 	}
 
 	requestResponseFromRemoteToLocal := func(remoteAddr *net.UDPAddr) []*natproto.SubmarinerNatDiscoveryResponse {
-		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&localEndpoint))
+		err := remoteListener.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: localEndpoint.Spec}))
 		Expect(err).NotTo(HaveOccurred())
 		return []*natproto.SubmarinerNatDiscoveryResponse{
 			parseResponseInLocalListener(awaitChan(remoteUDPSent), remoteAddr), /* Private IP request */

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -63,7 +63,7 @@ func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 }
 
 func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT, targetIP string) (uint64, error) {
-	targetPort, err := extractNATDiscoveryPort(&remoteNAT.endpoint.Spec)
+	targetPort, err := extractNATDiscoveryPort(&remoteNAT.endpoint)
 
 	if err != nil {
 		return 0, err

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -19,14 +19,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
+	"github.com/submariner-io/submariner/pkg/types"
 )
 
 var _ = When("a request is sent", func() {
 	var (
 		request        *natproto.SubmarinerNatDiscoveryRequest
-		remoteEndpoint submarinerv1.Endpoint
+		remoteEndpoint types.SubmarinerEndpoint
 		udpSent        chan []byte
 		ndInstance     *natDiscovery
 	)
@@ -43,7 +43,7 @@ var _ = When("a request is sent", func() {
 		ndInstance, udpSent, _ = createTestListener(&localEndpoint)
 		ndInstance.findSrcIP = func(_ string) string { return testLocalPrivateIP }
 
-		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&remoteEndpoint))
+		err := ndInstance.sendCheckRequest(newRemoteEndpointNAT(&types.SubmarinerEndpoint{Spec: remoteEndpoint.Spec}))
 		Expect(err).NotTo(HaveOccurred())
 
 		request = parseProtocolRequest(awaitChan(udpSent))


### PR DESCRIPTION
Reverts submariner-io/submariner#1254

Checking if this has something to do with the globalnet failures, although It seems completely unrelated in terms of changes, we have a suspiction that it could potentially be.