### PR TITLE
Add the port number to NATT discovery traces

### DIFF
--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -111,14 +111,14 @@ func (nd *natDiscovery) GetReadyChannel() chan *NATEndpointInfo {
 }
 
 func (nd *natDiscovery) Run(stopCh <-chan struct{}) error {
-	klog.V(log.DEBUG).Info("NAT starting listener")
+	klog.V(log.DEBUG).Infof("NAT discovery server starting on port %d", nd.serverPort)
 
 	if err := nd.runListener(stopCh); err != nil {
 		return err
 	}
 
 	go wait.Until(func() {
-		klog.V(log.TRACE).Info("NAT checking endpoint list")
+		klog.V(log.TRACE).Info("NAT discovery checking endpoint list")
 		nd.checkEndpointList()
 	}, time.Second, stopCh)
 

--- a/pkg/natdiscovery/request_handle.go
+++ b/pkg/natdiscovery/request_handle.go
@@ -49,8 +49,8 @@ func (nd *natDiscovery) handleRequestFromAddress(req *proto.SubmarinerNatDiscove
 		return nd.sendResponseToAddress(&response, addr)
 	}
 
-	klog.V(log.DEBUG).Infof("Received request from %s - REQUEST_NUMBER: 0x%x, SENDER: %q, RECEIVER: %q",
-		addr.IP.String(), req.RequestNumber, req.Sender.EndpointId, req.Receiver.EndpointId)
+	klog.V(log.DEBUG).Infof("Received request from %s:%d - REQUEST_NUMBER: 0x%x, SENDER: %q, RECEIVER: %q",
+		addr.IP.String(), addr.Port, req.RequestNumber, req.Sender.EndpointId, req.Receiver.EndpointId)
 
 	if req.Receiver.GetClusterId() != nd.localEndpoint.Spec.ClusterID {
 		klog.Warningf("Received NAT discovery packet for cluster %q, but we are cluster %q", req.Receiver.GetClusterId(),
@@ -106,8 +106,9 @@ func (nd *natDiscovery) sendResponseToAddress(response *proto.SubmarinerNatDisco
 		return errors.Wrapf(err, "error marshaling response %#v", response)
 	}
 
-	klog.V(log.DEBUG).Infof("Sending response to %s - REQUEST_NUMBER: 0x%x, RESPONSE: %v, SENDER: %q, RECEIVER: %q",
-		addr.IP.String(), response.RequestNumber, response.Response, response.GetSenderEndpointID(), response.GetReceiverEndpointID())
+	klog.V(log.DEBUG).Infof("Sending response to %s:%d - REQUEST_NUMBER: 0x%x, RESPONSE: %v, SENDER: %q, RECEIVER: %q",
+		addr.IP.String(), addr.Port, response.RequestNumber, response.Response, response.GetSenderEndpointID(),
+		response.GetReceiverEndpointID())
 
 	if length, err := nd.serverUDPWrite(buf, addr); err != nil {
 		return errors.Wrapf(err, "error sending response packet %#v", response)

--- a/pkg/natdiscovery/response_handle.go
+++ b/pkg/natdiscovery/response_handle.go
@@ -28,8 +28,8 @@ import (
 )
 
 func (nd *natDiscovery) handleResponseFromAddress(req *proto.SubmarinerNatDiscoveryResponse, addr *net.UDPAddr) error {
-	klog.V(log.DEBUG).Infof("Received response from %s - REQUEST_NUMBER: 0x%x, RESPONSE: %v, SENDER: %q, RECEIVER: %q",
-		addr.IP.String(), req.RequestNumber, req.Response, req.Sender.EndpointId, req.Receiver.EndpointId)
+	klog.V(log.DEBUG).Infof("Received response from %s:%d - REQUEST_NUMBER: 0x%x, RESPONSE: %v, SENDER: %q, RECEIVER: %q",
+		addr.IP.String(), addr.Port, req.RequestNumber, req.Response, req.Sender.EndpointId, req.Receiver.EndpointId)
 
 	if req.GetSender() == nil || req.GetReceiver() == nil || req.GetReceivedSrc() == nil {
 		return errors.Errorf("received malformed response %#v", req)


### PR DESCRIPTION
This is helpful when debugging multi-port environments.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
