### PR TITLE
Stop adding the endpoint PrivateIP/32 to the subnet list in libreswan

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -246,11 +246,10 @@ func (i *libreswan) GetConnections() ([]subv1.Connection, error) {
 }
 
 func extractSubnets(endpoint subv1.EndpointSpec) []string {
-	// Subnets
-	subnets := []string{endpoint.PrivateIP + "/32"}
+	subnets := make([]string, 0, len(endpoint.Subnets))
 
 	for _, subnet := range endpoint.Subnets {
-		if !strings.HasPrefix(subnet, endpoint.PrivateIP) {
+		if !strings.HasPrefix(subnet, endpoint.PrivateIP+"/") {
 			subnets = append(subnets, subnet)
 		}
 	}


### PR DESCRIPTION
This was initially introduced in this commit 2cb35578739f64de74f4395a4eb3c130c2df7aed
but it's not necessary anymore and has been verified with NAT and no-NAT
environments.

Fixes-Issue: #1253
Fixes-Issue: #1262

Although this reverts  2cb35578739f64de74f4395a4eb3c130c2df7aed functionality

I have manually verified that it works with NAT environments & that it passes all dataplane E2E:
```
[majopela@bluehat subm-demo]$ subctl show connections
Showing information for cluster "majopela-b--1618393797":
GATEWAY         CLUSTER                 REMOTE IP      NAT  CABLE DRIVER  SUBNETS                       STATUS     RTT avg.
ubuntu20        microk8s-cluster1       46.6.1.38      yes  libreswan     10.152.183.0/24, 10.1.0.0/16  connected  124.672361ms
ip-10-0-94-150  majopela-a--1618393797  3.138.186.212  yes  libreswan     172.30.0.0/16, 10.128.0.0/14  connected  303.063µs
```

```
•SSSSSS
Ran 11 of 36 Specs in 141.588 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 25 Skipped
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>