### PR TITLE
Remove clusterID param from Driver.GetActiveConnections

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -32,8 +32,8 @@ type Driver interface {
 	// Init initializes the driver with any state it needs.
 	Init() error
 
-	// GetActiveConnections returns an array of all the active connections for the given cluster.
-	GetActiveConnections(clusterID string) ([]v1.Connection, error)
+	// GetActiveConnections returns an array of all the active connections.
+	GetActiveConnections() ([]v1.Connection, error)
 
 	// GetConnections() returns an array of the existing connections, including status and endpoint info
 	GetConnections() ([]v1.Connection, error)

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -231,8 +231,8 @@ func (i *libreswan) refreshConnectionStatus() error {
 	return nil
 }
 
-// GetActiveConnections returns an array of all the active connections for the given cluster.
-func (i *libreswan) GetActiveConnections(clusterID string) ([]subv1.Connection, error) {
+// GetActiveConnections returns an array of all the active connections
+func (i *libreswan) GetActiveConnections() ([]subv1.Connection, error) {
 	return i.connections, nil
 }
 

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -348,7 +348,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint types.SubmarinerEndpoi
 	return nil
 }
 
-func (w *wireguard) GetActiveConnections(clusterID string) ([]v1.Connection, error) {
+func (w *wireguard) GetActiveConnections() ([]v1.Connection, error) {
 	// force caller to skip duplicate handling
 	return make([]v1.Connection, 0), nil
 }

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -137,7 +137,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 		delete(i.natDiscoveryPending, rnat.Endpoint.Spec.CableName)
 	}
 
-	activeConnections, err := i.driver.GetActiveConnections(endpoint.Spec.ClusterID)
+	activeConnections, err := i.driver.GetActiveConnections()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Although the cluster ID is passed to `GetActiveConnections`, the cable engine (`installCableWithNATInfo`) filters by ClusterID anyway in the subsequent loop. In turns out the latter is necessary b/c the libreswan driver does not honor the API contract and returns all Connections. Given this, we might as well just remove the cluster ID requirement from the API contract.

