### PR TITLE
Fix flaky errors with Globalnet CI jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.10.0
 	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40
 	github.com/submariner-io/admiral v0.9.0-rc0
-	github.com/submariner-io/shipyard v0.9.0-rc0
+	github.com/submariner-io/shipyard v0.9.0-rc0.0.20210428013206-a8065e7527c6
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200324154536-ceff61240acf

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0 h1:hOdN57gZTKzY0uIVGvE8X+IVpAlI5eCqAHxTe4S3kRI=
-github.com/ebay/go-ovn v0.1.1-0.20201007164241-da67e9744ec0/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
 github.com/ebay/go-ovn v0.1.1-0.20210414223409-7376ba97f8cd h1:SzLMEkeuU1V/qL2XPiDw1cMiFoVxdWCPjPjeTAN6zi0=
 github.com/ebay/go-ovn v0.1.1-0.20210414223409-7376ba97f8cd/go.mod h1:Du3Zt/R+DqyqtY5aNTd2gB9bg/igI1RR4fUj6AjmkjI=
 github.com/ebay/libovsdb v0.0.0-20190718202342-e49b8c4e1142 h1:xMG/5rkkDv9rjzbSi/pCOZ5OyKW3MhJFQ9E118xWuYU=
@@ -512,6 +510,8 @@ github.com/submariner-io/admiral v0.9.0-rc0 h1:qQRVX9YRszWxX6SoC5JoGOxM6sNHcUeXH
 github.com/submariner-io/admiral v0.9.0-rc0/go.mod h1:VgRQeLJPBadKEzsPG3kjizzHyc6qbvIbNidXzz8ikug=
 github.com/submariner-io/shipyard v0.9.0-rc0 h1:6HO5tgJ9SRzsy9WvMfsAQlOnKdqvTLIqbCiJTgarG8w=
 github.com/submariner-io/shipyard v0.9.0-rc0/go.mod h1:vDGWreRLu2VfBoR8J4UgPKJjatx8pLkj89qAgB+N0ZE=
+github.com/submariner-io/shipyard v0.9.0-rc0.0.20210428013206-a8065e7527c6 h1:4wpf6wcAkNzfjZS4qLIkYUQtH9eDneMXEBPWoQtIqQ0=
+github.com/submariner-io/shipyard v0.9.0-rc0.0.20210428013206-a8065e7527c6/go.mod h1:vDGWreRLu2VfBoR8J4UgPKJjatx8pLkj89qAgB+N0ZE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
The actual fix is made in Shipyard e2e framework via
the following PR. This PR modifies the references to
Shipyard repo.

https://github.com/submariner-io/shipyard/pull/530

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>