### PR TITLE
Fix intermittent data race failure in pinger

### DIFF
--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -52,6 +52,7 @@ type pingerInfo struct {
 	sync.Mutex
 	ip                 string
 	pingInterval       time.Duration
+	pingTimeout        time.Duration
 	maxPacketLossCount uint
 	statistics         statistics
 	failureMsg         string
@@ -63,6 +64,7 @@ func newPinger(ip string, pingInterval time.Duration, maxPacketLossCount uint) P
 	return &pingerInfo{
 		ip:                 ip,
 		pingInterval:       pingInterval,
+		pingTimeout:        pingTimeout,
 		maxPacketLossCount: maxPacketLossCount,
 		statistics: statistics{
 			size:         size,
@@ -112,7 +114,7 @@ func (p *pingerInfo) doPing() error {
 	pinger.Interval = p.pingInterval
 	pinger.SetPrivileged(privileged)
 	pinger.RecordRtts = false
-	pinger.Timeout = pingTimeout
+	pinger.Timeout = p.pingTimeout
 
 	pinger.OnSend = func(packet *ping.Packet) {
 		select {


### PR DESCRIPTION
The "_when the pinger timeout expires_" test can fail due to a data race while accessing the `pingTimeout` global. It updates `pingTimeout` in `BeforeEach` but the goroutine that reads it may still be running from the prior test. Store the global value in a pingerInfo field so the global var isn't accessed by multiple goroutines.

