### PR TITLE
Allow Gateway PublicIP to be specified by node label

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -84,6 +84,7 @@ const (
 	GatewayConfigLabelPrefix = "gateway.submariner.io/"
 	UDPPortConfig            = "udp-port"
 	NATTDiscoveryPortConfig  = "natt-discovery-port"
+	PublicIP                 = "public-ip"
 )
 
 const (
@@ -97,6 +98,7 @@ const (
 
 // ValidGatewayNodeConfig list should contain only keys that configure node specific settings via labels
 var ValidGatewayNodeConfig = []string{
+	PublicIP,
 	UDPPortConfig,
 	NATTDiscoveryPortConfig,
 }

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -70,12 +70,17 @@ func GetLocal(submSpec types.SubmarinerSpecification, privateIP string, gwNode *
 		},
 	}
 
-	publicIP, err := ipify.GetIp()
-	if err != nil {
-		return types.SubmarinerEndpoint{}, fmt.Errorf("could not determine public IP: %v", err)
-	}
+	if _, ok := endpoint.Spec.BackendConfig[submv1.PublicIP]; ok {
+		klog.Info("Using Remote IP specified by node label")
 
-	endpoint.Spec.PublicIP = publicIP
+		endpoint.Spec.PublicIP = endpoint.Spec.BackendConfig[submv1.PublicIP]
+	} else {
+		publicIP, err := ipify.GetIp()
+		if err != nil {
+			return types.SubmarinerEndpoint{}, fmt.Errorf("could not determine public IP: %v", err)
+		}
+		endpoint.Spec.PublicIP = publicIP
+	}
 
 	if !globalnetEnabled {
 		// When globalnet is enabled, HealthCheckIP will be the globalIP assigned to the Active GatewayNode.


### PR DESCRIPTION
This is my first Go contribution and I am still pretty new
to Kubernetes operators so feedback is appreciated.

In a completely disconnected environment submariner 0.9.0's ipify
connectivity requirement prevents our ability to use Submariner.

This PR allows you to specify a Gateway's PublicIP through a node
label (an idea I "borrowed" from @mangelajo in the Slack channel)
and if it is manually specified skips the call to ipify.

Related to submariner-io/submariner#1317