### PR TITLE
Create GN2.0 iptable chains in appropriate order

### DIFF
--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -66,6 +66,50 @@ func (i *Controller) initIPTableChains() error {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForPods)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForPods); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForPods, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForHeadlessSvcPods)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForHeadlessSvcPods, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForNamespace)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForNamespace); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForNamespace, err)
+	}
+
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForCluster)
+
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmGlobalnetEgressChainForCluster); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChainForCluster, err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForPods}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 2, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForHeadlessSvcPods}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 3, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForNamespace}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 4, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
+	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForCluster}
+	if err := util.InsertUnique(i.ipt, "nat", constants.SmGlobalnetEgressChain, 5, forwardToSubGlobalNetChain); err != nil {
+		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
+	}
+
 	return nil
 }
 

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -20,6 +20,12 @@ const (
 	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
 	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
 
+	// The following chains are added as part of GN 2.0 implementation
+	SmGlobalnetEgressChainForPods            = "SM-GN-EGRESS-PODS"
+	SmGlobalnetEgressChainForHeadlessSvcPods = "SM-GN-EGRESS-HDLS-PODS"
+	SmGlobalnetEgressChainForNamespace       = "SM-GN-EGRESS-NS"
+	SmGlobalnetEgressChainForCluster         = "SM-GN-EGRESS-CLUSTER"
+
 	// IPTable chains used by RouteAgent
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
 


### PR DESCRIPTION
This PR creates the necessary iptable chains in a specific order
and subsequent PRs will populate the iptable rules in the appropriate
chains.

Sample output of IPTables chains:
```
Chain SUBMARINER-GN-EGRESS (1 references)
num   pkts bytes target     prot opt in     out     source               destination         
1      950 59367 SUBMARINER-GN-MARK  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
2      950 59367 SM-GN-EGRESS-PODS  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
3      950 59367 SM-GN-EGRESS-HDLS-PODS  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
4      950 59367 SM-GN-EGRESS-NS  all  --  *      *       0.0.0.0/0            0.0.0.0/0           
5      950 59367 SM-GN-EGRESS-CLUSTER  all  --  *      *       0.0.0.0/0            0.0.0.0/0 
```

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>