### PR TITLE
Backport: Ensure that vx-submariner interface is up (#1284)

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy_iptables/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy_iptables/vxlan.go
@@ -50,6 +50,11 @@ func newVxlanIface(attrs *vxLanAttributes, activeEndPoint string) (*vxLanIface, 
 		return nil, err
 	}
 
+	// ip link set $vxLANIface up
+	if err := netlink.LinkSetUp(vxLANIface.link); err != nil {
+		return nil, fmt.Errorf("failed to bring up VxLAN interface: %v", err)
+	}
+
 	return vxLANIface, nil
 }
 


### PR DESCRIPTION
Fixes issue: https://github.com/submariner-io/submariner/issues/1275
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

(cherry picked from commit e57ecd99feb27d4a2e9e014a2db85f588d9abfa0)