### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our developer guide: https://submariner.io/development/
+2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
+3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
+4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
+5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
+6. Add labels to the PR as appropriate.
+
+This template is based on the K8s/K8s template:
+
+https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+-->


### PR DESCRIPTION
Add a template for PRs with tips and pointers to docs.

This completes a recommendation of the CII Best Practices program:

> It is SUGGESTED that this policy on adding tests (see test_policy) be
documented in the instructions for change proposals.

Depends on: https://github.com/submariner-io/submariner-website/pull/515
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>