### PR TITLE
Produce post-mortem output for all flake-finder jobs

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -27,5 +27,4 @@ jobs:
           using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }}
 
       - name: Post mortem
-        if: failure()
         uses: submariner-io/shipyard/gh-actions/post-mortem@devel


### PR DESCRIPTION
Sometimes we need to look at the log output of healthy jobs
and while it doesn't make sense (for resource reasons) to add
it all E2E runs, flake finder seems like a good place to add it.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
