### PR TITLE
IPAM ippool methods for Globalnet v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/cenk/hub v1.0.1 // indirect
 	github.com/coreos/go-iptables v0.6.0
 	github.com/ebay/go-ovn v0.1.1-0.20210414223409-7376ba97f8cd
+	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-ping/ping v0.0.0-20210407214646-e4e642a95741
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
+	github.com/psampaz/gods v1.12.0
 	github.com/submariner-io/admiral v0.9.0-rc0.0.20210506031438-f6fdcbce358a
 	github.com/submariner-io/shipyard v0.9.1-0.20210506024409-3beff067454a
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -744,6 +746,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/psampaz/gods v1.12.0 h1:JAMG9uIVsbSNR5r71skLw1w7dziOyHPRdyO/o0GMgRs=
+github.com/psampaz/gods v1.12.0/go.mod h1:d9CtHR1khiXncPVY9w+zQJtoKgbn5QHVDOsmtpuK5bI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=

--- a/pkg/globalnet/controllers/ipam/metrics.go
+++ b/pkg/globalnet/controllers/ipam/metrics.go
@@ -59,6 +59,16 @@ func RecordDeallocateGlobalIP(cidr string) {
 	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Inc()
 }
 
+func RecordAllocateGlobalIPs(cidr string, count int) {
+	globalIPsAllocatedGauge.With(prometheus.Labels{cidrLabel: cidr}).Add(float64(count))
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Sub(float64(count))
+}
+
+func RecordDeallocateGlobalIPs(cidr string, count int) {
+	globalIPsAllocatedGauge.With(prometheus.Labels{cidrLabel: cidr}).Sub(float64(count))
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Add(float64(count))
+}
+
 func RecordAvailability(cidr string, count int) {
 	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Set(float64(count))
 }


### PR DESCRIPTION
Globalnet v2 has some newer use cases for IPAM.

* `RequestIpIfAvailable` If requested IP not available, return error
* `AllocateIPBlock`: Allocate a contiguous block of IPs

Fixes #1347

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
