### PR TITLE
Backport: Implement multiple public IP resolvers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
-	github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40
 	github.com/submariner-io/admiral v0.9.0
 	github.com/submariner-io/shipyard v0.9.0
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -474,9 +474,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40 h1:31Y7UZ1yTYBU4E79CE52I/1IRi3TqiuwquXGNtZDXWs=
-github.com/rdegges/go-ipify v0.0.0-20150526035502-2d94a6a86c40/go.mod h1:j4c6zEU0eMG1oiZPUy+zD4ykX0NIpjZAEOEAviTWC18=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/main.go
+++ b/main.go
@@ -52,9 +52,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
 	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
-	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/submariner-io/submariner/pkg/util"
 )
 
 var (
@@ -110,9 +108,9 @@ func main() {
 		klog.Fatalf("Error creating submariner clientset: %s", err.Error())
 	}
 
-	localNode, err := node.GetLocalNode(cfg)
+	k8sClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		klog.Fatalf("Error getting information on the local node: %s", err.Error())
+		klog.Fatalf("Error creating Kubernetes clientset: %s", err.Error())
 	}
 
 	klog.Info("Creating the cable engine")
@@ -125,7 +123,7 @@ func main() {
 
 	submSpec.CableDriver = strings.ToLower(submSpec.CableDriver)
 
-	localEndpoint, err := endpoint.GetLocal(submSpec, util.GetLocalIP(), localNode)
+	localEndpoint, err := endpoint.GetLocal(submSpec, k8sClient)
 
 	if err != nil {
 		klog.Fatalf("Error creating local endpoint object from %#v: %v", submSpec, err)

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -84,6 +84,15 @@ const (
 	GatewayConfigLabelPrefix = "gateway.submariner.io/"
 	UDPPortConfig            = "udp-port"
 	NATTDiscoveryPortConfig  = "natt-discovery-port"
+	PublicIP                 = "public-ip"
+)
+
+// Valid PublicIP resolvers.
+const (
+	IPv4         = "ipv4" // ipv4:1.2.3.4
+	LoadBalancer = "lb"   // lb:external-gw-lb
+	API          = "api"  // api:api.ipify.org
+	DNS          = "dns"  // dns:mygateway.dns.name.com
 )
 
 // BackendConfig entries which aren't configured via labels, but exposed from the endpoints
@@ -95,6 +104,7 @@ const (
 var ValidGatewayNodeConfig = []string{
 	UDPPortConfig,
 	NATTDiscoveryPortConfig,
+	PublicIP,
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -24,17 +24,26 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/rdegges/go-ipify"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner/pkg/node"
+	"github.com/submariner-io/submariner/pkg/util"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
 )
 
-func GetLocal(submSpec types.SubmarinerSpecification, privateIP string, gwNode *v1.Node) (types.SubmarinerEndpoint, error) {
+func GetLocal(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Interface) (types.SubmarinerEndpoint, error) {
+	privateIP := util.GetLocalIP()
+
+	gwNode, err := node.GetLocalNode(k8sClient)
+	if err != nil {
+		klog.Fatalf("Error getting information on the local node: %s", err.Error())
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		return types.SubmarinerEndpoint{}, fmt.Errorf("error getting hostname: %v", err)
@@ -70,7 +79,7 @@ func GetLocal(submSpec types.SubmarinerSpecification, privateIP string, gwNode *
 		},
 	}
 
-	publicIP, err := ipify.GetIp()
+	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig)
 	if err != nil {
 		return types.SubmarinerEndpoint{}, fmt.Errorf("could not determine public IP: %v", err)
 	}

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -16,20 +16,30 @@ limitations under the License.
 package endpoint_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	endpoint "github.com/submariner-io/submariner/pkg/endpoint"
+
+	"github.com/submariner-io/submariner/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/types"
 )
 
+const testNodeName = "this-node"
+
 var _ = Describe("GetLocal", func() {
 	var submSpec types.SubmarinerSpecification
+	var client kubernetes.Interface
+	var testPrivateIP = util.GetLocalIP()
 	var node *v1.Node
+
 	const (
-		testPrivateIP       = "127.0.0.1"
 		testUDPPort         = "1111"
 		testUDPPortLabel    = "udp-port"
 		testNATTPortLabel   = "natt-discovery-port"
@@ -47,14 +57,19 @@ var _ = Describe("GetLocal", func() {
 
 		node = &v1.Node{
 			ObjectMeta: v1meta.ObjectMeta{
+				Name: testNodeName,
 				Labels: map[string]string{
 					backendConfigPrefix + testNATTPortLabel: "1234",
 					backendConfigPrefix + testUDPPortLabel:  testUDPPort,
 				}}}
+
+		client = fake.NewSimpleClientset(node)
+
+		os.Setenv("NODE_NAME", testNodeName)
 	})
 
 	It("should return a valid SubmarinerEndpoint object", func() {
-		endpoint, err := endpoint.GetLocal(submSpec, testPrivateIP, node)
+		endpoint, err := endpoint.GetLocal(submSpec, client)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(endpoint.Spec.ClusterID).To(Equal("east"))
@@ -70,7 +85,7 @@ var _ = Describe("GetLocal", func() {
 	When("no NAT discovery port label is set on the node", func() {
 		It("should return a valid SubmarinerEndpoint object", func() {
 			delete(node.Labels, testNATTPortLabel)
-			_, err := endpoint.GetLocal(submSpec, testPrivateIP, node)
+			_, err := endpoint.GetLocal(submSpec, client)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -1,0 +1,148 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+type publicIPResolverFunction func(clientset kubernetes.Interface, namespace, value string) (string, error)
+
+var publicIPMethods = map[string]publicIPResolverFunction{
+	v1.API:          publicAPI,
+	v1.IPv4:         publicIP,
+	v1.LoadBalancer: publicLoadBalancerIP,
+	v1.DNS:          publicDNSIP,
+}
+
+var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
+
+func getPublicIP(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Interface, backendConfig map[string]string) (string, error) {
+	config, ok := backendConfig[v1.PublicIP]
+	if !ok {
+		config = "api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"
+	}
+
+	resolvers := strings.Split(config, ",")
+	for _, resolver := range resolvers {
+		resolver = strings.Trim(resolver, " ")
+		parts := strings.Split(resolver, ":")
+		if len(parts) != 2 {
+			return "", errors.Errorf("invalid format for %q label: %q", v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+		}
+
+		method, ok := publicIPMethods[parts[0]]
+		if !ok {
+			return "", errors.Errorf("unknown resolver %q in %q label: %q", parts[0], v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+		}
+
+		ip, err := method(k8sClient, submSpec.Namespace, parts[1])
+		if err == nil {
+			return ip, nil
+		}
+
+		// If this resolved failed we log it, but we fall back to the next one
+		klog.Errorf("Error resolving public IP with resolver %s : %s", resolver, err.Error())
+	}
+
+	if len(resolvers) > 0 {
+		return "", errors.Errorf("Unable to resolve public IP by any of the resolver methods: %s", resolvers)
+	}
+
+	return "", nil
+}
+
+func publicAPI(clientset kubernetes.Interface, namespace, value string) (string, error) {
+	url := "https://" + value
+
+	//nolint:gosec // we really need to get from a non-predefined const URL
+	response, err := http.Get(url)
+	if err != nil {
+		return "", errors.Wrapf(err, "retrieving public IP from %s", url)
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", errors.Wrapf(err, "reading API response from %s", url)
+	}
+
+	return firstIPv4InString(string(body))
+}
+
+func publicIP(clientset kubernetes.Interface, namespace, value string) (string, error) {
+	return firstIPv4InString(value)
+}
+
+func publicLoadBalancerIP(clientset kubernetes.Interface, namespace, loadBalancerName string) (string, error) {
+	service, err := clientset.CoreV1().Services(namespace).Get(loadBalancerName, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting service %q for the public IP address", loadBalancerName)
+	}
+
+	if len(service.Status.LoadBalancer.Ingress) < 1 {
+		return "", errors.Errorf("service %q doesn't contain any LoadBalancer ingress", loadBalancerName)
+	}
+
+	ingress := service.Status.LoadBalancer.Ingress[0]
+	if ingress.IP != "" {
+		return ingress.IP, nil
+	}
+
+	if ingress.Hostname != "" {
+		ip, err := publicDNSIP(clientset, namespace, ingress.Hostname)
+		if err != nil {
+			return "", errors.Wrapf(err, "error resolving LoadBalancer ingress HostName %q", ingress.Hostname)
+		}
+
+		return ip, nil
+	}
+
+	return "", errors.Errorf("no IP or Hostname for service LoadBalancer %q Ingress", loadBalancerName)
+}
+
+func publicDNSIP(clientset kubernetes.Interface, namespace, fqdn string) (string, error) {
+	ips, err := net.LookupIP(fqdn)
+	if err != nil {
+		return "", errors.Wrapf(err, "error resolving DNS hostname %q for public IP", fqdn)
+	}
+
+	return ips[0].String(), nil
+}
+
+func firstIPv4InString(body string) (string, error) {
+	matches := IPv4RE.FindAllString(body, -1)
+	if len(matches) == 0 {
+		return "", errors.Errorf("No IPv4 found in: %q", body)
+	}
+
+	return matches[0], nil
+}

--- a/pkg/endpoint/public_ip_test.go
+++ b/pkg/endpoint/public_ip_test.go
@@ -1,0 +1,169 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package endpoint
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/submariner-io/submariner/pkg/types"
+)
+
+var _ = Describe("firstIPv4InString", func() {
+	When("the content has an IPv4", func() {
+		const testIP = "1.2.3.4"
+		const jsonIP = "{\"ip\": \"" + testIP + "\"}"
+
+		It("should return the IP", func() {
+			ip, err := firstIPv4InString(jsonIP)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+
+	When("the content doesn't have an IPv4", func() {
+		It("should result in error", func() {
+			ip, err := firstIPv4InString("no IPs here")
+			Expect(err).To(HaveOccurred())
+			Expect(ip).To(Equal(""))
+		})
+	})
+})
+
+const (
+	testServiceName = "my-loadbalancer"
+	testNamespace   = "namespace"
+)
+
+var _ = Describe("public ip resolvers", func() {
+	var submSpec types.SubmarinerSpecification
+	var backendConfig map[string]string
+
+	const (
+		publicIPConfig = "public-ip"
+		testIPDNS      = "4.3.2.1"
+		testIP         = "1.2.3.4"
+	)
+
+	BeforeEach(func() {
+		submSpec = types.SubmarinerSpecification{
+			Namespace: testNamespace,
+		}
+
+		backendConfig = map[string]string{}
+	})
+
+	When("a LoadBalancer with Ingress IP is specified", func() {
+		It("should return the IP", func() {
+			backendConfig[publicIPConfig] = "lb:" + testServiceName
+			client := fake.NewSimpleClientset(serviceWithIngress(v1.LoadBalancerIngress{Hostname: "", IP: testIP}))
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+
+	When("a LoadBalancer with Ingress hostname is specified", func() {
+		It("should return the IP", func() {
+			backendConfig[publicIPConfig] = "lb:" + testServiceName
+			client := fake.NewSimpleClientset(serviceWithIngress(v1.LoadBalancerIngress{Hostname: testIPDNS + ".nip.io",
+				IP: ""}))
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIPDNS))
+		})
+	})
+
+	When("a LoadBalancer with no ingress is specified", func() {
+		It("should return error", func() {
+			backendConfig[publicIPConfig] = "lb:" + testServiceName
+			client := fake.NewSimpleClientset(serviceWithIngress())
+			_, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("an IPv4 entry specified", func() {
+		It("should return the IP", func() {
+			backendConfig[publicIPConfig] = "ipv4:" + testIP
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+
+	When("a DNS entry specified", func() {
+		It("should return the IP", func() {
+			backendConfig[publicIPConfig] = "dns:" + testIPDNS + ".nip.io"
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIPDNS))
+		})
+	})
+
+	When("an API entry specified", func() {
+		It("should return some IP", func() {
+			backendConfig[publicIPConfig] = "api:api.ipify.org"
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(net.ParseIP(ip)).NotTo(BeNil())
+		})
+	})
+
+	When("multiple entries are specified", func() {
+		It("should return the first working one", func() {
+			backendConfig[publicIPConfig] = "ipv4:" + testIP + ",dns:" + testIPDNS + ".nip.io"
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+
+	When("multiple entries are specified and the first one doesn't succeed", func() {
+		It("should return the first working one", func() {
+			backendConfig[publicIPConfig] = "dns:thisdomaindoesntexistforsure.badbadbad,ipv4:" + testIP
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+})
+
+func serviceWithIngress(ingress ...v1.LoadBalancerIngress) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: v1meta.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testNamespace,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: ingress,
+			},
+		},
+	}
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -23,18 +23,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
-func GetLocalNode(cfg *rest.Config) (*v1.Node, error) {
+func GetLocalNode(clientset kubernetes.Interface) (*v1.Node, error) {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
 	if !ok {
 		return nil, errors.New("error reading the NODE_NAME from the environment")
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return nil, errors.Wrapf(err, "creating Kubernetes clientset")
 	}
 
 	node, err := clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})


### PR DESCRIPTION
The gateway nodes now can be labeled as:

gateway.submariner.io/public-ip=<resolver>[,resolver..]
where resolvers take the form of <method>:<parameter>

the implemented methods are:

- api
- lb
- ipv4
- dns

this commit also adds additional fallback API public-ip resolvers

In addition to https://api.ipify.org
- https://api.my-ip.io/ip
- https://ip4.seeip.org

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
(cherry picked from commit ca6d02e1efe507c209fd2d1eba2b301937daea94)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
