### PR TITLE
Allow the use of annotations to configure gateways

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -84,10 +84,10 @@ type EndpointSpec struct {
 }
 
 const (
-	GatewayConfigLabelPrefix = "gateway.submariner.io/"
-	UDPPortConfig            = "udp-port"
-	NATTDiscoveryPortConfig  = "natt-discovery-port"
-	PublicIP                 = "public-ip"
+	GatewayConfigPrefix     = "gateway.submariner.io/"
+	UDPPortConfig           = "udp-port"
+	NATTDiscoveryPortConfig = "natt-discovery-port"
+	PublicIP                = "public-ip"
 )
 
 const (

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -56,12 +56,12 @@ func getPublicIP(submSpec types.SubmarinerSpecification, k8sClient kubernetes.In
 		resolver = strings.Trim(resolver, " ")
 		parts := strings.Split(resolver, ":")
 		if len(parts) != 2 {
-			return "", errors.Errorf("invalid format for %q label: %q", v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+			return "", errors.Errorf("invalid format for %q annotation: %q", v1.GatewayConfigPrefix+v1.PublicIP, config)
 		}
 
 		method, ok := publicIPMethods[parts[0]]
 		if !ok {
-			return "", errors.Errorf("unknown resolver %q in %q label: %q", parts[0], v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+			return "", errors.Errorf("unknown resolver %q in %q annotation: %q", parts[0], v1.GatewayConfigPrefix+v1.PublicIP, config)
 		}
 
 		ip, err := method(k8sClient, submSpec.Namespace, parts[1])


### PR DESCRIPTION
Annotations will always have preference over labels, and
we should probably update the documentation to reflect the use
of annotations instead.

Fixes-Issue: #1352

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
