### PR TITLE
New IPAM for Globalnet v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenk/hub v1.0.1 // indirect
 	github.com/coreos/go-iptables v0.6.0
 	github.com/ebay/go-ovn v0.1.1-0.20210414223409-7376ba97f8cd
+	github.com/emirpasic/gods v1.12.0
 	github.com/go-ping/ping v0.0.0-20210407214646-e4e642a95741
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.2

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy0
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/ipam/ipam_suite_test.go
+++ b/pkg/ipam/ipam_suite_test.go
@@ -1,0 +1,30 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ipam_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIPAM(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IPAM Suite")
+}

--- a/pkg/ipam/ippool.go
+++ b/pkg/ipam/ippool.go
@@ -1,0 +1,210 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ipam
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"sync"
+
+	"github.com/emirpasic/gods/maps/treemap"
+)
+
+type IPPool struct {
+	cidr      string
+	net       *net.IPNet
+	size      int
+	available *treemap.Map // IntIP is the key, StringIP is value
+	sync.RWMutex
+}
+
+func NewIPPool(cidr string) (*IPPool, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+
+	ones, totalbits := network.Mask.Size()
+	size := int(math.Exp2(float64(totalbits-ones))) - 2 // don't count net and broadcast
+	if size < 2 {
+		return nil, fmt.Errorf("invalid prefix for CIDR %q", cidr)
+	}
+
+	pool := &IPPool{
+		cidr:      cidr,
+		net:       network,
+		size:      size,
+		available: treemap.NewWithIntComparator(),
+	}
+	startingIP := ipToInt(pool.net.IP) + 1
+
+	for i := 0; i < pool.size; i++ {
+		intIP := startingIP + i
+		ip := intToIP(intIP).String()
+		pool.available.Put(intIP, ip)
+	}
+
+	// TODO: RecordAvailability(cidr, size)
+
+	return pool, nil
+}
+
+func ipToInt(ip net.IP) int {
+	intIP := ip
+	if len(ip) == 16 {
+		intIP = ip[12:16]
+	}
+
+	return int(binary.BigEndian.Uint32(intIP))
+}
+
+func intToIP(ip int) net.IP {
+	netIP := make(net.IP, 4)
+	binary.BigEndian.PutUint32(netIP, uint32(ip))
+
+	return netIP
+}
+
+func StringIPToInt(stringIP string) int {
+	return ipToInt(net.ParseIP(stringIP))
+}
+
+func (p *IPPool) allocate() (string, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	iter := p.available.Iterator()
+	if !p.available.Empty() {
+		iter.Last()
+		ip := iter.Value().(string)
+		p.available.Remove(iter.Key())
+		// TODO: RecordAllocateGlobalIP(p.cidr)
+
+		return ip, nil
+	}
+
+	return "", errors.New("insufficient IPs available for allocation")
+}
+
+func (p *IPPool) Allocate(num int) ([]string, error) {
+	if p.available.Size() < num {
+		return nil, errors.New("insufficient IPs available for allocation")
+	}
+
+	ips := make([]string, num)
+
+	if num == 1 {
+		ip, err := p.allocate()
+		if err != nil {
+			return nil, err
+		}
+
+		ips[0] = ip
+
+		return ips, nil
+	}
+
+	intIPs := make([]int, num)
+	prev, current := 0, 0
+
+	p.Lock()
+	defer p.Unlock()
+
+	iter := p.available.Iterator()
+	for iter.Next() {
+		if current == num {
+			return p.allocateBlock(intIPs), nil
+		}
+
+		intIP := iter.Key().(int)
+		intIPs[current] = intIP
+		if current == 0 {
+			current++
+			continue
+		}
+
+		prevIntIP := intIPs[prev]
+		if prevIntIP+1 != intIP {
+			prev, current = 0, 0
+		} else {
+			prev = current
+			current++
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find contiguous block of %d IPs for allocation", num)
+}
+
+func (p *IPPool) Release(ips ...string) {
+	p.Lock()
+	defer p.Unlock()
+
+	for _, ip := range ips {
+		p.available.Put(StringIPToInt(ip), ip)
+	}
+}
+
+func (p *IPPool) Reserve(ips ...string) error {
+	num := len(ips)
+	intIPs := make([]int, num)
+
+	p.Lock()
+	defer p.Unlock()
+
+	for i := 0; i < num; i++ {
+		intIPs[i] = StringIPToInt(ips[i])
+		_, found := p.available.Get(intIPs[i])
+		if !found {
+			return fmt.Errorf("requested IP %s already allocated", ips[i])
+		}
+	}
+
+	for i := 0; i < num; i++ {
+		p.available.Remove(intIPs[i])
+	}
+
+	return nil
+}
+
+func (p *IPPool) IsAvailable(ip string) bool {
+	p.RLock()
+	_, result := p.available.Get(StringIPToInt(ip))
+	p.RUnlock()
+
+	return result
+}
+
+// Make sure Lock is already taken before calling this
+func (p *IPPool) allocateBlock(intIPs []int) []string {
+	num := len(intIPs)
+	ips := make([]string, num)
+
+	for i := 0; i < num; i++ {
+		ip, _ := p.available.Get(intIPs[i])
+		ips[i] = ip.(string)
+
+		p.available.Remove(intIPs[i])
+	}
+
+	// TODO: RecordAllocateGlobalIPs(p.cidr, num)
+
+	return ips
+}

--- a/pkg/ipam/ippool_test.go
+++ b/pkg/ipam/ippool_test.go
@@ -15,273 +15,346 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package ipam
+package ipam_test
 
 import (
+	"net"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner/pkg/ipam"
 )
 
-var _ = Describe("IPAM IP Pool", func() {
-	Context("Pool Creation", testPoolCreation)
-	//Context("IP Allocation", testIPAllocation)
-	//Context("IP Release", testIPRelease)
-	//Context("Block IPs", testBlockIPs)
-})
+const cidrWithSize2 = "169.254.1.0/30"
 
-const (
-	requestIP1    = "169.254.1.1"
-	service1      = "default/service1"
-	pod1          = "default/pod1"
-	pod2          = "default/pod2"
-	testCidr      = "169.254.1.1/30"
-	testBlockCidr = "169.254.1.1/28"
-	blockKey1     = "block1"
-	blockSize1    = 4
-	blockKey2     = "block2"
-	blockSize2    = 8
-)
+var _ = Describe("IP Pool creation", testPoolCreation)
+var _ = Describe("IP Pool allocation", testPoolAllocation)
+var _ = Describe("IP Pool release", testPoolRelease)
+var _ = Describe("IP Pool reserve", testPoolReserve)
+var _ = Describe("isContiguous", testIsContiguous)
 
 func testPoolCreation() {
-	When("CIDR is missing the prefix", func() {
-		It("should fail to create the IP pool with an error", func() {
-			pool, err := NewIPPool("169.254.0.0")
+	When("the CIDR is missing the prefix", func() {
+		It("should return an error", func() {
+			pool, err := ipam.NewIPPool("169.254.0.0")
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 	})
-	When("CIDR prefix is /33", func() {
-		It("should fail to create IP pool with an error", func() {
-			pool, err := NewIPPool("169.254.0.0/33")
+
+	When("the CIDR prefix is /33", func() {
+		It("should return an error", func() {
+			pool, err := ipam.NewIPPool("169.254.0.0/33")
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 	})
-	When("CIDR Prefix is /32", func() {
-		It("should fail to create IP pool with an error", func() {
-			pool, err := NewIPPool("169.254.1.0/32")
+
+	When("the CIDR Prefix is /32", func() {
+		It("should return an error", func() {
+			pool, err := ipam.NewIPPool("169.254.1.0/32")
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 	})
+
 	When("CIDR Prefix is /31", func() {
-		It("should fail to create IP pool with an error", func() {
-			pool, err := NewIPPool("169.254.1.0/31")
+		It("should return an error", func() {
+			pool, err := ipam.NewIPPool("169.254.1.0/31")
 			Expect(err).To(HaveOccurred())
 			Expect(pool).To(BeNil())
 		})
 	})
+
 	When("CIDR Prefix is /30", func() {
-		It("should create IP pool of size 2", func() {
-			pool, err := NewIPPool("169.254.1.0/30")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pool.available.Size()).Should(Equal(2))
+		It("should create the pool with size 2", func() {
+			pool, err := ipam.NewIPPool(cidrWithSize2)
+			Expect(err).To(Succeed())
+			Expect(pool.Size()).Should(Equal(2))
 		})
 	})
+
 	When("CIDR Prefix is /24", func() {
-		It("should create IP pool of size 254", func() {
-			pool, err := NewIPPool("169.254.1.0/24")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pool.available.Size()).Should(Equal(254))
+		It("should create the pool with size 254", func() {
+			pool, err := ipam.NewIPPool("169.254.1.0/24")
+			Expect(err).To(Succeed())
+			Expect(pool.Size()).Should(Equal(254))
 		})
 	})
+
 	When("CIDR Prefix is /16", func() {
-		It("should create an IP pool of size 65534", func() {
-			pool, err := NewIPPool("169.254.1.0/16")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pool.available.Size()).Should(Equal(65534))
+		It("should create the pool with size 65534", func() {
+			pool, err := ipam.NewIPPool("169.254.1.0/16")
+			Expect(err).To(Succeed())
+			Expect(pool.Size()).Should(Equal(65534))
 		})
 	})
 }
 
-//func testBlockIPs() {
-//	When("a block of IPs are allocated", testBlockIPsAllocated)
-//	When("a small contiguous block of IPs is available", testContiguousBlock)
-//}
-//
-//func testBlockIPsAllocated() {
-//	var (
-//		pool      *IPPool
-//		available int
-//		allocated int
-//		ips       []string
-//	)
-//
-//	BeforeEach(func() {
-//		var err error
-//		pool, err = NewIPPool(testBlockCidr)
-//		Expect(err).NotTo(HaveOccurred())
-//
-//		available = pool.available.Size()
-//
-//		ips, err = pool.AllocateIPBlock(blockKey1, blockSize1)
-//		Expect(err).NotTo(HaveOccurred())
-//		Expect(len(ips)).To(Equal(blockSize1))
-//	})
-//
-//	It("should decrement the available IP Pool size by blocksize", func() {
-//		Expect(available - pool.available.Size()).Should(Equal(blockSize1))
-//	})
-//
-//	It("Should return a contiguous set of IPs", func() {
-//		Expect(isContiguous(ips)).Should(BeTrue())
-//	})
-//
-//	When("any IP is requested", func() {
-//		var anyIP string
-//		BeforeEach(func() {
-//			var err error
-//
-//			anyIP, err = pool.Allocate(service1)
-//			Expect(err).NotTo(HaveOccurred())
-//		})
-//
-//		It("it should return an IP", func() {
-//			Expect(anyIP).NotTo(BeNil())
-//		})
-//		It("returned IP should not be from block of IPs allocated", func() {
-//			Expect(isIPInList(ips, anyIP)).Should(BeFalse())
-//		})
-//	})
-//
-//	When("an IP from block is requested", func() {
-//		It("it should return different IP", func() {
-//			ip, _ := pool.RequestIP(service1, ips[0])
-//			Expect(ip).To(Not(Equal(ips[0])))
-//		})
-//	})
-//
-//	When("another block of IPs is requested", func() {
-//		var (
-//			ips2 []string
-//		)
-//		BeforeEach(func() {
-//			var err error
-//
-//			ips2, err = pool.AllocateIPBlock(blockKey2, blockSize2)
-//			Expect(err).NotTo(HaveOccurred())
-//		})
-//
-//		It("should decrement the available IP Pool size by block size", func() {
-//			Expect(available - pool.available.Size()).Should(Equal(blockSize1 + blockSize2))
-//		})
-//
-//		It("should increment the allocated IP Pool size by block size", func() {
-//			Expect(len(pool.allocated) - allocated).Should(Equal(blockSize1 + blockSize2))
-//		})
-//
-//		It("should return a contiguous set of IPs", func() {
-//			Expect(isContiguous(ips2)).Should(BeTrue())
-//		})
-//
-//		It("should not overlap with previously allocated block", func() {
-//			Expect(isOverlap(ips, ips2)).Should(BeFalse())
-//		})
-//	})
-//
-//	When("block of IPs is released", func() {
-//		BeforeEach(func() {
-//			available = pool.available.Size()
-//			allocated = len(pool.allocated)
-//			pool.ReleaseIPBlock(blockKey1, blockSize1)
-//		})
-//
-//		It("should increment the available IP Pool size by block size", func() {
-//			Expect(pool.available.Size() - available).Should(Equal(blockSize1))
-//		})
-//
-//		It("should decrement the allocated IP Pool size by 1", func() {
-//			Expect(allocated - len(pool.allocated)).Should(Equal(blockSize1))
-//		})
-//	})
-//}
-//
-//func testContiguousBlock() {
-//	const svcKey = "svc"
-//	var (
-//		pool *IPPool
-//	)
-//
-//	BeforeEach(func() {
-//		var err error
-//		pool, err = NewIPPool(testBlockCidr)
-//		Expect(err).NotTo(HaveOccurred())
-//
-//		// Allocate IPs so that no contiguous block is more than blockSize1-1
-//		for i := 0; i < pool.size; i++ {
-//			if i%blockSize1 == 0 {
-//				_, err = pool.RequestIP(fmt.Sprintf("%s-%d", svcKey, i), fmt.Sprintf("169.254.1.%d", i+1))
-//				Expect(err).NotTo(HaveOccurred())
-//			}
-//		}
-//	})
-//
-//	When("any IP is requested", func() {
-//		var anyIP string
-//		BeforeEach(func() {
-//			var err error
-//
-//			anyIP, err = pool.Allocate(service1)
-//			Expect(err).NotTo(HaveOccurred())
-//		})
-//
-//		It("it should return an IP", func() {
-//			Expect(anyIP).NotTo(BeNil())
-//		})
-//	})
-//
-//	When("requesting IP Block of size greater than available contiguous block", func() {
-//		It("it should fail to allocate", func() {
-//			ips, err := pool.AllocateIPBlock(blockKey1, blockSize1)
-//			Expect(ips).To(BeNil())
-//			Expect(err).To(HaveOccurred())
-//		})
-//	})
-//
-//	When("requesting IP Block of size lesser than or equal to available contiguous block", func() {
-//		It("it should allocate", func() {
-//			ips, err := pool.AllocateIPBlock(blockKey1, blockSize1-1)
-//			Expect(err).ToNot(HaveOccurred())
-//			Expect(isContiguous(ips)).To(BeTrue())
-//		})
-//	})
-//}
-//
-//func isContiguous(ips []string) bool {
-//	size := len(ips)
-//	for prev, curr := 0, 0; curr < size; prev, curr = curr, curr+1 {
-//		if curr == 0 {
-//			continue
-//		}
-//
-//		if StringIPToInt(ips[prev])+1 != StringIPToInt(ips[curr]) {
-//			return false
-//		}
-//	}
-//
-//	return true
-//}
-//
-//func isIPInList(ips []string, ip string) bool {
-//	for _, v := range ips {
-//		if v == ip {
-//			return true
-//		}
-//	}
-//
-//	return false
-//}
-//
-//func isOverlap(list1, list2 []string) bool {
-//	result := make(map[string]bool)
-//	for _, v := range list1 {
-//		result[v] = true
-//	}
-//	for _, v := range list2 {
-//		if result[v] {
-//			return true
-//		}
-//	}
-//
-//	return false
-//}
+func testPoolAllocation() {
+	t := newTestDriver()
+
+	When("a single IP is requested", func() {
+		It("should return an IP contained in the CIDR", func() {
+			ip := t.allocate(1)[0]
+			Expect(t.network.Contains(net.ParseIP(ip))).To(BeTrue())
+			Expect(t.allocate(1)[0]).ToNot(Equal(ip))
+		})
+
+		Context("and the pool is exhausted", func() {
+			BeforeEach(func() {
+				t.cidr = cidrWithSize2
+			})
+
+			It("should return an error", func() {
+				t.allocate(1)
+				t.allocate(1)
+
+				_, err := t.pool.Allocate(1)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	When("a block is requested", func() {
+		It("should return a contiguous list of IPs contained in the CIDR", func() {
+			ips := t.allocate(10)
+			verifyContiguous(ips)
+
+			for _, ip := range ips {
+				Expect(t.network.Contains(net.ParseIP(ip))).To(BeTrue())
+			}
+		})
+
+		Context("followed by additional requests", func() {
+			It("should return unique IPs per request", func() {
+				ips := t.allocate(10)
+				ips = append(ips, t.allocate(1)...)
+
+				for i := 1; i <= 24; i++ {
+					n := t.allocate(10)
+					verifyContiguous(n)
+					ips = append(ips, n...)
+
+					if 1%10 == 0 {
+						ips = append(ips, t.allocate(1)...)
+					}
+				}
+
+				set := stringset.New()
+				for _, ip := range ips {
+					Expect(set.Add(ip)).To(BeTrue())
+				}
+			})
+		})
+
+		Context("and the pool is exhausted", func() {
+			BeforeEach(func() {
+				t.cidr = cidrWithSize2
+			})
+
+			It("should return an error", func() {
+				t.allocate(2)
+
+				_, err := t.pool.Allocate(2)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	When("a request is too large for the CIDR", func() {
+		BeforeEach(func() {
+			t.cidr = cidrWithSize2
+		})
+
+		It("should return an error", func() {
+			_, err := t.pool.Allocate(3)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the number requested is zero", func() {
+		It("should succeed", func() {
+			t.allocate(0)
+		})
+	})
+
+	When("the number requested is negative", func() {
+		It("should return an error", func() {
+			_, err := t.pool.Allocate(-1)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testPoolRelease() {
+	t := newTestDriver()
+
+	When("a single IP is released after allocation", func() {
+		BeforeEach(func() {
+			t.cidr = cidrWithSize2
+		})
+
+		It("should be available for re-allocation", func() {
+			t.allocate(1)
+			ip := t.allocate(1)[0]
+			Expect(t.pool.Release(ip)).To(Succeed())
+
+			ip2 := t.allocate(1)[0]
+			Expect(ip).To(Equal(ip2))
+		})
+	})
+
+	When("an IP block is released after allocation", func() {
+		It("should be available for re-allocation", func() {
+			t.allocate(150)
+			ips := t.allocate(50)
+
+			_, err := t.pool.Allocate(100)
+			Expect(err).To(HaveOccurred())
+
+			Expect(t.pool.Release(ips...)).To(Succeed())
+			t.allocate(100)
+		})
+	})
+
+	When("sufficient blocks are released after the pool becomes exhausted", func() {
+		Context("upon subsequent allocation", func() {
+			It("should eventually find a sufficient block", func() {
+				t.allocate(48)
+				t.allocate(2)
+				b1 := t.allocate(20) // 70
+				t.allocate(15)       // 85
+				b2 := t.allocate(5)  // 90
+				b3 := t.allocate(17) // 107
+				t.allocate(133)      // 240
+
+				Expect(t.pool.Release(b1...)).To(Succeed())
+				_, err := t.pool.Allocate(22)
+				Expect(err).To(HaveOccurred())
+
+				Expect(t.pool.Release(b2...)).To(Succeed())
+				_, err = t.pool.Allocate(22)
+				Expect(err).To(HaveOccurred())
+
+				Expect(t.pool.Release(b3...)).To(Succeed())
+				t.allocate(22)
+			})
+		})
+	})
+
+	When("an IP not in the CIDR range is released", func() {
+		It("should return and error and not return it to the pool", func() {
+			t.allocate(1)
+			Expect(t.pool.Release("169.253.1.1")).To(HaveOccurred())
+
+			ips, err := t.pool.Allocate(t.pool.Size())
+			Expect(err).To(Succeed())
+			Expect(stringset.New(ips...).Contains("169.253.1.1")).To(BeFalse())
+		})
+	})
+}
+
+func testPoolReserve() {
+	t := newTestDriver()
+
+	When("a block of IPs are available", func() {
+		It("should reserve them", func() {
+			err := t.pool.Reserve("169.254.1.1", "169.254.1.2", "169.254.1.3")
+			Expect(err).To(Succeed())
+
+			ips := t.allocate(251)
+			Expect(ips[0]).To(Equal("169.254.1.4"))
+			verifyContiguous(ips)
+		})
+	})
+
+	When("an IP isn't available", func() {
+		It("should return an error", func() {
+			ips := t.allocate(3)
+			err := t.pool.Reserve(ips...)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("an IP isn't in the CIDR range", func() {
+		It("should return an error", func() {
+			err := t.pool.Reserve("169.253.1.1")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testIsContiguous() {
+	When("contiguous", func() {
+		It("should return true", func() {
+			Expect(isContiguous([]string{"10.20.30.1", "10.20.30.2"})).To(BeTrue())
+			Expect(isContiguous([]string{"10.20.30.1", "10.20.30.2", "10.20.30.3"})).To(BeTrue())
+			Expect(isContiguous([]string{"1.2.3.255", "1.2.4.0"})).To(BeTrue())
+		})
+	})
+
+	When("not contiguous", func() {
+		It("should return false", func() {
+			Expect(isContiguous([]string{"10.20.30.1", "10.20.30.3"})).To(BeFalse())
+			Expect(isContiguous([]string{"10.20.30.2", "10.20.30.1"})).To(BeFalse())
+			Expect(isContiguous([]string{"10.20.30.1", "10.20.30.2", "10.20.30.4"})).To(BeFalse())
+			Expect(isContiguous([]string{"10.20.30.1", "10.20.31.2"})).To(BeFalse())
+			Expect(isContiguous([]string{"1.2.3.255", "1.2.4.1"})).To(BeFalse())
+		})
+	})
+}
+
+func isContiguous(ips []string) bool {
+	size := len(ips)
+	for prev, curr := 0, 0; curr < size; prev, curr = curr, curr+1 {
+		if curr == 0 {
+			continue
+		}
+
+		if ipam.StringIPToInt(ips[prev])+1 != ipam.StringIPToInt(ips[curr]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func verifyContiguous(ips []string) {
+	Expect(isContiguous(ips)).To(BeTrue(), "IPs are not contiguous: %v", ips)
+}
+
+type testDriver struct {
+	pool    *ipam.IPPool
+	cidr    string
+	network *net.IPNet
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		t.cidr = "169.254.1.0/24"
+	})
+
+	JustBeforeEach(func() {
+		var err error
+
+		_, t.network, err = net.ParseCIDR(t.cidr)
+		Expect(err).To(Succeed())
+
+		t.pool, err = ipam.NewIPPool(t.cidr)
+		Expect(err).To(Succeed())
+	})
+
+	return t
+}
+
+func (t *testDriver) allocate(num int) []string {
+	ips, err := t.pool.Allocate(num)
+	Expect(err).To(Succeed())
+	Expect(ips).To(HaveLen(num))
+
+	return ips
+}

--- a/pkg/ipam/ippool_test.go
+++ b/pkg/ipam/ippool_test.go
@@ -1,0 +1,287 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ipam
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IPAM IP Pool", func() {
+	Context("Pool Creation", testPoolCreation)
+	//Context("IP Allocation", testIPAllocation)
+	//Context("IP Release", testIPRelease)
+	//Context("Block IPs", testBlockIPs)
+})
+
+const (
+	requestIP1    = "169.254.1.1"
+	service1      = "default/service1"
+	pod1          = "default/pod1"
+	pod2          = "default/pod2"
+	testCidr      = "169.254.1.1/30"
+	testBlockCidr = "169.254.1.1/28"
+	blockKey1     = "block1"
+	blockSize1    = 4
+	blockKey2     = "block2"
+	blockSize2    = 8
+)
+
+func testPoolCreation() {
+	When("CIDR is missing the prefix", func() {
+		It("should fail to create the IP pool with an error", func() {
+			pool, err := NewIPPool("169.254.0.0")
+			Expect(err).To(HaveOccurred())
+			Expect(pool).To(BeNil())
+		})
+	})
+	When("CIDR prefix is /33", func() {
+		It("should fail to create IP pool with an error", func() {
+			pool, err := NewIPPool("169.254.0.0/33")
+			Expect(err).To(HaveOccurred())
+			Expect(pool).To(BeNil())
+		})
+	})
+	When("CIDR Prefix is /32", func() {
+		It("should fail to create IP pool with an error", func() {
+			pool, err := NewIPPool("169.254.1.0/32")
+			Expect(err).To(HaveOccurred())
+			Expect(pool).To(BeNil())
+		})
+	})
+	When("CIDR Prefix is /31", func() {
+		It("should fail to create IP pool with an error", func() {
+			pool, err := NewIPPool("169.254.1.0/31")
+			Expect(err).To(HaveOccurred())
+			Expect(pool).To(BeNil())
+		})
+	})
+	When("CIDR Prefix is /30", func() {
+		It("should create IP pool of size 2", func() {
+			pool, err := NewIPPool("169.254.1.0/30")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.available.Size()).Should(Equal(2))
+		})
+	})
+	When("CIDR Prefix is /24", func() {
+		It("should create IP pool of size 254", func() {
+			pool, err := NewIPPool("169.254.1.0/24")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.available.Size()).Should(Equal(254))
+		})
+	})
+	When("CIDR Prefix is /16", func() {
+		It("should create an IP pool of size 65534", func() {
+			pool, err := NewIPPool("169.254.1.0/16")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.available.Size()).Should(Equal(65534))
+		})
+	})
+}
+
+//func testBlockIPs() {
+//	When("a block of IPs are allocated", testBlockIPsAllocated)
+//	When("a small contiguous block of IPs is available", testContiguousBlock)
+//}
+//
+//func testBlockIPsAllocated() {
+//	var (
+//		pool      *IPPool
+//		available int
+//		allocated int
+//		ips       []string
+//	)
+//
+//	BeforeEach(func() {
+//		var err error
+//		pool, err = NewIPPool(testBlockCidr)
+//		Expect(err).NotTo(HaveOccurred())
+//
+//		available = pool.available.Size()
+//
+//		ips, err = pool.AllocateIPBlock(blockKey1, blockSize1)
+//		Expect(err).NotTo(HaveOccurred())
+//		Expect(len(ips)).To(Equal(blockSize1))
+//	})
+//
+//	It("should decrement the available IP Pool size by blocksize", func() {
+//		Expect(available - pool.available.Size()).Should(Equal(blockSize1))
+//	})
+//
+//	It("Should return a contiguous set of IPs", func() {
+//		Expect(isContiguous(ips)).Should(BeTrue())
+//	})
+//
+//	When("any IP is requested", func() {
+//		var anyIP string
+//		BeforeEach(func() {
+//			var err error
+//
+//			anyIP, err = pool.Allocate(service1)
+//			Expect(err).NotTo(HaveOccurred())
+//		})
+//
+//		It("it should return an IP", func() {
+//			Expect(anyIP).NotTo(BeNil())
+//		})
+//		It("returned IP should not be from block of IPs allocated", func() {
+//			Expect(isIPInList(ips, anyIP)).Should(BeFalse())
+//		})
+//	})
+//
+//	When("an IP from block is requested", func() {
+//		It("it should return different IP", func() {
+//			ip, _ := pool.RequestIP(service1, ips[0])
+//			Expect(ip).To(Not(Equal(ips[0])))
+//		})
+//	})
+//
+//	When("another block of IPs is requested", func() {
+//		var (
+//			ips2 []string
+//		)
+//		BeforeEach(func() {
+//			var err error
+//
+//			ips2, err = pool.AllocateIPBlock(blockKey2, blockSize2)
+//			Expect(err).NotTo(HaveOccurred())
+//		})
+//
+//		It("should decrement the available IP Pool size by block size", func() {
+//			Expect(available - pool.available.Size()).Should(Equal(blockSize1 + blockSize2))
+//		})
+//
+//		It("should increment the allocated IP Pool size by block size", func() {
+//			Expect(len(pool.allocated) - allocated).Should(Equal(blockSize1 + blockSize2))
+//		})
+//
+//		It("should return a contiguous set of IPs", func() {
+//			Expect(isContiguous(ips2)).Should(BeTrue())
+//		})
+//
+//		It("should not overlap with previously allocated block", func() {
+//			Expect(isOverlap(ips, ips2)).Should(BeFalse())
+//		})
+//	})
+//
+//	When("block of IPs is released", func() {
+//		BeforeEach(func() {
+//			available = pool.available.Size()
+//			allocated = len(pool.allocated)
+//			pool.ReleaseIPBlock(blockKey1, blockSize1)
+//		})
+//
+//		It("should increment the available IP Pool size by block size", func() {
+//			Expect(pool.available.Size() - available).Should(Equal(blockSize1))
+//		})
+//
+//		It("should decrement the allocated IP Pool size by 1", func() {
+//			Expect(allocated - len(pool.allocated)).Should(Equal(blockSize1))
+//		})
+//	})
+//}
+//
+//func testContiguousBlock() {
+//	const svcKey = "svc"
+//	var (
+//		pool *IPPool
+//	)
+//
+//	BeforeEach(func() {
+//		var err error
+//		pool, err = NewIPPool(testBlockCidr)
+//		Expect(err).NotTo(HaveOccurred())
+//
+//		// Allocate IPs so that no contiguous block is more than blockSize1-1
+//		for i := 0; i < pool.size; i++ {
+//			if i%blockSize1 == 0 {
+//				_, err = pool.RequestIP(fmt.Sprintf("%s-%d", svcKey, i), fmt.Sprintf("169.254.1.%d", i+1))
+//				Expect(err).NotTo(HaveOccurred())
+//			}
+//		}
+//	})
+//
+//	When("any IP is requested", func() {
+//		var anyIP string
+//		BeforeEach(func() {
+//			var err error
+//
+//			anyIP, err = pool.Allocate(service1)
+//			Expect(err).NotTo(HaveOccurred())
+//		})
+//
+//		It("it should return an IP", func() {
+//			Expect(anyIP).NotTo(BeNil())
+//		})
+//	})
+//
+//	When("requesting IP Block of size greater than available contiguous block", func() {
+//		It("it should fail to allocate", func() {
+//			ips, err := pool.AllocateIPBlock(blockKey1, blockSize1)
+//			Expect(ips).To(BeNil())
+//			Expect(err).To(HaveOccurred())
+//		})
+//	})
+//
+//	When("requesting IP Block of size lesser than or equal to available contiguous block", func() {
+//		It("it should allocate", func() {
+//			ips, err := pool.AllocateIPBlock(blockKey1, blockSize1-1)
+//			Expect(err).ToNot(HaveOccurred())
+//			Expect(isContiguous(ips)).To(BeTrue())
+//		})
+//	})
+//}
+//
+//func isContiguous(ips []string) bool {
+//	size := len(ips)
+//	for prev, curr := 0, 0; curr < size; prev, curr = curr, curr+1 {
+//		if curr == 0 {
+//			continue
+//		}
+//
+//		if StringIPToInt(ips[prev])+1 != StringIPToInt(ips[curr]) {
+//			return false
+//		}
+//	}
+//
+//	return true
+//}
+//
+//func isIPInList(ips []string, ip string) bool {
+//	for _, v := range ips {
+//		if v == ip {
+//			return true
+//		}
+//	}
+//
+//	return false
+//}
+//
+//func isOverlap(list1, list2 []string) bool {
+//	result := make(map[string]bool)
+//	for _, v := range list1 {
+//		result[v] = true
+//	}
+//	for _, v := range list2 {
+//		if result[v] {
+//			return true
+//		}
+//	}
+//
+//	return false
+//}


### PR DESCRIPTION
To support new use cases for IPAM introduced by Globalnet v2,
creating a newer version of IPAM that uses a sorted treemap
for IP Pool and modifies existing Allocate/Release methods
to allow allocation/release of multiple IPs.

Fixes #1347

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
