### PR TITLE
Update e2e to support globalnet 2.0 changes in future PRs

### DIFF
--- a/test/e2e/dataplane/resources.go
+++ b/test/e2e/dataplane/resources.go
@@ -1,0 +1,141 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dataplane
+
+import (
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	v1 "k8s.io/api/core/v1"
+)
+
+func VerifyDatapathConnectivity(p tcp.ConnectivityTestParams, globalnetEnabled bool) {
+	if globalnetEnabled {
+		verifyGlobalnetDatapathConnectivity(p)
+	} else {
+		tcp.RunConnectivityTest(p)
+	}
+}
+
+func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams) {
+	if p.ConnectionTimeout == 0 {
+		p.ConnectionTimeout = framework.TestContext.ConnectionTimeout
+	}
+
+	if p.ConnectionAttempts == 0 {
+		p.ConnectionAttempts = framework.TestContext.ConnectionAttempts
+	}
+
+	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP",
+		framework.TestContext.ClusterIDs[p.ToCluster]))
+
+	listenerPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:               framework.ListenerPod,
+		Cluster:            p.ToCluster,
+		Scheduling:         p.ToClusterScheduling,
+		ConnectionTimeout:  p.ConnectionTimeout,
+		ConnectionAttempts: p.ConnectionAttempts,
+	})
+
+	By(fmt.Sprintf("Pointing a ClusterIP service to the listener pod in cluster %q",
+		framework.TestContext.ClusterIDs[p.ToCluster]))
+
+	service := listenerPod.CreateService()
+	p.Framework.CreateServiceExport(p.ToCluster, service.Name)
+
+	// Wait for the globalIP annotation on the service.
+	service = p.Framework.AwaitUntilAnnotationOnService(p.ToCluster, constants.SmGlobalIP, service.Name, service.Namespace)
+	remoteIP := service.GetAnnotations()[constants.SmGlobalIP]
+
+	By(fmt.Sprintf("Creating a connector pod in cluster %q, which will attempt the specific UUID handshake over TCP",
+		framework.TestContext.ClusterIDs[p.FromCluster]))
+
+	connectorPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
+		Type:          framework.CustomPod,
+		Cluster:       p.FromCluster,
+		Scheduling:    p.FromClusterScheduling,
+		Networking:    p.Networking,
+		ContainerName: "connector-pod",
+		ImageName:     "quay.io/submariner/nettest:devel",
+		Command:       []string{"sleep", "600"},
+	})
+
+	cmd := []string{"sh", "-c", "for j in $(seq 50); do echo [dataplane] connector says " + connectorPod.Config.Data + "; done" +
+		" | for i in $(seq " + strconv.Itoa(int(p.ConnectionAttempts)) + ");" +
+		" do if nc -v " + remoteIP + " " + strconv.Itoa(connectorPod.Config.Port) + " -w " + strconv.Itoa(int(p.ConnectionTimeout)) + ";" +
+		" then break; else sleep " + strconv.Itoa(int(p.ConnectionTimeout/2)) + "; fi; done"}
+
+	stdOut, _, err := execCmdInBash(p, cmd, connectorPod.Pod)
+	Expect(err).To(BeNil())
+
+	By(fmt.Sprintf("Waiting for the listener pod %q on node %q to exit, returning what listener sent",
+		listenerPod.Pod.Name, listenerPod.Pod.Spec.NodeName))
+	listenerPod.AwaitFinish()
+	listenerPod.CheckSuccessfulFinish()
+	p.Framework.DeletePod(p.FromCluster, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
+
+	By("Verifying that the listener got the connector's data and the connector got the listener's data")
+	Expect(listenerPod.TerminationMessage).To(ContainSubstring(connectorPod.Config.Data))
+	Expect(stdOut).To(ContainSubstring(listenerPod.Config.Data))
+
+	if p.Networking == framework.PodNetworking && p.ToEndpointType == tcp.GlobalIP {
+		// When Globalnet is enabled (i.e., remoteEndpoint is a globalIP) and POD uses PodNetworking,
+		// Globalnet Controller MASQUERADEs the source-ip of the POD to the corresponding global-ip
+		// that is assigned to the POD.
+		By("Verifying the output of listener pod which must contain the globalIP of the connector POD")
+
+		podGlobalIP := connectorPod.Pod.GetAnnotations()[constants.SmGlobalIP]
+
+		Expect(podGlobalIP).ToNot(Equal(""))
+		Expect(listenerPod.TerminationMessage).To(ContainSubstring(podGlobalIP))
+	} else if p.Networking == framework.HostNetworking {
+		// when a POD is using the HostNetwork, it does not get an IPAddress from the podCIDR
+		// but it uses the HostIP. Submariner, for such PODs, would MASQUERADE the sourceIP of
+		// the outbound traffic (destined to remoteCluster) to the corresponding CNI interface
+		// ip-address on that Host and globalIP will NOT be annotated on the POD.
+		By("Verifying that globalIP annotation does not exist on the connector POD")
+		podGlobalIP := connectorPod.Pod.GetAnnotations()[constants.SmGlobalIP]
+		Expect(podGlobalIP).To(Equal(""))
+	}
+
+	p.Framework.DeleteService(p.ToCluster, service.Name)
+	p.Framework.DeleteServiceExport(p.ToCluster, service.Name)
+	p.Framework.DeletePod(p.ToCluster, listenerPod.Pod.Name, listenerPod.Pod.Namespace)
+	p.Framework.DeletePod(p.FromCluster, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
+}
+
+func execCmdInBash(p tcp.ConnectivityTestParams, cmd []string, pod *v1.Pod) (string, string, error) {
+	execOptions := framework.ExecOptions{
+		Command:            cmd,
+		Namespace:          pod.Namespace,
+		PodName:            pod.Name,
+		ContainerName:      pod.Spec.Containers[0].Name,
+		Stdin:              nil,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: true,
+	}
+
+	return p.Framework.ExecWithOptions(execOptions, p.FromCluster)
+}

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -35,7 +35,7 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				return
 			}
 
-			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+			VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,
@@ -43,7 +43,7 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				FromClusterScheduling: fromClusterScheduling,
 				ToCluster:             framework.ClusterB,
 				ToClusterScheduling:   toClusterScheduling,
-			})
+			}, framework.TestContext.GlobalnetEnabled)
 		})
 	}
 

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 )
 
 var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across overlapping clusters without discovery", func() {
@@ -35,7 +36,7 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				return
 			}
 
-			VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package dataplane
+package framework
 
 import (
 	"fmt"

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
-	"github.com/submariner-io/submariner/test/e2e/dataplane"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -79,7 +78,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 	f.AwaitGatewayFullyConnected(framework.ClusterA, activeGateway.Name)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
@@ -89,7 +88,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,
@@ -194,7 +193,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	f.AwaitSubmarinerEndpointRemoved(framework.ClusterB, submEndpoint.Name)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
@@ -204,7 +203,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	"github.com/submariner-io/submariner/test/e2e/dataplane"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -78,24 +79,24 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 	f.AwaitGatewayFullyConnected(framework.ClusterA, activeGateway.Name)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 }
 
 func AwaitNewSubmarinerGatewayPod(f *subFramework.Framework, cluster framework.ClusterIndex, prevPodUID types.UID) *v1.Pod {
@@ -193,22 +194,22 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	f.AwaitSubmarinerEndpointRemoved(framework.ClusterB, submEndpoint.Name)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 }

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	"github.com/submariner-io/submariner/test/e2e/dataplane"
 
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 )
@@ -61,22 +62,22 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	By(fmt.Sprintf("Found new route agent pod %q on node %q", newRouteAgentPod.Name, node.Name))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	})
+	}, framework.TestContext.GlobalnetEnabled)
 }

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -23,8 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
-	"github.com/submariner-io/submariner/test/e2e/dataplane"
-
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 )
 
@@ -62,7 +60,7 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	By(fmt.Sprintf("Found new route agent pod %q on node %q", newRouteAgentPod.Name, node.Name))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
@@ -72,7 +70,7 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	}, framework.TestContext.GlobalnetEnabled)
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	dataplane.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,


### PR DESCRIPTION
This PR does not modify the e2e tests as such but modifies the
way connector Pods are scheduled. This will allow us to modify
tests easily for Globalnet 2.0 use-case validation.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
