### PR TITLE
Allow the use of annotations to configure gateways

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -81,10 +81,10 @@ type EndpointSpec struct {
 }
 
 const (
-	GatewayConfigLabelPrefix = "gateway.submariner.io/"
-	UDPPortConfig            = "udp-port"
-	NATTDiscoveryPortConfig  = "natt-discovery-port"
-	PublicIP                 = "public-ip"
+	GatewayConfigPrefix     = "gateway.submariner.io/"
+	UDPPortConfig           = "udp-port"
+	NATTDiscoveryPortConfig = "natt-discovery-port"
+	PublicIP                = "public-ip"
 )
 
 // Valid PublicIP resolvers.

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -101,7 +101,7 @@ func GetLocal(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Inter
 }
 
 func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
-	backendConfig, err := getLabelsBackendConfig(nodeObj, map[string]string{})
+	backendConfig, err := getNodeBackendConfig(nodeObj)
 	if err != nil {
 		return backendConfig, err
 	}
@@ -130,21 +130,39 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 	return backendConfig, nil
 }
 
-func getLabelsBackendConfig(nodeObj *v1.Node, backendConfig map[string]string) (map[string]string, error) {
+func getNodeBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
+	backendConfig := map[string]string{}
+	if err := addConfigFrom(nodeObj.Name, nodeObj.Labels, backendConfig, ""); err != nil {
+		return backendConfig, err
+	}
+
+	if err := addConfigFrom(nodeObj.Name, nodeObj.Annotations, backendConfig,
+		"label %s=%s is overwritten by annotation with value %s"); err != nil {
+		return backendConfig, err
+	}
+
+	return backendConfig, nil
+}
+
+func addConfigFrom(nodeName string, configs, backendConfig map[string]string, warningDuplicate string) error {
 	validConfigs := stringset.New(submv1.ValidGatewayNodeConfig...)
 
-	for label, value := range nodeObj.Labels {
-		if strings.HasPrefix(label, submv1.GatewayConfigLabelPrefix) {
-			config := label[len(submv1.GatewayConfigLabelPrefix):]
+	for cfg, value := range configs {
+		if strings.HasPrefix(cfg, submv1.GatewayConfigPrefix) {
+			config := cfg[len(submv1.GatewayConfigPrefix):]
 			if !validConfigs.Contains(config) {
-				return backendConfig, errors.Errorf("unknown config label %q on node %q", nodeObj.Name, label)
+				return errors.Errorf("unknown config annotation %q on node %q", cfg, nodeName)
+			}
+
+			if oldValue, ok := backendConfig[config]; ok && warningDuplicate != "" {
+				klog.Warningf(warningDuplicate, cfg, oldValue, value)
 			}
 
 			backendConfig[config] = value
 		}
 	}
 
-	return backendConfig, nil
+	return nil
 }
 
 //TODO: to handle de-duplication of code/finding common parts with the route agent

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -55,12 +55,12 @@ func getPublicIP(submSpec types.SubmarinerSpecification, k8sClient kubernetes.In
 		resolver = strings.Trim(resolver, " ")
 		parts := strings.Split(resolver, ":")
 		if len(parts) != 2 {
-			return "", errors.Errorf("invalid format for %q label: %q", v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+			return "", errors.Errorf("invalid format for %q annotation: %q", v1.GatewayConfigPrefix+v1.PublicIP, config)
 		}
 
 		method, ok := publicIPMethods[parts[0]]
 		if !ok {
-			return "", errors.Errorf("unknown resolver %q in %q label: %q", parts[0], v1.GatewayConfigLabelPrefix+v1.PublicIP, config)
+			return "", errors.Errorf("unknown resolver %q in %q annotation: %q", parts[0], v1.GatewayConfigPrefix+v1.PublicIP, config)
 		}
 
 		ip, err := method(k8sClient, submSpec.Namespace, parts[1])


### PR DESCRIPTION
Annotations will always have preference over labels, and
we should probably update the documentation to reflect the use
of annotations instead.

Fixes-Issue: #1352

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
(cherry picked from commit 9c377062347baedce8b0493c62604aa3320581ef)
