### PR TITLE
Use update-only Federator in GN controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
-	github.com/submariner-io/admiral v0.10.0-m1
+	github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b
 	github.com/submariner-io/shipyard v0.10.0-m1
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.10.0-m1 h1:uHEnUPFUcf8hCWSrjiGJNgSwPkSM/u++iOiSo+ck4Ss=
-github.com/submariner-io/admiral v0.10.0-m1/go.mod h1:2kkQieEpnEAMHDw4e1wSKUQ5Z3ArycrfD3B6gXaSTDo=
+github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b h1:OM2iJnKPtaJjLChHcmOpM9j3tFasSVEWDKGVVYfqvn8=
+github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b/go.mod h1:oE3hQZJMvB8j9wHyLBZYmupCZK/G83z36QMgTn2vUlE=
 github.com/submariner-io/shipyard v0.10.0-m1 h1:ZpjnIaGkg0F++pFKbAgtbyfKDukimlOKiXhurrjB50w=
 github.com/submariner-io/shipyard v0.10.0-m1/go.mod h1:xzQRVCfdpFNqyRvjsj9c7/uhm1JZS0/Zce/0bt++tOg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -241,7 +241,7 @@ type GlobalEgressIPStatus struct {
 
 	// The list of allocated GlobalIPs.
 	// +optional
-	AllocatedIPs []string `json:"allocatedIPs"`
+	AllocatedIPs []string `json:"allocatedIPs,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -251,8 +251,13 @@ func awaitStatusConditions(client dynamic.ResourceInterface, name string, atInde
 		Expect(actual.Type).To(Equal(exp.Type))
 		Expect(actual.Status).To(Equal(exp.Status))
 		Expect(actual.LastTransitionTime).To(Not(BeNil()))
-		Expect(actual.Reason).To(Equal(exp.Reason))
 		Expect(actual.Message).To(Not(BeEmpty()))
+
+		if exp.Reason != "" {
+			Expect(actual.Reason).To(Equal(exp.Reason))
+		} else {
+			Expect(actual.Reason).To(Not(BeEmpty()))
+		}
 	}
 }
 

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -59,7 +59,7 @@ func NewGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool *ipam.
 		SourceClient:        config.SourceClient,
 		SourceNamespace:     corev1.NamespaceAll,
 		RestMapper:          config.RestMapper,
-		Federator:           federate.NewUpdateStatusFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll),
+		Federator:           federate.NewUpdateFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll),
 		Scheme:              config.Scheme,
 		Transform:           controller.process,
 		ResourcesEquivalent: syncer.AreSpecsEquivalent,
@@ -219,6 +219,7 @@ func allocateIPs(key string, numberOfIPs *int, pool *ipam.IPPool, status *submar
 	tryAppendStatusCondition(status, &metav1.Condition{
 		Type:    string(submarinerv1.GlobalEgressIPAllocated),
 		Status:  metav1.ConditionTrue,
+		Reason:  "Success",
 		Message: fmt.Sprintf("Allocated %d global IP(s)", *numberOfIPs),
 	})
 


### PR DESCRIPTION
- Use update-only `Federator` as the update status `Federator` was problematic.
- The `Reason` field in `metav1.Conditon` must be non-empty
- The `AllocatedIPs` field needs to specify "omitempty" as it's not required.

