### PR TITLE
Update README install docs, Helm over Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ See the [Prerequisites docs on Submariner's website](https://submariner.io/getti
 
 ## Installation
 
-Submariner supports deployment via an Operator as well as Helm Charts. The Operator can be deployed directly or via the `subctl` CLI helper
-utility. `subctl` greatly simplifies the deployment of Submariner, and is therefore the recommended deployment method.
+Submariner is deployed and manged by its Operator. The Operator can be deployed directly, or by using Submariner's Helm Charts, or by using
+Submariner's `subctl` CLI helper utility. `subctl` is the recommended deployment method because in addition to easy deployment it also
+provides testing, debugging, and bug-reporting capabilities.
 
 ### Installation using Operator via subctl
 


### PR DESCRIPTION
Refactor the README's installation docs to clarify that the Operator is
always used, even for Helm deployments. Also generally refactor install
docs summary for clarity and to mention recently-added subctl features.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
