### PR TITLE
Fix status.Conditions in Globalnet 2.0 CRDs

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -233,11 +233,7 @@ const (
 
 type GlobalEgressIPStatus struct {
 	// +optional
-	// +patchStrategy=merge
-	// +patchMergeKey=type
-	// +listType=map
-	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// The list of allocated GlobalIPs.
 	// +optional
@@ -324,11 +320,7 @@ const (
 
 type GlobalIngressIPStatus struct {
 	// +optional
-	// +patchStrategy=merge
-	// +patchMergeKey=type
-	// +listType=map
-	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// The GlobalIP allocated to this object.
 	// +optional


### PR DESCRIPTION
Using a patchStrategy of merge with key does not allow us
to append changes to the status.Conditions when the allocation
is changed. This PR fixes it.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
