### PR TITLE
Simplify error handling

### DIFF
--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -139,22 +139,13 @@ func (n *netlinkType) EnableLooseModeReversePathFilter(interfaceName string) err
 	// We won't ever create rp_filter, and its permissions are 644
 	// #nosec G306
 	err := ioutil.WriteFile("/proc/sys/net/ipv4/conf/"+interfaceName+"/rp_filter", []byte("2"), 0644)
-	if err != nil {
-		return errors.WithMessagef(err, "unable to update rp_filter proc entry for interface %q", interfaceName)
-	}
-
-	return nil
+	return errors.WithMessagef(err, "unable to update rp_filter proc entry for interface %q", interfaceName)
 }
 
 func (n *netlinkType) FlushRouteTable(tableID int) error {
 	// The conversion doesn't introduce a security problem
 	// #nosec G204
-	cmd := exec.Command("/sbin/ip", "r", "flush", "table", strconv.Itoa(tableID))
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return exec.Command("/sbin/ip", "r", "flush", "table", strconv.Itoa(tableID)).Run()
 }
 
 func (n *netlinkType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
@@ -167,9 +158,6 @@ func (n *netlinkType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
 
 	// #nosec G306
 	err = ioutil.WriteFile("/proc/sys/net/ipv4/tcp_base_mss", []byte(baseMss), 0644)
-	if err != nil {
-		return errors.WithMessagef(err, "unable to update value of tcp_base_mss to %ss", baseMss)
-	}
 
-	return nil
+	return errors.WithMessagef(err, "unable to update value of tcp_base_mss to %ss", baseMss)
 }


### PR DESCRIPTION
Remove a few cases of unnecessary nil comparisons with err
(errors.WithMessagef performs the check itself).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
