### PR TITLE
Support Globalnet EgressIPs at the cluster level

### DIFF
--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -23,9 +23,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/federate"
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/controllers/iptablesdriver"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +38,8 @@ import (
 	"k8s.io/klog"
 )
 
-func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool *ipam.IPPool) (Interface, error) {
+func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, localSubnets stringset.Interface,
+	pool *ipam.IPPool) (Interface, error) {
 	var err error
 
 	klog.Info("Creating ClusterGlobalEgressIP controller")
@@ -58,7 +62,7 @@ func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool
 	}
 
 	client := config.SourceClient.Resource(*gvr)
-	obj, err := client.Get(context.TODO(), defaultEgressIP.Name, metav1.GetOptions{})
+	_, err = client.Get(context.TODO(), defaultEgressIP.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		klog.Infof("Creating ClusterGlobalEgressIP resource %q", defaultEgressIP.Name)
 
@@ -68,13 +72,6 @@ func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool
 		}
 	} else if err != nil {
 		return nil, errors.WithMessagef(err, "error retrieving ClusterGlobalEgressIP resource %q", defaultEgressIP.Name)
-	}
-
-	if obj != nil {
-		err = controller.reserveAllocatedIPs(federator, obj)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	controller.resourceSyncer, err = syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
@@ -93,32 +90,53 @@ func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool
 		return nil, err
 	}
 
+	iptIface, err := iptablesdriver.NewIPTableInterface()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error creating the IPTablesInterface handler")
+	}
+
+	controller.iptIface = iptIface
+	controller.localSubnets = localSubnets
+
 	return controller, nil
 }
 
 func (c *clusterGlobalEgressIPController) process(from runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
 	clusterGlobalEgressIP := from.(*submarinerv1.ClusterGlobalEgressIP)
+	numberOfIPs := clusterGlobalEgressIP.Spec.NumberOfIPs
+	if numberOfIPs == nil {
+		one := 1
+		numberOfIPs = &one
+	}
 
-	klog.Infof("Processing %sd %#v", op, clusterGlobalEgressIP)
+	klog.Infof("Processing %sd for %q, Spec.NumberOfIPs: %d, Status: %#v", op, clusterGlobalEgressIP.Name,
+		*numberOfIPs, clusterGlobalEgressIP.Status)
+
+	prevStatus := clusterGlobalEgressIP.Status
+
+	if err := c.validate(numberOfIPs, clusterGlobalEgressIP); err != nil {
+		klog.Warningf("Error: %v", err)
+		return checkStatusChanged(&prevStatus, &clusterGlobalEgressIP.Status, clusterGlobalEgressIP), false
+	}
+
+	key, _ := cache.MetaNamespaceKeyFunc(clusterGlobalEgressIP)
 
 	switch op {
 	case syncer.Create:
 		prevStatus := clusterGlobalEgressIP.Status
-		requeue := c.onCreate(clusterGlobalEgressIP)
-
+		requeue := c.onCreate(key, numberOfIPs, &clusterGlobalEgressIP.Status)
 		return checkStatusChanged(&prevStatus, &clusterGlobalEgressIP.Status, clusterGlobalEgressIP), requeue
 	case syncer.Update:
-		// TODO handle update
+		requeue := c.onUpdate(key, numberOfIPs, &clusterGlobalEgressIP.Status)
+		return checkStatusChanged(&prevStatus, &clusterGlobalEgressIP.Status, clusterGlobalEgressIP), requeue
 	case syncer.Delete:
-		return nil, c.onRemove(clusterGlobalEgressIP)
+		return nil, c.onRemove(key, clusterGlobalEgressIP)
 	}
 
 	return nil, false
 }
 
-func (c *clusterGlobalEgressIPController) onCreate(egressIP *submarinerv1.ClusterGlobalEgressIP) bool {
-	key, _ := cache.MetaNamespaceKeyFunc(egressIP)
-
+func (c *clusterGlobalEgressIPController) validate(numberOfIPs *int, egressIP *submarinerv1.ClusterGlobalEgressIP) error {
 	if egressIP.Name != ClusterGlobalEgressIPName {
 		tryAppendStatusCondition(&egressIP.Status.Conditions, &metav1.Condition{
 			Type:   string(submarinerv1.GlobalEgressIPAllocated),
@@ -128,14 +146,177 @@ func (c *clusterGlobalEgressIPController) onCreate(egressIP *submarinerv1.Cluste
 				ClusterGlobalEgressIPName),
 		})
 
+		return errors.Errorf("ClusterGlobalEgressIP with name %q is not supported, only well-known"+
+			" name %q is supported", egressIP.Name, ClusterGlobalEgressIPName)
+	}
+
+	if *numberOfIPs < 0 {
+		tryAppendStatusCondition(&egressIP.Status.Conditions, &metav1.Condition{
+			Type:    string(submarinerv1.GlobalEgressIPAllocated),
+			Status:  metav1.ConditionFalse,
+			Reason:  "InvalidInput",
+			Message: "The NumberOfIPs cannot be negative",
+		})
+
+		return errors.Errorf("NumberOfIPs %q in %q cannot be less than 0", *numberOfIPs, egressIP.Name)
+	}
+
+	if *numberOfIPs == 0 {
+		tryAppendStatusCondition(&egressIP.Status.Conditions, &metav1.Condition{
+			Type:    string(submarinerv1.GlobalEgressIPAllocated),
+			Status:  metav1.ConditionFalse,
+			Reason:  "ZeroInput",
+			Message: "No global IPs to allocate",
+		})
+
+		return errors.Errorf("NumberOfIPs %q in %q cannot be 0", *numberOfIPs, egressIP.Name)
+	}
+
+	return nil
+}
+
+func (c *clusterGlobalEgressIPController) onCreate(key string, numberOfIPs *int, status *submarinerv1.GlobalEgressIPStatus) bool {
+	// When Globalnet Pod is restarted or migrated, we just have to Sync the IPPool cache and IPTable rules.
+	if *numberOfIPs == len(status.AllocatedIPs) {
+		err := c.pool.Reserve(status.AllocatedIPs...)
+		if err != nil {
+			klog.Errorf("Error allocating IPs %v for %q: %v", status.AllocatedIPs, key, err)
+			tryAppendStatusCondition(&status.Conditions, &metav1.Condition{
+				Type:    string(submarinerv1.GlobalEgressIPAllocated),
+				Status:  metav1.ConditionFalse,
+				Reason:  "IPPoolAllocationFailed",
+				Message: fmt.Sprintf("Error allocating %v global IP(s) from the pool: %v", status.AllocatedIPs, err),
+			})
+
+			return false
+		}
+
+		if err := c.programClusterGlobalEgressRules(status); err != nil {
+			_ = c.pool.Release(status.AllocatedIPs...)
+			status.AllocatedIPs = []string{}
+
+			klog.Errorf("Error syncing the IPTable rules on the node for %q: %v", key, err)
+
+			return true
+		}
+
 		return false
 	}
 
-	return allocateIPs(key, egressIP.Spec.NumberOfIPs, c.pool, &egressIP.Status)
+	return c.allocateGlobalIPs(key, numberOfIPs, status)
 }
 
-func (c *clusterGlobalEgressIPController) onRemove(egressIP *submarinerv1.ClusterGlobalEgressIP) bool { // nolint unparam
-	// TODO - remove IP table rules for the allocated IPs
+func (c *clusterGlobalEgressIPController) onUpdate(key string, numberOfIPs *int, status *submarinerv1.GlobalEgressIPStatus) bool {
+	if *numberOfIPs == len(status.AllocatedIPs) {
+		klog.V(log.DEBUG).Infof("Update called for %q, but numberOfIPs %q are already allocated", key, *numberOfIPs)
+		return false
+	}
+
+	// If numGlobalIPs is modified, delete the existing allocation.
+	if len(status.AllocatedIPs) > 0 {
+		c.flushClusterGlobalEgressRules(status)
+		_ = c.pool.Release(status.AllocatedIPs...)
+	}
+
+	return c.allocateGlobalIPs(key, numberOfIPs, status)
+}
+
+func (c *clusterGlobalEgressIPController) onRemove(key string, egressIP *submarinerv1.ClusterGlobalEgressIP) bool { // nolint unparam
+	if len(egressIP.Status.AllocatedIPs) > 0 {
+		c.flushClusterGlobalEgressRules(&egressIP.Status)
+		_ = c.pool.Release(egressIP.Status.AllocatedIPs...)
+	}
+
+	return false
+}
+
+func (c *clusterGlobalEgressIPController) flushClusterGlobalEgressRules(status *submarinerv1.GlobalEgressIPStatus) {
+	snatIP := c.getTargetSNATIPaddress(status.AllocatedIPs)
+	if snatIP == "" {
+		klog.Warning("flushClusterGlobalEgressRules called with 0 AllocatedIPs")
+		return
+	}
+
+	c.deleteClusterGlobalEgressRules(c.localSubnets.Elements(), snatIP)
+}
+
+func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPList []string, snatIP string) {
+	for _, srcIP := range srcIPList {
+		if err := c.iptIface.RemoveClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
+			klog.Errorf("Error while cleaning up ClusterEgressIPs: %v", err)
+		}
+	}
+}
+
+func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(status *submarinerv1.GlobalEgressIPStatus) error {
+	snatIP := c.getTargetSNATIPaddress(status.AllocatedIPs)
+	if snatIP == "" {
+		klog.Warning("programClusterGlobalEgressRules called with 0 AllocatedIPs")
+		return nil
+	}
+
+	egressRulesProgrammed := []string{}
+
+	for _, srcIP := range c.localSubnets.Elements() {
+		if err := c.iptIface.AddClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
+			c.deleteClusterGlobalEgressRules(egressRulesProgrammed, snatIP)
+
+			return err
+		}
+
+		egressRulesProgrammed = append(egressRulesProgrammed, srcIP)
+	}
+
+	return nil
+}
+
+func (c *clusterGlobalEgressIPController) getTargetSNATIPaddress(allocIPs []string) string {
+	var snatIP string
+
+	allocatedIPs := len(allocIPs)
+
+	if allocatedIPs == 1 {
+		snatIP = allocIPs[0]
+	} else if allocatedIPs > 1 {
+		snatIP = fmt.Sprintf("%s-%s", allocIPs[0], allocIPs[len(allocIPs)-1])
+	}
+
+	return snatIP
+}
+
+func (c *clusterGlobalEgressIPController) allocateGlobalIPs(key string, numberOfIPs *int, status *submarinerv1.GlobalEgressIPStatus) bool {
+	klog.Infof("Allocating %d global IP(s) for %q", *numberOfIPs, key)
+
+	status.AllocatedIPs = make([]string, 0, *numberOfIPs)
+
+	var err error
+	status.AllocatedIPs, err = c.pool.Allocate(*numberOfIPs)
+	if err != nil {
+		klog.Errorf("Error allocating IPs for %q: %v", key, err)
+		tryAppendStatusCondition(&status.Conditions, &metav1.Condition{
+			Type:    string(submarinerv1.GlobalEgressIPAllocated),
+			Status:  metav1.ConditionFalse,
+			Reason:  "IPPoolAllocationFailed",
+			Message: fmt.Sprintf("Error allocating %d global IP(s) from the pool: %v", numberOfIPs, err),
+		})
+
+		return true
+	}
+
+	err = c.programClusterGlobalEgressRules(status)
+	if err != nil {
+		_ = c.pool.Release(status.AllocatedIPs...)
+		status.AllocatedIPs = []string{}
+
+		return true
+	}
+
+	tryAppendStatusCondition(&status.Conditions, &metav1.Condition{
+		Type:    string(submarinerv1.GlobalEgressIPAllocated),
+		Status:  metav1.ConditionTrue,
+		Reason:  "Success",
+		Message: fmt.Sprintf("Allocated %d global IP(s)", *numberOfIPs),
+	})
 
 	return false
 }

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
@@ -74,6 +75,7 @@ type testDriverBase struct {
 	scheme                 *runtime.Scheme
 	ipt                    *fakeIPT.IPTables
 	pool                   *ipam.IPPool
+	localSubnets           stringset.Interface
 	globalCIDR             string
 	globalEgressIPs        dynamic.ResourceInterface
 	clusterGlobalEgressIPs dynamic.ResourceInterface
@@ -90,6 +92,7 @@ func newTestDriverBase() *testDriverBase {
 		scheme:     runtime.NewScheme(),
 		ipt:        fakeIPT.New(),
 		globalCIDR: localCIDR,
+		localSubnets: stringset.NewSynchronized(),
 	}
 
 	Expect(mcsv1a1.AddToScheme(t.scheme)).To(Succeed())

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -89,9 +89,9 @@ func newTestDriverBase() *testDriverBase {
 	t := &testDriverBase{
 		restMapper: test.GetRESTMapperFor(&submarinerv1.Endpoint{}, &corev1.Service{}, &corev1.Node{}, &corev1.Pod{},
 			&submarinerv1.GlobalEgressIP{}, &submarinerv1.ClusterGlobalEgressIP{}, &submarinerv1.GlobalIngressIP{}, &mcsv1a1.ServiceExport{}),
-		scheme:     runtime.NewScheme(),
-		ipt:        fakeIPT.New(),
-		globalCIDR: localCIDR,
+		scheme:       runtime.NewScheme(),
+		ipt:          fakeIPT.New(),
+		globalCIDR:   localCIDR,
 		localSubnets: stringset.NewSynchronized(),
 	}
 

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -143,9 +143,9 @@ func newGatewayMonitorTestDriver() *gatewayMonitorTestDriver {
 
 func (t *gatewayMonitorTestDriver) start() {
 	os.Setenv("NODE_NAME", nodeName)
-
 	var err error
 
+	localSubnets := []string{}
 	t.hostName, err = os.Hostname()
 	Expect(err).To(Succeed())
 
@@ -153,7 +153,7 @@ func (t *gatewayMonitorTestDriver) start() {
 		ClusterID:  clusterID,
 		Namespace:  namespace,
 		GlobalCIDR: []string{localCIDR},
-	}, watcher.Config{
+	}, localSubnets, watcher.Config{
 		RestMapper: t.restMapper,
 		Client:     t.dynClient,
 		Scheme:     t.scheme,

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -247,7 +247,7 @@ func checkStatusChanged(oldStatus, newStatus interface{}, retObj runtime.Object)
 		return nil
 	}
 
-	klog.V(log.DEBUG).Infof("Updated: %#v", newStatus)
+	klog.V(log.TRACE).Infof("Updated: %#v", newStatus)
 
 	return retObj
 }

--- a/pkg/globalnet/controllers/iptables/iface.go
+++ b/pkg/globalnet/controllers/iptables/iface.go
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package iptablesdriver
+package iptables
 
 import (
 	"fmt"
@@ -33,24 +33,24 @@ type Interface interface {
 	RemoveClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error
 }
 
-type IPTableIface struct {
+type ipTables struct {
 	ipt iptables.Interface
 }
 
-func NewIPTableInterface() (*IPTableIface, error) {
+func New() (Interface, error) {
 	iptableHandler, err := iptables.New()
 	if err != nil {
 		return nil, err
 	}
 
-	iptableIface := &IPTableIface{
+	iptableIface := &ipTables{
 		ipt: iptableHandler,
 	}
 
 	return iptableIface, nil
 }
 
-func (i *IPTableIface) AddClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
+func (i *ipTables) AddClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
 	ruleSpec := []string{"-p", "all", "-s", sourceIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", snatIP}
 	klog.V(log.DEBUG).Infof("Installing iptable egress rules for Cluster: %s", strings.Join(ruleSpec, " "))
 
@@ -61,7 +61,7 @@ func (i *IPTableIface) AddClusterEgressRules(sourceIP, snatIP, globalNetIPTableM
 	return nil
 }
 
-func (i *IPTableIface) RemoveClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
+func (i *ipTables) RemoveClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
 	ruleSpec := []string{"-p", "all", "-s", sourceIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", snatIP}
 	klog.V(log.DEBUG).Infof("Deleting iptable egress rules for Cluster: %s", strings.Join(ruleSpec, " "))
 

--- a/pkg/globalnet/controllers/iptablesdriver/iface.go
+++ b/pkg/globalnet/controllers/iptablesdriver/iface.go
@@ -1,0 +1,73 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package iptablesdriver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/iptables"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+
+	"k8s.io/klog"
+)
+
+type Interface interface {
+	AddClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error
+	RemoveClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error
+}
+
+type IPTableIface struct {
+	ipt iptables.Interface
+}
+
+func NewIPTableInterface() (*IPTableIface, error) {
+	iptableHandler, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+
+	iptableIface := &IPTableIface{
+		ipt: iptableHandler,
+	}
+
+	return iptableIface, nil
+}
+
+func (i *IPTableIface) AddClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
+	ruleSpec := []string{"-p", "all", "-s", sourceIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", snatIP}
+	klog.V(log.DEBUG).Infof("Installing iptable egress rules for Cluster: %s", strings.Join(ruleSpec, " "))
+
+	if err := i.ipt.AppendUnique("nat", constants.SmGlobalnetEgressChainForCluster, ruleSpec...); err != nil {
+		return fmt.Errorf("error appending iptables rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
+	}
+
+	return nil
+}
+
+func (i *IPTableIface) RemoveClusterEgressRules(sourceIP, snatIP, globalNetIPTableMark string) error {
+	ruleSpec := []string{"-p", "all", "-s", sourceIP, "-m", "mark", "--mark", globalNetIPTableMark, "-j", "SNAT", "--to", snatIP}
+	klog.V(log.DEBUG).Infof("Deleting iptable egress rules for Cluster: %s", strings.Join(ruleSpec, " "))
+
+	if err := i.ipt.Delete("nat", constants.SmGlobalnetEgressChainForCluster, ruleSpec...); err != nil {
+		return fmt.Errorf("error deleting iptables rule \"%s\": %v", strings.Join(ruleSpec, " "), err)
+	}
+
+	return nil
+}

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -23,7 +23,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/watcher"
-	"github.com/submariner-io/submariner/pkg/globalnet/controllers/iptablesdriver"
+	iptiface "github.com/submariner-io/submariner/pkg/globalnet/controllers/iptables"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -96,7 +96,7 @@ type podWatcher struct {
 
 type clusterGlobalEgressIPController struct {
 	*baseIPAllocationController
-	iptIface     iptablesdriver.Interface
+	iptIface     iptiface.Interface
 	localSubnets stringset.Interface
 }
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/watcher"
+	"github.com/submariner-io/submariner/pkg/globalnet/controllers/iptablesdriver"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,6 +68,7 @@ type gatewayMonitor struct {
 	isGatewayNode   bool
 	nodeName        string
 	syncMutex       sync.Mutex
+	localSubnets    stringset.Interface
 	remoteSubnets   stringset.Interface
 	controllers     []Interface
 }
@@ -94,6 +96,8 @@ type podWatcher struct {
 
 type clusterGlobalEgressIPController struct {
 	*baseIPAllocationController
+	iptIface     iptablesdriver.Interface
+	localSubnets stringset.Interface
 }
 
 type globalIngressIPController struct {


### PR DESCRIPTION
This PR includes support for ClusterGlobalEgressIPs.
Currently, the code is validated manually and using
the unit tests but will be enabled in a future PR
once the other controllers are also implemented.

Fixes issue: https://github.com/submariner-io/submariner/issues/1163
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
