### PR TITLE
Only write sysctl files if necessary

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -5,9 +5,8 @@ WORKDIR /var/submariner
 
 # iproute and iptables are used internally
 # libreswan provides IKE
-# procps-ng is needed for sysctl
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft libreswan procps-ng && \
+           iproute iptables iptables-nft libreswan && \
     dnf -y clean all
 
 COPY package/submariner.sh package/pluto bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/

--- a/package/submariner.sh
+++ b/package/submariner.sh
@@ -14,6 +14,6 @@ else
     DEBUG="-v=${SUBMARINER_VERBOSITY}"
 fi
 
-sysctl -w net.ipv4.conf.all.send_redirects=0
+[[ "$(cat /proc/sys/net/ipv4/conf/all/send_redirects)" = 0 ]] || echo 0 > /proc/sys/net/ipv4/conf/all/send_redirects
 
 exec submariner-gateway ${DEBUG} -alsologtostderr


### PR DESCRIPTION
Check sysctl values before writing them. This allows the container to
function with read-only /proc/sys as long as the values are correct on
entry.

While we’re at it, drop the procps-ng requirement by accessing the
relevant files under /proc/sys directly, instead of using sysctl (this
matches what the Go code was already doing).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
