### PR TITLE
Accept default public IP setting from environment variable

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -48,7 +48,11 @@ var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 func getPublicIP(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Interface, backendConfig map[string]string) (string, error) {
 	config, ok := backendConfig[v1.PublicIP]
 	if !ok {
-		config = "api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"
+		if submSpec.PublicIP != "" {
+			config = submSpec.PublicIP
+		} else {
+			config = "api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"
+		}
 	}
 
 	resolvers := strings.Split(config, ",")

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -39,6 +39,7 @@ type SubmarinerSpecification struct {
 	CableDriver                   string
 	ClusterID                     string
 	Namespace                     string
+	PublicIP                      string
 	Token                         string
 	Debug                         bool
 	NATEnabled                    bool


### PR DESCRIPTION
SUBMARINER_PUBLICIP is now accepted as part of the input environment
variables. This environment variable will override the default.
    
The order of preferrence for setting the public IP resolvers on a
gateway will remain as follows:
    
1) Annotation set on the gateway as gateway.submariner.io/public-ip=....
2) Environment variable passed as SUBMARINER_PUBLICIP
3) the default `"api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"`
    
Related-Issue: https://github.com/submariner-io/submariner/issues/1071
Related-Issue: https://github.com/submariner-io/submariner-operator/pull/1406
    
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
