### PR TITLE
Update Owner removal docs in governance summary

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,8 +35,10 @@ This is not meant to define Submariner's governance, but instead to document it 
   * In short, by reviewing pull requests and receiving Committer/Owner approval.
     See the [Committer Requirements](https://submariner.io/community/contributor-roles/#committer-requirements) for details.
 * How are project committers removed?
-  * Project Owners and Committers can be removed by stepping down or by two thirds vote of Project Owners, per the Submariner
-    [Contributor Roles](https://submariner.io/community/contributor-roles).
+  * Committers can be removed by stepping down or by two thirds vote of Project Owners, per the Submariner [Committer Responsibilities and
+    Privileges](https://submariner.io/community/contributor-roles/#committer-responsibilities-and-privileges). Project Owner removals are
+    currently frozen except for stepping down or for Code of Conduct violations. See the [Owner Removal and Future Elected
+    Governance](https://submariner.io/community/contributor-roles/#owner-removal-and-future-elected-governance) documentation for details.
 * If the project raises funds, who decides how this money is spent?
   * Project Owners are responsible for deciding how funds are spent, per the Submariner
     [Owner Responsibilities and Privileges](https://submariner.io/community/contributor-roles/#owner-responsibilities-and-privileges).


### PR DESCRIPTION
Update the GOVERANCE.md summary of Submariner's governance to reflect
the recent consensus regarding Project Owner removals being temporarily
frozen (to prevent hostile takeovers) until we can move to elected
governance. Point at authoritative docs on website for details.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
