### PR TITLE
Fix CODEOWNERS file to include sub-directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Auto-generated, do not edit; see CODEOWNERS.in
 * @mangelajo @Oats87 @skitt @tpantelis
 /.github/workflows/ @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
-/package/* @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
-/pkg/globalnet/* @mangelajo @Oats87 @skitt @sridhargaddam @tpantelis
-/pkg/routeagent_driver/* @mangelajo @Oats87 @skitt @sridhargaddam @tpantelis
+/package/ @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
+/pkg/globalnet/ @mangelajo @Oats87 @skitt @sridhargaddam @tpantelis
+/pkg/routeagent_driver/ @mangelajo @Oats87 @skitt @sridhargaddam @tpantelis
 /scripts/ @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
 Dockerfile.dapper @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
 Makefile* @mangelajo @mkolesnik @Oats87 @skitt @tpantelis

--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -2,5 +2,5 @@
 @Oats87 *
 @skitt *
 @tpantelis *
-@mkolesnik /.github/workflows/ /scripts/ Makefile* Dockerfile.dapper /package/*
-@sridhargaddam /pkg/globalnet/* /pkg/routeagent_driver/*
+@mkolesnik /.github/workflows/ /scripts/ Makefile* Dockerfile.dapper /package/
+@sridhargaddam /pkg/globalnet/ /pkg/routeagent_driver/


### PR DESCRIPTION
The `docs/*` pattern will match files like `docs/getting-started.md`
but not further nested files. To include all files including sub-directories,
we should be using `docs/`

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
