### PR TITLE
Follow-up to #1387

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -48,11 +48,9 @@ func NewGatewayMonitor(spec Specification, localCIDRs []string, config watcher.C
 		baseController: newBaseController(),
 		spec:           spec,
 		isGatewayNode:  false,
-		localSubnets:   stringset.NewSynchronized(),
+		localSubnets:   stringset.New(localCIDRs...).Elements(),
 		remoteSubnets:  stringset.NewSynchronized(),
 	}
-
-	gatewayMonitor.localSubnets.AddAll(localCIDRs...)
 
 	var err error
 

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Endpoint monitoring", func() {
 		})
 
 		It("should start the controllers", func() {
-			t.awaitClusterGlobalEgressIPStatusAllocated(controllers.ClusterGlobalEgressIPName, 1)
+			t.awaitClusterGlobalEgressIPStatusAllocated(1)
 
 			t.createGlobalEgressIP(newGlobalEgressIP(globalEgressIPName, nil, nil))
 			t.awaitGlobalEgressIPStatusAllocated(globalEgressIPName, 1)
@@ -71,7 +71,7 @@ var _ = Describe("Endpoint monitoring", func() {
 
 		Context("and then removed", func() {
 			JustBeforeEach(func() {
-				t.awaitClusterGlobalEgressIPStatusAllocated(controllers.ClusterGlobalEgressIPName, 1)
+				t.awaitClusterGlobalEgressIPStatusAllocated(1)
 
 				Expect(t.endpoints.Delete(context.TODO(), endpointName, metav1.DeleteOptions{})).To(Succeed())
 			})

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/submariner-io/admiral/pkg/federate"
-	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -247,7 +246,7 @@ func checkStatusChanged(oldStatus, newStatus interface{}, retObj runtime.Object)
 		return nil
 	}
 
-	klog.V(log.TRACE).Infof("Updated: %#v", newStatus)
+	klog.Infof("Updated: %#v", newStatus)
 
 	return retObj
 }

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -68,7 +68,7 @@ type gatewayMonitor struct {
 	isGatewayNode   bool
 	nodeName        string
 	syncMutex       sync.Mutex
-	localSubnets    stringset.Interface
+	localSubnets    []string
 	remoteSubnets   stringset.Interface
 	controllers     []Interface
 }
@@ -97,7 +97,7 @@ type podWatcher struct {
 type clusterGlobalEgressIPController struct {
 	*baseIPAllocationController
 	iptIface     iptiface.Interface
-	localSubnets stringset.Interface
+	localSubnets []string
 }
 
 type globalIngressIPController struct {


### PR DESCRIPTION
#1387

- Enhanced unit tests to cover more cases including updates, `NumberOfIPs` negative/zero, deletion et al
- Release the previous allocated IPs if `NumberOfIPs` is updated to 0
-  Modified `validate` to return a success/fail bool instead of error. It's a user error so we don't need to explicitly log a warning/error since we append a `Status` condition.
- Changed `localSubnets` to an array since that is effectively the way it's used and it's not intended to change.

Related to https://github.com/submariner-io/submariner/issues/1163
