### PR TITLE
Backport: Validate CIDRs before making changes to the cluster

### DIFF
--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -16,8 +16,48 @@ limitations under the License.
 package cidr
 
 import (
+	"fmt"
 	"net"
+
+	"k8s.io/klog"
 )
+
+func OverlappingSubnets(localServiceCIDRs, localPodCIDRs, remoteSubnets []string) error {
+	// If the remoteSubnets [*] overlap with local cluster Pod/Service CIDRs we
+	// should not update the IPTable rules on the host, as it will disrupt the
+	// functionality of the local cluster. So, lets validate that subnets do not
+	// overlap before we program any IPTable rules on the host for inter-cluster
+	// traffic.
+	// [*] Note: In a non-GlobalNet deployment, remoteSubnets will be a list of
+	// Pod/Service CIDRs, whereas in a GlobalNet deployment, it will be a list of
+	// globalCIDRs allocated to the clusters.
+	for _, serviceCidr := range localServiceCIDRs {
+		overlap, err := IsOverlapping(remoteSubnets, serviceCidr)
+		if err != nil {
+			// Ideally this case will never hit, as the subnets are valid CIDRs
+			klog.Warningf("unable to validate overlapping Service CIDR: %s", err)
+		}
+
+		if overlap {
+			return fmt.Errorf("local Service CIDR %q, overlaps with remote cluster subnets %s",
+				serviceCidr, remoteSubnets)
+		}
+	}
+
+	for _, podCidr := range localPodCIDRs {
+		overlap, err := IsOverlapping(remoteSubnets, podCidr)
+		if err != nil {
+			klog.Warningf("unable to validate overlapping Pod CIDR: %s", err)
+		}
+
+		if overlap {
+			return fmt.Errorf("local Pod CIDR %q, overlaps with remote cluster subnets %s",
+				podCidr, remoteSubnets)
+		}
+	}
+
+	return nil
+}
 
 func IsOverlapping(cidrList []string, cidr string) (bool, error) {
 	_, newNet, err := net.ParseCIDR(cidr)

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -90,7 +90,7 @@ func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
-	if err := kp.overlappingSubnets(endpoint.Spec.Subnets); err != nil {
+	if err := cidr.OverlappingSubnets(kp.localServiceCidr, kp.localClusterCidr, endpoint.Spec.Subnets); err != nil {
 		// Skip processing the endpoint when CIDRs overlap and return nil to avoid re-queuing.
 		klog.Errorf("overlappingSubnets for new remote %#v returned error: %v", endpoint, err)
 		return nil
@@ -140,43 +140,6 @@ func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 
 	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Delete)
 	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Delete)
-
-	return nil
-}
-
-func (kp *SyncHandler) overlappingSubnets(remoteSubnets []string) error {
-	// If the remoteSubnets [*] overlap with local cluster Pod/Service CIDRs we
-	// should not update the IPTable rules on the host, as it will disrupt the
-	// functionality of the local cluster. So, lets validate that subnets do not
-	// overlap before we program any IPTable rules on the host for inter-cluster
-	// traffic.
-	// [*] Note: In a non-GlobalNet deployment, remoteSubnets will be a list of
-	// Pod/Service CIDRs, whereas in a GlobalNet deployment, it will be a list of
-	// globalCIDRs allocated to the clusters.
-	for _, serviceCidr := range kp.localServiceCidr {
-		overlap, err := cidr.IsOverlapping(remoteSubnets, serviceCidr)
-		if err != nil {
-			// Ideally this case will never hit, as the subnets are valid CIDRs
-			klog.Warningf("unable to validate overlapping Service CIDR: %s", err)
-		}
-
-		if overlap {
-			return fmt.Errorf("local Service CIDR %q, overlaps with remote cluster subnets %s",
-				serviceCidr, remoteSubnets)
-		}
-	}
-
-	for _, podCidr := range kp.localClusterCidr {
-		overlap, err := cidr.IsOverlapping(remoteSubnets, podCidr)
-		if err != nil {
-			klog.Warningf("unable to validate overlapping Pod CIDR: %s", err)
-		}
-
-		if overlap {
-			return fmt.Errorf("local Pod CIDR %q, overlaps with remote cluster subnets %s",
-				podCidr, remoteSubnets)
-		}
-	}
 
 	return nil
 }

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	"k8s.io/klog"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -121,6 +122,12 @@ func (ovn *Handler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	if err := cidr.OverlappingSubnets(ovn.config.ServiceCidr, ovn.config.ClusterCidr, endpoint.Spec.Subnets); err != nil {
+		// Skip processing the endpoint when CIDRs overlap and return nil to avoid re-queuing.
+		klog.Errorf("overlappingSubnets for new remote %#v returned error: %v", endpoint, err)
+		return nil
+	}
+
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
 
@@ -139,6 +146,12 @@ func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 }
 
 func (ovn *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
+	if err := cidr.OverlappingSubnets(ovn.config.ServiceCidr, ovn.config.ClusterCidr, endpoint.Spec.Subnets); err != nil {
+		// Skip processing the endpoint when CIDRs overlap and return nil to avoid re-queuing.
+		klog.Errorf("overlappingSubnets for new remote %#v returned error: %v", endpoint, err)
+		return nil
+	}
+
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
 


### PR DESCRIPTION
In a non-Globalnet deployment with OVN CNI, if the remote CIDRs
overlap with the localCluster CIDRs, we should throw an appropriate
error and avoid making changes to the local cluster nodes.

Fixes Issue: https://github.com/submariner-io/submariner/issues/1399
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

(cherry picked from commit 0b2b92a0bb3712eee5e21dd114842ce670f9a86c)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
