### PR TITLE
Only use 2 clusters for testing E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
 
-override E2E_ARGS += cluster2 cluster3 cluster1
+override E2E_ARGS += cluster2 cluster1
 override UNIT_TEST_ARGS += test
 override VALIDATE_ARGS += --skip-dirs pkg/client
 

--- a/scripts/cluster_settings
+++ b/scripts/cluster_settings
@@ -1,4 +1,9 @@
 # Specific settings for the submariner E2E
+clusters=('cluster1' 'cluster2')
+
 cluster_nodes['cluster1']="control-plane worker"
 cluster_nodes['cluster2']="control-plane worker worker"
-cluster_nodes['cluster3']="control-plane worker worker"
+
+cluster_cni=( ['cluster1']="weave" ['cluster2']="weave" )
+
+cluster_subm=( ['cluster1']="true" ['cluster2']="true" )

--- a/scripts/cluster_settings.ovn
+++ b/scripts/cluster_settings.ovn
@@ -1,3 +1,10 @@
 # Specific settings for the submariner E2E with OVN CNI
 
-cluster_cni=( ['cluster1']="ovn" ['cluster2']="ovn" ['cluster3']="ovn" )
+clusters=('cluster1' 'cluster2')
+
+cluster_nodes['cluster1']="control-plane worker"
+cluster_nodes['cluster2']="control-plane worker worker"
+
+cluster_cni=( ['cluster1']="ovn" ['cluster2']="ovn" )
+
+cluster_subm=( ['cluster1']="true" ['cluster2']="true" )


### PR DESCRIPTION
Currently the E2E tests don't do any testing that requires more than 2
clusters, so this should save time for jobs on the CI.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
