### PR TITLE
Reallocate global IPs if IP pool reserve fails

### DIFF
--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -18,9 +18,16 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/submariner-io/admiral/pkg/federate"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/ipam"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
 )
 
 func newBaseController() *baseController {
@@ -50,31 +57,82 @@ func (c *baseSyncerController) Start() error {
 	return c.resourceSyncer.Start(c.stopCh)
 }
 
-// nolint unparam - 'federator' will be used
-func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Federator, obj *unstructured.Unstructured) error {
-	var err error
+func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Federator, obj *unstructured.Unstructured,
+	postReserve func(allocatedIPs []string) error) error {
+	var reservedIPs []string
+
+	clearAllocatedIPs := func() {}
 
 	ips, ok, _ := unstructured.NestedStringSlice(obj.Object, "status", "allocatedIPs")
 	if ok {
-		err = c.pool.Reserve(ips...)
-		if err != nil {
-			// TODO: null out the allocatedIPs
-			return err
+		reservedIPs = ips
+		clearAllocatedIPs = func() {
+			_ = unstructured.SetNestedStringSlice(obj.Object, []string{}, "status", "allocatedIPs")
 		}
 	} else {
-		ip, _, _ := unstructured.NestedString(obj.Object, "status", "allocatedIP")
-		if ip != "" {
-			err = c.pool.Reserve(ip)
-			if err != nil {
-				// TODO: null out the allocatedIP
-				return err
+		ip, ok, _ := unstructured.NestedString(obj.Object, "status", "allocatedIP")
+		if ok && ip != "" {
+			reservedIPs = []string{ip}
+			clearAllocatedIPs = func() {
+				_ = unstructured.SetNestedField(obj.Object, "", "status", "allocatedIP")
 			}
 		}
 	}
 
-	// if err != nil {
-	//	 TODO: call federator.Distribute to update the obj
-	// }
+	err := c.pool.Reserve(reservedIPs...)
+
+	if err == nil && len(reservedIPs) > 0 {
+		err = postReserve(reservedIPs)
+		if err != nil {
+			_ = c.pool.Release(reservedIPs...)
+		}
+	}
+
+	if err != nil {
+		key, _ := cache.MetaNamespaceKeyFunc(obj)
+
+		klog.Warningf("Could not reserve allocated GlobalIPs for %q: %v", key, err)
+
+		clearAllocatedIPs()
+
+		conditions := conditionsFromUnstructured(obj)
+
+		tryAppendStatusCondition(&conditions, &metav1.Condition{
+			Type:    string(submarinerv1.GlobalEgressIPAllocated),
+			Status:  metav1.ConditionFalse,
+			Reason:  "ReserveAllocatedIPsFailed",
+			Message: fmt.Sprintf("Error reserving the allocated global IP(s) from the pool: %v", err),
+		})
+
+		conditionsToUnstructured(conditions, obj)
+
+		klog.Infof("Updating %q: %#v", key, obj)
+
+		return federator.Distribute(obj)
+	}
 
 	return nil
+}
+
+func conditionsFromUnstructured(from *unstructured.Unstructured) []metav1.Condition {
+	rawConditions, _, _ := unstructured.NestedSlice(from.Object, "status", "conditions")
+
+	conditions := make([]metav1.Condition, len(rawConditions))
+
+	for i := range rawConditions {
+		c := &metav1.Condition{}
+		_ = runtime.DefaultUnstructuredConverter.FromUnstructured(rawConditions[i].(map[string]interface{}), c)
+		conditions[i] = *c
+	}
+
+	return conditions
+}
+
+func conditionsToUnstructured(conditions []metav1.Condition, to *unstructured.Unstructured) {
+	newConditions := make([]interface{}, len(conditions))
+	for i := range conditions {
+		newConditions[i], _ = runtime.DefaultUnstructuredConverter.ToUnstructured(&conditions[i])
+	}
+
+	_ = unstructured.SetNestedSlice(to.Object, newConditions, "status", "conditions")
 }

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -231,7 +231,6 @@ func awaitNoAllocatedIPs(client dynamic.ResourceInterface, name string) {
 	}, 200*time.Millisecond).Should(Equal(0))
 }
 
-// nolint unparam - `atIndex` always receives `0` - remove once a caller passes non-zero
 func (t *testDriverBase) awaitEgressIPStatus(client dynamic.ResourceInterface, name string, expNumIPS int, atIndex int,
 	expCond ...metav1.Condition) {
 	awaitStatusConditions(client, name, atIndex, expCond...)
@@ -255,7 +254,6 @@ func (t *testDriverBase) awaitEgressIPStatusAllocated(client dynamic.ResourceInt
 	})
 }
 
-// nolint unparam - `atIndex` always receives `0` - remove once a caller passes non-zero
 func (t *testDriverBase) awaitIngressIPStatus(name string, atIndex int, expCond ...metav1.Condition) {
 	awaitStatusConditions(t.globalIngressIPs, name, atIndex, expCond...)
 

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -64,7 +64,10 @@ func NewGlobalEgressIPController(config syncer.ResourceSyncerConfig, pool *ipam.
 	federator := federate.NewUpdateFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll)
 
 	for i := range list.Items {
-		err = controller.reserveAllocatedIPs(federator, &list.Items[i])
+		err = controller.reserveAllocatedIPs(federator, &list.Items[i], func(reservedIPs []string) error {
+			return nil // TODO
+		})
+
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/globalnet/controllers/global_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_egressip_controller_test.go
@@ -166,6 +166,11 @@ func newGlobalEgressIPControllerTestDriver() *globalEgressIPControllerTestDriver
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+
+		var err error
+
+		t.pool, err = ipam.NewIPPool(t.globalCIDR)
+		Expect(err).To(Succeed())
 	})
 
 	JustBeforeEach(func() {
@@ -181,9 +186,6 @@ func newGlobalEgressIPControllerTestDriver() *globalEgressIPControllerTestDriver
 
 func (t *globalEgressIPControllerTestDriver) start() {
 	var err error
-
-	t.pool, err = ipam.NewIPPool(t.globalCIDR)
-	Expect(err).To(Succeed())
 
 	t.controller, err = controllers.NewGlobalEgressIPController(syncer.ResourceSyncerConfig{
 		SourceClient: t.dynClient,

--- a/pkg/ipam/ippool.go
+++ b/pkg/ipam/ippool.go
@@ -174,6 +174,10 @@ func (p *IPPool) Release(ips ...string) error {
 
 func (p *IPPool) Reserve(ips ...string) error {
 	num := len(ips)
+	if num == 0 {
+		return nil
+	}
+
 	intIPs := make([]int, num)
 
 	p.Lock()


### PR DESCRIPTION
If it can't reserve the previously allocated IP(s) on  startup, likely due to global CIDR change, empty the previously allocated IP(s) and update the Status condition appropriately so the create callback will re-allocate.