### PR TITLE
Fix panic in GetKubeProxyClusterIPServiceChainName

### DIFF
--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -420,16 +420,11 @@ func newClusterIPService() *corev1.Service {
 	}
 }
 
-func newHeadlessService(name string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: corev1.ServiceSpec{
-			ClusterIP: corev1.ClusterIPNone,
-			Type:      corev1.ServiceTypeClusterIP,
-		},
-	}
+func newHeadlessService() *corev1.Service {
+	s := newClusterIPService()
+	s.Spec.ClusterIP = corev1.ClusterIPNone
+
+	return s
 }
 
 func isValidIPForCIDR(cidr, ip string) bool {

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -108,7 +108,7 @@ func (c *serviceExportController) onCreate(serviceExport *mcsv1a1.ServiceExport)
 
 	chainName, chainExists, err := c.iptIface.GetKubeProxyClusterIPServiceChainName(service, kubeProxyServiceChainPrefix)
 	if err != nil {
-		klog.Errorf("Error getting kube-proxy chain name for service %q", key)
+		klog.Errorf("Error getting kube-proxy chain name for service %q: %v", key, err)
 		return nil, true
 	}
 

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("ServiceExport controller", func() {
 
 	When("an existing headless Service is exported", func() {
 		BeforeEach(func() {
-			t.createServiceExport(t.createService(newHeadlessService(serviceName)))
+			t.createServiceExport(t.createService(newHeadlessService()))
 		})
 
 		It("should create an appropriate GlobalIngressIP", func() {


### PR DESCRIPTION
"_index out of range [0] with length 0_" - due to no `Port` in the `Service` spec. Thus occurs intermittently during the headless service test case if it runs long enough to reach the call to `GetKubeProxyClusterIPServiceChainName`. A `Service` can't be created without ports in K8s so modified the test accordingly.

