### PR TITLE
Speedup NAT detection when behind a cloud load balancer

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -88,6 +88,7 @@ const (
 	UDPPortConfig           = "udp-port"
 	NATTDiscoveryPortConfig = "natt-discovery-port"
 	PublicIP                = "public-ip"
+	UsingLoadBalancer       = "using-loadbalancer"
 )
 
 const (

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -68,6 +68,10 @@ func GetLocal(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Inter
 		return types.SubmarinerEndpoint{}, err
 	}
 
+	if strings.HasPrefix(submSpec.PublicIP, submv1.LoadBalancer+":") {
+		backendConfig[submv1.UsingLoadBalancer] = "true"
+	}
+
 	endpoint := types.SubmarinerEndpoint{
 		Spec: submv1.EndpointSpec{
 			CableName:     fmt.Sprintf("submariner-cable-%s-%s", submSpec.ClusterID, strings.ReplaceAll(privateIP, ".", "-")),


### PR DESCRIPTION
As a result of #1410, the NATT port, most of the time is not properly
exposed by the load balancer. But it's ok to assume in this case
that packets will traverse NAT.

The discovery when the other side is a load balancer backed endpoint
times out after 6 seconds, allowing 2 tries on private IP to give it
a chance. If timed out it will default to Public IP and NAT.

Related-Issue: #1410

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
