### PR TITLE
Handle IP tables errors for cluster egress and service ingress

### DIFF
--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/klog"
 )
 
+const maxRequeues = 20
+
 func newBaseController() *baseController {
 	return &baseController{
 		stopCh: make(chan struct{}),
@@ -114,6 +116,30 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 	return nil
 }
 
+func (c *baseIPAllocationController) flushRulesAndReleaseIPs(key string, numRequeues int, flushRules func(allocatedIPs []string) error,
+	allocatedIPs ...string) bool {
+	if len(allocatedIPs) == 0 {
+		return false
+	}
+
+	klog.Infof("Releasing previously allocated IPs %v for %q", allocatedIPs, key)
+
+	err := flushRules(allocatedIPs)
+	if err != nil {
+		klog.Errorf("Error flushing the IP table rules for %q: %v", key, err)
+
+		if shouldRequeue(numRequeues) {
+			return true
+		}
+	}
+
+	if err := c.pool.Release(allocatedIPs...); err != nil {
+		klog.Errorf("Error while releasing the global IPs for %q: %v", key, err)
+	}
+
+	return false
+}
+
 func conditionsFromUnstructured(from *unstructured.Unstructured) []metav1.Condition {
 	rawConditions, _, _ := unstructured.NestedSlice(from.Object, "status", "conditions")
 
@@ -135,4 +161,8 @@ func conditionsToUnstructured(conditions []metav1.Condition, to *unstructured.Un
 	}
 
 	_ = unstructured.SetNestedSlice(to.Object, newConditions, "status", "conditions")
+}
+
+func shouldRequeue(numRequeues int) bool {
+	return numRequeues < maxRequeues
 }

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -130,11 +130,11 @@ func (c *clusterGlobalEgressIPController) process(from runtime.Object, numRequeu
 			return checkStatusChanged(&prevStatus, &clusterGlobalEgressIP.Status, clusterGlobalEgressIP), false
 		}
 
-		requeue := c.onCreateOrUpdate(key, numberOfIPs, &clusterGlobalEgressIP.Status)
+		requeue := c.onCreateOrUpdate(key, numberOfIPs, &clusterGlobalEgressIP.Status, numRequeues)
 
 		return checkStatusChanged(&prevStatus, &clusterGlobalEgressIP.Status, clusterGlobalEgressIP), requeue
 	case syncer.Delete:
-		return nil, c.onRemove(clusterGlobalEgressIP)
+		return nil, c.onDelete(key, &clusterGlobalEgressIP.Status, numRequeues)
 	}
 
 	return nil, false
@@ -176,48 +176,36 @@ func (c *clusterGlobalEgressIPController) validate(numberOfIPs int, egressIP *su
 	return true
 }
 
-func (c *clusterGlobalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int, status *submarinerv1.GlobalEgressIPStatus) bool {
+func (c *clusterGlobalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int, status *submarinerv1.GlobalEgressIPStatus,
+	numRequeues int) bool {
 	if numberOfIPs == len(status.AllocatedIPs) {
 		klog.V(log.DEBUG).Infof("Update called for %q, but numberOfIPs %d are already allocated", key, numberOfIPs)
 		return false
 	}
 
-	// If numGlobalIPs is modified, delete the existing allocation.
-	if len(status.AllocatedIPs) > 0 {
-		klog.Infof("Releasing previously allocated IPs %v", status.AllocatedIPs)
-
-		c.flushClusterGlobalEgressRules(status)
-
-		if err := c.pool.Release(status.AllocatedIPs...); err != nil {
-			klog.Errorf("Error while releasing the global IPs: %v", err)
-		}
+	if requeue := c.flushRulesAndReleaseIPs(key, numRequeues, c.flushClusterGlobalEgressRules, status.AllocatedIPs...); requeue {
+		return true
 	}
 
 	return c.allocateGlobalIPs(key, numberOfIPs, status)
 }
 
-func (c *clusterGlobalEgressIPController) onRemove(egressIP *submarinerv1.ClusterGlobalEgressIP) bool {
-	if len(egressIP.Status.AllocatedIPs) > 0 {
-		c.flushClusterGlobalEgressRules(&egressIP.Status)
-
-		if err := c.pool.Release(egressIP.Status.AllocatedIPs...); err != nil {
-			klog.Errorf("Error while releasing the global IPs: %v", err)
-		}
-	}
-
-	return false
+func (c *clusterGlobalEgressIPController) onDelete(key string, status *submarinerv1.GlobalEgressIPStatus, numRequeues int) bool {
+	return c.flushRulesAndReleaseIPs(key, numRequeues, c.flushClusterGlobalEgressRules, status.AllocatedIPs...)
 }
 
-func (c *clusterGlobalEgressIPController) flushClusterGlobalEgressRules(status *submarinerv1.GlobalEgressIPStatus) {
-	c.deleteClusterGlobalEgressRules(c.localSubnets, c.getTargetSNATIPaddress(status.AllocatedIPs))
+func (c *clusterGlobalEgressIPController) flushClusterGlobalEgressRules(allocatedIPs []string) error {
+	return c.deleteClusterGlobalEgressRules(c.localSubnets, c.getTargetSNATIPaddress(allocatedIPs))
 }
 
-func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPList []string, snatIP string) {
+func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPList []string, snatIP string) error {
 	for _, srcIP := range srcIPList {
 		if err := c.iptIface.RemoveClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
-			klog.Errorf("Error while cleaning up ClusterEgressIPs: %v", err)
+			return err
 		}
 	}
+
+	return nil
 }
 
 func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(allocatedIPs []string) error {
@@ -226,7 +214,7 @@ func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(alloca
 
 	for _, srcIP := range c.localSubnets {
 		if err := c.iptIface.AddClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
-			c.deleteClusterGlobalEgressRules(egressRulesProgrammed, snatIP)
+			_ = c.deleteClusterGlobalEgressRules(egressRulesProgrammed, snatIP)
 
 			return err
 		}
@@ -276,6 +264,12 @@ func (c *clusterGlobalEgressIPController) allocateGlobalIPs(key string, numberOf
 	err = c.programClusterGlobalEgressRules(allocatedIPs)
 	if err != nil {
 		klog.Errorf("Error programming egress IP table rules for %q: %v", key, err)
+		tryAppendStatusCondition(&status.Conditions, &metav1.Condition{
+			Type:    string(submarinerv1.GlobalEgressIPAllocated),
+			Status:  metav1.ConditionFalse,
+			Reason:  "ProgramIPTableRulesFailed",
+			Message: fmt.Sprintf("Error programming egress rules: %v", err),
+		})
 
 		_ = c.pool.Release(allocatedIPs...)
 

--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -114,7 +114,7 @@ func (c *globalIngressIPController) process(from runtime.Object, numRequeues int
 
 		return checkStatusChanged(&prevStatus, &ingressIP.Status, ingressIP), requeue
 	case syncer.Delete:
-		return c.onDelete(ingressIP)
+		return nil, c.onDelete(ingressIP, numRequeues)
 	}
 
 	return nil, false
@@ -146,22 +146,24 @@ func (c *globalIngressIPController) onCreate(ingressIP *submarinerv1.GlobalIngre
 	if ingressIP.Spec.Target == submarinerv1.ClusterIPService {
 		chainName := ingressIP.GetAnnotations()[kubeProxyIPTableChainAnnotation]
 		if chainName == "" {
-			klog.Warningf("%q annotation is missing on %q", kubeProxyIPTableChainAnnotation, key)
+			_ = c.pool.Release(ips...)
 
-			if err := c.pool.Release(ips...); err != nil {
-				klog.Errorf("Error while releasing the global IPs: %v", err)
-			}
+			klog.Warningf("%q annotation is missing on %q", kubeProxyIPTableChainAnnotation, key)
 
 			return true
 		}
 
 		err = c.iptIface.AddIngressRulesForService(ips[0], chainName)
 		if err != nil {
-			klog.Errorf("Error while programming Service %q ingress rules. %v", key, err)
+			_ = c.pool.Release(ips...)
 
-			if err := c.pool.Release(ips...); err != nil {
-				klog.Errorf("Sync rules failed and error while releasing the global IPs: %v", err)
-			}
+			klog.Errorf("Error while programming Service %q ingress rules: %v", key, err)
+			tryAppendStatusCondition(&ingressIP.Status.Conditions, &metav1.Condition{
+				Type:    string(submarinerv1.GlobalEgressIPAllocated),
+				Status:  metav1.ConditionFalse,
+				Reason:  "ProgramIPTableRulesFailed",
+				Message: fmt.Sprintf("Error programming ingress rules: %v", err),
+			})
 
 			return true
 		}
@@ -179,29 +181,23 @@ func (c *globalIngressIPController) onCreate(ingressIP *submarinerv1.GlobalIngre
 	return false
 }
 
-func (c *globalIngressIPController) onDelete(ingressIP *submarinerv1.GlobalIngressIP) (runtime.Object, bool) {
+func (c *globalIngressIPController) onDelete(ingressIP *submarinerv1.GlobalIngressIP, numRequeues int) bool {
 	if ingressIP.Status.AllocatedIP == "" {
-		return nil, false
+		return false
 	}
 
 	key, _ := cache.MetaNamespaceKeyFunc(ingressIP)
 
-	if ingressIP.Spec.Target == submarinerv1.ClusterIPService {
-		chainName := ingressIP.GetAnnotations()[kubeProxyIPTableChainAnnotation]
-		if chainName != "" {
-			err := c.iptIface.RemoveIngressRulesForService(ingressIP.Status.AllocatedIP, chainName)
-			if err != nil {
-				klog.Errorf("Error while deleting Service %q ingress rules. %v", key, err)
+	return c.flushRulesAndReleaseIPs(key, numRequeues, func(allocatedIPs []string) error {
+		if ingressIP.Spec.Target == submarinerv1.ClusterIPService {
+			chainName := ingressIP.GetAnnotations()[kubeProxyIPTableChainAnnotation]
+			if chainName != "" {
+				return c.iptIface.RemoveIngressRulesForService(ingressIP.Status.AllocatedIP, chainName)
+			} else {
+				klog.Warningf("%q annotation is missing on %q", kubeProxyIPTableChainAnnotation, key)
 			}
-		} else {
-			klog.Warningf("%q annotation is missing on %q", kubeProxyIPTableChainAnnotation, key)
 		}
-	}
 
-	err := c.pool.Release(ingressIP.Status.AllocatedIP)
-	if err != nil {
-		klog.Errorf("Error releasing IP %s for GlobalIngressIP %q", ingressIP.Status.AllocatedIP, key)
-	}
-
-	return ingressIP, false
+		return nil
+	}, ingressIP.Status.AllocatedIP)
 }

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -74,6 +74,25 @@ var _ = Describe("GlobalIngressIP controller", func() {
 			})
 		})
 
+		Context("and programming of IP tables initially fails", func() {
+			BeforeEach(func() {
+				t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(kubeProxyIPTableChainName))
+			})
+
+			It("should eventually allocate a global IP", func() {
+				awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
+					Type:   string(submarinerv1.GlobalEgressIPAllocated),
+					Status: metav1.ConditionFalse,
+					Reason: "ProgramIPTableRulesFailed",
+				}, metav1.Condition{
+					Type:   string(submarinerv1.GlobalEgressIPAllocated),
+					Status: metav1.ConditionTrue,
+				})
+
+				t.awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
+			})
+		})
+
 		Context("and then removed", func() {
 			var allocatedIP string
 
@@ -87,6 +106,17 @@ var _ = Describe("GlobalIngressIP controller", func() {
 			It("should release the allocated global IP", func() {
 				t.awaitIPsReleasedFromPool(allocatedIP)
 				t.awaitNoIPTableRules(allocatedIP)
+			})
+
+			Context("and cleanup of IP tables initially fails", func() {
+				BeforeEach(func() {
+					t.ipt.AddFailOnDeleteRuleMatcher(ContainSubstring(kubeProxyIPTableChainName))
+				})
+
+				It("should eventually cleanup the IP tables and reallocate", func() {
+					t.awaitIPsReleasedFromPool(allocatedIP)
+					t.awaitNoIPTableRules(allocatedIP)
+				})
 			})
 		})
 	})
@@ -133,7 +163,7 @@ var _ = Describe("GlobalIngressIP controller", func() {
 				t.verifyIPsReservedInPool(t.getGlobalIngressIPStatus(existing.Name).AllocatedIP)
 			})
 
-			It("should program the relevant iptable rules", func() {
+			It("should program the relevant IP table rules", func() {
 				t.awaitIPTableRules(existing.Status.AllocatedIP)
 			})
 
@@ -156,6 +186,28 @@ var _ = Describe("GlobalIngressIP controller", func() {
 					t.awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
 				})
 			})
+
+			Context("and programming the IP table rules fails", func() {
+				BeforeEach(func() {
+					t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(existing.Status.AllocatedIP))
+				})
+
+				It("should reallocate the global IP", func() {
+					t.awaitIngressIPStatus(globalIngressIPName, 0,
+						metav1.Condition{
+							Type:   string(submarinerv1.GlobalEgressIPAllocated),
+							Status: metav1.ConditionFalse,
+							Reason: "ReserveAllocatedIPsFailed",
+						}, metav1.Condition{
+							Type:   string(submarinerv1.GlobalEgressIPAllocated),
+							Status: metav1.ConditionTrue,
+						})
+
+					allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
+					t.awaitIPTableRules(allocatedIP)
+					t.awaitIPsReleasedFromPool(existing.Status.AllocatedIP)
+				})
+			})
 		})
 
 		Context("without an allocated IP", func() {
@@ -163,7 +215,7 @@ var _ = Describe("GlobalIngressIP controller", func() {
 				t.createGlobalIngressIP(existing)
 			})
 
-			It("should allocate it and program the relevant iptable rules", func() {
+			It("should allocate it and program the relevant IP table rules", func() {
 				t.awaitIngressIPStatusAllocated(globalIngressIPName)
 				t.awaitIPTableRules(existing.Status.AllocatedIP)
 			})


### PR DESCRIPTION
Re-queue on IP tables failure. For delete, cap it to 20 retries. Added unit test cases to cover the various scenarios. 

See the individual commits for details.