### PR TITLE
Enable GN2.0 controllers and validate e2e clusteregress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/submariner-io/admiral v0.10.0-m2
-	github.com/submariner-io/shipyard v0.10.0-m2
+	github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718
 	github.com/uw-labs/lichen v0.1.4
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,9 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.10.0-m2 h1:udiPxHOZSxhi0xnLcFqUfb5vmqIKSyTX+PQPVU0nOB8=
 github.com/submariner-io/admiral v0.10.0-m2/go.mod h1:UP2oUxGyHdcixfPXI/1JMaASI38ILSyytb1b+pn/ru8=
-github.com/submariner-io/shipyard v0.10.0-m2 h1:ZE1x6FW2I21O+koM/FTuj8RuZtB4kzevasuZJSlEEj4=
 github.com/submariner-io/shipyard v0.10.0-m2/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
+github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718 h1:aJEWCnTiw22tf8KQI8kjkUv4aq91aVkhppAmsMRQ0dE=
+github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This PR enables the new Globalnet 2.0 controllers and also
validates the e2e tests for cluster level egressIPs.

Depends on https://github.com/submariner-io/shipyard/pull/587

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
