### PR TITLE
Move globalnet constants to separate package

### DIFF
--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 )
 
 func (d *DatastoreSyncer) handleCreateOrUpdateNode(obj runtime.Object, numRequeues int) bool {

--- a/pkg/globalnet/constants/constants.go
+++ b/pkg/globalnet/constants/constants.go
@@ -1,0 +1,34 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package constants
+
+const (
+	ClusterGlobalEgressIPName = "cluster-egress.submariner.io"
+
+	SmGlobalnetIngressChain = "SUBMARINER-GN-INGRESS"
+	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
+	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
+
+	// The following chains are added as part of GN 2.0 implementation
+	SmGlobalnetEgressChainForPods            = "SM-GN-EGRESS-PODS"
+	SmGlobalnetEgressChainForHeadlessSvcPods = "SM-GN-EGRESS-HDLS-PODS"
+	SmGlobalnetEgressChainForNamespace       = "SM-GN-EGRESS-NS"
+	SmGlobalnetEgressChainForCluster         = "SM-GN-EGRESS-CLUSTER"
+
+	SmGlobalIP = "submariner.io/globalIp"
+)

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers/iptables"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func NewClusterGlobalEgressIPController(config syncer.ResourceSyncerConfig, loca
 
 	defaultEgressIP := &submarinerv1.ClusterGlobalEgressIP{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterGlobalEgressIPName,
+			Name: constants.ClusterGlobalEgressIPName,
 		},
 	}
 
@@ -140,13 +141,13 @@ func (c *clusterGlobalEgressIPController) process(from runtime.Object, numRequeu
 }
 
 func (c *clusterGlobalEgressIPController) validate(numberOfIPs int, egressIP *submarinerv1.ClusterGlobalEgressIP) bool {
-	if egressIP.Name != ClusterGlobalEgressIPName {
+	if egressIP.Name != constants.ClusterGlobalEgressIPName {
 		tryAppendStatusCondition(&egressIP.Status.Conditions, &metav1.Condition{
 			Type:   string(submarinerv1.GlobalEgressIPAllocated),
 			Status: metav1.ConditionFalse,
 			Reason: "InvalidInstance",
 			Message: fmt.Sprintf("Only the ClusterGlobalEgressIP instance with the well-known name %q is supported",
-				ClusterGlobalEgressIPName),
+				constants.ClusterGlobalEgressIPName),
 		})
 
 		return false

--- a/pkg/globalnet/controllers/cluster_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +38,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 	When("the well-known ClusterGlobalEgressIP does not exist on startup", func() {
 		It("should create it and allocate the global IP", func() {
 			t.awaitClusterGlobalEgressIPStatusAllocated(1)
-			t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+			t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 		})
 	})
 
@@ -47,7 +47,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 			var existing *submarinerv1.ClusterGlobalEgressIP
 
 			BeforeEach(func() {
-				existing = newClusterGlobalEgressIP(controllers.ClusterGlobalEgressIPName, 3)
+				existing = newClusterGlobalEgressIP(constants.ClusterGlobalEgressIPName, 3)
 				existing.Status.AllocatedIPs = []string{"169.254.1.100", "169.254.1.101", "169.254.1.102"}
 			})
 
@@ -86,7 +86,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 				It("should reallocate the global IPs", func() {
 					t.awaitClusterGlobalEgressIPStatusAllocated(*existing.Spec.NumberOfIPs)
-					t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+					t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 				})
 
 				It("should release the previously allocated IPs", func() {
@@ -111,7 +111,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 				})
 
 				It("should reallocate the global IPs", func() {
-					t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, *existing.Spec.NumberOfIPs, 1,
+					t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, *existing.Spec.NumberOfIPs, 1,
 						metav1.Condition{
 							Type:   string(submarinerv1.GlobalEgressIPAllocated),
 							Status: metav1.ConditionFalse,
@@ -121,7 +121,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 							Status: metav1.ConditionTrue,
 						})
 
-					t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+					t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 				})
 			})
 
@@ -132,7 +132,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 				})
 
 				It("should reallocate the global IPs", func() {
-					t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, *existing.Spec.NumberOfIPs, 0,
+					t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, *existing.Spec.NumberOfIPs, 0,
 						metav1.Condition{
 							Type:   string(submarinerv1.GlobalEgressIPAllocated),
 							Status: metav1.ConditionFalse,
@@ -142,7 +142,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 							Status: metav1.ConditionTrue,
 						})
 
-					allocatedIPs := getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs
+					allocatedIPs := getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs
 					t.awaitIPTableRules(allocatedIPs...)
 					t.awaitIPsReleasedFromPool(existing.Status.AllocatedIPs...)
 				})
@@ -151,11 +151,11 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 		Context("with the NumberOfIPs negative", func() {
 			BeforeEach(func() {
-				t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(controllers.ClusterGlobalEgressIPName, -1))
+				t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(constants.ClusterGlobalEgressIPName, -1))
 			})
 
 			It("should add an appropriate Status condition", func() {
-				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
+				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionFalse,
 					Reason: "InvalidInput",
@@ -165,11 +165,11 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 		Context("with the NumberOfIPs zero", func() {
 			BeforeEach(func() {
-				t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(controllers.ClusterGlobalEgressIPName, 0))
+				t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(constants.ClusterGlobalEgressIPName, 0))
 			})
 
 			It("should add an appropriate Status condition", func() {
-				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
+				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionFalse,
 					Reason: "ZeroInput",
@@ -183,7 +183,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 		var numberOfIPs int
 
 		BeforeEach(func() {
-			existing = newClusterGlobalEgressIP(controllers.ClusterGlobalEgressIPName, 2)
+			existing = newClusterGlobalEgressIP(constants.ClusterGlobalEgressIPName, 2)
 			existing.Status.AllocatedIPs = []string{"169.254.1.100", "169.254.1.101"}
 			t.createClusterGlobalEgressIP(existing)
 		})
@@ -200,7 +200,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 			It("should reallocate the global IPs", func() {
 				t.awaitClusterGlobalEgressIPStatusAllocated(numberOfIPs)
-				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 			})
 
 			It("should release the previously allocated IPs", func() {
@@ -216,7 +216,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 			It("should reallocate the global IPs", func() {
 				t.awaitClusterGlobalEgressIPStatusAllocated(numberOfIPs)
-				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 			})
 
 			It("should release the previously allocated IPs", func() {
@@ -231,7 +231,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 			})
 
 			It("should update the Status appropriately", func() {
-				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
+				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, 0, 0, metav1.Condition{
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionFalse,
 					Reason: "ZeroInput",
@@ -253,7 +253,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 			It("should eventually cleanup the IP tables and reallocate", func() {
 				t.awaitNoIPTableRules(existing.Status.AllocatedIPs...)
 				t.awaitClusterGlobalEgressIPStatusAllocated(numberOfIPs)
-				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 			})
 		})
 
@@ -265,7 +265,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 
 			It("should eventually reallocate the global IPs", func() {
 				t.awaitNoIPTableRules(existing.Status.AllocatedIPs...)
-				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, numberOfIPs, 0, metav1.Condition{
+				t.awaitEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, numberOfIPs, 0, metav1.Condition{
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionFalse,
 					Reason: "ProgramIPTableRulesFailed",
@@ -273,7 +273,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionTrue,
 				})
-				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs...)
+				t.awaitIPTableRules(getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs...)
 			})
 		})
 
@@ -283,7 +283,7 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 			})
 
 			It("should add an appropriate Status condition", func() {
-				awaitStatusConditions(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, 0, metav1.Condition{
+				awaitStatusConditions(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, 0, metav1.Condition{
 					Type:   string(submarinerv1.GlobalEgressIPAllocated),
 					Status: metav1.ConditionFalse,
 					Reason: "IPPoolAllocationFailed",
@@ -296,13 +296,13 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 		var allocatedIPs []string
 
 		BeforeEach(func() {
-			t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(controllers.ClusterGlobalEgressIPName, 1))
+			t.createClusterGlobalEgressIP(newClusterGlobalEgressIP(constants.ClusterGlobalEgressIPName, 1))
 		})
 
 		JustBeforeEach(func() {
 			t.awaitClusterGlobalEgressIPStatusAllocated(1)
-			allocatedIPs = getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName).AllocatedIPs
-			Expect(t.clusterGlobalEgressIPs.Delete(context.TODO(), controllers.ClusterGlobalEgressIPName, metav1.DeleteOptions{}))
+			allocatedIPs = getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs
+			Expect(t.clusterGlobalEgressIPs.Delete(context.TODO(), constants.ClusterGlobalEgressIPName, metav1.DeleteOptions{}))
 		})
 
 		It("should release the previously allocated IPs", func() {

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -29,11 +29,12 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	fakeIPT "github.com/submariner-io/submariner/pkg/iptables/fake"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -168,7 +169,7 @@ func (t *testDriverBase) awaitGlobalEgressIPStatusAllocated(name string, expNumI
 }
 
 func (t *testDriverBase) awaitClusterGlobalEgressIPStatusAllocated(expNumIPS int) {
-	t.awaitEgressIPStatusAllocated(t.clusterGlobalEgressIPs, controllers.ClusterGlobalEgressIPName, expNumIPS)
+	t.awaitEgressIPStatusAllocated(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName, expNumIPS)
 }
 
 func (t *testDriverBase) createPod(p *corev1.Pod) *corev1.Pod {
@@ -211,7 +212,7 @@ func (t *testDriverBase) createNode(name, cniInterfaceIP, globalIP string) *core
 		},
 	}
 
-	addAnnotation(node, constants.CNIInterfaceIP, cniInterfaceIP)
+	addAnnotation(node, routeAgent.CNIInterfaceIP, cniInterfaceIP)
 	addAnnotation(node, constants.SmGlobalIP, globalIP)
 
 	return fromUnstructured(test.CreateResource(t.nodes, node), &corev1.Node{}).(*corev1.Node)

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -31,10 +31,11 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/ipam"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"github.com/submariner-io/submariner/pkg/netlink"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -343,14 +344,14 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChain, err)
 	}
 
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", routeAgent.SmPostRoutingChain)
 
-	if err := util.CreateChainIfNotExists(g.ipt, "nat", constants.SmPostRoutingChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmPostRoutingChain, err)
+	if err := util.CreateChainIfNotExists(g.ipt, "nat", routeAgent.SmPostRoutingChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", routeAgent.SmPostRoutingChain, err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChain}
-	if err := util.PrependUnique(g.ipt, "nat", constants.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
+	if err := util.PrependUnique(g.ipt, "nat", routeAgent.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -28,8 +28,9 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -57,7 +58,7 @@ var _ = Describe("Endpoint monitoring", func() {
 		It("should add the appropriate IP table chains", func() {
 			t.ipt.AwaitChain("nat", constants.SmGlobalnetIngressChain)
 			t.ipt.AwaitChain("nat", constants.SmGlobalnetEgressChain)
-			t.ipt.AwaitChain("nat", constants.SmPostRoutingChain)
+			t.ipt.AwaitChain("nat", routeAgent.SmPostRoutingChain)
 			t.ipt.AwaitChain("nat", constants.SmGlobalnetMarkChain)
 		})
 

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -25,9 +25,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/globalnet/controllers/ipam/gatewaymonitor.go
+++ b/pkg/globalnet/controllers/ipam/gatewaymonitor.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"

--- a/pkg/globalnet/controllers/ipam/globalnet.go
+++ b/pkg/globalnet/controllers/ipam/globalnet.go
@@ -26,7 +26,8 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/util"
 )
 
@@ -48,14 +49,14 @@ func (i *Controller) initIPTableChains() error {
 		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmGlobalnetEgressChain, err)
 	}
 
-	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
+	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", routeAgent.SmPostRoutingChain)
 
-	if err := util.CreateChainIfNotExists(i.ipt, "nat", constants.SmPostRoutingChain); err != nil {
-		return fmt.Errorf("error creating iptables chain %s: %v", constants.SmPostRoutingChain, err)
+	if err := util.CreateChainIfNotExists(i.ipt, "nat", routeAgent.SmPostRoutingChain); err != nil {
+		return fmt.Errorf("error creating iptables chain %s: %v", routeAgent.SmPostRoutingChain, err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChain}
-	if err := util.PrependUnique(i.ipt, "nat", constants.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
+	if err := util.PrependUnique(i.ipt, "nat", routeAgent.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 

--- a/pkg/globalnet/controllers/ipam/globalnet_egress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_egress.go
@@ -25,7 +25,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 )
 
 func (i *Controller) updateEgressRulesForResource(resourceName, sourceIP, globalIP string, addRules bool) error {

--- a/pkg/globalnet/controllers/ipam/globalnet_ingress.go
+++ b/pkg/globalnet/controllers/ipam/globalnet_ingress.go
@@ -27,7 +27,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 )
 
 func (i *Controller) updateIngressRulesForService(globalIP, chainName string, addRules bool) error {

--- a/pkg/globalnet/controllers/ipam/node_handler.go
+++ b/pkg/globalnet/controllers/ipam/node_handler.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 )
 
 func (i *Controller) onNodeUpdated(oldObj, newObj *unstructured.Unstructured) bool {
-	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[constants.CNIInterfaceIP]
-	newCNIIfaceIPOnNode := newObj.GetAnnotations()[constants.CNIInterfaceIP]
+	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[routeAgent.CNIInterfaceIP]
+	newCNIIfaceIPOnNode := newObj.GetAnnotations()[routeAgent.CNIInterfaceIP]
 
 	return oldCNIIfaceIPOnNode == newCNIIfaceIPOnNode && i.areGlobalIPsEquivalent(oldObj, newObj)
 }
@@ -44,7 +44,7 @@ func (i *Controller) processNode(from runtime.Object, numRequeues int, op syncer
 		return nil, false
 	}
 
-	cniIfaceIP := node.GetAnnotations()[constants.CNIInterfaceIP]
+	cniIfaceIP := node.GetAnnotations()[routeAgent.CNIInterfaceIP]
 	if cniIfaceIP == "" {
 		// To support connectivity from HostNetwork to remoteCluster, globalnet requires the
 		// cniIfaceIP of the respective node. Route-agent running on the node annotates the
@@ -58,7 +58,7 @@ func (i *Controller) processNode(from runtime.Object, numRequeues int, op syncer
 
 func (i *Controller) processRemovedNode(node *k8sv1.Node) {
 	globalIP := node.Annotations[SubmarinerIPAMGlobalIP]
-	cniIfaceIP := node.Annotations[constants.CNIInterfaceIP]
+	cniIfaceIP := node.Annotations[routeAgent.CNIInterfaceIP]
 	if globalIP != "" && cniIfaceIP != "" {
 		key, _ := cache.MetaNamespaceKeyFunc(node)
 
@@ -74,7 +74,7 @@ func (i *Controller) processRemovedNode(node *k8sv1.Node) {
 }
 
 func (i *Controller) updateNode(node *k8sv1.Node) (runtime.Object, bool) {
-	cniIfaceIP := node.GetAnnotations()[constants.CNIInterfaceIP]
+	cniIfaceIP := node.GetAnnotations()[routeAgent.CNIInterfaceIP]
 
 	return i.updateGlobalIP(node, func(globalIP string) error {
 		return i.syncNodeRules(node.Name, cniIfaceIP, globalIP, AddRules)

--- a/pkg/globalnet/controllers/iptables/iface.go
+++ b/pkg/globalnet/controllers/iptables/iface.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/iptables"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/klog"

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -24,9 +24,10 @@ import (
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	admUtil "github.com/submariner-io/admiral/pkg/util"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers/iptables"
 	"github.com/submariner-io/submariner/pkg/ipam"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,7 +110,7 @@ func (n *nodeController) process(from runtime.Object, numRequeues int, op syncer
 }
 
 func (n *nodeController) allocateIP(node *corev1.Node, op syncer.Operation) (runtime.Object, bool) {
-	cniIfaceIP := node.GetAnnotations()[constants.CNIInterfaceIP]
+	cniIfaceIP := node.GetAnnotations()[routeAgent.CNIInterfaceIP]
 	if cniIfaceIP == "" {
 		// To support connectivity from HostNetwork to remoteCluster, globalnet requires the
 		// cniIfaceIP of the respective node. Route-agent running on the node annotates the
@@ -154,7 +155,7 @@ func (n *nodeController) reserveAllocatedIP(federator federate.Federator, obj *u
 		return nil
 	}
 
-	cniIfaceIP := obj.GetAnnotations()[constants.CNIInterfaceIP]
+	cniIfaceIP := obj.GetAnnotations()[routeAgent.CNIInterfaceIP]
 	if cniIfaceIP == "" {
 		// To support Gateway healthCheck, globalnet requires the cniIfaceIP of the respective node.
 		// Route-agent running on the node annotates the respective node with the cniIfaceIP.
@@ -205,8 +206,8 @@ func (n *nodeController) onNodeUpdated(oldObj, newObj *unstructured.Unstructured
 		return true
 	}
 
-	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[constants.CNIInterfaceIP]
-	newCNIIfaceIPOnNode := newObj.GetAnnotations()[constants.CNIInterfaceIP]
+	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[routeAgent.CNIInterfaceIP]
+	newCNIIfaceIPOnNode := newObj.GetAnnotations()[routeAgent.CNIInterfaceIP]
 	oldGlobalIPOnNode := oldObj.GetAnnotations()[constants.SmGlobalIP]
 	newGlobalIPOnNode := newObj.GetAnnotations()[constants.SmGlobalIP]
 

--- a/pkg/globalnet/controllers/node_controller_test.go
+++ b/pkg/globalnet/controllers/node_controller_test.go
@@ -25,9 +25,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -107,7 +108,7 @@ var _ = Describe("Node controller", func() {
 			JustBeforeEach(func() {
 				t.awaitNoNodeGlobalIP()
 
-				addAnnotation(node, constants.CNIInterfaceIP, cniInterfaceIP)
+				addAnnotation(node, routeAgent.CNIInterfaceIP, cniInterfaceIP)
 				test.UpdateResource(t.nodes, node)
 			})
 
@@ -132,10 +133,10 @@ var _ = Describe("Node controller", func() {
 			})
 
 			It("re-program the iptable rules", func() {
-				oldCNIIfaceIP := node.GetAnnotations()[constants.CNIInterfaceIP]
+				oldCNIIfaceIP := node.GetAnnotations()[routeAgent.CNIInterfaceIP]
 
 				time.Sleep(time.Millisecond * 300)
-				addAnnotation(node, constants.CNIInterfaceIP, cniInterfaceIP)
+				addAnnotation(node, routeAgent.CNIInterfaceIP, cniInterfaceIP)
 				test.UpdateResource(t.nodes, node)
 
 				t.ipt.AwaitNoRule("nat", constants.SmGlobalnetIngressChain, ContainSubstring(oldCNIIfaceIP))

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	ClusterGlobalEgressIPName = "cluster-egress.submariner.io"
-
 	// Globalnet uses MARK target to mark traffic destined to remote clusters.
 	// Some of the CNIs also use iptable MARK targets in the pipeline. This should not
 	// be a problem because Globalnet is only marking traffic destined to Submariner

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -18,16 +18,6 @@ limitations under the License.
 package constants
 
 const (
-	SmGlobalnetIngressChain = "SUBMARINER-GN-INGRESS"
-	SmGlobalnetEgressChain  = "SUBMARINER-GN-EGRESS"
-	SmGlobalnetMarkChain    = "SUBMARINER-GN-MARK"
-
-	// The following chains are added as part of GN 2.0 implementation
-	SmGlobalnetEgressChainForPods            = "SM-GN-EGRESS-PODS"
-	SmGlobalnetEgressChainForHeadlessSvcPods = "SM-GN-EGRESS-HDLS-PODS"
-	SmGlobalnetEgressChainForNamespace       = "SM-GN-EGRESS-NS"
-	SmGlobalnetEgressChainForCluster         = "SM-GN-EGRESS-CLUSTER"
-
 	// IPTable chains used by RouteAgent
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
 
@@ -45,9 +35,6 @@ const (
 	// supporting connectivity from HostNetwork to remoteClusters.
 	// [#] interface on the node that has an IPAddress from the clusterCIDR
 	CNIInterfaceIP = "submariner.io/cniIfaceIp"
-
-	// TODO (revisit): Unify this constant across different components
-	SmGlobalIP = "submariner.io/globalIp"
 
 	RouteAgentInterClusterNetworkTableID = 149
 

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
-	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -100,7 +100,7 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams) {
 	if p.ToEndpointType == tcp.GlobalIP {
 		By("Verifying the output of listener pod which must contain the globalIP assigned to the Cluster")
 
-		podGlobalIP := p.Framework.AwaitClusterGlobalEgressIPs(p.FromCluster, controllers.ClusterGlobalEgressIPName)
+		podGlobalIP := p.Framework.AwaitClusterGlobalEgressIPs(p.FromCluster, constants.ClusterGlobalEgressIPName)
 		Expect(podGlobalIP).ToNot(Equal(""))
 		Expect(listenerPod.TerminationMessage).To(ContainSubstring(podGlobalIP[0]))
 	}


### PR DESCRIPTION
E2E referenced a constant in the **pkg/globalnet/controllers** package which pulls in `go-iptables` et al which breaks `subctl`. Moved the constant to a separate package and also moved other `globalnet` constants that were
in the **routeagent-driver** package but weren't referenced by the `routeagent` code.
