### PR TITLE
Ensure CDR names are lower case

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
 	v1typed "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -201,7 +202,7 @@ func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 			LocalEndpoint: localEndpoint.Spec,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        localEndpoint.Spec.Hostname,
+			Name:        util.EnsureValidName(localEndpoint.Spec.Hostname),
 			Annotations: map[string]string{updateTimestampAnnotation: strconv.FormatInt(time.Now().UTC().Unix(), 10)}},
 	}
 

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -220,7 +220,7 @@ func (d *DatastoreSyncer) createLocalCluster() error {
 
 	cluster := &submarinerv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: d.localCluster.Spec.ClusterID,
+			Name: util.EnsureValidName(d.localCluster.Spec.ClusterID),
 		},
 		Spec: d.localCluster.Spec,
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Util", func() {
 
 	Describe("Function CompareEndpointSpec", testCompareEndpointSpec)
 
+	Describe("Function EnsureValidName", testEnsureValidName)
 })
 
 func testParseSecure() {
@@ -107,7 +108,7 @@ func testGetEndpointCRDName() {
 			})
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(name).To(Equal("ClusterID-CableName"))
+			Expect(name).To(Equal("clusterid-cablename"))
 		})
 	})
 
@@ -303,6 +304,27 @@ func testCompareEndpointSpec() {
 					Backend:       "libreswan",
 					BackendConfig: map[string]string{"key": "bbb"},
 				})).To(BeFalse())
+		})
+	})
+}
+
+func testEnsureValidName() {
+	When("the string is valid", func() {
+		It("should not convert it", func() {
+			Expect(util.EnsureValidName("digits-1234567890")).To(Equal("digits-1234567890"))
+			Expect(util.EnsureValidName("example.com")).To(Equal("example.com"))
+		})
+	})
+
+	When("the string has upper case letters", func() {
+		It("should convert to lower", func() {
+			Expect(util.EnsureValidName("No-UPPER-caSe-aLLoweD")).To(Equal("no-upper-case-allowed"))
+		})
+	})
+
+	When("the string has non-alphanumeric letters", func() {
+		It("should convert them approriately", func() {
+			Expect(util.EnsureValidName("no-!@*()#$-chars")).To(Equal("no---------chars"))
 		})
 	})
 }


### PR DESCRIPTION
K8s only allows lower case alphanumeric characters, '-'. or '.'.

Fixes https://github.com/submariner-io/submariner/issues/1372

