### PR TITLE
OVN: Validate CIDRs in network-plugin-syncer

### DIFF
--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/kelseyhightower/envconfig"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,6 +50,12 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler().Done()
 
+	var env environment.Specification
+	err := envconfig.Process("submariner", &env)
+	if err != nil {
+		klog.Fatalf("Error reading the environment variables: %s", err.Error())
+	}
+
 	networkPlugin := os.Getenv("SUBMARINER_NETWORKPLUGIN")
 
 	if networkPlugin == "" {
@@ -55,7 +63,7 @@ func main() {
 	}
 
 	registry := event.NewRegistry("networkplugin-syncer", networkPlugin)
-	if err := registry.AddHandlers(logger.NewHandler(), ovn.NewSyncHandler(getK8sClient())); err != nil {
+	if err := registry.AddHandlers(logger.NewHandler(), ovn.NewSyncHandler(getK8sClient(), env)); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}
 


### PR DESCRIPTION
In a non-Globalnet deployment with OVN CNI, if the remote CIDRs
overlap with the localCluster CIDRs, an appropriate error message
should be logged and we should avoid making changes to the local
cluster nodes.

Fixes Issue: https://github.com/submariner-io/submariner/issues/1399
Signed-Off-by: Sridhar Gaddam sgaddam@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
