### PR TITLE
Trim newlines when reading from sysctl

### DIFF
--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -164,6 +164,9 @@ func setSysctl(path string, contents []byte) error {
 		return err
 	}
 
+	// Ignore leading and terminating newlines
+	existing = bytes.Trim(existing, "\n")
+
 	if bytes.Equal(existing, contents) {
 		return nil
 	}


### PR DESCRIPTION
Values read from sysctl have trailing newlines, but the values we set
don't; trim the newlines before comparing to ensure we don't attempt
to write needlessly.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
