### PR TITLE
Datapath support for GlobalEgressIPs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v1.5.2
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10
 	sigs.k8s.io/controller-runtime v0.7.0
 	sigs.k8s.io/mcs-api v0.1.0
 )

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -168,3 +168,17 @@ func conditionsToUnstructured(conditions []metav1.Condition, to *unstructured.Un
 func shouldRequeue(numRequeues int) bool {
 	return numRequeues < maxRequeues
 }
+
+func getTargetSNATIPaddress(allocIPs []string) string {
+	var snatIP string
+
+	allocatedIPs := len(allocIPs)
+
+	if allocatedIPs == 1 {
+		snatIP = allocIPs[0]
+	} else {
+		snatIP = fmt.Sprintf("%s-%s", allocIPs[0], allocIPs[len(allocIPs)-1])
+	}
+
+	return snatIP
+}

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -195,7 +195,7 @@ func (c *clusterGlobalEgressIPController) onDelete(key string, status *submarine
 }
 
 func (c *clusterGlobalEgressIPController) flushClusterGlobalEgressRules(allocatedIPs []string) error {
-	return c.deleteClusterGlobalEgressRules(c.localSubnets, c.getTargetSNATIPaddress(allocatedIPs))
+	return c.deleteClusterGlobalEgressRules(c.localSubnets, getTargetSNATIPaddress(allocatedIPs))
 }
 
 func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPList []string, snatIP string) error {
@@ -209,7 +209,7 @@ func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPLi
 }
 
 func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(allocatedIPs []string) error {
-	snatIP := c.getTargetSNATIPaddress(allocatedIPs)
+	snatIP := getTargetSNATIPaddress(allocatedIPs)
 	egressRulesProgrammed := []string{}
 
 	for _, srcIP := range c.localSubnets {
@@ -223,20 +223,6 @@ func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(alloca
 	}
 
 	return nil
-}
-
-func (c *clusterGlobalEgressIPController) getTargetSNATIPaddress(allocIPs []string) string {
-	var snatIP string
-
-	allocatedIPs := len(allocIPs)
-
-	if allocatedIPs == 1 {
-		snatIP = allocIPs[0]
-	} else {
-		snatIP = fmt.Sprintf("%s-%s", allocIPs[0], allocIPs[len(allocIPs)-1])
-	}
-
-	return snatIP
 }
 
 func (c *clusterGlobalEgressIPController) allocateGlobalIPs(key string, numberOfIPs int, status *submarinerv1.GlobalEgressIPStatus) bool {

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
+	"github.com/submariner-io/submariner/pkg/ipset"
+	fakeIPSet "github.com/submariner-io/submariner/pkg/ipset/fake"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	fakeIPT "github.com/submariner-io/submariner/pkg/iptables/fake"
 	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
@@ -79,6 +81,7 @@ type testDriverBase struct {
 	dynClient              dynamic.Interface
 	scheme                 *runtime.Scheme
 	ipt                    *fakeIPT.IPTables
+	ipSet                  *fakeIPSet.IPSet
 	pool                   *ipam.IPPool
 	localSubnets           []string
 	globalCIDR             string
@@ -97,6 +100,7 @@ func newTestDriverBase() *testDriverBase {
 			&submarinerv1.GlobalEgressIP{}, &submarinerv1.ClusterGlobalEgressIP{}, &submarinerv1.GlobalIngressIP{}, &mcsv1a1.ServiceExport{}),
 		scheme:       runtime.NewScheme(),
 		ipt:          fakeIPT.New(),
+		ipSet:        fakeIPSet.New(),
 		globalCIDR:   localCIDR,
 		localSubnets: []string{},
 	}
@@ -125,6 +129,10 @@ func newTestDriverBase() *testDriverBase {
 
 	iptables.NewFunc = func() (iptables.Interface, error) {
 		return t.ipt, nil
+	}
+
+	ipset.NewFunc = func() ipset.Interface {
+		return t.ipSet
 	}
 
 	return t

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -25,7 +25,9 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	iptiface "github.com/submariner-io/submariner/pkg/globalnet/controllers/iptables"
 	"github.com/submariner-io/submariner/pkg/ipam"
+	"github.com/submariner-io/submariner/pkg/ipset"
 	"github.com/submariner-io/submariner/pkg/iptables"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -45,6 +47,9 @@ const (
 	// of kube-proxy changes, globalnet needs to be modified accordingly.
 	// Reference: https://bit.ly/2OPhlwk
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
+
+	// The prefix used for the ipset chains created by Globalnet pod.
+	IPSetPrefix = "SM-GN-"
 
 	AddRules    = true
 	DeleteRules = false
@@ -94,11 +99,15 @@ type globalEgressIPController struct {
 	*baseIPAllocationController
 	sync.Mutex
 	podWatchers   map[string]*podWatcher
+	ipSetIface    ipset.Interface
 	watcherConfig watcher.Config
 }
 
 type podWatcher struct {
-	stopCh chan struct{}
+	stopCh      chan struct{}
+	ipSetName   string
+	ipSetIface  ipset.Interface
+	podSelector *metav1.LabelSelector
 }
 
 type clusterGlobalEgressIPController struct {

--- a/pkg/ipset/fake/ipset.go
+++ b/pkg/ipset/fake/ipset.go
@@ -1,0 +1,93 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fake
+
+import (
+	"sync"
+
+	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner/pkg/ipset"
+)
+
+type IPSet struct {
+	sync.Mutex
+	chainRules  map[string]stringset.Interface
+	tableChains map[string]stringset.Interface
+}
+
+func New() *IPSet {
+	ipSet := &IPSet{
+		chainRules:  map[string]stringset.Interface{},
+		tableChains: map[string]stringset.Interface{},
+	}
+
+	return ipSet
+}
+
+func (i *IPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
+	// TODO, have to implement these apis for unit testing.
+	return nil
+}
+
+func (i *IPSet) FlushSet(set string) error {
+	return nil
+}
+
+func (i *IPSet) DestroySet(set string) error {
+	return nil
+}
+
+func (i *IPSet) DestroyAllSets() error {
+	return nil
+}
+
+func (i *IPSet) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) error {
+	return nil
+}
+
+func (i *IPSet) DelEntry(entry, set string) error {
+	return nil
+}
+
+func (i *IPSet) TestEntry(entry, set string) (bool, error) {
+	return true, nil
+}
+
+func (i *IPSet) ListEntries(set string) ([]string, error) {
+	return nil, nil
+}
+
+func (i *IPSet) ListSets() ([]string, error) {
+	return nil, nil
+}
+
+func (i *IPSet) GetVersion() (string, error) {
+	return "", nil
+}
+
+func (i *IPSet) AddEntryWithOptions(entry *ipset.Entry, set *ipset.IPSet, ignoreExistErr bool) error {
+	return nil
+}
+
+func (i *IPSet) DelEntryWithOptions(set, entry string, options ...string) error {
+	return nil
+}
+
+func (i *IPSet) SaveAllSets() ([]byte, error) {
+	return nil, nil
+}

--- a/pkg/ipset/ipset.go
+++ b/pkg/ipset/ipset.go
@@ -1,0 +1,699 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipset
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	glog "k8s.io/klog"
+	utilexec "k8s.io/utils/exec"
+)
+
+var _ = Interface(&runner{})
+
+// Interface is an injectable interface for running ipset commands.  Implementations must be goroutine-safe.
+type Interface interface {
+	// FlushSet deletes all entries from a named set.
+	FlushSet(set string) error
+	// DestroySet deletes a named set.
+	DestroySet(set string) error
+	// DestroyAllSets deletes all sets.
+	DestroyAllSets() error
+	// CreateSet creates a new set.  It will ignore error when the set already exists if ignoreExistErr=true.
+	CreateSet(set *IPSet, ignoreExistErr bool) error
+	// AddEntry adds a new entry to the named set.  It will ignore error when the entry already exists if ignoreExistErr=true.
+	AddEntry(entry string, set *IPSet, ignoreExistErr bool) error
+	// DelEntry deletes one entry from the named set
+	DelEntry(entry string, set string) error
+	// Test test if an entry exists in the named set
+	TestEntry(entry string, set string) (bool, error)
+	// ListEntries lists all the entries from a named set
+	ListEntries(set string) ([]string, error)
+	// ListSets list all set names from kernel
+	ListSets() ([]string, error)
+	// GetVersion returns the "X.Y" version string for ipset.
+	GetVersion() (string, error)
+
+	AddEntryWithOptions(entry *Entry, set *IPSet, ignoreExistErr bool) error
+
+	DelEntryWithOptions(set, entry string, options ...string) error
+
+	SaveAllSets() ([]byte, error)
+}
+
+// IPSetCmd represents the ipset util.  We use ipset command for ipset execute.
+const IPSetCmd = "ipset"
+
+// EntryMemberPattern is the regular expression pattern of ipset member list.
+// The raw output of ipset command `ipset list {set}` is similar to,
+// Name: foobar
+// Type: hash:ip,port
+// Revision: 2
+// Header: family inet hashsize 1024 maxelem 65536
+// Size in memory: 16592
+// References: 0
+// Members:
+// 192.168.1.2,tcp:8080
+// 192.168.1.1,udp:53
+var EntryMemberPattern = "(?m)^(.*\n)*Members:\n"
+
+// VersionPattern is the regular expression pattern of ipset version string.
+// ipset version output is similar to "v6.10".
+var VersionPattern = "v[0-9]+\\.[0-9]+"
+
+// IPSet implements an Interface to an set.
+type IPSet struct {
+	// Name is the set name.
+	Name string
+	// SetType specifies the ipset type.
+	SetType Type
+	// HashFamily specifies the protocol family of the IP addresses to be stored in the set.
+	// The default is inet, i.e IPv4.  If users want to use IPv6, they should specify inet6.
+	HashFamily string
+	// HashSize specifies the hash table size of ipset.
+	HashSize int
+	// MaxElem specifies the max element number of ipset.
+	MaxElem int
+	// PortRange specifies the port range of bitmap:port type ipset.
+	PortRange string
+	// TODO: add comment message for ipset
+}
+
+// #lizard forgives
+// Validate checks if a given ipset is valid or not.
+func (set *IPSet) Validate() bool {
+	// Check if protocol is valid for `HashIPPort`, `HashIPPortIP` and `HashIPPortNet` type set.
+	if set.SetType == HashIPPort || set.SetType == HashIPPortIP || set.SetType == HashIPPortNet ||
+		set.SetType == HashNet || set.SetType == HashNetPort {
+		if valid := validateHashFamily(set.HashFamily); !valid {
+			return false
+		}
+	}
+	// check set type
+	if valid := validateIPSetType(set.SetType); !valid {
+		return false
+	}
+	// check port range for bitmap type set
+
+	if set.SetType == BitmapPort {
+		if valid := validatePortRange(set.PortRange); !valid {
+			return false
+		}
+	}
+
+	// check hash size value of ipset
+	if set.HashSize <= 0 {
+		return false
+	}
+
+	// check max elem value of ipset
+	if set.MaxElem <= 0 {
+		glog.Errorf("Invalid maxelem value %d, should be >0", set.MaxElem)
+		return false
+	}
+
+	return true
+}
+
+// Entry represents a ipset entry.
+type Entry struct {
+	// IP is the entry's IP.  The IP address protocol corresponds to the HashFamily of IPSet.
+	// All entries' IP addresses in the same ip set has same the protocol, IPv4 or IPv6.
+	IP string
+	// Port is the entry's Port.
+	Port int
+	// Protocol is the entry's Protocol.  The protocols of entries in the same ip set are all
+	// the same.  The accepted protocols are TCP and UDP.
+	Protocol string
+	// Net is the entry's IP network address.  Network address with zero prefix size can NOT
+	// be stored.
+	Net string
+	// IP2 is the entry's second IP.  IP2 may not be empty for `hash:ip,port,ip` type ip set.
+	IP2 string
+	// SetType is the type of ipset where the entry exists.
+	SetType Type
+	//  [ timeout value ] [ packets value ] [ bytes value ] [ comment string ] [ skbmark value ] [ skbprio value ] [ skbqueue value ]
+	Options []string
+}
+
+// Validate checks if a given ipset entry is valid or not.  The set parameter is the ipset that entry belongs to.
+func (e *Entry) Validate(set *IPSet) bool {
+	if e.Port < 0 {
+		glog.Errorf("Entry %v port number %d should be >=0 for ipset %v", e, e.Port, set)
+		return false
+	}
+
+	switch e.SetType {
+	case HashIP:
+		return e.validateHashIP(set)
+	case HashIPPort:
+		return e.validateHashIPPort(set)
+	case HashIPPortIP:
+		return e.validateHashIPPortIP(set)
+	case HashIPPortNet:
+		return e.validateHashIPPortNet(set)
+	case BitmapPort:
+		return e.validateBitmapPort(set)
+	case HashNet:
+		return e.validateHashNet(set)
+	case HashNetPort:
+		return e.validateHashNetPort(set)
+	}
+
+	return true
+}
+
+func (e *Entry) validateHashIP(set *IPSet) bool {
+	if net.ParseIP(e.IP) == nil {
+		glog.Errorf("Error parsing entry %v ip address %v for ipset %v", e, e.IP, set)
+		return false
+	}
+
+	return true
+}
+
+func (e *Entry) validateHashNet(set *IPSet) bool {
+	// Net can not be empty for `hash:net,port` type ip set
+	if _, ipNet, _ := net.ParseCIDR(e.Net); ipNet == nil {
+		glog.Errorf("Error parsing entry %v ip net %v for ipset %v", e, e.Net, set)
+		return false
+	}
+
+	return false
+}
+
+func (e *Entry) validateHashIPPort(set *IPSet) bool {
+	if valid := e.validateProtocol(); !valid {
+		return false
+	}
+
+	return e.validateHashIP(set)
+}
+
+func (e *Entry) validateHashIPPortIP(set *IPSet) bool {
+	if valid := e.validateHashIPPort(set); !valid {
+		return false
+	}
+	// IP2 can not be empty for `hash:ip,port,ip` type ip set
+	if net.ParseIP(e.IP2) == nil {
+		glog.Errorf("Error parsing entry %v second ip address %v for ipset %v", e, e.IP2, set)
+		return false
+	}
+
+	return true
+}
+
+func (e *Entry) validateHashIPPortNet(set *IPSet) bool {
+	return e.validateHashIP(set) && e.validateHashNetPort(set)
+}
+
+func (e *Entry) validateBitmapPort(set *IPSet) bool {
+	// check if port number satisfies its ipset's requirement of port range
+	if set == nil {
+		glog.Errorf("Unable to reference ip set where the entry %v exists", e)
+		return false
+	}
+
+	begin, end, err := parsePortRange(set.PortRange)
+	if err != nil {
+		glog.Errorf("Failed to parse set %v port range %s for ipset %v, error: %v", set, set.PortRange, set, err)
+		return false
+	}
+
+	if e.Port < begin || e.Port > end {
+		glog.Errorf("Entry %v port number %d is not in the port range %s of its ipset %v", e, e.Port, set.PortRange, set)
+		return false
+	}
+
+	return true
+}
+
+func (e *Entry) validateHashNetPort(set *IPSet) bool {
+	return e.validateProtocol() && e.validateHashNet(set)
+}
+
+func (e *Entry) validateProtocol() bool {
+	if e.Protocol == "" {
+		e.Protocol = ProtocolTCP
+	}
+
+	if valid := validateProtocol(e.Protocol); !valid {
+		return false
+	}
+
+	return true
+}
+
+// String returns the string format for ipset entry.
+func (e *Entry) String() string {
+	switch e.SetType {
+	case HashIP:
+		// Entry{192.168.1.1} -> 192.168.1.1
+		return e.IP
+	case HashIPPort:
+		// Entry{192.168.1.1, udp, 53} -> 192.168.1.1,udp:53
+		// Entry{192.168.1.2, tcp, 8080} -> 192.168.1.2,tcp:8080
+		return fmt.Sprintf("%s,%s:%s", e.IP, e.Protocol, strconv.Itoa(e.Port))
+	case HashIPPortIP:
+		// Entry{192.168.1.1, udp, 53, 10.0.0.1} -> 192.168.1.1,udp:53,10.0.0.1
+		// Entry{192.168.1.2, tcp, 8080, 192.168.1.2} -> 192.168.1.2,tcp:8080,192.168.1.2
+		return fmt.Sprintf("%s,%s:%s,%s", e.IP, e.Protocol, strconv.Itoa(e.Port), e.IP2)
+	case HashIPPortNet:
+		// Entry{192.168.1.2, udp, 80, 10.0.1.0/24} -> 192.168.1.2,udp:80,10.0.1.0/24
+		// Entry{192.168.2,25, tcp, 8080, 10.1.0.0/16} -> 192.168.2,25,tcp:8080,10.1.0.0/16
+		return fmt.Sprintf("%s,%s:%s,%s", e.IP, e.Protocol, strconv.Itoa(e.Port), e.Net)
+	case HashNet:
+		// Entry{udp, 10.0.1.0/24} -> 10.0.1.0/24
+		return e.Net
+	case HashNetPort:
+		// Entry{udp, 80, 10.0.1.0/24} -> 10.0.1.0/24,udp:80
+		return fmt.Sprintf("%s,%s:%s", e.Net, e.Protocol, strconv.Itoa(e.Port))
+	case BitmapPort:
+		// Entry{53} -> 53
+		// Entry{8080} -> 8080
+		return strconv.Itoa(e.Port)
+	}
+
+	return ""
+}
+
+type runner struct {
+	exec utilexec.Interface
+}
+
+var NewFunc func() Interface
+
+// New returns a new Interface which will exec ipset.
+func New(exec utilexec.Interface) Interface {
+	if NewFunc != nil {
+		return NewFunc()
+	}
+
+	return &runner{
+		exec: exec,
+	}
+}
+
+// CreateSet creates a new set,  it will ignore error when the set already exists if ignoreExistErr=true.
+func (runner *runner) CreateSet(set *IPSet, ignoreExistErr bool) error {
+	// Setting default values if not present
+	if set.HashSize == 0 {
+		set.HashSize = 1024
+	}
+
+	if set.MaxElem == 0 {
+		set.MaxElem = 65536
+	}
+
+	// Default protocol is IPv4
+	if set.HashFamily == "" {
+		set.HashFamily = ProtocolFamilyIPV4
+	}
+
+	// Default ipset type is "hash:ip,port"
+	if len(set.SetType) == 0 {
+		set.SetType = HashIPPort
+	}
+
+	if set.PortRange == "" {
+		set.PortRange = DefaultPortRange
+	}
+
+	// Validate ipset before creating
+	valid := set.Validate()
+	if !valid {
+		return fmt.Errorf("error creating ipset since it's invalid")
+	}
+
+	return runner.createSet(set, ignoreExistErr)
+}
+
+// If ignoreExistErr is set to true, then the -exist option of ipset will be specified, ipset ignores the error
+// otherwise raised when the same set (setname and create parameters are identical) already exists.
+func (runner *runner) createSet(set *IPSet, ignoreExistErr bool) error {
+	args := []string{"create", set.Name, string(set.SetType)}
+	if set.SetType == HashIPPortIP || set.SetType == HashIPPort {
+		args = append(args,
+			"family", set.HashFamily,
+			"hashsize", strconv.Itoa(set.HashSize),
+			"maxelem", strconv.Itoa(set.MaxElem),
+		)
+	}
+
+	if set.SetType == BitmapPort {
+		args = append(args, "range", set.PortRange)
+	}
+
+	if ignoreExistErr {
+		args = append(args, "-exist")
+	}
+
+	glog.V(log.DEBUG).Infof("running ipset %v", args)
+
+	if _, err := runner.exec.Command(IPSetCmd, args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("error creating ipset %s, error: %v", set.Name, err)
+	}
+
+	return nil
+}
+
+// AddEntry adds a new entry to the named set.
+// If the -exist option is specified, ipset ignores the error otherwise raised when
+// the same set (setname and create parameters are identical) already exists.
+func (runner *runner) AddEntry(entry string, set *IPSet, ignoreExistErr bool) error {
+	args := []string{"add", set.Name, entry}
+	if ignoreExistErr {
+		args = append(args, "-exist")
+	}
+
+	if _, err := runner.exec.Command(IPSetCmd, args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("error adding entry %s, error: %v", entry, err)
+	}
+
+	return nil
+}
+
+func (runner *runner) AddEntryWithOptions(entry *Entry, set *IPSet, ignoreExistErr bool) error {
+	args := []string{"add"}
+	if ignoreExistErr {
+		args = append(args, "-exist")
+	}
+
+	args = append(args, set.Name, entry.String())
+	args = append(args, entry.Options...)
+	glog.V(log.DEBUG).Infof("running ipset %v", args)
+
+	if _, err := runner.exec.Command(IPSetCmd, args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("error adding entry %s, error: %v", entry, err)
+	}
+
+	return nil
+}
+
+// DelEntry is used to delete the specified entry from the set.
+func (runner *runner) DelEntry(entry, set string) error {
+	if _, err := runner.exec.Command(IPSetCmd, "del", set, entry).CombinedOutput(); err != nil {
+		return fmt.Errorf("error deleting entry %s: from set: %s, error: %v", entry, set, err)
+	}
+
+	return nil
+}
+
+func (runner *runner) DelEntryWithOptions(set, entry string, options ...string) error {
+	// ipset del should not add options
+	if _, err := runner.exec.Command(IPSetCmd, "del", set, entry).CombinedOutput(); err != nil {
+		return fmt.Errorf("error deleting entry %s: from set: %s, error: %v", entry, set, err)
+	}
+
+	return nil
+}
+
+// TestEntry is used to check whether the specified entry is in the set or not.
+func (runner *runner) TestEntry(entry, set string) (bool, error) {
+	if out, err := runner.exec.Command(IPSetCmd, "test", set, entry).CombinedOutput(); err == nil {
+		reg := regexp.MustCompile("NOT")
+		if reg.MatchString(string(out)) {
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, fmt.Errorf("error testing entry %s: %v (%s)", entry, err, out)
+	}
+}
+
+// FlushSet deletes all entries from a named set.
+func (runner *runner) FlushSet(set string) error {
+	if _, err := runner.exec.Command(IPSetCmd, "flush", set).CombinedOutput(); err != nil {
+		return fmt.Errorf("error flushing set: %s, error: %v", set, err)
+	}
+
+	return nil
+}
+
+// DestroySet is used to destroy a named set.
+func (runner *runner) DestroySet(set string) error {
+	glog.V(log.DEBUG).Infof("running ipset destroy %s", set)
+
+	if out, err := runner.exec.Command(IPSetCmd, "destroy", set).CombinedOutput(); err != nil {
+		return fmt.Errorf("error destroying set %s, error: %v(%s)", set, err, out)
+	}
+
+	return nil
+}
+
+// DestroyAllSets is used to destroy all sets.
+func (runner *runner) DestroyAllSets() error {
+	if _, err := runner.exec.Command(IPSetCmd, "destroy").CombinedOutput(); err != nil {
+		return fmt.Errorf("error destroying all sets, error: %v", err)
+	}
+
+	return nil
+}
+
+// ListSets list all set names from kernel
+func (runner *runner) ListSets() ([]string, error) {
+	out, err := runner.exec.Command(IPSetCmd, "list", "-n").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error listing all sets, error: %v", err)
+	}
+
+	return strings.Split(string(out), "\n"), nil
+}
+
+// ListEntries lists all the entries from a named set.
+func (runner *runner) ListEntries(set string) ([]string, error) {
+	if set == "" {
+		return nil, fmt.Errorf("set name can't be nil")
+	}
+
+	out, err := runner.exec.Command(IPSetCmd, "list", set).CombinedOutput()
+
+	if err != nil {
+		return nil, fmt.Errorf("error listing set: %s, error: %v", set, err)
+	}
+
+	memberMatcher := regexp.MustCompile(EntryMemberPattern)
+	list := memberMatcher.ReplaceAllString(string(out), "")
+	strs := strings.Split(list, "\n")
+	results := make([]string, 0)
+
+	for i := range strs {
+		if len(strs[i]) > 0 {
+			results = append(results, strs[i])
+		}
+	}
+
+	return results, nil
+}
+
+// GetVersion returns the version string.
+func (runner *runner) GetVersion() (string, error) {
+	return getIPSetVersionString(runner.exec)
+}
+
+// getIPSetVersionString runs "ipset --version" to get the version string
+// in the form of "X.Y", i.e "6.19"
+func getIPSetVersionString(exec utilexec.Interface) (string, error) {
+	cmd := exec.Command(IPSetCmd, "--version")
+	cmd.SetStdin(bytes.NewReader([]byte{}))
+	cmdBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	versionMatcher := regexp.MustCompile(VersionPattern)
+	match := versionMatcher.FindStringSubmatch(string(cmdBytes))
+	if match == nil {
+		return "", fmt.Errorf("no ipset version found in string: %s", cmdBytes)
+	}
+
+	return match[0], nil
+}
+
+// checks if port range is valid. The begin port number is not necessarily less than
+// end port number - ipset util can accept it.  It means both 1-100 and 100-1 are valid.
+func validatePortRange(portRange string) bool {
+	strs := strings.Split(portRange, "-")
+
+	if len(strs) != 2 {
+		glog.Errorf("port range should be in the format of `a-b`")
+		return false
+	}
+
+	for i := range strs {
+		num, err := strconv.Atoi(strs[i])
+		if err != nil {
+			glog.Errorf("Failed to parse %s, error: %v", strs[i], err)
+			return false
+		}
+
+		if num < 0 {
+			glog.Errorf("port number %d should be >=0", num)
+			return false
+		}
+	}
+
+	return true
+}
+
+// checks if the given ipset type is valid.
+func validateIPSetType(set Type) bool {
+	for _, valid := range ValidIPSetTypes {
+		if set == valid {
+			return true
+		}
+	}
+
+	glog.Errorf("Currently supported ipset types are: %v, %s is not supported", ValidIPSetTypes, set)
+
+	return false
+}
+
+// checks if given hash family is supported in ipset
+func validateHashFamily(family string) bool {
+	if family == ProtocolFamilyIPV4 || family == ProtocolFamilyIPV6 {
+		return true
+	}
+
+	glog.Errorf("Currently supported ip set hash families are: [%s, %s], %s is not supported", ProtocolFamilyIPV4, ProtocolFamilyIPV6, family)
+
+	return false
+}
+
+// IsNotFoundError returns true if the error indicates "not found".  It parses
+// the error string looking for known values, which is imperfect but works in
+// practice.
+func IsNotFoundError(err error) bool {
+	es := err.Error()
+
+	if strings.Contains(es, "does not exist") {
+		// set with the same name already exists
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/errcode.c#L32-L33
+		return true
+	}
+
+	if strings.Contains(es, "element is missing") {
+		// entry is missing from the set
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1904
+		// https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1925
+		return true
+	}
+
+	return false
+}
+
+// checks if given protocol is supported in entry
+func validateProtocol(protocol string) bool {
+	if protocol == ProtocolTCP || protocol == ProtocolUDP {
+		return true
+	}
+
+	glog.Errorf("Invalid entry's protocol: %s, supported protocols are [%s, %s]", protocol, ProtocolTCP, ProtocolUDP)
+
+	return false
+}
+
+// parsePortRange parse the begin and end port from a raw string(format: a-b).  beginPort <= endPort
+// in the return value.
+func parsePortRange(portRange string) (beginPort, endPort int, err error) {
+	if portRange == "" {
+		portRange = DefaultPortRange
+	}
+
+	strs := strings.Split(portRange, "-")
+	if len(strs) != 2 {
+		// port number -1 indicates invalid
+		return -1, -1, fmt.Errorf("port range should be in the format of `a-b`")
+	}
+
+	for i := range strs {
+		num, err := strconv.Atoi(strs[i])
+		if err != nil {
+			// port number -1 indicates invalid
+			return -1, -1, err
+		}
+
+		if num < 0 {
+			// port number -1 indicates invalid
+			return -1, -1, fmt.Errorf("port number %d should be >=0", num)
+		}
+
+		if i == 0 {
+			beginPort = num
+			continue
+		}
+
+		endPort = num
+		// switch when first port number > second port number
+		if beginPort > endPort {
+			endPort = beginPort
+			beginPort = num
+		}
+	}
+
+	return beginPort, endPort, nil
+}
+
+// SaveAllSets list all set names from kernel
+func (runner *runner) SaveAllSets() ([]byte, error) {
+	out, err := runner.exec.Command(IPSetCmd, "list").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error saving all sets, error: %v", err)
+	}
+
+	return out, nil
+}

--- a/pkg/ipset/types.go
+++ b/pkg/ipset/types.go
@@ -1,0 +1,102 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+ * Tencent is pleased to support the open source community by making TKEStack available.
+ *
+ * Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipset
+
+// Type represents the ipset type
+type Type string
+
+const (
+	HashIP Type = "hash:ip"
+	// HashIPPort represents the `hash:ip,port` type ipset.  The hash:ip,port is similar to hash:ip but
+	// you can store IP address and protocol-port pairs in it.  TCP, SCTP, UDP, UDPLITE, ICMP and ICMPv6 are supported
+	// with port numbers/ICMP(v6) types and other protocol numbers without port information.
+	HashIPPort Type = "hash:ip,port"
+	// HashIPPortIP represents the `hash:ip,port,ip` type ipset.  The hash:ip,port,ip set type uses a hash to store
+	// IP address, port number and a second IP address triples.  The port number is interpreted together with a
+	// protocol (default TCP) and zero protocol number cannot be used.
+	HashIPPortIP Type = "hash:ip,port,ip"
+	// HashIPPortNet represents the `hash:ip,port,net` type ipset.  The hash:ip,port,net set type uses a hash
+	// to store IP address, port number and IP network address triples.  The port number is interpreted together
+	// with a protocol (default TCP) and zero protocol number cannot be used. Network address with zero prefix
+	// size cannot be stored either.
+	HashIPPortNet Type = "hash:ip,port,net"
+	// BitmapPort represents the `bitmap:port` type ipset.  The bitmap:port set type uses a memory range, where each bit
+	// represents one TCP/UDP port.  A bitmap:port type of set can store up to 65535 ports.
+	BitmapPort Type = "bitmap:port"
+
+	HashNet Type = "hash:net"
+
+	HashNetPort Type = "hash:net,port"
+)
+
+// DefaultPortRange defines the default bitmap:port valid port range.
+const DefaultPortRange string = "0-65535"
+
+const (
+	// ProtocolFamilyIPV4 represents IPv4 protocol.
+	ProtocolFamilyIPV4 = "inet"
+	// ProtocolFamilyIPV6 represents IPv6 protocol.
+	ProtocolFamilyIPV6 = "inet6"
+	// ProtocolTCP represents TCP protocol.
+	ProtocolTCP = "tcp"
+	// ProtocolUDP represents UDP protocol.
+	ProtocolUDP = "udp"
+)
+
+// ValidIPSetTypes defines the supported ip set type.
+var ValidIPSetTypes = []Type{
+	HashIP,
+	HashIPPort,
+	HashIPPortIP,
+	BitmapPort,
+	HashIPPortNet,
+	HashNet,
+	HashNetPort,
+}


### PR DESCRIPTION
This PR implements the datapath support for GlobalEgressIPs
at the namespace level as well as for objects with PodSelectors.

Fixes issue: https://github.com/submariner-io/submariner/issues/1164
Fixes issue: https://github.com/submariner-io/submariner/issues/1165
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
