### PR TITLE
Add shared ingress pod controllers

### DIFF
--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -520,7 +520,10 @@ func newClusterIPService() *corev1.Service {
 }
 
 func newHeadlessService() *corev1.Service {
-	s := newClusterIPService()
+	return toHeadlessService(newClusterIPService())
+}
+
+func toHeadlessService(s *corev1.Service) *corev1.Service {
 	s.Spec.ClusterIP = corev1.ClusterIPNone
 	s.Spec.Selector = map[string]string{"pod": s.Name}
 

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -273,14 +273,19 @@ func (g *gatewayMonitor) startControllers() error {
 
 	g.controllers = append(g.controllers, c)
 
-	c, err = NewServiceExportController(*g.syncerConfig)
+	podControllers, err := NewIngressPodControllers(*g.syncerConfig)
+	if err != nil {
+		return errors.WithMessage(err, "error creating the IngressPodControllers")
+	}
+
+	c, err = NewServiceExportController(*g.syncerConfig, podControllers)
 	if err != nil {
 		return errors.WithMessage(err, "error creating the ServiceExport controller")
 	}
 
 	g.controllers = append(g.controllers, c)
 
-	c, err = NewServiceController(*g.syncerConfig, c)
+	c, err = NewServiceController(*g.syncerConfig, podControllers)
 	if err != nil {
 		return errors.WithMessage(err, "error creating the Service controller")
 	}

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -70,6 +70,14 @@ var _ = Describe("Endpoint monitoring", func() {
 
 			t.createServiceExport(t.createService(newClusterIPService()))
 			t.awaitIngressIPStatusAllocated(serviceName)
+
+			service := newClusterIPService()
+			service.Name = "headless-nginx"
+			service = toHeadlessService(service)
+			backendPod := newHeadlessServicePod(service.Name)
+			t.createPod(backendPod)
+			t.createServiceExport(t.createService(service))
+			t.awaitHeadlessGlobalIngressIP(service.Name, backendPod.Name)
 		})
 
 		Context("and then removed", func() {

--- a/pkg/globalnet/controllers/ingress_pod_controllers.go
+++ b/pkg/globalnet/controllers/ingress_pod_controllers.go
@@ -1,0 +1,98 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"context"
+
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/admiral/pkg/util"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog"
+)
+
+func NewIngressPodControllers(config syncer.ResourceSyncerConfig) (*IngressPodControllers, error) {
+	_, gvr, err := util.ToUnstructuredResource(&submarinerv1.GlobalIngressIP{}, config.RestMapper)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IngressPodControllers{
+		controllers: map[string]*ingressPodController{},
+		config:      config,
+		ingressIPs:  config.SourceClient.Resource(*gvr),
+	}, nil
+}
+
+func (c *IngressPodControllers) start(service *corev1.Service) error {
+	c.Lock()
+	defer c.Unlock()
+
+	key := c.key(service.Name, service.Namespace)
+	if _, exists := c.controllers[key]; exists {
+		return nil
+	}
+
+	controller, err := startIngressPodController(service, c.config)
+	if err != nil {
+		return err
+	}
+
+	c.controllers[key] = controller
+
+	return nil
+}
+
+func (c *IngressPodControllers) stopAll() {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, controller := range c.controllers {
+		controller.Stop()
+	}
+
+	c.controllers = map[string]*ingressPodController{}
+}
+
+func (c *IngressPodControllers) stopAndCleanup(serviceName, serviceNamespace string) {
+	c.Lock()
+	defer c.Unlock()
+
+	key := c.key(serviceName, serviceNamespace)
+	controller, exists := c.controllers[key]
+	if exists {
+		controller.Stop()
+		delete(c.controllers, key)
+	}
+
+	svcSelector := labels.SelectorFromSet(map[string]string{ServiceRefLabel: serviceName}).String()
+	err := c.ingressIPs.Namespace(serviceNamespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: svcSelector})
+
+	if err != nil && !errors.IsNotFound(err) {
+		klog.Errorf("Error deleting GlobalIngressIPs for service %q: %v", key, err)
+	}
+}
+
+func (c *IngressPodControllers) key(n, ns string) string {
+	return ns + "/" + n
+}

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/ipset"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -47,6 +48,8 @@ const (
 	// of kube-proxy changes, globalnet needs to be modified accordingly.
 	// Reference: https://bit.ly/2OPhlwk
 	kubeProxyServiceChainPrefix = "KUBE-SVC-"
+
+	ServiceRefLabel = "submariner.io/serviceRef"
 
 	// The prefix used for the ipset chains created by Globalnet pod.
 	IPSetPrefix = "SM-GN-"
@@ -123,13 +126,13 @@ type serviceExportController struct {
 	*baseSyncerController
 	services       dynamic.NamespaceableResourceInterface
 	iptIface       iptiface.Interface
-	podControllers sync.Map
-	config         syncer.ResourceSyncerConfig
+	podControllers *IngressPodControllers
+	scheme         *runtime.Scheme
 }
 
 type serviceController struct {
 	*baseSyncerController
-	svcExController *serviceExportController
+	podControllers *IngressPodControllers
 }
 
 type nodeController struct {
@@ -140,8 +143,14 @@ type nodeController struct {
 
 type ingressPodController struct {
 	*baseSyncerController
-	ingressIPs   dynamic.NamespaceableResourceInterface
 	svcName      string
 	namespace    string
 	ingressIPMap stringset.Interface
+}
+
+type IngressPodControllers struct {
+	sync.Mutex
+	controllers map[string]*ingressPodController
+	config      syncer.ResourceSyncerConfig
+	ingressIPs  dynamic.NamespaceableResourceInterface
 }


### PR DESCRIPTION
Eliminated the direct coupling between the `serviceExportController` and `serviceController` by adding a shared struct to store, start and stop the `ingressPodController` instances and cleanup the `GlobalIngressIP` objects.
