### PR TITLE
Ignore protobuf and document entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     ignore:
+      # protobuf must be handled manually
+      - dependency-name: google.golang.org/protobuf
+      # K8s dependencies must be handled manually
       - dependency-name: k8s.io/api
         versions:
           - "> 0.17.0"
@@ -18,4 +21,5 @@ updates:
       - dependency-name: sigs.k8s.io/controller-runtime
         versions:
           - "> 0.3.0"
+      # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
When we upgrade protobuf, we should also upgrade the generation tool,
but that results in a change to generated files, failing the PR. As a
result, dependabot can never produce valid PRs to upgrade protobuf.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
