### PR TITLE
Set min/max limits for num of Egress IPs

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -211,6 +211,8 @@ type GlobalEgressIP struct {
 type GlobalEgressIPSpec struct {
 	// The requested number of contiguous GlobalIPs to allocate from the Globalnet CIDR assigned to the cluster.
 	// If not specified, defaults to 1.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=20
 	// +optional
 	NumberOfIPs *int `json:"numberOfIPs,omitempty"`
 
@@ -267,6 +269,8 @@ type ClusterGlobalEgressIP struct {
 type ClusterGlobalEgressIPSpec struct {
 	// The requested number of contiguous GlobalIPs to allocate from the Globalnet CIDR assigned to the cluster.
 	// If not specified, defaults to 1.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=20
 	// +optional
 	NumberOfIPs *int `json:"numGlobalIPs,omitempty"`
 }


### PR DESCRIPTION
Add validations to *EgressIPs for numberOfIPs to min 0 and max 20

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
