### PR TITLE
Fix race condition in globalEgressIPController tests

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -106,7 +106,7 @@ type globalEgressIPController struct {
 type podWatcher struct {
 	stopCh      chan struct{}
 	ipSetName   string
-	ipSetIface  ipset.Interface
+	namedIPSet  ipset.Named
 	podSelector *metav1.LabelSelector
 }
 

--- a/pkg/ipset/named.go
+++ b/pkg/ipset/named.go
@@ -1,0 +1,73 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ipset
+
+type Named interface {
+	Name() string
+	Flush() error
+	Destroy() error
+	Create(ignoreExistErr bool) error
+	AddEntry(entry string, ignoreExistErr bool) error
+	DelEntry(entry string) error
+	TestEntry(entry string) (bool, error)
+	ListEntries() ([]string, error)
+}
+
+type namedType struct {
+	iface Interface
+	set   IPSet
+}
+
+func NewNamed(set IPSet, iface Interface) Named {
+	return &namedType{
+		iface: iface,
+		set:   set,
+	}
+}
+
+func (n *namedType) Name() string {
+	return n.set.Name
+}
+
+func (n *namedType) Flush() error {
+	return n.iface.FlushSet(n.set.Name)
+}
+
+func (n *namedType) Destroy() error {
+	return n.iface.DestroySet(n.set.Name)
+}
+
+func (n *namedType) Create(ignoreExistErr bool) error {
+	return n.iface.CreateSet(&n.set, ignoreExistErr)
+}
+
+func (n *namedType) AddEntry(entry string, ignoreExistErr bool) error {
+	return n.iface.AddEntry(entry, &n.set, ignoreExistErr)
+}
+
+func (n *namedType) DelEntry(entry string) error {
+	return n.iface.DelEntry(entry, n.set.Name)
+}
+
+func (n *namedType) TestEntry(entry string) (bool, error) {
+	return n.iface.TestEntry(entry, n.set.Name)
+}
+
+func (n *namedType) ListEntries() ([]string, error) {
+	return n.iface.ListEntries(n.set.Name)
+}


### PR DESCRIPTION
The `podWatcher` is created asynchronously and may still be starting in the background when the next test is started causing a race when the `podWatcher` tries to create the ipset interface via the NewFunc hook.

To prevent this, pass the ipset interface to the podWatcher. The `podWatcher` already is passed the ipset name so instead of also passing the interface, a new `Named` ipset interface was added to encapsulate the named ipset and the general interface. Also modified the `globalEgressIPController` to use the `Named` ipset.
