### PR TITLE
Fix issues with MTU settings

### DIFF
--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -1,0 +1,58 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mtu
+
+import (
+	"k8s.io/klog"
+
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/netlink"
+)
+
+type mtuHandler struct {
+	event.HandlerBase
+}
+
+func NewMTUHandler() event.Handler {
+	return &mtuHandler{}
+}
+
+func (h *mtuHandler) GetNetworkPlugins() []string {
+	return []string{event.AnyNetworkPlugin}
+}
+
+func (h *mtuHandler) GetName() string {
+	return "MTU handler"
+}
+
+func (h *mtuHandler) Init() error {
+	klog.Infof("Updating configurations for Path MTU")
+	configureTCPMTUProbe()
+
+	return nil
+}
+
+func configureTCPMTUProbe() {
+	mtuProbe := "2"
+	baseMss := "1024"
+
+	err := netlink.New().ConfigureTCPMTUProbe(mtuProbe, baseMss)
+	if err != nil {
+		klog.Warningf(err.Error())
+	}
+}

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
 )
 
@@ -88,6 +89,7 @@ func main() {
 		ovn.NewHandler(env, smClientset),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
+		mtu.NewMTUHandler(),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}


### PR DESCRIPTION
When the clusters have different MTU configures,  some of
the e2e tests are failing.  TCPMTU probe is now enabled to
fix this on all route agents.
Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
