### PR TITLE
Datapath support for headless services

### DIFF
--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -110,6 +110,10 @@ func (c *ingressPodController) process(from runtime.Object, numRequeues int, op 
 
 	klog.Infof("%q ingress Pod %s for service %s", op, key, c.svcName)
 
+	ingressIP.ObjectMeta.Annotations = map[string]string{
+		headlessSvcPodIP: pod.Status.PodIP,
+	}
+
 	ingressIP.Spec = submarinerv1.GlobalIngressIPSpec{
 		Target:     submarinerv1.HeadlessServicePod,
 		ServiceRef: &corev1.LocalObjectReference{Name: c.svcName},

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -118,7 +118,6 @@ func (c *serviceExportController) onCreate(serviceExport *mcsv1a1.ServiceExport)
 
 	if service.Spec.ClusterIP == corev1.ClusterIPNone {
 		// Headless service
-		// TODO: kuberProxyServiceChain?
 		return c.onCreateHeadless(key, service)
 	}
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -42,6 +42,9 @@ const (
 	// This is an internal annotation used between service export controller and global-ingress controller.
 	kubeProxyIPTableChainAnnotation = "submariner.io/kubeproxy-iptablechain"
 
+	// This is an internal annotation used between ingress pod controller and global-ingress controller.
+	headlessSvcPodIP = "submariner.io/headless-svc-pod-ip"
+
 	// Currently Submariner Globalnet implementation (for services) works with kube-proxy
 	// and uses iptable chain-names programmed by kube-proxy. If the internal implementation
 	// of kube-proxy changes, globalnet needs to be modified accordingly.
@@ -117,6 +120,8 @@ type clusterGlobalEgressIPController struct {
 
 type globalIngressIPController struct {
 	*baseIPAllocationController
+	pods   dynamic.NamespaceableResourceInterface
+	config syncer.ResourceSyncerConfig
 }
 
 type serviceExportController struct {


### PR DESCRIPTION
This PR implements datapath support for Headless Service Pods.
For each of the backend Pod we will create a Ingress object
and the corresponding globalIP can be read from the object.
This PR also handles the reconsiliation code which will validate
if any of the Headless Service backend pods were deleted while
the globalnet Pod was down and handles it. Unit tests and e2e tests
will be added in subsequent PRs.

Fixes issue: https://github.com/submariner-io/submariner/issues/732
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
