### PR TITLE
Reconcile GlobalIngressIPs on startup

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -273,6 +273,15 @@ func (g *gatewayMonitor) startControllers() error {
 
 	g.controllers = append(g.controllers, c)
 
+	// The GlobalIngressIP controller needs to be started before the ServiceExport and Service controllers to ensure
+	// reconciliation works properly.
+	c, err = NewGlobalIngressIPController(*g.syncerConfig, pool)
+	if err != nil {
+		return errors.WithMessage(err, "error creating the GlobalIngressIP controller")
+	}
+
+	g.controllers = append(g.controllers, c)
+
 	podControllers, err := NewIngressPodControllers(*g.syncerConfig)
 	if err != nil {
 		return errors.WithMessage(err, "error creating the IngressPodControllers")
@@ -288,13 +297,6 @@ func (g *gatewayMonitor) startControllers() error {
 	c, err = NewServiceController(*g.syncerConfig, podControllers)
 	if err != nil {
 		return errors.WithMessage(err, "error creating the Service controller")
-	}
-
-	g.controllers = append(g.controllers, c)
-
-	c, err = NewGlobalIngressIPController(*g.syncerConfig, pool)
-	if err != nil {
-		return errors.WithMessage(err, "error creating the GlobalIngressIP controller")
 	}
 
 	g.controllers = append(g.controllers, c)

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -123,13 +123,12 @@ type clusterGlobalEgressIPController struct {
 
 type globalIngressIPController struct {
 	*baseIPAllocationController
-	pods   dynamic.NamespaceableResourceInterface
-	config syncer.ResourceSyncerConfig
 }
 
 type serviceExportController struct {
 	*baseSyncerController
 	services       dynamic.NamespaceableResourceInterface
+	ingressIPs     dynamic.ResourceInterface
 	iptIface       iptiface.Interface
 	podControllers *IngressPodControllers
 	scheme         *runtime.Scheme
@@ -137,6 +136,7 @@ type serviceExportController struct {
 
 type serviceController struct {
 	*baseSyncerController
+	ingressIPs     dynamic.ResourceInterface
 	podControllers *IngressPodControllers
 }
 


### PR DESCRIPTION
Cleanup `GlobalIngressIPs` whose associated `Service`/`ServiceExport`/`Pod` were deleted while controllers were down.
