### PR TITLE
Update globalIngressIPController unit tests

### DIFF
--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -82,7 +82,13 @@ func NewGlobalIngressIPController(config syncer.ResourceSyncerConfig, pool *ipam
 			if gip.Spec.Target == submarinerv1.ClusterIPService {
 				return controller.iptIface.AddIngressRulesForService(reservedIPs[0], target)
 			} else if gip.Spec.Target == submarinerv1.HeadlessServicePod {
-				return controller.iptIface.AddIngressRulesForHeadlessSvcPod(reservedIPs[0], target)
+				err := controller.iptIface.AddIngressRulesForHeadlessSvcPod(reservedIPs[0], target)
+				if err != nil {
+					return err
+				}
+
+				key, _ := cache.MetaNamespaceKeyFunc(obj)
+				return controller.iptIface.AddEgressRulesForHeadlessSVCPods(key, target, reservedIPs[0], globalNetIPTableMark)
 			}
 			return nil
 		})

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -35,268 +35,231 @@ import (
 var _ = Describe("GlobalIngressIP controller", func() {
 	t := newGlobalIngressIPControllerDriver()
 
-	When("a GlobalIngressIP is created", func() {
-		JustBeforeEach(func() {
-			t.createGlobalIngressIP(&submarinerv1.GlobalIngressIP{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: globalIngressIPName,
-					Annotations: map[string]string{
-						"submariner.io/kubeproxy-iptablechain": kubeProxyIPTableChainName,
-					},
-				},
-				Spec: submarinerv1.GlobalIngressIPSpec{
-					Target: submarinerv1.ClusterIPService,
-					ServiceRef: &corev1.LocalObjectReference{
-						Name: "db-service",
-					},
-				},
-			})
-		})
+	podIP := "10.1.2.3"
 
-		It("should successfully allocate a global IP", func() {
-			t.awaitIngressIPStatusAllocated(globalIngressIPName)
-			allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
-			t.awaitIPTableRules(allocatedIP)
-		})
+	clusterIPServiceIngress := &submarinerv1.GlobalIngressIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: globalIngressIPName,
+			Annotations: map[string]string{
+				"submariner.io/kubeproxy-iptablechain": kubeProxyIPTableChainName,
+			},
+		},
+		Spec: submarinerv1.GlobalIngressIPSpec{
+			Target: submarinerv1.ClusterIPService,
+			ServiceRef: &corev1.LocalObjectReference{
+				Name: "db-service",
+			},
+		},
+	}
 
-		Context("with the IP pool exhausted", func() {
-			BeforeEach(func() {
-				_, err := t.pool.Allocate(t.pool.Size())
-				Expect(err).To(Succeed())
-			})
+	headlessServiceIngress := &submarinerv1.GlobalIngressIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: globalIngressIPName,
+			Annotations: map[string]string{
+				"submariner.io/headless-svc-pod-ip": podIP,
+			},
+		},
+		Spec: submarinerv1.GlobalIngressIPSpec{
+			Target: submarinerv1.HeadlessServicePod,
+			ServiceRef: &corev1.LocalObjectReference{
+				Name: "db-service",
+			},
+			PodRef: &corev1.LocalObjectReference{
+				Name: "pod-1",
+			},
+		},
+	}
 
-			It("should add an appropriate Status condition", func() {
-				awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
-					Type:   string(submarinerv1.GlobalEgressIPAllocated),
-					Status: metav1.ConditionFalse,
-					Reason: "IPPoolAllocationFailed",
-				})
-			})
-		})
+	awaitHeadlessServicePodRules := func(ip string) {
+		t.awaitPodEgressRules(podIP, ip)
+		t.awaitPodIngressRules(podIP, ip)
+	}
 
-		Context("and programming of IP tables initially fails", func() {
-			BeforeEach(func() {
-				t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(kubeProxyIPTableChainName))
-			})
+	awaitNoHeadlessServicePodRules := func(ip string) {
+		t.awaitNoPodEgressRules(podIP, ip)
+		t.awaitNoPodIngressRules(podIP, ip)
+	}
 
-			It("should eventually allocate a global IP", func() {
-				awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
-					Type:   string(submarinerv1.GlobalEgressIPAllocated),
-					Status: metav1.ConditionFalse,
-					Reason: "ProgramIPTableRulesFailed",
-				}, metav1.Condition{
-					Type:   string(submarinerv1.GlobalEgressIPAllocated),
-					Status: metav1.ConditionTrue,
-				})
-
-				t.awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
-			})
-		})
-
-		Context("and then removed", func() {
-			var allocatedIP string
-
-			JustBeforeEach(func() {
-				t.awaitIngressIPStatusAllocated(globalIngressIPName)
-				allocatedIP = t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
-
-				Expect(t.globalIngressIPs.Delete(context.TODO(), globalIngressIPName, metav1.DeleteOptions{})).To(Succeed())
-			})
-
-			It("should release the allocated global IP", func() {
-				t.awaitIPsReleasedFromPool(allocatedIP)
-				t.awaitNoIPTableRules(allocatedIP)
-			})
-
-			Context("and cleanup of IP tables initially fails", func() {
-				BeforeEach(func() {
-					t.ipt.AddFailOnDeleteRuleMatcher(ContainSubstring(kubeProxyIPTableChainName))
-				})
-
-				It("should eventually cleanup the IP tables and reallocate", func() {
-					t.awaitIPsReleasedFromPool(allocatedIP)
-					t.awaitNoIPTableRules(allocatedIP)
-				})
-			})
-		})
+	When("a GlobalIngressIP for a cluster IP Service is created", func() {
+		testGlobalIngressIPCreated(t, clusterIPServiceIngress, t.awaitServiceIngressRules, t.awaitNoServiceIngressRules,
+			kubeProxyIPTableChainName)
 	})
 
-	When("a GlobalIngressIP exists on startup", func() {
-		var existing *submarinerv1.GlobalIngressIP
-
-		BeforeEach(func() {
-			existing = &submarinerv1.GlobalIngressIP{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: globalIngressIPName,
-					Annotations: map[string]string{
-						"submariner.io/kubeproxy-iptablechain": kubeProxyIPTableChainName,
-					},
-				},
-				Spec: submarinerv1.GlobalIngressIPSpec{
-					Target: submarinerv1.ClusterIPService,
-					ServiceRef: &corev1.LocalObjectReference{
-						Name: "db-service",
-					},
-				},
-			}
-		})
-
-		Context("with an allocated IP", func() {
-			BeforeEach(func() {
-				existing.Status.AllocatedIP = "169.254.1.100"
-				t.createGlobalIngressIP(existing)
-			})
-
-			It("should not reallocate the global IP", func() {
-				Consistently(func() string {
-					return t.getGlobalIngressIPStatus(existing.Name).AllocatedIP
-				}, 200*time.Millisecond).Should(Equal(existing.Status.AllocatedIP))
-			})
-
-			It("should not update the Status conditions", func() {
-				Consistently(func() int {
-					return len(t.getGlobalIngressIPStatus(existing.Name).Conditions)
-				}, 200*time.Millisecond).Should(Equal(0))
-			})
-
-			It("should reserve the previously allocated IP", func() {
-				t.verifyIPsReservedInPool(t.getGlobalIngressIPStatus(existing.Name).AllocatedIP)
-			})
-
-			It("should program the relevant IP table rules", func() {
-				t.awaitIPTableRules(existing.Status.AllocatedIP)
-			})
-
-			Context("and it's already reserved", func() {
-				BeforeEach(func() {
-					Expect(t.pool.Reserve(existing.Status.AllocatedIP)).To(Succeed())
-				})
-
-				It("should reallocate the global IP", func() {
-					t.awaitIngressIPStatus(globalIngressIPName, 0,
-						metav1.Condition{
-							Type:   string(submarinerv1.GlobalEgressIPAllocated),
-							Status: metav1.ConditionFalse,
-							Reason: "ReserveAllocatedIPsFailed",
-						}, metav1.Condition{
-							Type:   string(submarinerv1.GlobalEgressIPAllocated),
-							Status: metav1.ConditionTrue,
-						})
-
-					t.awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
-				})
-			})
-
-			Context("and programming the IP table rules fails", func() {
-				BeforeEach(func() {
-					t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(existing.Status.AllocatedIP))
-				})
-
-				It("should reallocate the global IP", func() {
-					t.awaitIngressIPStatus(globalIngressIPName, 0,
-						metav1.Condition{
-							Type:   string(submarinerv1.GlobalEgressIPAllocated),
-							Status: metav1.ConditionFalse,
-							Reason: "ReserveAllocatedIPsFailed",
-						}, metav1.Condition{
-							Type:   string(submarinerv1.GlobalEgressIPAllocated),
-							Status: metav1.ConditionTrue,
-						})
-
-					allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
-					t.awaitIPTableRules(allocatedIP)
-					t.awaitIPsReleasedFromPool(existing.Status.AllocatedIP)
-				})
-			})
-		})
-
-		Context("without an allocated IP", func() {
-			BeforeEach(func() {
-				t.createGlobalIngressIP(existing)
-			})
-
-			It("should allocate it and program the relevant IP table rules", func() {
-				t.awaitIngressIPStatusAllocated(globalIngressIPName)
-				t.awaitIPTableRules(existing.Status.AllocatedIP)
-			})
-		})
+	When("a GlobalIngressIP for a headless Service is created", func() {
+		testGlobalIngressIPCreated(t, headlessServiceIngress, awaitHeadlessServicePodRules, awaitNoHeadlessServicePodRules, podIP)
 	})
 
-	When("a GlobalIngressIP for Headless Service is created", func() {
-		podIP := "10.1.2.3"
-		JustBeforeEach(func() {
-			t.createGlobalIngressIP(&submarinerv1.GlobalIngressIP{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: globalIngressIPName,
-					Annotations: map[string]string{
-						"submariner.io/headless-svc-pod-ip": podIP,
-					},
-				},
-				Spec: submarinerv1.GlobalIngressIPSpec{
-					Target: submarinerv1.HeadlessServicePod,
-					ServiceRef: &corev1.LocalObjectReference{
-						Name: "db-service",
-					},
-					PodRef: &corev1.LocalObjectReference{
-						Name: "pod-1",
-					},
-				},
-			})
-		})
+	When("a GlobalIngressIP for a cluster IP Service exists on startup", func() {
+		testExistingGlobalIngressIP(t, clusterIPServiceIngress, t.awaitServiceIngressRules)
+	})
 
-		It("should successfully allocate a global IP", func() {
-			t.awaitIngressIPStatusAllocated(globalIngressIPName)
-			allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
-			t.awaitEgressIPTableRules(podIP, allocatedIP)
-		})
-
-		Context("and programming of IP tables initially fails", func() {
-			BeforeEach(func() {
-				t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(podIP))
-			})
-
-			It("should eventually allocate a global IP", func() {
-				awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
-					Type:   string(submarinerv1.GlobalEgressIPAllocated),
-					Status: metav1.ConditionFalse,
-					Reason: "ProgramIPTableRulesFailed",
-				}, metav1.Condition{
-					Type:   string(submarinerv1.GlobalEgressIPAllocated),
-					Status: metav1.ConditionTrue,
-				})
-
-				t.awaitEgressIPTableRules(podIP, t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
-			})
-		})
-
-		Context("and then removed", func() {
-			var allocatedIP string
-
-			JustBeforeEach(func() {
-				t.awaitIngressIPStatusAllocated(globalIngressIPName)
-				allocatedIP = t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
-
-				Expect(t.globalIngressIPs.Delete(context.TODO(), globalIngressIPName, metav1.DeleteOptions{})).To(Succeed())
-			})
-
-			It("should release the allocated global IP", func() {
-				t.awaitIPsReleasedFromPool(allocatedIP)
-				t.awaitNoEgressIPTableRules(podIP, allocatedIP)
-			})
-
-			Context("and cleanup of IP tables initially fails", func() {
-				BeforeEach(func() {
-					t.ipt.AddFailOnDeleteRuleMatcher(ContainSubstring(podIP))
-				})
-
-				It("should eventually cleanup the IP tables", func() {
-					t.awaitIPsReleasedFromPool(allocatedIP)
-					t.awaitNoEgressIPTableRules(podIP, allocatedIP)
-				})
-			})
-		})
+	When("a GlobalIngressIP for a headless Service exists on startup", func() {
+		testExistingGlobalIngressIP(t, headlessServiceIngress, awaitHeadlessServicePodRules)
 	})
 })
+
+func testGlobalIngressIPCreated(t *globalIngressIPControllerTestDriver, ingressIP *submarinerv1.GlobalIngressIP,
+	awaitIPTableRules, awaitNoIPTableRules func(string), ruleMatch string) {
+	JustBeforeEach(func() {
+		t.createGlobalIngressIP(ingressIP)
+	})
+
+	It("should successfully allocate a global IP", func() {
+		t.awaitIngressIPStatusAllocated(globalIngressIPName)
+		allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
+		awaitIPTableRules(allocatedIP)
+	})
+
+	Context("with the IP pool exhausted", func() {
+		BeforeEach(func() {
+			_, err := t.pool.Allocate(t.pool.Size())
+			Expect(err).To(Succeed())
+		})
+
+		It("should add an appropriate Status condition", func() {
+			awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
+				Type:   string(submarinerv1.GlobalEgressIPAllocated),
+				Status: metav1.ConditionFalse,
+				Reason: "IPPoolAllocationFailed",
+			})
+		})
+	})
+
+	Context("and programming of IP tables initially fails", func() {
+		BeforeEach(func() {
+			t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(ruleMatch))
+		})
+
+		It("should eventually allocate a global IP", func() {
+			awaitStatusConditions(t.globalIngressIPs, globalIngressIPName, 0, metav1.Condition{
+				Type:   string(submarinerv1.GlobalEgressIPAllocated),
+				Status: metav1.ConditionFalse,
+				Reason: "ProgramIPTableRulesFailed",
+			}, metav1.Condition{
+				Type:   string(submarinerv1.GlobalEgressIPAllocated),
+				Status: metav1.ConditionTrue,
+			})
+
+			awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
+		})
+	})
+
+	Context("and then removed", func() {
+		var allocatedIP string
+
+		JustBeforeEach(func() {
+			t.awaitIngressIPStatusAllocated(globalIngressIPName)
+			allocatedIP = t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
+
+			Expect(t.globalIngressIPs.Delete(context.TODO(), globalIngressIPName, metav1.DeleteOptions{})).To(Succeed())
+		})
+
+		It("should release the allocated global IP", func() {
+			t.awaitIPsReleasedFromPool(allocatedIP)
+			awaitNoIPTableRules(allocatedIP)
+		})
+
+		Context("and cleanup of IP tables initially fails", func() {
+			BeforeEach(func() {
+				t.ipt.AddFailOnDeleteRuleMatcher(ContainSubstring(ruleMatch))
+			})
+
+			It("should eventually cleanup the IP tables and reallocate", func() {
+				t.awaitIPsReleasedFromPool(allocatedIP)
+				awaitNoIPTableRules(allocatedIP)
+			})
+		})
+	})
+}
+
+func testExistingGlobalIngressIP(t *globalIngressIPControllerTestDriver, ingressIP *submarinerv1.GlobalIngressIP,
+	awaitIPTableRules func(string)) {
+	var existing *submarinerv1.GlobalIngressIP
+
+	BeforeEach(func() {
+		existing = ingressIP.DeepCopy()
+	})
+
+	Context("with an allocated IP", func() {
+		BeforeEach(func() {
+			existing.Status.AllocatedIP = "169.254.1.100"
+			t.createGlobalIngressIP(existing)
+		})
+
+		It("should not reallocate the global IP", func() {
+			Consistently(func() string {
+				return t.getGlobalIngressIPStatus(existing.Name).AllocatedIP
+			}, 200*time.Millisecond).Should(Equal(existing.Status.AllocatedIP))
+		})
+
+		It("should not update the Status conditions", func() {
+			Consistently(func() int {
+				return len(t.getGlobalIngressIPStatus(existing.Name).Conditions)
+			}, 200*time.Millisecond).Should(Equal(0))
+		})
+
+		It("should reserve the previously allocated IP", func() {
+			t.verifyIPsReservedInPool(t.getGlobalIngressIPStatus(existing.Name).AllocatedIP)
+		})
+
+		It("should program the relevant IP table rules", func() {
+			awaitIPTableRules(existing.Status.AllocatedIP)
+		})
+
+		Context("and it's already reserved", func() {
+			BeforeEach(func() {
+				Expect(t.pool.Reserve(existing.Status.AllocatedIP)).To(Succeed())
+			})
+
+			It("should reallocate the global IP", func() {
+				t.awaitIngressIPStatus(globalIngressIPName, 0,
+					metav1.Condition{
+						Type:   string(submarinerv1.GlobalEgressIPAllocated),
+						Status: metav1.ConditionFalse,
+						Reason: "ReserveAllocatedIPsFailed",
+					}, metav1.Condition{
+						Type:   string(submarinerv1.GlobalEgressIPAllocated),
+						Status: metav1.ConditionTrue,
+					})
+
+				awaitIPTableRules(t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP)
+			})
+		})
+
+		Context("and programming the IP table rules fails", func() {
+			BeforeEach(func() {
+				t.ipt.AddFailOnAppendRuleMatcher(ContainSubstring(existing.Status.AllocatedIP))
+			})
+
+			It("should reallocate the global IP", func() {
+				t.awaitIngressIPStatus(globalIngressIPName, 0,
+					metav1.Condition{
+						Type:   string(submarinerv1.GlobalEgressIPAllocated),
+						Status: metav1.ConditionFalse,
+						Reason: "ReserveAllocatedIPsFailed",
+					}, metav1.Condition{
+						Type:   string(submarinerv1.GlobalEgressIPAllocated),
+						Status: metav1.ConditionTrue,
+					})
+
+				allocatedIP := t.getGlobalIngressIPStatus(globalIngressIPName).AllocatedIP
+				awaitIPTableRules(allocatedIP)
+				t.awaitIPsReleasedFromPool(existing.Status.AllocatedIP)
+			})
+		})
+	})
+
+	Context("without an allocated IP", func() {
+		BeforeEach(func() {
+			t.createGlobalIngressIP(existing)
+		})
+
+		It("should allocate it and program the relevant IP table rules", func() {
+			t.awaitIngressIPStatusAllocated(globalIngressIPName)
+			awaitIPTableRules(existing.Status.AllocatedIP)
+		})
+	})
+}
 
 type globalIngressIPControllerTestDriver struct {
 	*testDriverBase
@@ -338,18 +301,26 @@ func (t *globalIngressIPControllerTestDriver) start() {
 	Expect(t.controller.Start()).To(Succeed())
 }
 
-func (t *globalIngressIPControllerTestDriver) awaitIPTableRules(ip string) {
+func (t *globalIngressIPControllerTestDriver) awaitServiceIngressRules(ip string) {
 	t.ipt.AwaitRule("nat", constants.SmGlobalnetIngressChain, And(ContainSubstring(ip), ContainSubstring(kubeProxyIPTableChainName)))
 }
 
-func (t *globalIngressIPControllerTestDriver) awaitNoIPTableRules(ip string) {
+func (t *globalIngressIPControllerTestDriver) awaitNoServiceIngressRules(ip string) {
 	t.ipt.AwaitNoRule("nat", constants.SmGlobalnetIngressChain, Or(ContainSubstring(ip), ContainSubstring(kubeProxyIPTableChainName)))
 }
 
-func (t *globalIngressIPControllerTestDriver) awaitEgressIPTableRules(podIP, snatIP string) {
+func (t *globalIngressIPControllerTestDriver) awaitPodEgressRules(podIP, snatIP string) {
 	t.ipt.AwaitRule("nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods, And(ContainSubstring(podIP), ContainSubstring(snatIP)))
 }
 
-func (t *globalIngressIPControllerTestDriver) awaitNoEgressIPTableRules(podIP, snatIP string) {
+func (t *globalIngressIPControllerTestDriver) awaitNoPodEgressRules(podIP, snatIP string) {
+	t.ipt.AwaitNoRule("nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods, Or(ContainSubstring(podIP), ContainSubstring(snatIP)))
+}
+
+func (t *globalIngressIPControllerTestDriver) awaitPodIngressRules(podIP, snatIP string) {
+	t.ipt.AwaitRule("nat", constants.SmGlobalnetIngressChain, And(ContainSubstring(podIP), ContainSubstring(snatIP)))
+}
+
+func (t *globalIngressIPControllerTestDriver) awaitNoPodIngressRules(podIP, snatIP string) {
 	t.ipt.AwaitNoRule("nat", constants.SmGlobalnetIngressChain, Or(ContainSubstring(podIP), ContainSubstring(snatIP)))
 }

--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/stringset"
 	"github.com/submariner-io/admiral/pkg/syncer"
@@ -96,7 +98,7 @@ func (c *ingressPodController) process(from runtime.Object, numRequeues int, op 
 
 	ingressIP := &submarinerv1.GlobalIngressIP{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getIngressIPName(pod),
+			Name:      fmt.Sprintf("pod-%.59s", pod.Name),
 			Namespace: pod.Namespace,
 			Labels: map[string]string{
 				ServiceRefLabel: c.svcName,


### PR DESCRIPTION
Added verification of headless service pod ingress rules and refactored the test cases so they all run for both `HeadlessServicePod` and `ClusterIPService` types. Also fixed issues found and other minor modifications. See individual commits for details.