### PR TITLE
Detach the license header from the package declarations

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -108,6 +108,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/apis/submariner.io/v1/doc.go
+++ b/pkg/apis/submariner.io/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 
 // +groupName=submariner.io
+
 package v1

--- a/pkg/apis/submariner.io/v1/endpoint.go
+++ b/pkg/apis/submariner.io/v1/endpoint.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/apis/submariner.io/v1/register.go
+++ b/pkg/apis/submariner.io/v1/register.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/apis/submariner.io/v1/string.go
+++ b/pkg/apis/submariner.io/v1/string.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/apis/submariner.io/v1/string_test.go
+++ b/pkg/apis/submariner.io/v1/string_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cable
 
 import (

--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package libreswan
 
 import (

--- a/pkg/cable/libreswan/libreswan_suite_test.go
+++ b/pkg/cable/libreswan/libreswan_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package libreswan_test
 
 import (

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package libreswan
 
 import (

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package libreswan
 
 import (

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package vxlan
 
 import (

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package wireguard
 
 import (

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package wireguard
 
 import (

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cableengine
 
 import (

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cableengine_test
 
 import (

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/cableengine/healthchecker/fake/pinger.go
+++ b/pkg/cableengine/healthchecker/fake/pinger.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/cableengine/healthchecker/healthchecker.go
+++ b/pkg/cableengine/healthchecker/healthchecker.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker
 
 import (

--- a/pkg/cableengine/healthchecker/healthchecker_suite_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker_test
 
 import (

--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker_test
 
 import (

--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker
 
 import (

--- a/pkg/cableengine/healthchecker/pinger_test.go
+++ b/pkg/cableengine/healthchecker/pinger_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker
 
 import (

--- a/pkg/cableengine/healthchecker/statistics.go
+++ b/pkg/cableengine/healthchecker/statistics.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker
 
 import (

--- a/pkg/cableengine/healthchecker/statistics_test.go
+++ b/pkg/cableengine/healthchecker/statistics_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package healthchecker
 
 import (

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer
 
 import (

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package syncer_test
 
 import (

--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cidr
 
 import (

--- a/pkg/controllers/datastoresyncer/datastore_0.8.0_upgrade_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_0.8.0_upgrade_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer_test
 
 import (

--- a/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer_test
 
 import (

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer_test
 
 import (

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer
 
 import (

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer_test
 
 import (

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package datastoresyncer
 
 import (

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tunnel
 
 import (

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tunnel_test
 
 import (

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoint
 
 import (

--- a/pkg/endpoint/local_endpoint_suite_test.go
+++ b/pkg/endpoint/local_endpoint_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoint_test
 
 import (

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoint_test
 
 import (

--- a/pkg/endpoint/public_ip_test.go
+++ b/pkg/endpoint/public_ip_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpoint
 
 import (

--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/event/controller/controller_suite_test.go
+++ b/pkg/event/controller/controller_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/event/controller/controller_test.go
+++ b/pkg/event/controller/controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/event/controller/endpoint_updated.go
+++ b/pkg/event/controller/endpoint_updated.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/event/controller/node_handlers.go
+++ b/pkg/event/controller/node_handlers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/event/event_suite_test.go
+++ b/pkg/event/event_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package event_test
 
 import (

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package event
 
 import (

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package logger
 
 import (

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package event
 
 import (

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package event_test
 
 import (

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package testing
 
 import (

--- a/pkg/globalnet/constants/constants.go
+++ b/pkg/globalnet/constants/constants.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constants
 
 const (

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/cluster_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/egress_pod_watcher.go
+++ b/pkg/globalnet/controllers/egress_pod_watcher.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/global_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_egressip_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/ingress_pod_controllers.go
+++ b/pkg/globalnet/controllers/ingress_pod_controllers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/iptables/iface.go
+++ b/pkg/globalnet/controllers/iptables/iface.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package iptables
 
 import (

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/node_controller_test.go
+++ b/pkg/globalnet/controllers/node_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/service_controller.go
+++ b/pkg/globalnet/controllers/service_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/service_controller_test.go
+++ b/pkg/globalnet/controllers/service_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers_test
 
 import (

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controllers
 
 import (

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/ipam/ipam_suite_test.go
+++ b/pkg/ipam/ipam_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ipam_test
 
 import (

--- a/pkg/ipam/ippool.go
+++ b/pkg/ipam/ippool.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ipam
 
 import (

--- a/pkg/ipam/ippool_test.go
+++ b/pkg/ipam/ippool_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ipam_test
 
 import (

--- a/pkg/ipset/fake/ipset.go
+++ b/pkg/ipset/fake/ipset.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/ipset/named.go
+++ b/pkg/ipset/named.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ipset
 
 type Named interface {

--- a/pkg/iptables/fake/iptables.go
+++ b/pkg/iptables/fake/iptables.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package iptables
 
 import (

--- a/pkg/natdiscovery/listener_test.go
+++ b/pkg/natdiscovery/listener_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/natdiscovery_test.go
+++ b/pkg/natdiscovery/natdiscovery_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/natdiscovery/request_send_test.go
+++ b/pkg/natdiscovery/request_send_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package natdiscovery
 
 import (

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fake
 
 import (

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package netlink
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/env.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/env.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import "os"

--- a/pkg/networkplugin-syncer/handlers/ovn/handler.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/infrastructure.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/infrastructure.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package nbctl
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl_suite_test.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/nbctl/nbctl_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package nbctl
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/ovn_suite_test.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_ovn_cluster_north.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_south.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/routers.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/routers.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/routers_test.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/routers_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/services.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/services.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/subnets.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/subnets.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/handlers/ovn/subnets_test.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/subnets_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pod
 
 import (

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cabledriver
 
 import (

--- a/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cabledriver
 
 import (

--- a/pkg/routeagent_driver/cni/cni_iface.go
+++ b/pkg/routeagent_driver/cni/cni_iface.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cni
 
 import (

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constants
 
 const (

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package environment
 
 type Specification struct {

--- a/pkg/routeagent_driver/handlers/kubeproxy/constants.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/constants.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 const (

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy_test
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy_test
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package kubeproxy
 
 import (

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mtu
 
 import (

--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 const (

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import (

--- a/pkg/routeagent_driver/handlers/ovn/subnets.go
+++ b/pkg/routeagent_driver/handlers/ovn/subnets.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ovn
 
 import "github.com/submariner-io/admiral/pkg/stringset"

--- a/pkg/routeagent_driver/iptables/iptables.go
+++ b/pkg/routeagent_driver/iptables/iptables.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package iptables
 
 import (

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package types
 
 import (

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clusterfiles
 
 import (

--- a/pkg/util/clusterfiles/cluster_files_test.go
+++ b/pkg/util/clusterfiles/cluster_files_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clusterfiles_test
 
 import (

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util_test
 
 import (

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util_test
 
 import (

--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cluster
 
 import (

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dataplane
 
 import (

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dataplane
 
 import (

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package dataplane
 
 import (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package e2e
 
 import (

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/submariner_resources.go
+++ b/test/e2e/framework/submariner_resources.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package redundancy
 
 import (

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package redundancy
 
 import (

--- a/test/external/e2e_external_test.go
+++ b/test/external/e2e_external_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package external
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -20,6 +20,7 @@ limitations under the License.
 
 // Place any runtime dependencies as imports in this file.
 // Go modules will be forced to download and install them.
+
 package tools
 
 import (


### PR DESCRIPTION
This ensures that our license headers aren’t considered as part of the
package documentation.

Depends on https://github.com/submariner-io/shipyard/pull/598
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
