### PR TITLE
Configure TCPMTU probe instead of iptable rules

### DIFF
--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	kp_iptables "github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy_iptables"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/mtu"
 )
 
 var (
@@ -65,6 +66,7 @@ func main() {
 		logger.NewHandler(),
 		kp_iptables.NewSyncHandler(env.ClusterCidr, env.ServiceCidr, smClientset),
 		ovn.NewHandler(env, smClientset),
+		mtu.NewMTUHandler(),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}

--- a/pkg/routeagent_driver/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/mtu/mtuhandler.go
@@ -1,0 +1,72 @@
+package mtu
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"k8s.io/klog"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/event"
+)
+
+type mtuHandler struct {
+	event.HandlerBase
+}
+
+func NewMTUHandler() event.Handler {
+	return &mtuHandler{}
+}
+
+func (h *mtuHandler) GetNetworkPlugins() []string {
+	return []string{event.AnyNetworkPlugin}
+}
+
+func (h *mtuHandler) GetName() string {
+	return "MTU handler"
+}
+
+func (h *mtuHandler) Init() error {
+	klog.Infof("Updating configurations for Path MTU")
+	configureTCPMTUProbe()
+
+	return nil
+}
+
+func configureTCPMTUProbe() {
+	mtuProbe := "2"
+	baseMss := "1024"
+
+	err := ConfigureTCPMTUProbe(mtuProbe, baseMss)
+	if err != nil {
+		klog.Warningf(err.Error())
+	}
+}
+
+func ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
+	err := setSysctl("/proc/sys/net/ipv4/tcp_mtu_probing", []byte(mtuProbe))
+	if err != nil {
+		return errors.WithMessagef(err, "unable to update value of tcp_mtu_probing to %s", mtuProbe)
+	}
+
+	err = setSysctl("/proc/sys/net/ipv4/tcp_base_mss", []byte(baseMss))
+
+	return errors.WithMessagef(err, "unable to update value of tcp_base_mss to %ss", baseMss)
+}
+
+func setSysctl(path string, contents []byte) error {
+	existing, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Ignore leading and terminating newlines
+	existing = bytes.Trim(existing, "\n")
+
+	if bytes.Equal(existing, contents) {
+		return nil
+	}
+	// Permissions are already 644, the files are never created
+	// #nosec G306
+	return ioutil.WriteFile(path, contents, 0644)
+}


### PR DESCRIPTION
This enables TCP MTU probing by default with a base mss of 1024.

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
