### PR TITLE
Fix OVN route-agent plugin IPtables handling

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -22,11 +22,9 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/stringset"
 	npSyncerOvn "github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
@@ -173,53 +171,14 @@ func (ovn *Handler) setupChainIptables(table, chain string, ruleGen forwardRuleS
 }
 
 func (ovn *Handler) updateNoMasqueradeIPTables() error {
-	ipt, err := iptables.New()
+	rules := ovn.getNoMasqueradRuleSpecs()
+
+	ipt, err := submiptables.New()
 	if err != nil {
 		return errors.Wrap(err, "error initializing iptables")
 	}
 
-	rules, err := ipt.List("nat", constants.SmPostRoutingChain)
-	if err != nil {
-		return errors.Wrapf(err, "error listing the rules in %s chain", constants.SmPostRoutingChain)
-	}
-
-	ruleStrings := stringset.New()
-
-	for _, rule := range rules {
-		ruleSpec := strings.Split(rule, " ")
-		if ruleSpec[0] == "-A" {
-			ruleSpec = ruleSpec[2:] // remove "-A", "SUBMARINER-POSTROUTING"
-			ruleStrings.Add(strings.Trim(strings.Join(ruleSpec, " "), " "))
-		}
-	}
-
-	for _, ruleSpec := range ovn.getNoMasqueradRuleSpecs() {
-		ruleString := strings.Join(ruleSpec, " ")
-		if ruleStrings.Contains(ruleString) {
-			ruleStrings.Remove(ruleString)
-		} else {
-			klog.Infof("Adding iptables rule in %q: %v", constants.SmPostRoutingChain, ruleSpec)
-
-			if err := ipt.Append("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
-				return errors.Wrapf(err, "error adding remote cluster rule to %v to %q", ruleSpec, constants.SmPostRoutingChain)
-			}
-		}
-	}
-
-	// remaining elements should not be there, remove them
-	for _, rule := range ruleStrings.Elements() {
-		klog.Infof("Deleting stale iptables rule in %q: %q", constants.SmPostRoutingChain, rule)
-		ruleSpec := strings.Split(rule, " ")
-
-		if err := ipt.Delete("nat", constants.SmPostRoutingChain, ruleSpec...); err != nil {
-			// Log and let go, as this is not a fatal error, or something that will make real harm,
-			// it's more harmful to keep retrying. At this point on next update deletion of stale rules
-			// will happen again
-			klog.Warningf("Unable to delete iptables entry from %q: %q", constants.SmPostRoutingChain, rule)
-		}
-	}
-
-	return nil
+	return submiptables.UpdateChainRules(ipt, "nat", constants.SmPostRoutingChain, rules)
 }
 
 func (ovn *Handler) getNoMasqueradRuleSpecs() [][]string {

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -110,12 +110,14 @@ func (ovn *Handler) getMSSClampingRuleSpecs() ([][]string, error) {
 
 	// NOTE: This is a workaround for submariner issues:
 	//   * https://github.com/submariner-io/submariner/issues/1278
+	//   * https://github.com/submariner-io/submariner/issues/1488
 	// TODO: get the kernel to steer the ICMPs back to ovn-k8s-sub0 interface properly, or write a packet
 	//       reflector in the route agent for that type of packets
 	for _, remoteCIDR := range ovn.getRemoteSubnets().Elements() {
 		rules = append(rules, []string{"-d", remoteCIDR, "-p", "tcp",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU)})
-
+		rules = append(rules, []string{"-s", remoteCIDR, "-p", "tcp",
+			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU)})
 	}
 
 	// NOTE: This is a workaround for submariner issue https://github.com/submariner-io/submariner/issues/1022

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -114,16 +114,16 @@ func (ovn *Handler) getMSSClampingRuleSpecs() ([][]string, error) {
 	// TODO: get the kernel to steer the ICMPs back to ovn-k8s-sub0 interface properly, or write a packet
 	//       reflector in the route agent for that type of packets
 	for _, remoteCIDR := range ovn.getRemoteSubnets().Elements() {
-		rules = append(rules, []string{"-d", remoteCIDR, "-p", "tcp",
+		rules = append(rules, []string{"-d", remoteCIDR, "-p", "tcp", "-m", "tcp",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU)})
-		rules = append(rules, []string{"-s", remoteCIDR, "-p", "tcp",
+		rules = append(rules, []string{"-s", remoteCIDR, "-p", "tcp", "-m", "tcp",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU)})
 	}
 
 	// NOTE: This is a workaround for submariner issue https://github.com/submariner-io/submariner/issues/1022
 	// TODO: work with the core-ovn community to make sure that load balancers propagate ICMPs back to pods
 	for _, serviceCIDR := range ovn.config.ServiceCidr {
-		rules = append(rules, []string{"-o", ovnK8sSubmarinerInterface, "-d", serviceCIDR, "-p", "tcp",
+		rules = append(rules, []string{"-o", ovnK8sSubmarinerInterface, "-d", serviceCIDR, "-p", "tcp", "-m", "tcp",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU)})
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/iptables"
 	"k8s.io/klog"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -46,14 +47,21 @@ type Handler struct {
 	remoteEndpoints       map[string]*submV1.Endpoint
 	isGateway             bool
 	netlink               netlink.Interface
+	ipt                   iptables.Interface
 }
 
 func NewHandler(env environment.Specification, smClientSet clientset.Interface) *Handler {
+	ipt, err := iptables.New()
+	if err != nil {
+		klog.Fatalf("Error initializing iptables in OVN routeagent handler: %s", err)
+	}
+
 	return &Handler{
 		config:          &env,
 		smClient:        smClientSet,
 		remoteEndpoints: map[string]*submV1.Endpoint{},
 		netlink:         netlink.New(),
+		ipt:             ipt,
 	}
 }
 


### PR DESCRIPTION
See the individual commits:

- refactor out UpdateChainRules for reuse
- Create separete forward and clamping chains, use UpdateChain
- Add incomming SYN , SYN/ACK clamping on responses to fix the full TCP negotiation
- Make sure that UpdateChainRules works for us 
- Create iptables interface only once in the OVN route-agent handler 

Closes-Issue: #1488 
Closes-Issue: #1489 