### PR TITLE
Implement e2e tests for GlobalEgressIP use-cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/submariner-io/admiral v0.10.0-rc0
-	github.com/submariner-io/shipyard v0.10.0-rc0.0.20210716111649-643fec17cb5f
+	github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd
 	github.com/uw-labs/lichen v0.1.4
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/submariner-io/admiral v0.10.0-rc0 h1:u0oNxmIZzYZL32AxfHi3JWp74EHGR2MjuHBQjwprPzg=
 github.com/submariner-io/admiral v0.10.0-rc0/go.mod h1:kpbW6dzbRetPshT/Tq2W+peYCeI8eF4JOiH9y+UtGEM=
 github.com/submariner-io/shipyard v0.10.0-rc0/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
-github.com/submariner-io/shipyard v0.10.0-rc0.0.20210716111649-643fec17cb5f h1:9asR2duMBB1RuIh/IenRC5VLjpAnXq5ASPgnCcB/ntw=
-github.com/submariner-io/shipyard v0.10.0-rc0.0.20210716111649-643fec17cb5f/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
+github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd h1:1Fuq5zXrX9lJUqIkhAg96jS7pBSrqwtKYxIgcvk1e0I=
+github.com/submariner-io/shipyard v0.10.0-rc0.0.20210719115546-4e6aefed5ecd/go.mod h1:+B8Hrs2vYg7XKFMk61HVg1ev/twSYFIJg3hWiJnCuq0=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -21,7 +21,9 @@ package framework
 import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
@@ -46,6 +48,9 @@ func NewFramework(baseName string) *Framework {
 
 func beforeSuite() {
 	framework.By("Creating submariner clients")
+
+	err := submarinerv1.AddToScheme(scheme.Scheme)
+	Expect(err).To(BeNil())
 
 	for _, restConfig := range framework.RestConfigs {
 		SubmarinerClients = append(SubmarinerClients, createSubmarinerClient(restConfig))

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -96,7 +96,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
@@ -106,7 +106,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 }
 
 func AwaitNewSubmarinerGatewayPod(f *subFramework.Framework, cluster framework.ClusterIndex, prevPodUID types.UID) *v1.Pod {
@@ -228,7 +228,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
@@ -238,5 +238,5 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 }

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -68,7 +68,7 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
@@ -78,5 +78,5 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 		ToCluster:             framework.ClusterA,
 		ToClusterScheduling:   framework.NonGatewayNode,
 		ToEndpointType:        defaultEndpointType(),
-	}, framework.TestContext.GlobalnetEnabled)
+	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 }


### PR DESCRIPTION
This PR implements e2e tests that validate globalEgressIPs using NamespaceSelectors
and PodSelectors.

Fixes issue: https://github.com/submariner-io/submariner/issues/1167
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
