### PR TITLE
Ignore CNI Interface when healthcheck is disabled

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -93,14 +93,15 @@ func GetLocal(submSpec types.SubmarinerSpecification, k8sClient kubernetes.Inter
 
 	endpoint.Spec.PublicIP = publicIP
 
-	if !globalnetEnabled {
+	if submSpec.HealthCheckEnabled && !globalnetEnabled {
 		// When globalnet is enabled, HealthCheckIP will be the globalIP assigned to the Active GatewayNode.
 		// In a fresh deployment, globalIP annotation for the node might take few seconds. So we listen on NodeEvents
 		// and update the endpoint HealthCheckIP (to globalIP) in datastoreSyncer at a later stage. This will trigger
 		// the HealthCheck between the clusters.
 		endpoint.Spec.HealthCheckIP, err = getCNIInterfaceIPAddress(submSpec.ClusterCidr)
 		if err != nil {
-			return types.SubmarinerEndpoint{}, fmt.Errorf("error getting CNI Interface IP address: %v", err)
+			return types.SubmarinerEndpoint{}, fmt.Errorf("error getting CNI Interface IP address: %v."+
+				"Please disable the health check if your CNI does not expose a pod IP on the nodes", err)
 		}
 	}
 

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -84,7 +84,7 @@ func verifyGateway(gw *submarinerv1.Gateway, otherCluster string) (bool, string,
 				conn.Endpoint.ClusterID, conn.Status, conn.StatusMessage), nil
 		}
 
-		if !framework.TestContext.GlobalnetEnabled {
+		if gw.Status.LocalEndpoint.HealthCheckIP != "" {
 			if conn.LatencyRTT == nil {
 				return false, fmt.Sprintf("Connection for cluster %q has no LatencyRTT information", otherCluster), nil
 			}


### PR DESCRIPTION
On some platforms, it was seen that CNI Interface on the node
was missing. Submariner uses the CNIInterface IP for certain use-cases
like HostNetwork to remoteCluster support and for Healthcheck use-cases.
The current code was expecting the CNIInterface to be present even
when the healthcheck is disabled, this PR fixes it.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
