### PR TITLE
fix udp port publishing

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -95,6 +95,7 @@ const (
 
 const (
 	DefaultNATTDiscoveryPort = "4490"
+	DefaultUDPPort           = "4500"
 )
 
 // Valid PublicIP resolvers.

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -114,6 +114,16 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 		return backendConfig, err
 	}
 
+	// If the node has no specific UDP port assigned for dataplane, expose the cluster default one
+	if _, ok := backendConfig[submv1.UDPPortConfig]; !ok {
+		udpPort := os.Getenv("CE_IPSEC_NATTPORT")
+		if udpPort == "" {
+			udpPort = submv1.DefaultUDPPort
+		}
+
+		backendConfig[submv1.UDPPortConfig] = udpPort
+	}
+
 	// Enable and publish the natt-discovery-port by default
 	if _, ok := backendConfig[submv1.NATTDiscoveryPortConfig]; !ok {
 		backendConfig[submv1.NATTDiscoveryPortConfig] = submv1.DefaultNATTDiscoveryPort


### PR DESCRIPTION
The UDP port can be modified also by --natt-port in subctl join,
which translates to CE_IPSEC_NATTPORT environment variable.

The node annotations have preferrence over that, and that's the cluster
default, but if we don't publish the port on the Endpoint
the other clusters can't properly connect.

Fixes-Issue: #1490

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
