### PR TITLE
Backport: also publish the UDP port for non-annotated gw nodes

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -85,6 +85,7 @@ const (
 	UDPPortConfig           = "udp-port"
 	NATTDiscoveryPortConfig = "natt-discovery-port"
 	PublicIP                = "public-ip"
+	DefaultUDPPort          = "4500"
 )
 
 // Valid PublicIP resolvers.

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -106,6 +106,16 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 		return backendConfig, err
 	}
 
+	// If the node has no specific UDP port assigned for dataplane, expose the cluster default one
+	if _, ok := backendConfig[submv1.UDPPortConfig]; !ok {
+		udpPort := os.Getenv("CE_IPSEC_NATTPORT")
+		if udpPort == "" {
+			udpPort = submv1.DefaultUDPPort
+		}
+
+		backendConfig[submv1.UDPPortConfig] = udpPort
+	}
+
 	//TODO: we should allow the cable drivers to capture and expose BackendConfig settings, instead of doing
 	//      it here.
 	preferredServerStr := os.Getenv("CE_IPSEC_PREFERREDSERVER")

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	endpoint "github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 
 	"github.com/submariner-io/submariner/pkg/util"
 	v1 "k8s.io/api/core/v1"
@@ -41,6 +41,7 @@ var _ = Describe("GetLocal", func() {
 
 	const (
 		testUDPPort         = "1111"
+		testClusterUDPPort  = "2222"
 		testUDPPortLabel    = "udp-port"
 		testNATTPortLabel   = "natt-discovery-port"
 		backendConfigPrefix = "gateway.submariner.io/"
@@ -80,6 +81,27 @@ var _ = Describe("GetLocal", func() {
 		Expect(endpoint.Spec.Subnets).To(Equal(subnets))
 		Expect(endpoint.Spec.NATEnabled).To(Equal(false))
 		Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
+	})
+
+	When("gateway node is not annotated with udp port", func() {
+		It("should return the udp-port backend config of the cluster", func() {
+			delete(node.Labels, backendConfigPrefix+testUDPPortLabel)
+			client = fake.NewSimpleClientset(node)
+			os.Setenv("CE_IPSEC_NATTPORT", testClusterUDPPort)
+
+			endpoint, err := endpoint.GetLocal(submSpec, client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testClusterUDPPort))
+		})
+	})
+
+	When("gateway node is annotated with udp port", func() {
+		It("should return the udp-port backend from the annotation", func() {
+			os.Setenv("CE_IPSEC_NATTPORT", testClusterUDPPort)
+			endpoint, err := endpoint.GetLocal(submSpec, client)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
+		})
 	})
 
 	When("no NAT discovery port label is set on the node", func() {


### PR DESCRIPTION
The UDP port can be modified also by --natt-port in subctl join,
which translates to CE_IPSEC_NATTPORT environment variable.

The node annotations have preferrence over that, and that's the cluster
default, but if we don't publish the port on the Endpoint
the other clusters can't properly connect.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
(cherry picked from commit ae3c5016aa59373f3d2ca608eb4620b2fd436bab)
