### PR TITLE
Limit cluster-id to 63 chars

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -37,6 +37,8 @@ type Cluster struct {
 }
 
 type ClusterSpec struct {
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=1
 	ClusterID   string   `json:"cluster_id"` // perhaps this could just be a hash of the name...?
 	ColorCodes  []string `json:"color_codes"`
 	ServiceCIDR []string `json:"service_cidr"`
@@ -71,6 +73,8 @@ func (ep *Endpoint) GatewayIP() net.IP {
 }
 
 type EndpointSpec struct {
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=1
 	ClusterID string `json:"cluster_id"`
 	CableName string `json:"cable_name"`
 	// +optional


### PR DESCRIPTION
ClusterID is now stored as a label on the endpoint object when its
pushed to the Broker. K8s restricts the label values to 63 chars.
So adding the corresponding check.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
