### PR TITLE
E2e, delete ServiceExport before Service

### DIFF
--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -178,8 +178,8 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, egressIPT
 
 	Expect(listenerPod.TerminationMessage).To(matchIP)
 
-	p.Framework.DeleteService(p.ToCluster, service.Name)
 	p.Framework.DeleteServiceExport(p.ToCluster, service.Name)
+	p.Framework.DeleteService(p.ToCluster, service.Name)
 	p.Framework.DeletePod(p.ToCluster, listenerPod.Pod.Name, listenerPod.Pod.Namespace)
 	p.Framework.DeletePod(p.FromCluster, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
 }


### PR DESCRIPTION
Since Globalnet internally uses kubeproxy iptable chain, if we delete
the serviceExport first, we will give Globalnet opportunity to remove
the iptable references ahead of kubeproxy. This will inturn reduce the
possibilities of flaky errors to some extent.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
