### PR TITLE
Fix e2e failure when health-check is disabled

### DIFF
--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -84,7 +84,7 @@ func verifyGateway(gw *submarinerv1.Gateway, otherCluster string) (bool, string,
 				conn.Endpoint.ClusterID, conn.Status, conn.StatusMessage), nil
 		}
 
-		if gw.Status.LocalEndpoint.HealthCheckIP != "" {
+		if gw.Status.LocalEndpoint.HealthCheckIP != "" && conn.Endpoint.HealthCheckIP != "" {
 			if conn.LatencyRTT == nil {
 				return false, fmt.Sprintf("Connection for cluster %q has no LatencyRTT information", otherCluster), nil
 			}


### PR DESCRIPTION
When two clusters are connected and healthcheck is disabled in one of
them and we try to run e2e on the other cluster, it results in an error.
This PR fixes it.

Fixes issue: https://github.com/submariner-io/submariner/issues/1519
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
