### PR TITLE
Ignore all vendor directories

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -9,4 +9,4 @@ rules:
     ignore: '.github/workflows/*.yml'
 
 ignore: |
-  /vendor
+  **/vendor


### PR DESCRIPTION
Now that we have multiple modules, and they're vendored correctly
before running yamllint, we need to ensure that all vendor directories
are ignored.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
