### PR TITLE
Install kmod so we can load kernel modules

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -5,8 +5,9 @@ WORKDIR /var/submariner
 
 # iproute is used internally
 # libreswan provides IKE
+# kmod is required so that libreswan can load modules
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute libreswan && \
+           iproute libreswan kmod && \
     dnf -y clean all
 
 COPY package/submariner.sh package/pluto bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/


### PR DESCRIPTION
Libreswan tries to load a number of acceleration modules, but without
kmod, this fails (silently).

To actually be useful this will also require giving the container
access to /lib/modules; this will be done in the operator.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
