### PR TITLE
Implement globalnet for headless service without selector

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -323,8 +323,9 @@ type GlobalIngressIPSpec struct {
 type TargetType string
 
 const (
-	ClusterIPService   TargetType = "ClusterIPService"
-	HeadlessServicePod TargetType = "HeadlessServicePod"
+	ClusterIPService         TargetType = "ClusterIPService"
+	HeadlessServicePod       TargetType = "HeadlessServicePod"
+	HeadlessServiceEndpoints TargetType = "HeadlessServiceEndpoints"
 )
 
 type GlobalIngressIPStatus struct {

--- a/pkg/globalnet/constants/constants.go
+++ b/pkg/globalnet/constants/constants.go
@@ -29,6 +29,7 @@ const (
 	// The following chains are added as part of GN 2.0 implementation.
 	SmGlobalnetEgressChainForPods            = "SM-GN-EGRESS-PODS"
 	SmGlobalnetEgressChainForHeadlessSvcPods = "SM-GN-EGRESS-HDLS-PODS"
+	SmGlobalnetEgressChainForHeadlessSvcEPs  = "SM-GN-EGRESS-HDLS-EPS"
 	SmGlobalnetEgressChainForNamespace       = "SM-GN-EGRESS-NS"
 	SmGlobalnetEgressChainForCluster         = "SM-GN-EGRESS-CLUSTER"
 

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -73,11 +73,21 @@ func (c *baseSyncerController) Start() error {
 	return c.resourceSyncer.Start(c.stopCh) // nolint:wrapcheck  // Let the caller wrap it
 }
 
-func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector string,
+func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector, fieldSelector string,
 	transform func(obj *unstructured.Unstructured) runtime.Object,
 ) {
+	listOptions := metav1.ListOptions{}
+
+	if labelSelector != "" {
+		listOptions.LabelSelector = labelSelector
+	}
+
+	if fieldSelector != "" {
+		listOptions.FieldSelector = fieldSelector
+	}
+
 	c.resourceSyncer.Reconcile(func() []runtime.Object {
-		objList, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		objList, err := client.List(context.TODO(), listOptions)
 		if err != nil {
 			klog.Errorf("Error listing resources for reconciliation: %v", err)
 			return nil

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -76,18 +76,11 @@ func (c *baseSyncerController) Start() error {
 func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector, fieldSelector string,
 	transform func(obj *unstructured.Unstructured) runtime.Object,
 ) {
-	listOptions := metav1.ListOptions{}
-
-	if labelSelector != "" {
-		listOptions.LabelSelector = labelSelector
-	}
-
-	if fieldSelector != "" {
-		listOptions.FieldSelector = fieldSelector
-	}
-
 	c.resourceSyncer.Reconcile(func() []runtime.Object {
-		objList, err := client.List(context.TODO(), listOptions)
+		objList, err := client.List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labelSelector,
+			FieldSelector: fieldSelector,
+		})
 		if err != nil {
 			klog.Errorf("Error listing resources for reconciliation: %v", err)
 			return nil

--- a/pkg/globalnet/controllers/ingress_endpoints_controller.go
+++ b/pkg/globalnet/controllers/ingress_endpoints_controller.go
@@ -1,0 +1,206 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/federate"
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/admiral/pkg/util"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+func startIngressEndpointsController(svc *corev1.Service, config *syncer.ResourceSyncerConfig) (*ingressEndpointsController, error) {
+	var err error
+
+	_, gvr, err := util.ToUnstructuredResource(&submarinerv1.GlobalIngressIP{}, config.RestMapper)
+	if err != nil {
+		return nil, errors.Wrap(err, "error converting resource")
+	}
+
+	controller := &ingressEndpointsController{
+		baseSyncerController: newBaseSyncerController(),
+		svcName:              svc.Name,
+		namespace:            svc.Namespace,
+		config:               *config,
+		ingressIPs:           config.SourceClient.Resource(*gvr),
+	}
+
+	fieldSelector := fields.Set(map[string]string{"metadata.name": svc.Name}).AsSelector().String()
+
+	controller.resourceSyncer, err = syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
+		Name:                "Ingress Endpoints syncer",
+		ResourceType:        &corev1.Endpoints{},
+		SourceClient:        config.SourceClient,
+		SourceNamespace:     svc.Namespace,
+		RestMapper:          config.RestMapper,
+		Federator:           federate.NewCreateFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll),
+		Scheme:              config.Scheme,
+		Transform:           controller.process,
+		SourceFieldSelector: fieldSelector,
+		ResourcesEquivalent: areEndpointsEqual,
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating the endpoints syncer")
+	}
+
+	if err := controller.Start(); err != nil {
+		return nil, errors.Wrap(err, "error starting the endpoint syncer")
+	}
+
+	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(corev1.NamespaceAll)
+	controller.reconcile(ingressIPs, "" /* labelSelector */, fieldSelector, func(obj *unstructured.Unstructured) runtime.Object {
+		endpointsName, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
+		if exists {
+			return &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      endpointsName,
+					Namespace: obj.GetNamespace(),
+				},
+			}
+		}
+
+		return nil
+	})
+
+	klog.Infof("Created Endpoints controller for (%s/%s) with selector %q", svc.Namespace, svc.Name, fieldSelector)
+
+	return controller, nil
+}
+
+func (c *ingressEndpointsController) process(from runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
+	endpoints := from.(*corev1.Endpoints)
+
+	switch op {
+	case syncer.Create, syncer.Update:
+		return c.onCreateOrUpdate(endpoints, op)
+	case syncer.Delete:
+		return c.onDelete(endpoints)
+	}
+
+	return nil, false
+}
+
+func (c *ingressEndpointsController) onCreateOrUpdate(endpoints *corev1.Endpoints, op syncer.Operation) (runtime.Object, bool) {
+	key, _ := cache.MetaNamespaceKeyFunc(endpoints)
+
+	klog.Infof("%q ingress Endpoints %s for service %s", op, key, c.svcName)
+
+	// Get list of current endpoint IPs
+	epIPs := map[string]bool{}
+
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			epIPs[addr.IP] = true
+		}
+	}
+
+	// Get List of existing ingressIPs
+	selector := labels.SelectorFromSet(map[string]string{ServiceRefLabel: endpoints.Name}).String()
+
+	existingIngressIPs, err := c.ingressIPs.Namespace(endpoints.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, true
+	}
+
+	// Delete unused ingressIPs
+	for _, ingressIP := range existingIngressIPs.Items {
+		annotations := ingressIP.GetAnnotations()
+		if epIP, ok := annotations[headlessSvcEndpointsIP]; ok {
+			// ingressIP is still used
+			if _, used := epIPs[epIP]; used {
+				// Delete from the hash to avoid recreating existing ingressIP
+				delete(epIPs, epIP)
+				// Skip deleting ingressIP
+				continue
+			}
+		}
+
+		err := c.ingressIPs.Namespace(ingressIP.GetNamespace()).Delete(context.TODO(), ingressIP.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return nil, true
+		}
+	}
+
+	// Create new ingressIPs
+	for epIP := range epIPs {
+		ingressIP := newIngressIP(endpoints.Name, endpoints.Namespace, epIP)
+
+		ingressIP.ObjectMeta.Annotations = map[string]string{
+			headlessSvcEndpointsIP: epIP,
+		}
+
+		ingressIP.Spec = submarinerv1.GlobalIngressIPSpec{
+			Target:     submarinerv1.HeadlessServiceEndpoints,
+			ServiceRef: &corev1.LocalObjectReference{Name: c.svcName},
+		}
+
+		uIngressIP, _, err := util.ToUnstructuredResource(ingressIP, c.config.RestMapper)
+		if err != nil {
+			return nil, true
+		}
+
+		_, err = c.ingressIPs.Namespace(ingressIP.GetNamespace()).Create(context.TODO(), uIngressIP, metav1.CreateOptions{})
+		if err != nil {
+			return nil, true
+		}
+	}
+
+	return nil, false
+}
+
+func (c *ingressEndpointsController) onDelete(endpoints *corev1.Endpoints) (runtime.Object, bool) {
+	key, _ := cache.MetaNamespaceKeyFunc(endpoints)
+
+	selector := labels.SelectorFromSet(map[string]string{ServiceRefLabel: endpoints.Name}).String()
+
+	err := c.ingressIPs.Namespace(endpoints.Namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, true
+	}
+
+	klog.Infof("Ingress Endpoints %s for service %s deleted", key, c.svcName)
+
+	return nil, false
+}
+
+func newIngressIP(name, namespace, epIP string) *submarinerv1.GlobalIngressIP {
+	return &submarinerv1.GlobalIngressIP{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("ep-%.44s-%.15s", name, epIP),
+			Namespace: namespace,
+			Labels: map[string]string{
+				ServiceRefLabel: name,
+			},
+		},
+	}
+}

--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -80,7 +80,7 @@ func startIngressPodController(svc *corev1.Service, config *syncer.ResourceSynce
 
 	ingressIPSelector := labels.Set(selector).AsSelector().String()
 	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(corev1.NamespaceAll)
-	controller.reconcile(ingressIPs, ingressIPSelector, func(obj *unstructured.Unstructured) runtime.Object {
+	controller.reconcile(ingressIPs, ingressIPSelector, "" /* fieldSelector*/, func(obj *unstructured.Unstructured) runtime.Object {
 		podName, exists, _ := unstructured.NestedString(obj.Object, "spec", "podRef", "name")
 		if exists {
 			return &corev1.Pod{

--- a/pkg/globalnet/controllers/service_controller.go
+++ b/pkg/globalnet/controllers/service_controller.go
@@ -74,22 +74,23 @@ func (c *serviceController) Start() error {
 		return err
 	}
 
-	c.reconcile(c.ingressIPs, "", func(obj *unstructured.Unstructured) runtime.Object {
-		name, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
-		if exists {
-			return &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: obj.GetNamespace(),
-				},
-				Spec: corev1.ServiceSpec{
-					Type: corev1.ServiceTypeClusterIP,
-				},
+	c.reconcile(c.ingressIPs, "" /* labelSelector */, "", /* fieldSelector */
+		func(obj *unstructured.Unstructured) runtime.Object {
+			name, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
+			if exists {
+				return &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: obj.GetNamespace(),
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				}
 			}
-		}
 
-		return nil
-	})
+			return nil
+		})
 
 	return nil
 }

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -44,6 +44,9 @@ const (
 	// This is an internal annotation used between ingress pod controller and global-ingress controller.
 	headlessSvcPodIP = "submariner.io/headless-svc-pod-ip"
 
+	// This is an internal annotation used between ingress endpoints controller and global-ingress controller.
+	headlessSvcEndpointsIP = "submariner.io/headless-svc-endpoints-ip"
+
 	ServiceRefLabel = "submariner.io/serviceRef"
 
 	// InternalServicePrefix is a prefix used for internal services.
@@ -135,12 +138,13 @@ type globalIngressIPController struct {
 
 type serviceExportController struct {
 	*baseSyncerController
-	services             dynamic.NamespaceableResourceInterface
-	ingressIPs           dynamic.ResourceInterface
-	iptIface             iptiface.Interface
-	podControllers       *IngressPodControllers
-	endpointsControllers *ServiceExportEndpointsControllers
-	scheme               *runtime.Scheme
+	services                    dynamic.NamespaceableResourceInterface
+	ingressIPs                  dynamic.ResourceInterface
+	iptIface                    iptiface.Interface
+	podControllers              *IngressPodControllers
+	endpointsControllers        *ServiceExportEndpointsControllers
+	ingressEndpointsControllers *IngressEndpointsControllers
+	scheme                      *runtime.Scheme
 }
 
 type serviceController struct {
@@ -180,4 +184,19 @@ type ServiceExportEndpointsControllers struct {
 	mutex       sync.Mutex
 	controllers map[string]*endpointsController
 	config      syncer.ResourceSyncerConfig
+}
+
+type ingressEndpointsController struct {
+	*baseSyncerController
+	svcName    string
+	namespace  string
+	config     syncer.ResourceSyncerConfig
+	ingressIPs dynamic.NamespaceableResourceInterface
+}
+
+type IngressEndpointsControllers struct {
+	mutex       sync.Mutex
+	controllers map[string]*ingressEndpointsController
+	config      syncer.ResourceSyncerConfig
+	ingressIPs  dynamic.NamespaceableResourceInterface
 }

--- a/pkg/globalnet/controllers/uninstall.go
+++ b/pkg/globalnet/controllers/uninstall.go
@@ -56,6 +56,7 @@ func UninstallDataPath() {
 		// The chains have to be deleted in a specific order.
 		constants.SmGlobalnetEgressChainForCluster,
 		constants.SmGlobalnetEgressChainForHeadlessSvcPods,
+		constants.SmGlobalnetEgressChainForHeadlessSvcEPs,
 		constants.SmGlobalnetEgressChainForNamespace,
 		constants.SmGlobalnetEgressChainForPods,
 		constants.SmGlobalnetIngressChain,

--- a/test/external/dataplane/gn_connectivity.go
+++ b/test/external/dataplane/gn_connectivity.go
@@ -35,8 +35,16 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+type ExtEndpointType int
+
+const (
+	ClusterIP ExtEndpointType = iota
+	Headless
+)
+
 type globalnetTestParams struct {
 	ClusterEgressIPType subFramework.GlobalEgressIPType
+	ExtEndpointType     ExtEndpointType
 }
 
 /*
@@ -79,7 +87,7 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 	var egressIPType subFramework.GlobalEgressIPType
 	var err error
 
-	verifyInteraction := func(clusterScheduling framework.NetworkPodScheduling) {
+	verifyInteraction := func(clusterScheduling framework.NetworkPodScheduling, extEpType ExtEndpointType) {
 		It("should be able to connect from/to an external app to/from a pod in a cluster", func() {
 			if !framework.TestContext.GlobalnetEnabled {
 				framework.Skipf("Globalnet is not enabled, skipping the test...")
@@ -96,6 +104,7 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 				},
 				globalnetTestParams{
 					ClusterEgressIPType: egressIPType,
+					ExtEndpointType:     extEpType,
 				})
 		})
 	}
@@ -115,11 +124,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 
 			// Access from a pod on NonGatewayNodes to external apps is not supported for a gateway-cluster (*4)
 			PWhen("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -132,11 +141,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 
 			// Access from a pod on NonGatewayNodes to external apps is not supported for a gateway-cluster (*4)
 			PWhen("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -149,11 +158,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 
 			// Access from a pod on NonGatewayNodes to external apps is not supported for a gateway-cluster (*4)
 			PWhen("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -170,11 +179,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 
 			// Access from a pod on NonGatewayNodes to external apps is not supported for a gateway-cluster (*4)
 			PWhen("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 	})
@@ -193,11 +202,19 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 			})
 
 			When("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
+			})
+
+			When("the pod is not on a gateway and access to external via headless service", func() {
+				verifyInteraction(framework.NonGatewayNode, Headless)
+			})
+
+			When("the pod is on a gateway and access to external via headless service", func() {
+				verifyInteraction(framework.GatewayNode, Headless)
 			})
 		})
 
@@ -209,11 +226,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 			})
 
 			When("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -225,11 +242,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 			})
 
 			When("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -243,11 +260,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 			// Access from a pod with HostNetworking fails if a pod is not on NonGateway nodes (*3)
 			// TODO: it needs to be documented?
 			PWhen("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 
@@ -259,11 +276,11 @@ var _ = Describe("[external-dataplane-globalnet] Connectivity", func() {
 			})
 
 			When("the pod is not on a gateway", func() {
-				verifyInteraction(framework.NonGatewayNode)
+				verifyInteraction(framework.NonGatewayNode, ClusterIP)
 			})
 
 			When("the pod is on a gateway", func() {
-				verifyInteraction(framework.GatewayNode)
+				verifyInteraction(framework.GatewayNode, ClusterIP)
 			})
 		})
 	})
@@ -280,12 +297,21 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	dockerIP := docker.GetIP(extNetName)
 
 	// Create service without selector and endpoints for dockerIP, and export the service
-	extSvc := p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", 80)
+	var extSvc *v1.Service
+
+	switch g.ExtEndpointType {
+	case ClusterIP:
+		extSvc = p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", 80)
+	case Headless:
+		// TODO: move this method to framework
+		extSvc = createHeadlessTCPServiceWithoutSelector(p.Framework, extClusterIdx, "extsvc", "http", 80)
+	}
+
 	p.Framework.CreateTCPEndpoints(extClusterIdx, extSvc.Name, "http", dockerIP, 80)
 	p.Framework.CreateServiceExport(extClusterIdx, extSvc.Name)
 
 	// Get globalIPs for the extApp to use later
-	extIngressGlobalIP := p.Framework.AwaitGlobalIngressIP(extClusterIdx, extSvc.Name, extSvc.Namespace)
+	extIngressGlobalIP := getGlobalIngressIPForExternal(p, g, extSvc, dockerIP)
 	Expect(extIngressGlobalIP).ToNot(Equal(""))
 
 	extEgressGlobalIPs := p.Framework.AwaitClusterGlobalEgressIPs(extClusterIdx, constants.ClusterGlobalEgressIPName)
@@ -321,19 +347,27 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	command := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", remoteIP, 80, p.Framework.Namespace, clusterName)}
 	_, _ = docker.RunCommand(command...)
 
-	By(fmt.Sprintf("Verifying the pod received the request from one of egressGlobalIPs %v", extEgressGlobalIPs))
-
 	podLog := np.GetLog()
+
 	if p.Cluster == extClusterIdx {
 		// TODO: current behavior is that source IP from external app to the pod in the cluster that directly connected to
 		// external network is the gateway IP of the pod network. Consider if it can be consistent.
+		By("Verifying the pod received the request from any IP")
 		Expect(podLog).To(MatchRegexp(".*GET /%s%s .*", p.Framework.Namespace, clusterName))
 	} else {
-		matchRegexp := MatchRegexp("%s .*GET /%s%s .*", extEgressGlobalIPs[0], p.Framework.Namespace, clusterName)
-		for i := 1; i < len(extEgressGlobalIPs); i++ {
-			matchRegexp = Or(matchRegexp, MatchRegexp("%s .*GET /%s%s .*", extEgressGlobalIPs[i], p.Framework.Namespace, clusterName))
+		switch g.ExtEndpointType {
+		case ClusterIP:
+			By(fmt.Sprintf("Verifying the pod received the request from one of egressGlobalIPs %v", extEgressGlobalIPs))
+			matchRegexp := MatchRegexp("%s .*GET /%s%s .*", extEgressGlobalIPs[0], p.Framework.Namespace, clusterName)
+			for i := 1; i < len(extEgressGlobalIPs); i++ {
+				matchRegexp = Or(matchRegexp, MatchRegexp("%s .*GET /%s%s .*", extEgressGlobalIPs[i], p.Framework.Namespace, clusterName))
+			}
+			Expect(podLog).To(matchRegexp)
+		case Headless:
+			// For access from headless service, source IP is the globalIngressIP of the external app
+			By(fmt.Sprintf("Verifying the pod received the request from globalIngressIP of the external app %v", extIngressGlobalIP))
+			Expect(podLog).To(MatchRegexp("%s .*GET /%s%s .*", extIngressGlobalIP, p.Framework.Namespace, clusterName))
 		}
-		Expect(podLog).To(matchRegexp)
 	}
 
 	framework.Logf("%s", podLog)
@@ -398,13 +432,15 @@ func newGlobalEgressIPObj(namespace string, selector *metav1.LabelSelector) (*un
 
 func createSvc(p testParams, np *framework.NetworkPod) *v1.Service {
 	switch p.ToEndpointType {
-	case tcp.GlobalServiceIP, tcp.PodIP, tcp.ServiceIP:
+	default:
+		fallthrough
+	case tcp.PodIP, tcp.ServiceIP:
+		framework.Failf("Unsupported ToEndpointType %v was passed", p.ToEndpointType)
+	case tcp.GlobalServiceIP:
 		return np.CreateService()
 	case tcp.GlobalPodIP:
 		return p.Framework.CreateHeadlessTCPService(np.Config.Cluster, np.Pod.Labels["test-app"],
 			np.Config.Port)
-	default:
-		framework.Failf("Unsupported ToEndpointType %v was passed", p.ToEndpointType)
 	}
 
 	return nil
@@ -424,6 +460,21 @@ func getGlobalIngressIP(p testParams, service *v1.Service) string {
 		ingressIPName := fmt.Sprintf("pod-%s", podList.Items[0].Name)
 
 		return p.Framework.AwaitGlobalIngressIP(p.Cluster, ingressIPName, service.Namespace)
+	}
+
+	return ""
+}
+
+func getGlobalIngressIPForExternal(p testParams, g globalnetTestParams, service *v1.Service, dockerIP string) string {
+	extClusterIdx, err := getGatewayClusterIndex(framework.TestContext.ClusterIDs)
+	Expect(err).NotTo(HaveOccurred())
+
+	switch g.ExtEndpointType {
+	case ClusterIP:
+		return p.Framework.AwaitGlobalIngressIP(extClusterIdx, service.Name, service.Namespace)
+	case Headless:
+		ingressIPName := fmt.Sprintf("ep-%.44s-%.15s", service.Name, dockerIP)
+		return p.Framework.AwaitGlobalIngressIP(extClusterIdx, ingressIPName, service.Namespace)
 	}
 
 	return ""
@@ -453,4 +504,13 @@ func getPodGlobalIPs(p testParams, g globalnetTestParams, np *framework.NetworkP
 	}
 
 	return []string{}
+}
+
+func createHeadlessTCPServiceWithoutSelector(f *framework.Framework, cluster framework.ClusterIndex,
+	svcName, portName string, port int,
+) *v1.Service {
+	serviceSpec := f.NewService(svcName, portName, port, v1.ProtocolTCP, nil, true)
+	sc := framework.KubeClients[cluster].CoreV1().Services(f.Namespace)
+
+	return f.CreateService(sc, serviceSpec)
 }


### PR DESCRIPTION
This PR adds support for globalnet for headless service without selector.

Fixes: #1537 

Dependency:
- RBAC:
  - [x] submariner-io/submariner-operator#1582
  - [x] submariner-io/submariner-charts#169
  - [x] #1582