### PR TITLE
Ignore endpoint events if processed already.

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
@@ -38,10 +39,11 @@ type SyncHandler struct {
 	localClusterCidr []string
 	localServiceCidr []string
 
-	remoteSubnets    stringset.Interface
-	remoteSubnetGw   map[string]net.IP
-	remoteVTEPs      stringset.Interface
-	routeCacheGWNode stringset.Interface
+	remoteSubnets           stringset.Interface
+	remoteSubnetGw          map[string]net.IP
+	remoteVTEPs             stringset.Interface
+	routeCacheGWNode        stringset.Interface
+	remoteEndpointTimeStamp map[string]v1.Time
 
 	syncHandlerMutex     sync.Mutex
 	isGatewayNode        bool
@@ -57,16 +59,17 @@ type SyncHandler struct {
 
 func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 	return &SyncHandler{
-		localClusterCidr:     localClusterCidr,
-		localServiceCidr:     localServiceCidr,
-		localCableDriver:     "",
-		remoteSubnets:        stringset.NewSynchronized(),
-		remoteSubnetGw:       map[string]net.IP{},
-		remoteVTEPs:          stringset.NewSynchronized(),
-		routeCacheGWNode:     stringset.NewSynchronized(),
-		isGatewayNode:        false,
-		wasGatewayPreviously: false,
-		netLink:              netlink.New(),
+		localClusterCidr:        localClusterCidr,
+		localServiceCidr:        localServiceCidr,
+		localCableDriver:        "",
+		remoteSubnets:           stringset.NewSynchronized(),
+		remoteSubnetGw:          map[string]net.IP{},
+		remoteEndpointTimeStamp: map[string]v1.Time{},
+		remoteVTEPs:             stringset.NewSynchronized(),
+		routeCacheGWNode:        stringset.NewSynchronized(),
+		isGatewayNode:           false,
+		wasGatewayPreviously:    false,
+		netLink:                 netlink.New(),
 	}
 }
 


### PR DESCRIPTION
In deployments, if we delete submariner-gateway machineset and then
later delete the submariner namespace in a cluster. It would lead
to a stale endpoint in other clusters. Now if we create a machineset
and join the cluster again, the old endpoint gets cleared. But the old
endpoint delete event comes after the new endpoint is created and the
host network routing rules gets deleted.

With this fix, a delete event will be ignored if it has timestamp older
than the current endpoint.

Fixes: #1544

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
