### PR TITLE
Rename job so it won't shard on stable branches

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  target_devel:
-    name: PR targets devel
+  target_branch:
+    name: PR targets branch
     runs-on: ubuntu-latest
     steps:
       - name: Check that the PR targets devel


### PR DESCRIPTION
Right now auto release logic updates `devel` to the stable branch name
when creating stable branches. This leads to this job "sharding" into
multiple jobs, and messes up branch protections.

To keep things simple, the main job name will remain the same so that
there's no "PR targets X" and "PR targets Y" jobs, just the one "PR
targets branch" job

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
