### PR TITLE
Support e2e on single node deployments

### DIFF
--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -38,6 +38,11 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				return
 			}
 
+			if subFramework.IsSingleNodeDeployment(fromClusterScheduling, toClusterScheduling, framework.ClusterA,
+				framework.ClusterB) {
+				return
+			}
+
 			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -38,8 +38,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				return
 			}
 
-			if subFramework.IsSingleNodeDeployment(fromClusterScheduling, toClusterScheduling, framework.ClusterA,
-				framework.ClusterB) {
+			if !subFramework.CanExecuteNonGatewayConnectivityTest(fromClusterScheduling, toClusterScheduling,
+				framework.ClusterA, framework.ClusterB) {
 				return
 			}
 

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 )
 
 var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters without discovery", func() {
@@ -35,6 +36,12 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 				framework.Skipf("Globalnet enabled, skipping the test...")
 				return
 			}
+
+			if subFramework.IsSingleNodeDeployment(fromClusterScheduling, toClusterScheduling, framework.ClusterA,
+				framework.ClusterB) {
+				return
+			}
+
 			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -37,8 +37,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 				return
 			}
 
-			if subFramework.IsSingleNodeDeployment(fromClusterScheduling, toClusterScheduling, framework.ClusterA,
-				framework.ClusterB) {
+			if !subFramework.CanExecuteNonGatewayConnectivityTest(fromClusterScheduling, toClusterScheduling,
+				framework.ClusterA, framework.ClusterB) {
 				return
 			}
 

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -241,3 +241,22 @@ func GetGlobalnetEgressParams(egressIP GlobalEgressIPType) GlobalnetTestParams {
 		GlobalEgressIP:   egressIP,
 	}
 }
+
+func IsSingleNodeDeployment(sourceNode, destNode framework.NetworkPodScheduling,
+	sourceCluster, destCluster framework.ClusterIndex) bool {
+	if sourceNode == framework.NonGatewayNode &&
+		framework.TestContext.NumNodesInCluster[sourceCluster] == 1 {
+		framework.Skipf("Skipping the test as cluster %q has only a single node...",
+			framework.TestContext.ClusterIDs[sourceCluster])
+		return true
+	}
+
+	if destNode == framework.NonGatewayNode &&
+		framework.TestContext.NumNodesInCluster[destCluster] == 1 {
+		framework.Skipf("Skipping the test as cluster %q has only a single node...",
+			framework.TestContext.ClusterIDs[destCluster])
+		return true
+	}
+
+	return false
+}

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -242,21 +242,21 @@ func GetGlobalnetEgressParams(egressIP GlobalEgressIPType) GlobalnetTestParams {
 	}
 }
 
-func IsSingleNodeDeployment(sourceNode, destNode framework.NetworkPodScheduling,
+func CanExecuteNonGatewayConnectivityTest(sourceNode, destNode framework.NetworkPodScheduling,
 	sourceCluster, destCluster framework.ClusterIndex) bool {
 	if sourceNode == framework.NonGatewayNode &&
 		framework.TestContext.NumNodesInCluster[sourceCluster] == 1 {
 		framework.Skipf("Skipping the test as cluster %q has only a single node...",
 			framework.TestContext.ClusterIDs[sourceCluster])
-		return true
+		return false
 	}
 
 	if destNode == framework.NonGatewayNode &&
 		framework.TestContext.NumNodesInCluster[destCluster] == 1 {
 		framework.Skipf("Skipping the test as cluster %q has only a single node...",
 			framework.TestContext.ClusterIDs[destCluster])
-		return true
+		return false
 	}
 
-	return false
+	return true
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -56,6 +56,8 @@ func beforeSuite() {
 	}
 
 	framework.DetectGlobalnet()
+	err = framework.InitNumClusterNodes()
+	Expect(err).To(BeNil())
 }
 
 func (f *Framework) GetGatewayInformer(cluster framework.ClusterIndex) (cache.SharedIndexInformer, chan struct{}) {

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -98,6 +98,11 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 		ToEndpointType:        defaultEndpointType(),
 	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 
+	if !subFramework.CanExecuteNonGatewayConnectivityTest(framework.NonGatewayNode, framework.NonGatewayNode,
+		framework.ClusterB, framework.ClusterA) {
+		return
+	}
+
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
@@ -132,6 +137,12 @@ func defaultEndpointType() tcp.EndpointType {
 }
 
 func testGatewayFailOverScenario(f *subFramework.Framework) {
+	if framework.TestContext.NumNodesInCluster[framework.ClusterA] == 1 {
+		framework.Skipf("Skipping the test as cluster %q has only a single node...",
+			framework.TestContext.ClusterIDs[framework.ClusterA])
+		return
+	}
+
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
@@ -229,6 +240,11 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 		ToClusterScheduling:   framework.GatewayNode,
 		ToEndpointType:        defaultEndpointType(),
 	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
+
+	if !subFramework.CanExecuteNonGatewayConnectivityTest(framework.NonGatewayNode, framework.NonGatewayNode,
+		framework.ClusterB, framework.ClusterA) {
+		return
+	}
 
 	By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{


### PR DESCRIPTION
Currently, in e2e, we schedule pods sometimes on gateway nodes and sometimes
on non-gateway nodes to cover a wide range of use-cases. However, when the
same tests are executed on a single node deployments it returns an unfriendly
error message which would be hard to understand. This PR modifies the code
to run only the applicable test-scenarios.

Depends on: https://github.com/submariner-io/shipyard/pull/654
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
