### PR TITLE
Replace deprecated functions

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -20,7 +20,7 @@ package endpoint
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"regexp"
@@ -98,7 +98,7 @@ func publicAPI(clientset kubernetes.Interface, namespace, value string) (string,
 
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", errors.Wrapf(err, "reading API response from %s", url)
 	}

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -20,8 +20,8 @@ package netlink
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 
@@ -160,7 +160,7 @@ func (n *netlinkType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
 }
 
 func setSysctl(path string, contents []byte) error {
-	existing, err := ioutil.ReadFile(path)
+	existing, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -173,5 +173,5 @@ func setSysctl(path string, contents []byte) error {
 	}
 	// Permissions are already 644, the files are never created
 	// #nosec G306
-	return ioutil.WriteFile(path, contents, 0644)
+	return os.WriteFile(path, contents, 0644)
 }

--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -21,7 +21,7 @@ package ovn
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	goovn "github.com/ebay/go-ovn"
@@ -98,7 +98,7 @@ func getOVNTLSConfig(pkFile, certFile, caFile string) (*tls.Config, error) {
 
 	rootCAs := x509.NewCertPool()
 
-	data, err := ioutil.ReadFile(caFile)
+	data, err := os.ReadFile(caFile)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failure loading OVNDB ca bundle")

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -105,7 +105,7 @@ func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (s
 		return "", errors.Wrapf(err, "error creating %s directory to store %s", dir, diskFilePath)
 	}
 
-	err = ioutil.WriteFile(diskFilePath, data, 0400)
+	err = os.WriteFile(diskFilePath, data, 0400)
 	if err != nil {
 		klog.Error(err)
 		return "", errors.Wrapf(err, "error writing cluster file to  %q", diskFilePath)

--- a/pkg/util/clusterfiles/cluster_files_test.go
+++ b/pkg/util/clusterfiles/cluster_files_test.go
@@ -19,7 +19,7 @@ limitations under the License.
 package clusterfiles_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -98,7 +98,7 @@ var _ = Describe("Cluster Files Get", func() {
 		It("should return the data in a tmp file", func() {
 			file, err := clusterfiles.Get(client, "secret://ns1/my-secret/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := ioutil.ReadFile(file)
+			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
 		})
@@ -108,7 +108,7 @@ var _ = Describe("Cluster Files Get", func() {
 		It("should return the data in a tmp file", func() {
 			file, err := clusterfiles.Get(client, "configmap://ns1/my-configmap/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := ioutil.ReadFile(file)
+			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
 		})
@@ -118,7 +118,7 @@ var _ = Describe("Cluster Files Get", func() {
 		It("should return the data in a tmp file", func() {
 			file, err := clusterfiles.Get(client, "configmap://ns1/my-configmap-binary/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := ioutil.ReadFile(file)
+			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
 		})


### PR DESCRIPTION
* ioutil.ReadFile → os.ReadFile
* ioutil.WriteFile → os.WriteFile
* ioutil.ReadAll → io.ReadAll

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
