### PR TITLE
Hide mutexes

### DIFF
--- a/pkg/ipset/fake/ipset.go
+++ b/pkg/ipset/fake/ipset.go
@@ -31,7 +31,7 @@ import (
 )
 
 type IPSet struct {
-	sync.Mutex
+	mutex                    sync.Mutex
 	sets                     map[string]stringset.Interface
 	failOnDestroySetMatchers []interface{}
 	failOnCreateSetMatchers  []interface{}
@@ -48,8 +48,8 @@ func New() *IPSet {
 }
 
 func (i *IPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchForError(&i.failOnCreateSetMatchers, set.Name)
 	if err != nil {
@@ -70,8 +70,8 @@ func (i *IPSet) CreateSet(set *ipset.IPSet, ignoreExistErr bool) error {
 }
 
 func (i *IPSet) FlushSet(set string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	entries := i.sets[set]
 	if entries == nil {
@@ -84,8 +84,8 @@ func (i *IPSet) FlushSet(set string) error {
 }
 
 func (i *IPSet) DestroySet(set string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchForError(&i.failOnDestroySetMatchers, set)
 	if err != nil {
@@ -102,8 +102,8 @@ func (i *IPSet) DestroySet(set string) error {
 }
 
 func (i *IPSet) DestroyAllSets() error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.sets = map[string]stringset.Interface{}
 
@@ -111,8 +111,8 @@ func (i *IPSet) DestroyAllSets() error {
 }
 
 func (i *IPSet) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchForError(&i.failOnAddEntryMatchers, entry)
 	if err != nil {
@@ -132,8 +132,8 @@ func (i *IPSet) AddEntry(entry string, set *ipset.IPSet, ignoreExistErr bool) er
 }
 
 func (i *IPSet) DelEntry(entry, set string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchForError(&i.failOnDelEntryMatchers, entry)
 	if err != nil {
@@ -151,8 +151,8 @@ func (i *IPSet) DelEntry(entry, set string) error {
 }
 
 func (i *IPSet) TestEntry(entry, set string) (bool, error) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	entries := i.sets[set]
 	if entries == nil {
@@ -163,8 +163,8 @@ func (i *IPSet) TestEntry(entry, set string) (bool, error) {
 }
 
 func (i *IPSet) ListEntries(set string) ([]string, error) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	entries := i.sets[set]
 	if entries == nil {
@@ -175,8 +175,8 @@ func (i *IPSet) ListEntries(set string) ([]string, error) {
 }
 
 func (i *IPSet) ListSets() ([]string, error) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	sets := []string{}
 
@@ -192,8 +192,8 @@ func (i *IPSet) GetVersion() (string, error) {
 }
 
 func (i *IPSet) AddEntryWithOptions(entry *ipset.Entry, set *ipset.IPSet, ignoreExistErr bool) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	entries := i.sets[set.Name]
 	if entries == nil {
@@ -260,29 +260,29 @@ func (i *IPSet) AwaitNoEntry(set string, stringOrMatcher interface{}) {
 }
 
 func (i *IPSet) AddFailOnDestroySetMatchers(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnDestroySetMatchers = append(i.failOnDestroySetMatchers, stringOrMatcher)
 }
 
 func (i *IPSet) AddFailOnCreateSetMatchers(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnCreateSetMatchers = append(i.failOnCreateSetMatchers, stringOrMatcher)
 }
 
 func (i *IPSet) AddFailOnAddEntryMatchers(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnAddEntryMatchers = append(i.failOnAddEntryMatchers, stringOrMatcher)
 }
 
 func (i *IPSet) AddFailOnDelEntryMatchers(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnDelEntryMatchers = append(i.failOnDelEntryMatchers, stringOrMatcher)
 }

--- a/pkg/iptables/fake/iptables.go
+++ b/pkg/iptables/fake/iptables.go
@@ -28,7 +28,7 @@ import (
 )
 
 type IPTables struct {
-	sync.Mutex
+	mutex                    sync.Mutex
 	chainRules               map[string]stringset.Interface
 	tableChains              map[string]stringset.Interface
 	failOnAppendRuleMatchers []interface{}
@@ -57,8 +57,8 @@ func (i *IPTables) Insert(table, chain string, pos int, rulespec ...string) erro
 }
 
 func (i *IPTables) Delete(table, chain string, rulespec ...string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchRuleForError(&i.failOnDeleteRuleMatchers, rulespec...)
 	if err != nil {
@@ -74,8 +74,8 @@ func (i *IPTables) Delete(table, chain string, rulespec ...string) error {
 }
 
 func (i *IPTables) addRule(table, chain string, rulespec ...string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	err := matchRuleForError(&i.failOnAppendRuleMatchers, rulespec...)
 	if err != nil {
@@ -112,8 +112,8 @@ func (i *IPTables) List(table, chain string) ([]string, error) {
 }
 
 func (i *IPTables) listRules(table, chain string) []string {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	rules := i.chainRules[table+"/"+chain]
 	if rules != nil {
@@ -128,8 +128,8 @@ func (i *IPTables) ListChains(table string) ([]string, error) {
 }
 
 func (i *IPTables) listChains(table string) []string {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	chains := i.tableChains[table]
 	if chains != nil {
@@ -145,8 +145,8 @@ func (i *IPTables) NewChain(table, chain string) error {
 }
 
 func (i *IPTables) ClearChain(table, chain string) error {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	chainSet := i.tableChains[table]
 	if chainSet != nil {
@@ -157,8 +157,8 @@ func (i *IPTables) ClearChain(table, chain string) error {
 }
 
 func (i *IPTables) AddChainsFor(table string, chains ...string) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	chainSet := i.tableChains[table]
 	if chainSet == nil {
@@ -194,15 +194,15 @@ func (i *IPTables) AwaitNoRule(table, chain string, stringOrMatcher interface{})
 }
 
 func (i *IPTables) AddFailOnAppendRuleMatcher(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnAppendRuleMatchers = append(i.failOnAppendRuleMatchers, stringOrMatcher)
 }
 
 func (i *IPTables) AddFailOnDeleteRuleMatcher(stringOrMatcher interface{}) {
-	i.Lock()
-	defer i.Unlock()
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
 
 	i.failOnDeleteRuleMatchers = append(i.failOnDeleteRuleMatchers, stringOrMatcher)
 }

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -30,7 +30,7 @@ import (
 )
 
 type NetLink struct {
-	sync.Mutex
+	mutex       sync.Mutex
 	linkIndices map[string]int
 	links       map[string]netlink.Link
 	routes      map[int][]netlink.Route
@@ -49,15 +49,15 @@ func New() *NetLink {
 }
 
 func (n *NetLink) SetLinkIndex(name string, index int) {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	n.linkIndices[name] = index
 }
 
 func (n *NetLink) LinkAdd(link netlink.Link) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	if _, found := n.links[link.Attrs().Name]; found {
 		return syscall.EEXIST
@@ -70,8 +70,8 @@ func (n *NetLink) LinkAdd(link netlink.Link) error {
 }
 
 func (n *NetLink) LinkDel(link netlink.Link) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	delete(n.links, link.Attrs().Name)
 
@@ -79,8 +79,8 @@ func (n *NetLink) LinkDel(link netlink.Link) error {
 }
 
 func (n *NetLink) LinkByName(name string) (netlink.Link, error) {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	link, found := n.links[name]
 	if !found {
@@ -99,8 +99,8 @@ func (n *NetLink) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
 }
 
 func (n *NetLink) NeighAppend(neigh *netlink.Neigh) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	n.neighbors[neigh.LinkIndex] = append(n.neighbors[neigh.LinkIndex], *neigh)
 
@@ -108,8 +108,8 @@ func (n *NetLink) NeighAppend(neigh *netlink.Neigh) error {
 }
 
 func (n *NetLink) NeighDel(neigh *netlink.Neigh) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	neighbors := n.neighbors[neigh.LinkIndex]
 	for i := range neighbors {
@@ -123,8 +123,8 @@ func (n *NetLink) NeighDel(neigh *netlink.Neigh) error {
 }
 
 func (n *NetLink) RouteAdd(route *netlink.Route) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	n.routes[route.LinkIndex] = append(n.routes[route.LinkIndex], *route)
 
@@ -132,8 +132,8 @@ func (n *NetLink) RouteAdd(route *netlink.Route) error {
 }
 
 func (n *NetLink) RouteDel(route *netlink.Route) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	routes := n.routes[route.LinkIndex]
 
@@ -148,8 +148,8 @@ func (n *NetLink) RouteDel(route *netlink.Route) error {
 }
 
 func (n *NetLink) FlushRouteTable(table int) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	for index, routes := range n.routes {
 		newRoutes := []netlink.Route{}
@@ -167,8 +167,8 @@ func (n *NetLink) FlushRouteTable(table int) error {
 }
 
 func (n *NetLink) RouteGet(destination net.IP) ([]netlink.Route, error) {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	routes := []netlink.Route{}
 	for _, rts := range n.routes {
@@ -183,15 +183,15 @@ func (n *NetLink) RouteGet(destination net.IP) ([]netlink.Route, error) {
 }
 
 func (n *NetLink) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	return n.routes[link.Attrs().Index], nil
 }
 
 func (n *NetLink) RuleAdd(rule *netlink.Rule) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	if _, found := n.rules[rule.Table]; found {
 		return os.ErrExist
@@ -203,8 +203,8 @@ func (n *NetLink) RuleAdd(rule *netlink.Rule) error {
 }
 
 func (n *NetLink) RuleDel(rule *netlink.Rule) error {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	if _, found := n.rules[rule.Table]; !found {
 		return os.ErrNotExist
@@ -289,8 +289,8 @@ func (n *NetLink) AwaitNoRoutes(linkIndex int, destCIDRs ...string) {
 }
 
 func (n *NetLink) neighborIPList(linkIndex int) []net.IP {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	ips := []net.IP{}
 	for _, neigh := range n.neighbors[linkIndex] {
@@ -321,8 +321,8 @@ func (n *NetLink) AwaitNoNeighbors(linkIndex int, expIPs ...string) {
 }
 
 func (n *NetLink) getRule(table int) *netlink.Rule {
-	n.Lock()
-	defer n.Unlock()
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 
 	r, found := n.rules[table]
 	if !found {


### PR DESCRIPTION
This is flagged by the latest gocritic:
https://go-critic.com/overview.html#exposedSyncMutex-ref

This patch avoids exposing the mutex functions on the containing
struct.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
