### PR TITLE
Hide more mutexes

### DIFF
--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -32,7 +32,7 @@ import (
 const DriverName = "fake-driver"
 
 type Driver struct {
-	sync.Mutex
+	mutex                       sync.Mutex
 	init                        chan struct{}
 	ErrOnInit                   error
 	activeConnections           map[string]v1.Connection
@@ -61,8 +61,8 @@ func (d *Driver) Init() error {
 }
 
 func (d *Driver) GetActiveConnections() ([]v1.Connection, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	ret := []v1.Connection{}
 	for _, c := range d.activeConnections {
@@ -85,8 +85,8 @@ func (d *Driver) GetConnections() ([]v1.Connection, error) {
 }
 
 func (d *Driver) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	err := d.ErrOnConnectToEndpoint
 	if err != nil {
@@ -103,8 +103,8 @@ func (d *Driver) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (
 }
 
 func (d *Driver) DisconnectFromEndpoint(endpoint types.SubmarinerEndpoint) error {
-	d.Lock()
-	defer d.Unlock()
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 
 	err := d.ErrOnDisconnectFromEndpoint
 	if err != nil {

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -28,7 +28,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 )
 
-type Engine struct {
+type Engine struct { // nolint:gocritic // This mutex is exposed but we tweak it in tests
 	sync.Mutex
 	Connections               []v1.Connection
 	ListCableConnectionsError error

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -42,7 +42,7 @@ import (
 )
 
 type GatewaySyncer struct {
-	sync.Mutex
+	mutex       sync.Mutex
 	client      v1typed.GatewayInterface
 	engine      cableengine.Engine
 	version     string
@@ -85,15 +85,15 @@ func (gs *GatewaySyncer) Run(stopCh <-chan struct{}) {
 }
 
 func (gs *GatewaySyncer) syncGatewayStatus() {
-	gs.Lock()
-	defer gs.Unlock()
+	gs.mutex.Lock()
+	defer gs.mutex.Unlock()
 
 	gs.syncGatewayStatusSafe()
 }
 
 func (gs *GatewaySyncer) SetGatewayStatusError(err error) {
-	gs.Lock()
-	defer gs.Unlock()
+	gs.mutex.Lock()
+	defer gs.mutex.Unlock()
 
 	gs.statusError = err
 	gs.syncGatewayStatusSafe()

--- a/pkg/globalnet/controllers/ingress_pod_controllers.go
+++ b/pkg/globalnet/controllers/ingress_pod_controllers.go
@@ -45,8 +45,8 @@ func NewIngressPodControllers(config syncer.ResourceSyncerConfig) (*IngressPodCo
 }
 
 func (c *IngressPodControllers) start(service *corev1.Service) error {
-	c.Lock()
-	defer c.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	key := c.key(service.Name, service.Namespace)
 	if _, exists := c.controllers[key]; exists {
@@ -64,8 +64,8 @@ func (c *IngressPodControllers) start(service *corev1.Service) error {
 }
 
 func (c *IngressPodControllers) stopAll() {
-	c.Lock()
-	defer c.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	for _, controller := range c.controllers {
 		controller.Stop()
@@ -75,8 +75,8 @@ func (c *IngressPodControllers) stopAll() {
 }
 
 func (c *IngressPodControllers) stopAndCleanup(serviceName, serviceNamespace string) {
-	c.Lock()
-	defer c.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	key := c.key(serviceName, serviceNamespace)
 	controller, exists := c.controllers[key]

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -157,7 +157,7 @@ type ingressPodController struct {
 }
 
 type IngressPodControllers struct {
-	sync.Mutex
+	mutex       sync.Mutex
 	controllers map[string]*ingressPodController
 	config      syncer.ResourceSyncerConfig
 	ingressIPs  dynamic.NamespaceableResourceInterface


### PR DESCRIPTION
This is flagged by the latest gocritic:
https://go-critic.com/overview.html#exposedSyncMutex-ref

 This patch avoids exposing the mutex functions on the containing
struct.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
