### PR TITLE
Enable desired 1.43.1 linters and document disabled ones

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - durationcheck
     - errcheck
     - errorlint
+    - errname
     - exhaustive
     # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
     - exportloopref

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
     - nakedret
     # - nestif # This calculates cognitive complexity but we're doing that elsewhere
     - nilerr
+    - nilnil
     # - nlreturn # This is reasonable with a block-size of 2 but setting it above isn't honored
     # - noctx # We don't send HTTP requests
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,9 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
+    - contextcheck
     # - cyclop # This is equivalent to gocyclo
     - deadcode
     - depguard
@@ -65,6 +67,8 @@ linters:
     # - ifshort # This is a style preference and doesn't seem compelling
     - importas
     - ineffassign
+    # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
+    #             an interface to avoid exposing the entire underlying struct
     # - interfacer # Deprecated since v1.38.0
     - lll
     - makezero
@@ -89,6 +93,7 @@ linters:
     - structcheck
     - stylecheck
     # - tagliatelle # Inconsistent with stylecheck and not as good
+    # - tenv # Not relevant for our Ginkgo UTs
     - testpackage
     # - thelper # Not relevant for our Ginkgo UTs
     # - tparallel # Not relevant for our Ginkgo UTs
@@ -97,6 +102,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
     - wastedassign
     - whitespace
     - wrapcheck

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -95,7 +95,7 @@ func randomRequestCounter() (uint64, error) {
 	return n.Uint64(), nil
 }
 
-var errorNoNATDiscoveryPort = errors.New("NATT discovery port missing in endpoint")
+var errNoNATDiscoveryPort = errors.New("NATT discovery port missing in endpoint")
 
 func extractNATDiscoveryPort(endpoint *v1.EndpointSpec) (int32, error) {
 	natDiscoveryPort, err := endpoint.GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
@@ -104,7 +104,7 @@ func extractNATDiscoveryPort(endpoint *v1.EndpointSpec) (int32, error) {
 	}
 
 	if natDiscoveryPort == 0 {
-		return natDiscoveryPort, errorNoNATDiscoveryPort
+		return natDiscoveryPort, errNoNATDiscoveryPort
 	}
 
 	return natDiscoveryPort, nil
@@ -150,7 +150,7 @@ func (nd *natDiscovery) AddEndpoint(endpoint *v1.Endpoint) {
 
 	// support nat discovery disabled or a remote cluster endpoint which still hasn't implemented this protocol
 	if _, err := extractNATDiscoveryPort(&endpoint.Spec); err != nil || nd.serverPort == 0 {
-		if !errors.Is(err, errorNoNATDiscoveryPort) {
+		if !errors.Is(err, errNoNATDiscoveryPort) {
 			klog.Errorf("Error extracting NATT discovery port from endpoint %q: %v", endpoint.Spec.CableName, err)
 		}
 

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -54,7 +54,7 @@ var _ = Describe("[dataplane] Gateway status reporting", func() {
 				func() (interface{}, error) {
 					resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
 					if apierrors.IsNotFound(err) {
-						return nil, nil
+						return nil, nil // nolint:nilnil // Returning nil value is intentional
 					}
 					return resGw, err
 				},


### PR DESCRIPTION
`golangci-lint` 1.43.1 adds a few more available linters. See individual commits for details.