### PR TITLE
Add metrics to Globalnet 2.0

### DIFF
--- a/pkg/globalnet/metrics/metrics.go
+++ b/pkg/globalnet/metrics/metrics.go
@@ -1,0 +1,69 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	cidrLabel = "cidr"
+)
+
+var (
+	globalIPsAvailabilityGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "submariner_global_IP_availability",
+			Help: "Count of available global IPs per CIDR",
+		},
+		[]string{
+			cidrLabel,
+		},
+	)
+	globalIPsAllocatedGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "submariner_global_IP_allocated",
+			Help: "Count of global IPs allocated for Pods/Services per CIDR",
+		},
+		[]string{
+			cidrLabel,
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(globalIPsAvailabilityGauge, globalIPsAllocatedGauge)
+}
+
+func RecordAllocateGlobalIP(cidr string) {
+	globalIPsAllocatedGauge.With(prometheus.Labels{cidrLabel: cidr}).Inc()
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Dec()
+}
+
+func RecordAllocateGlobalIPs(cidr string, count int) {
+	globalIPsAllocatedGauge.With(prometheus.Labels{cidrLabel: cidr}).Add(float64(count))
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Sub(float64(count))
+}
+
+func RecordDeallocateGlobalIP(cidr string) {
+	globalIPsAllocatedGauge.With(prometheus.Labels{cidrLabel: cidr}).Dec()
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Inc()
+}
+
+func RecordAvailability(cidr string, count int) {
+	globalIPsAvailabilityGauge.With(prometheus.Labels{cidrLabel: cidr}).Set(float64(count))
+}

--- a/pkg/ipam/ippool.go
+++ b/pkg/ipam/ippool.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/emirpasic/gods/maps/treemap"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/globalnet/metrics"
 )
 
 type IPPool struct {
@@ -65,7 +66,7 @@ func NewIPPool(cidr string) (*IPPool, error) {
 		pool.available.Put(intIP, ip)
 	}
 
-	// TODO: RecordAvailability(cidr, size)
+	metrics.RecordAvailability(cidr, size)
 
 	return pool, nil
 }
@@ -97,7 +98,7 @@ func (p *IPPool) allocateOne() ([]string, error) {
 	iter := p.available.Iterator()
 	if iter.Last() {
 		p.available.Remove(iter.Key())
-		// TODO: RecordAllocateGlobalIP(p.cidr)
+		metrics.RecordAllocateGlobalIP(p.cidr)
 
 		return []string{iter.Value().(string)}, nil
 	}
@@ -149,7 +150,7 @@ func (p *IPPool) Allocate(num int) ([]string, error) {
 				firstIntIP++
 			}
 
-			// TODO: RecordAllocateGlobalIPs(p.cidr, num)
+			metrics.RecordAllocateGlobalIPs(p.cidr, num)
 
 			return retIPs, nil
 		}
@@ -169,6 +170,7 @@ func (p *IPPool) Release(ips ...string) error {
 		}
 
 		p.available.Put(StringIPToInt(ip), ip)
+		metrics.RecordDeallocateGlobalIP(p.cidr)
 	}
 
 	return nil
@@ -201,6 +203,7 @@ func (p *IPPool) Reserve(ips ...string) error {
 	for i := 0; i < num; i++ {
 		p.available.Remove(intIPs[i])
 	}
+	metrics.RecordAllocateGlobalIPs(p.cidr, num)
 
 	return nil
 }


### PR DESCRIPTION
Add 2 metrics to globalnet:
1. submariner_global_IP_availability
2. submariner_global_IP_allocated
Those metrics reffers to the global CIDR shared by all globalnet controllers

Partly Fix: #1471

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
