### PR TITLE
Formalize local build settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,5 @@ endif
 
 # Disable rebuilding Makefile
 Makefile Makefile.inc: ;
+
+print-%: ; @echo $* = $($*) 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export BASE_BRANCH
 
 # Define LOCAL_BUILD to build directly on the host and not inside a Dapper container
 ifdef LOCAL_BUILD
-DAPPER_HOST_ARCH ?= $(shell go env GOHOSTARCH | cut -d= -f2 | tr -d '"')
+DAPPER_HOST_ARCH ?= $(shell go env GOHOSTARCH)
 SHIPYARD_DIR ?= ../shipyard
 SCRIPTS_DIR ?= $(SHIPYARD_DIR)/scripts/shared
 
@@ -140,5 +140,3 @@ endif
 
 # Disable rebuilding Makefile
 Makefile Makefile.inc: ;
-
-print-%: ; @echo $* = $($*) 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,17 @@ BASE_BRANCH ?= devel
 PROTOC_VERSION=3.17.3
 export BASE_BRANCH
 
+# Define LOCAL_BUILD to build directly on the host and not inside a Dapper container
+ifdef LOCAL_BUILD
+DAPPER_HOST_ARCH ?= $(shell go env GOHOSTARCH | cut -d= -f2 | tr -d '"')
+SHIPYARD_DIR ?= ../shipyard
+SCRIPTS_DIR ?= $(SHIPYARD_DIR)/scripts/shared
+
+export DAPPER_HOST_ARCH
+export SHIPYARD_DIR
+export SCRIPTS_DIR
+endif
+
 ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper


### PR DESCRIPTION
This PR formalizes the settings needed for a "local build", outside of a Dapper container.

A developer should run (for example) `LOCAL_BUILD=1 make images` to build all images on their machine.
If `LOCAL_BUILD` is defined, the Makefile sets the needed variables to defaults under the following assumptions:
- Shipyard location is `../shipyard` (this would be the typical case if both repos are cloned under the same (e.g., `submariner-io`) directory); and
- `DAPPER_HOST_ARCH` is derived from `go env GOHOSTARCH`

All values are picked from outside the Makefile, if already defined.

Signed-off-by: Etai Lev Ran <elevran@gmail.com>