### PR TITLE
Fix issue with gateway name in e2e

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/util"
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -76,7 +77,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	By(fmt.Sprintf("Ensuring that the gateway reports as active on %q", clusterAName))
 
-	activeGateway := f.AwaitGatewayFullyConnected(framework.ClusterA, gatewayNodes[0].Name)
+	activeGateway := f.AwaitGatewayFullyConnected(framework.ClusterA, util.EnsureValidName(gatewayNodes[0].Name))
 
 	By(fmt.Sprintf("Deleting submariner gateway pod %q", gatewayPod.Name))
 	f.DeletePod(framework.ClusterA, gatewayPod.Name, framework.TestContext.SubmarinerNamespace)
@@ -85,7 +86,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 	By(fmt.Sprintf("Found new submariner gateway pod %q", newGatewayPod.Name))
 
 	By(fmt.Sprintf("Waiting for the gateway to be up and connected %q", newGatewayPod.Name))
-	f.AwaitGatewayFullyConnected(framework.ClusterA, activeGateway.Name)
+	f.AwaitGatewayFullyConnected(framework.ClusterA, util.EnsureValidName(activeGateway.Name))
 
 	By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
 	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
@@ -157,7 +158,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 
 	By(fmt.Sprintf("Ensuring that two Gateways become available in cluster %q", clusterAName))
 
-	f.AwaitGatewayFullyConnected(framework.ClusterA, initialGatewayNode.Name)
+	f.AwaitGatewayFullyConnected(framework.ClusterA, util.EnsureValidName(initialGatewayNode.Name))
 	gwPassive := f.AwaitGatewayWithStatus(framework.ClusterA, initialNonGatewayNode.Name, subv1.HAStatusPassive)
 	Expect(gwPassive.Status.Connections).To(BeEmpty(), "The passive gateway must have no connections")
 
@@ -204,7 +205,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	By(fmt.Sprintf("Found new submariner gateway pod %q", newGatewayPod.Name))
 
 	By(fmt.Sprintf("Waiting for the new pod %q to report as active and fully connected", newGatewayPod.Name))
-	f.AwaitGatewayFullyConnected(framework.ClusterA, newGatewayPod.Spec.NodeName)
+	f.AwaitGatewayFullyConnected(framework.ClusterA, util.EnsureValidName(newGatewayPod.Spec.NodeName))
 
 	By(fmt.Sprintf("Checking that gateway pod %q updated the HA status label", newGatewayPod.Name))
 


### PR DESCRIPTION
The submariner gateway name is not always the same as the node name.
It is generated using an API, hence using the same API	for test
as well, to avoid failures in some scenarios.

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
