### PR TITLE
Globalnet fix for issues with multiple headless svs

### DIFF
--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -66,9 +66,10 @@ func (c *baseSyncerController) Start() error {
 	return c.resourceSyncer.Start(c.stopCh) // nolint:wrapcheck  // Let the caller wrap it
 }
 
-func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, transform func(obj *unstructured.Unstructured) runtime.Object) {
+func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector string,
+	transform func(obj *unstructured.Unstructured) runtime.Object) {
 	c.resourceSyncer.Reconcile(func() []runtime.Object {
-		objList, err := client.List(context.TODO(), metav1.ListOptions{})
+		objList, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			klog.Errorf("Error listing resources for reconciliation: %v", err)
 			return nil

--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -74,8 +74,13 @@ func startIngressPodController(svc *corev1.Service, config *syncer.ResourceSynce
 		return nil, errors.Wrap(err, "error starting the syncer")
 	}
 
+	selector := map[string]string{
+		ServiceRefLabel: svc.Name,
+	}
+
+	ingressIPSelector := labels.Set(selector).AsSelector().String()
 	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(corev1.NamespaceAll)
-	controller.reconcile(ingressIPs, func(obj *unstructured.Unstructured) runtime.Object {
+	controller.reconcile(ingressIPs, ingressIPSelector, func(obj *unstructured.Unstructured) runtime.Object {
 		podName, exists, _ := unstructured.NestedString(obj.Object, "spec", "podRef", "name")
 		if exists {
 			return &corev1.Pod{

--- a/pkg/globalnet/controllers/service_controller.go
+++ b/pkg/globalnet/controllers/service_controller.go
@@ -74,7 +74,7 @@ func (c *serviceController) Start() error {
 		return err
 	}
 
-	c.reconcile(c.ingressIPs, func(obj *unstructured.Unstructured) runtime.Object {
+	c.reconcile(c.ingressIPs, "", func(obj *unstructured.Unstructured) runtime.Object {
 		name, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
 		if exists {
 			return &corev1.Service{

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -98,7 +98,7 @@ func (c *serviceExportController) Start() error {
 		return err
 	}
 
-	c.reconcile(c.ingressIPs, func(obj *unstructured.Unstructured) runtime.Object {
+	c.reconcile(c.ingressIPs, "", func(obj *unstructured.Unstructured) runtime.Object {
 		name, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
 		if exists {
 			return &mcsv1a1.ServiceExport{


### PR DESCRIPTION
The reconciler method used in startIngressPodController was listing all the
globalIngressIP objects in the cluster and was deleting the previous ones.
Because of this, at any point of time, only one globalIngressIP object was
existing for an Headless Service that is exported. This PR updates the
reconciler to use labelSelector such that it only tries to list the pods
that match the associated label of the headless svc.

Fixes issue: https://github.com/submariner-io/submariner/issues/1634
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
