### PR TITLE
Wait for whack to reap its process

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -212,7 +212,7 @@ func retrieveActiveConnectionStats() (map[string]int, map[string]int, error) {
 		}
 	}
 
-	return activeConnectionsRx, activeConnectionsTx, nil
+	return activeConnectionsRx, activeConnectionsTx, errors.Wrap(cmd.Wait(), "error waiting for whack to complete")
 }
 
 func (i *libreswan) refreshConnectionStatus() error {


### PR DESCRIPTION
Whenever we start a process, we need to ensure we wait for it to
complete; there was one instance where we didn't do so with whack,
this fixes it.

Fixes: #1659
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
