### PR TITLE
Move test for oldest K8s version to Operator

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -24,9 +24,6 @@ jobs:
             globalnet: 'globalnet'
           - ovn: 'ovn'
             cable_driver: 'wireguard'
-        include:
-          # This is the oldest K8s version we try to support
-          - k8s_version: '1.17'
     steps:
       - name: Check out the repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
Move the test for the oldest K8s version thought to work with Submariner
to the submariner-operator repo where it's consumed. It will also be
better documented when re-added.

Relates-to: submariner-io/submariner-website#624

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
