### PR TITLE
Endpoint objects are updated with no change every 30s filling logs

### DIFF
--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -155,7 +155,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 
 		prevTimestamp := i.installedCables[active.Endpoint.CableName]
 
-		klog.V(log.DEBUG).Infof("Found a pre-existing cable %q with timestamp %q that belongs to this cluster %s",
+		klog.V(log.TRACE).Infof("Found a pre-existing cable %q with timestamp %q that belongs to this cluster %s",
 			active.Endpoint.CableName, prevTimestamp, endpoint.Spec.ClusterID)
 
 		if endpoint.CreationTimestamp.Before(&prevTimestamp) {
@@ -169,7 +169,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 			// config has changed.
 			if active.UsingIP == rnat.UseIP && active.UsingNAT == rnat.UseNAT &&
 				reflect.DeepEqual(active.Endpoint.BackendConfig, endpoint.Spec.BackendConfig) {
-				klog.V(log.DEBUG).Infof("Connection info (IP: %s, NAT: %v, BackendConfig: %v) for cable %q is unchanged"+
+				klog.V(log.TRACE).Infof("Connection info (IP: %s, NAT: %v, BackendConfig: %v) for cable %q is unchanged"+
 					" - not re-installing", active.UsingIP, active.UsingNAT, active.Endpoint.BackendConfig, active.Endpoint.CableName)
 				return nil
 			}
@@ -203,7 +203,7 @@ func (i *engine) installCableWithNATInfo(rnat *natdiscovery.NATEndpointInfo) err
 
 func (i *engine) InstallCable(endpoint *v1.Endpoint) error {
 	if endpoint.Spec.ClusterID == i.localCluster.ID {
-		klog.V(log.DEBUG).Infof("Not installing cable for local cluster")
+		klog.V(log.TRACE).Infof("Not installing cable for local cluster")
 		return nil
 	}
 

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -72,7 +72,7 @@ func StartController(engine cableengine.Engine, namespace string, config *watche
 func (c *controller) handleCreatedOrUpdatedEndpoint(obj runtime.Object, numRequeues int) bool {
 	endpoint := obj.(*v1.Endpoint)
 
-	klog.V(log.DEBUG).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
+	klog.V(log.TRACE).Infof("Tunnel controller processing added or updated submariner Endpoint object: %#v", endpoint)
 
 	err := c.engine.InstallCable(endpoint)
 	if err != nil {


### PR DESCRIPTION
On a Submariner deployment, the submariner-gateway-xxxx container logs are being
filled by recurring log every 30s even though nothing has changed. See issue for
more details. Changing the logs to TRACE.

Closes: #1568

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
