### PR TITLE
Update Calico network plugin name

### DIFF
--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -19,6 +19,8 @@ limitations under the License.
 package event
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/stringset"
@@ -53,10 +55,10 @@ func (er *Registry) addHandler(eventHandler Handler) error {
 	evNetworkPlugins := stringset.New()
 
 	for _, np := range eventHandler.GetNetworkPlugins() {
-		evNetworkPlugins.Add(np)
+		evNetworkPlugins.Add(strings.ToLower(np))
 	}
 
-	if evNetworkPlugins.Contains(AnyNetworkPlugin) || evNetworkPlugins.Contains(er.networkPlugin) {
+	if evNetworkPlugins.Contains(AnyNetworkPlugin) || evNetworkPlugins.Contains(strings.ToLower(er.networkPlugin)) {
 		if err := eventHandler.Init(); err != nil {
 			return errors.Wrapf(err, "Event handler %q failed to initialize", eventHandler.GetName())
 		}


### PR DESCRIPTION
According to documentation [1], calico should be configured as
an OpenShift third-party network plugin named 'Calico'.

Fixes: submariner-io/submariner-operator#1852 
[1]
https://projectcalico.docs.tigera.io/getting-started/openshift/installation

Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
