### PR TITLE
Build images without Dapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ else
 SETTINGS ?= $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-images: build
-
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e /)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ dockertogoarch = $(patsubst arm/v7,arm,$(1))
 
 deploy: images
 
+e2e: vendor/modules.txt
+
 golangci-lint: pkg/natdiscovery/proto/natdiscovery.pb.go
 
 unit: pkg/natdiscovery/proto/natdiscovery.pb.go

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,4 +1,17 @@
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/submariner
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-gateway
+
 FROM fedora:34
+ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
@@ -10,6 +23,6 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
            iproute libreswan kmod && \
     dnf -y clean all
 
-COPY package/submariner.sh package/pluto bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/
+COPY --from=builder ${SOURCE}/package/submariner.sh ${SOURCE}/package/pluto ${SOURCE}/bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/
 
 ENTRYPOINT submariner.sh

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,4 +1,17 @@
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/submariner
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-globalnet
+
 FROM fedora:34
+ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
@@ -7,11 +20,11 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
            iproute iptables iptables-nft ipset && \
     dnf -y clean all
 
-COPY package/submariner-globalnet.sh bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/
+COPY --from=builder ${SOURCE}/package/submariner-globalnet.sh ${SOURCE}/bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/
 
 # Wrapper scripts to choose the appropriate iptables
 # https://github.com/kubernetes-sigs/iptables-wrappers
-COPY package/iptables-wrapper-installer.sh /usr/sbin/
+COPY --from=builder ${SOURCE}/package/iptables-wrapper-installer.sh /usr/sbin/
 RUN /usr/sbin/iptables-wrapper-installer.sh
 
 ENTRYPOINT submariner-globalnet.sh

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,4 +1,17 @@
-FROM fedora:34 
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/submariner
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-networkplugin-syncer
+
+FROM fedora:34
+ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
@@ -8,7 +21,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
     dnf -y clean all
 
 # install the networkpluginc-sync
-COPY package/submariner-networkplugin-syncer.sh bin/${TARGETPLATFORM}/submariner-networkplugin-syncer /usr/local/bin/
+COPY --from=builder ${SOURCE}/package/submariner-networkplugin-syncer.sh ${SOURCE}/bin/${TARGETPLATFORM}/submariner-networkplugin-syncer /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/submariner-networkplugin-syncer.sh"]
 

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,4 +1,17 @@
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/submariner
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-route-agent
+
 FROM fedora:34
+ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
@@ -7,11 +20,11 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
            iproute iptables iptables-nft ipset openvswitch procps-ng && \
     dnf -y clean all
 
-COPY package/submariner-route-agent.sh bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/
+COPY --from=builder ${SOURCE}/package/submariner-route-agent.sh ${SOURCE}/bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/
 
 # Wrapper scripts to choose the appropriate iptables
 # https://github.com/kubernetes-sigs/iptables-wrappers
-COPY package/iptables-wrapper-installer.sh /usr/sbin/
+COPY --from=builder ${SOURCE}/package/iptables-wrapper-installer.sh /usr/sbin/
 RUN /usr/sbin/iptables-wrapper-installer.sh
 
 ENTRYPOINT submariner-route-agent.sh


### PR DESCRIPTION
We can achieve the same effect as running with Dapper, without Dapper,
by building images in multiple stages. The first stage runs in a
container built from our Shipyard base image, and subsequent stages
build our deliverable images.

This brings the following benefits:

* our container image builds are driven by our container descriptors,
  not by a combination of our Makefiles and container descriptors;
  this is more familiar to developers used to containers
* providing container descriptor-driven builds allows more third-party
  tools to be used directly, e.g. repository-hosted container image
  builds (on Quay or GitHub notably) and container descriptor analysis
  tools
* the risk of differences between "proper" container builds and local
  builds (with LOCAL_BUILD=1) is eliminated
* our build no longer depends on being able to build containers inside
  containers (which isn't supported everywhere)
* by building the binaries we want to ship in our container images
  during the container image build, we can ensure that the binaries
  are built for the architecture expected by the container image

The default target platform is linux/amd64 for the time being.

Depends on https://github.com/submariner-io/shipyard/pull/713

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
