### PR TITLE
Track framework.ExecWithOptions changes in shipyard

### DIFF
--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -196,7 +196,7 @@ func execCmdInBash(p tcp.ConnectivityTestParams, cmd []string, pod *v1.Pod) (str
 		PreserveWhitespace: true,
 	}
 
-	return p.Framework.ExecWithOptions(execOptions, p.FromCluster)
+	return p.Framework.ExecWithOptions(&execOptions, p.FromCluster)
 }
 
 func getGlobalIngressIP(p tcp.ConnectivityTestParams, service *v1.Service) string {


### PR DESCRIPTION
Shipyard's definition changed to accept pointer, not struct (large struct lint error),
reflecting this change into submariner

Signed-off-by: Etai Lev Ran <etail@il.ibm.com>
