### PR TITLE
Adjust to Shipyard framework changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/submariner-io/admiral v0.12.0-m3
-	github.com/submariner-io/shipyard v0.12.0-m3
+	github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1
 	github.com/uw-labs/lichen v0.1.5
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.12.0-m3 h1:ohJK0FmJHzDIy9f/FJGR47ANESbStpPVhdN4UYbvtys=
 github.com/submariner-io/admiral v0.12.0-m3/go.mod h1:UBcJ547DlOWcX13HtWBS83tmd+DcWDu9FDbmI0iDSU4=
-github.com/submariner-io/shipyard v0.12.0-m3 h1:kMVYrEPLEH9KyAHp49bmVEVsukfrIWWIqgsqgNII4nc=
 github.com/submariner-io/shipyard v0.12.0-m3/go.mod h1:el/lH6ed/1BN1FvEXlptiib7qT2cTwEQ4AMceH3js9g=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1 h1:MY/4ZJfGgw1NN02toflab3k6s5cFtpXwDjlXZy3Bqyw=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -185,7 +185,7 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, egressIPT
 }
 
 func execCmdInBash(p tcp.ConnectivityTestParams, cmd []string, pod *v1.Pod) (string, string, error) {
-	execOptions := framework.ExecOptions{
+	execOptions := &framework.ExecOptions{
 		Command:            cmd,
 		Namespace:          pod.Namespace,
 		PodName:            pod.Name,


### PR DESCRIPTION
Shipyard commit f506ea3c ("Enabled gocritic, fix issues") changed
ExecWithOptions to expect options as a pointer.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
