### PR TITLE
Don't recommend deploying operator directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ See the [Prerequisites docs](https://submariner.io/getting-started/#prerequisite
 
 ## Installation
 
-Submariner is deployed and manged by its Operator. The Operator can be deployed directly, or by using Submariner's Helm Charts, or by using
-Submariner's `subctl` CLI helper utility. `subctl` is the recommended deployment method because it has the most refined deployment user
-experience and additionally provides testing and bug-diagnosing capabilities.
+Submariner is always deployed using a Go-based Kubernetes custom controller, called an
+[Operator](https://github.com/submariner-io/submariner-operator), that provides API-based installation and management. Deployment tools like
+the *`subctl`* command line utility and Helm charts wrap the Operator. The recommended deployment method is `subctl`, as it is currently the
+default in CI and provides diagnostic features.
+
+See the [Deplyment docs](https://submariner.io/operations/deployment/) on Submariner's website.
 
 ### Installation using subctl
 


### PR DESCRIPTION
Deployments always use the operator, but should consume it through
subctl or Helm. Deploying the operator directly, manually, would be
complex and is not recommended.

Also refactor the Install section, link to website's parallel docs.

Fixes: submariner-io/submariner-website#465

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
