### PR TITLE
Routeagent datapath cleanup

### DIFF
--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -21,7 +21,9 @@ package constants
 const (
 	// IPTable chains used by RouteAgent.
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
+	SmInputChain       = "SUBMARINER-INPUT"
 	PostRoutingChain   = "POSTROUTING"
+	InputChain         = "INPUT"
 	MangleTable        = "mangle"
 	RemoteCIDRIPSet    = "SUBMARINER-REMOTECIDRS"
 	LocalCIDRIPSet     = "SUBMARINER-LOCALCIDRS"
@@ -55,4 +57,7 @@ const (
 	NetworkPluginOpenShiftSDN  = "OpenShiftSDN"
 	NetworkPluginOVNKubernetes = "OVNKubernetes"
 	NetworkPluginCalico        = "calico"
+
+	NATTable    = "nat"
+	FilterTable = "filter"
 )

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -1,0 +1,120 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeproxy
+
+import (
+	"net"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/iptables"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog"
+)
+
+func (kp *SyncHandler) Stop(uninstall bool) error {
+	if !uninstall {
+		return nil
+	}
+
+	klog.Infof("Uinstalling Submariner changes from the node %q", kp.hostname)
+	klog.Infof("Flushing route table %d entries", constants.RouteAgentHostNetworkTableID)
+
+	err := kp.netLink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
+	if err != nil {
+		// We can safely ignore this error, as this table will exist only on GW nodes
+		klog.V(log.TRACE).Infof("Flushing routing table %d returned error. Can be ignored on non-Gw node: %v",
+			constants.RouteAgentHostNetworkTableID, err)
+	}
+
+	deleteVxLANInterface()
+	deleteIPTableChains()
+
+	return nil
+}
+
+func deleteVxLANInterface() {
+	iface := &netlink.Vxlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  VxLANIface,
+			Flags: net.FlagUp,
+		},
+		VxlanId: 100,
+		SrcAddr: nil,
+		Port:    VxLANPort,
+	}
+
+	klog.Infof("Deleting the %q interface", VxLANIface)
+
+	err := netlinkAPI.New().LinkDel(iface)
+	if err != nil {
+		klog.Errorf("Failed to delete the the vxlan interface %q: %v", VxLANIface, err)
+	}
+}
+
+func deleteIPTableChains() {
+	ipt, err := iptables.New()
+	if err != nil {
+		klog.Errorf("Failed to initialize IPTable interface: %v", err)
+		return
+	}
+
+	klog.Infof("Flushing iptable entries in %q chain of %q table", constants.SmPostRoutingChain, constants.NATTable)
+
+	if err := ipt.ClearChain(constants.NATTable, constants.SmPostRoutingChain); err != nil {
+		klog.Errorf("Error flushing iptables chain %q of %q table: %v", constants.SmPostRoutingChain,
+			constants.NATTable, err)
+	}
+
+	klog.Infof("Deleting iptable entry in %q chain of %q table", constants.PostRoutingChain, constants.NATTable)
+
+	ruleSpec := []string{"-j", constants.SmPostRoutingChain}
+	if err := ipt.Delete(constants.NATTable, constants.PostRoutingChain, ruleSpec...); err != nil {
+		klog.Errorf("Error deleting iptables rule from %q chain: %v", constants.PostRoutingChain, err)
+	}
+
+	klog.Infof("Deleting iptable %q chain of %q table", constants.SmPostRoutingChain, constants.NATTable)
+
+	if err := ipt.DeleteChain(constants.NATTable, constants.SmPostRoutingChain); err != nil {
+		klog.Errorf("Error deleting iptable chain %q of table %q: %v", constants.SmPostRoutingChain,
+			constants.NATTable, err)
+	}
+
+	klog.Infof("Flushing iptable entries in %q chain of %q table", constants.SmInputChain, constants.FilterTable)
+
+	if err := ipt.ClearChain(constants.FilterTable, constants.SmInputChain); err != nil {
+		klog.Errorf("Error flushing iptables chain %q of %q table: %v", constants.SmInputChain,
+			constants.FilterTable, err)
+	}
+
+	klog.Infof("Deleting iptable entry in %q chain of %q table", constants.InputChain, constants.FilterTable)
+
+	ruleSpec = []string{"-p", "udp", "-m", "udp", "-j", constants.SmInputChain}
+	if err := ipt.Delete(constants.FilterTable, constants.InputChain, ruleSpec...); err != nil {
+		klog.Errorf("Error deleting iptables rule from %q chain: %v", constants.InputChain, err)
+	}
+
+	klog.Infof("Deleting iptable %q chain of %q table", constants.SmInputChain, constants.FilterTable)
+
+	if err := ipt.DeleteChain(constants.FilterTable, constants.SmInputChain); err != nil {
+		klog.Errorf("Error deleting iptable chain %q of table %q: %v", constants.SmInputChain,
+			constants.FilterTable, err)
+	}
+}


### PR DESCRIPTION
This is part of Submariner uninstallation EPIC and this PR
implements the cleanup of route-agent pod resources programmed in
a cluster.

The following resources are deleted:
1. IPtable rules
2. IPset rules
3. vx-submariner tunnel interface

Fixes: https://github.com/submariner-io/submariner/issues/1635
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
