### PR TITLE
Build Submariner images for x86-64 and ARM64

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -1,0 +1,19 @@
+---
+name: Multi-arch builds
+
+on:
+  pull_request:
+
+jobs:
+  apply-suggestions-commits:
+    name: Check the multi-arch builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Set up QEMU (to support building on non-native architectures)
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
+      - name: Build the multi-arch images
+        run: make LOCAL_BUILD=1 multiarch-images

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ ifneq (,$(DAPPER_HOST_ARCH))
 # Running in Dapper
 
 IMAGES ?= submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
+MULTIARCH_IMAGES ?= $(IMAGES)
 PRELOAD_IMAGES = $(IMAGES) submariner-operator
+PLATFORMS ?= linux/amd64,linux/arm64
 
 ifneq (,$(filter ovn,$(_using)))
 SETTINGS ?= $(DAPPER_SOURCE)/.shipyard.e2e.ovn.yml
@@ -45,13 +47,13 @@ override VALIDATE_ARGS += --skip-dirs pkg/client
 # When cross-building, we need to map Go architectures and operating systems to Docker buildx platforms:
 # Docker buildx platform | Fedora support? | Go
 # --------------------------------------------------
-# linux/amd64            | Yes (amd64)     | linux/amd64
-# linux/arm64            | Yes (arm64v8)   | linux/arm64
+# linux/amd64            | Yes (x86_64)    | linux/amd64
+# linux/arm64            | Yes (aarch64)   | linux/arm64
 # linux/riscv64          | No              | linux/riscv64
 # linux/ppc64le          | Yes (ppc64le)   | linux/ppc64le
 # linux/s390x            | Yes (s390x)     | linux/s390x
 # linux/386              | No              | linux/386
-# linux/arm/v7           | Yes (arm32v7)   | linux/arm
+# linux/arm/v7           | Yes (armv7hl)   | linux/arm
 # linux/arm/v6           | No              | N/A
 #
 # References: https://github.com/golang/go/blob/master/src/go/build/syslist.go
@@ -103,7 +105,6 @@ comma := ,
 ARCHES ?= amd64
 BINARIES = submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
 ARCH_BINARIES := $(foreach arch,$(subst $(comma),$(space),$(ARCHES)),$(foreach binary,$(BINARIES),bin/linux/$(call gotodockerarch,$(arch))/$(binary)))
-IMAGES_ARGS = --platform $(subst $(space),$(comma),$(foreach arch,$(subst $(comma),$(space),$(ARCHES)),linux/$(call gotodockerarch,$(arch))))
 
 build: $(ARCH_BINARIES)
 

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,8 +1,7 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
@@ -10,7 +9,7 @@ COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-gateway
 
-FROM fedora:34
+FROM --platform=${TARGETPLATFORM} fedora:34
 ARG SOURCE
 ARG TARGETPLATFORM
 

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,8 +1,7 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
@@ -10,7 +9,7 @@ COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-globalnet
 
-FROM fedora:34
+FROM --platform=${TARGETPLATFORM} fedora:34
 ARG SOURCE
 ARG TARGETPLATFORM
 

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,8 +1,7 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
@@ -10,14 +9,15 @@ COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-networkplugin-syncer
 
-FROM fedora:34
+FROM --platform=${TARGETPLATFORM} fedora:34
 ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
-RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/x86_64/ovn-20.06.2-4.fc33.x86_64.rpm && \
+RUN arch=${TARGETPLATFORM} && arch=${arch##*/} && case ${arch} in amd64) arch=x86_64;; arm64) arch=aarch64;; esac && \
+    dnf -y install --nodocs --setopt=install_weak_deps=0 \
+           https://kojipkgs.fedoraproject.org//packages/ovn/20.06.2/4.fc33/${arch}/ovn-20.06.2-4.fc33.${arch}.rpm && \
     dnf -y clean all
 
 # install the networkpluginc-sync

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,8 +1,7 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
@@ -10,7 +9,7 @@ COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/submariner-route-agent
 
-FROM fedora:34
+FROM --platform=${TARGETPLATFORM} fedora:34
 ARG SOURCE
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
This relies on cross-building support in the Shipyard base image and
project Makefiles to avoid having to provide a native Shipyard base
image (and slower compilation using QEMU). The final image build stage
relies on support for the target architecture however.

The TARGETPLATFORM default is dropped from the container definitions;
it is expected to be provided by the build environment (buildx
currently), and setting it prevents us from actually building foreign
images.

Depends on https://github.com/submariner-io/submariner/pull/1676
Depends on https://github.com/submariner-io/shipyard/pull/721
Depends on https://github.com/submariner-io/shipyard/pull/728
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
