### PR TITLE
Fix new linter errors from golangci-lint 1.44.2

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -30,7 +30,6 @@ import (
 
 // Driver is used by the ipsec engine to actually connect the tunnels.
 type Driver interface {
-
 	// Init initializes the driver with any state it needs.
 	Init() error
 

--- a/pkg/cableengine/healthchecker/healthchecker.go
+++ b/pkg/cableengine/healthchecker/healthchecker.go
@@ -46,7 +46,6 @@ const (
 
 type Interface interface {
 	Start(stopCh <-chan struct{}) error
-
 	GetLatencyInfo(endpoint *submarinerv1.EndpointSpec) *LatencyInfo
 }
 

--- a/pkg/ipset/ipset.go
+++ b/pkg/ipset/ipset.go
@@ -87,11 +87,8 @@ type Interface interface {
 	ListSets() ([]string, error)
 	// GetVersion returns the "X.Y" version string for ipset.
 	GetVersion() (string, error)
-
 	AddEntryWithOptions(entry *Entry, set *IPSet, ignoreExistErr bool) error
-
 	DelEntryWithOptions(set, entry string, options ...string) error
-
 	ListAllSetInfo() (string, error)
 }
 

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -37,28 +37,20 @@ type Interface interface {
 	LinkDel(link netlink.Link) error
 	LinkByName(name string) (netlink.Link, error)
 	LinkSetUp(link netlink.Link) error
-
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
-
 	NeighAppend(neigh *netlink.Neigh) error
 	NeighDel(neigh *netlink.Neigh) error
-
 	RouteAdd(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
 	RouteGet(destination net.IP) ([]netlink.Route, error)
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
-
 	FlushRouteTable(tableID int) error
-
 	RuleAdd(rule *netlink.Rule) error
 	RuleDel(rule *netlink.Rule) error
-
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
-
 	EnableLooseModeReversePathFilter(interfaceName string) error
-
 	ConfigureTCPMTUProbe(mtuProbe, baseMss string) error
 }
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -89,7 +89,7 @@ func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 	if endpoint.Spec.Backend == "wireguard" {
 		// NOTE: This assumes that LocalEndpointCreated happens before than TransitionToGatewayNode
 		if routingInterface, err = net.InterfaceByName(wireguard.DefaultDeviceName); err != nil {
-			return errors.Wrapf(err, "Wireguard interface %s not found on the node.", wireguard.DefaultDeviceName)
+			return errors.Wrapf(err, "Wireguard interface %s not found on the node", wireguard.DefaultDeviceName)
 		}
 	} else {
 		if routingInterface, err = netlink.GetDefaultGatewayInterface(); err != nil {


### PR DESCRIPTION
Fixes gofumpt and revive errors that show up when we upgrade from
golangci-lint 1.43.0 to 1.44.2.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
