### PR TITLE
Implement Gateway datapath cleanup

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -48,6 +48,9 @@ type Driver interface {
 
 	// GetName returns driver's name
 	GetName() string
+
+	// Cleanup performs the necessary uninstallation.
+	Cleanup() error
 }
 
 // Function prototype to create a new driver.

--- a/pkg/cable/fake/driver.go
+++ b/pkg/cable/fake/driver.go
@@ -145,3 +145,7 @@ func (d *Driver) AwaitDisconnectFromEndpoint(expected *v1.EndpointSpec) {
 func (d *Driver) AwaitNoDisconnectFromEndpoint() {
 	Consistently(d.disconnectFromEndpoint, 500*time.Millisecond).ShouldNot(Receive(), "DisconnectFromEndpoint was unexpectedly called")
 }
+
+func (d *Driver) Cleanup() error {
+	return nil
+}

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -36,8 +36,8 @@ import (
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/submariner-io/submariner/pkg/util"
 	"k8s.io/klog"
 )
 
@@ -615,5 +615,5 @@ func (i *libreswan) runPluto() error {
 func (i *libreswan) Cleanup() error {
 	klog.Info("Uninstalling the libreswan cable driver")
 
-	return util.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -37,6 +37,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
 	"k8s.io/klog"
 )
 
@@ -609,4 +610,10 @@ func (i *libreswan) runPluto() error {
 	}
 
 	return nil
+}
+
+func (i *libreswan) Cleanup() error {
+	klog.Info("Uninstalling the libreswan cable driver")
+
+	return util.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -559,5 +559,5 @@ func parseSubnets(subnets []string) []net.IPNet {
 func (v *vxlan) Cleanup() error {
 	klog.Infof("Uninstalling the vxlan cable driver")
 
-	return util.DeleteVxLANIfaceAlongWithRoutes(VxlanIface, TableID) // nolint:wrapcheck  // No need to wrap this error
+	return util.DeleteIfaceAlongWithRoutes(VxlanIface, TableID) // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -35,6 +35,7 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"k8s.io/klog"
@@ -553,4 +554,10 @@ func parseSubnets(subnets []string) []net.IPNet {
 	}
 
 	return nets
+}
+
+func (v *vxlan) Cleanup() error {
+	klog.Infof("Uninstalling the vxlan cable driver")
+
+	return util.DeleteVxLANIfaceAlongWithRoutes(VxlanIface, TableID) // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -35,7 +35,6 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	"github.com/submariner-io/submariner/pkg/types"
-	"github.com/submariner-io/submariner/pkg/util"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"k8s.io/klog"
@@ -559,5 +558,5 @@ func parseSubnets(subnets []string) []net.IPNet {
 func (v *vxlan) Cleanup() error {
 	klog.Infof("Uninstalling the vxlan cable driver")
 
-	return util.DeleteIfaceAlongWithRoutes(VxlanIface, TableID) // nolint:wrapcheck  // No need to wrap this error
+	return netlinkAPI.DeleteIfaceAndAssociatedRoutes(VxlanIface, TableID) // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -469,3 +469,18 @@ func genPsk(psk string) (wgtypes.Key, error) {
 	pskBytes := sha256.Sum256([]byte(psk))
 	return wgtypes.NewKey(pskBytes[:]) // nolint:wrapcheck // Let the caller wrap it
 }
+
+func (w *wireguard) Cleanup() error {
+	klog.Info("Uninstalling the wireguard cable driver")
+
+	link, err := netlink.LinkByName(DefaultDeviceName)
+	if err != nil && !errors.Is(err, netlink.LinkNotFoundError{}) {
+		return errors.Wrapf(err, "error retrieving the wireguard interface %q", DefaultDeviceName)
+	}
+
+	if err := netlink.LinkDel(link); err != nil {
+		return errors.Wrapf(err, "failed to delete existing WireGuard device %q", DefaultDeviceName)
+	}
+
+	return nil
+}

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -60,6 +60,9 @@ type Engine interface {
 	GetHAStatus() v1.HAStatus
 	// SetupNATDiscovery configures the handler for nat discovery of the endpoints.
 	SetupNATDiscovery(natDiscovery natdiscovery.Interface)
+
+	// Cleanup performs the necessary steps to uninstall the cable driver.
+	Cleanup() error
 }
 
 type engine struct {
@@ -275,4 +278,12 @@ func (i *engine) ListCableConnections() ([]v1.Connection, error) {
 	}
 	// if no driver, we can safely report that no connections exist.
 	return []v1.Connection{}, nil
+}
+
+func (i *engine) Cleanup() error {
+	if i.driver != nil {
+		return i.driver.Cleanup() // nolint:wrapcheck  // No need to wrap this error
+	}
+
+	return nil
 }

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -112,3 +112,7 @@ func (e *Engine) VerifyRemoveCable(expected *v1.EndpointSpec) {
 
 func (e *Engine) SetupNATDiscovery(natDiscovery natdiscovery.Interface) {
 }
+
+func (e *Engine) Cleanup() error {
+	return nil
+}

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -21,7 +21,7 @@ package cabledriver
 import (
 	"github.com/submariner-io/submariner/pkg/cable/vxlan"
 	"github.com/submariner-io/submariner/pkg/event"
-	"github.com/submariner-io/submariner/pkg/util"
+	"github.com/submariner-io/submariner/pkg/netlink"
 	"k8s.io/klog"
 )
 
@@ -44,5 +44,5 @@ func (h *vxlanCleanup) GetName() string {
 func (h *vxlanCleanup) TransitionToNonGateway() error {
 	klog.Infof("Cleaning up the routes")
 
-	return util.DeleteIfaceAlongWithRoutes(vxlan.VxlanIface, vxlan.TableID) // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteIfaceAndAssociatedRoutes(vxlan.VxlanIface, vxlan.TableID) // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -44,5 +44,5 @@ func (h *vxlanCleanup) GetName() string {
 func (h *vxlanCleanup) TransitionToNonGateway() error {
 	klog.Infof("Cleaning up the routes")
 
-	return util.DeleteVxLANIfaceAlongWithRoutes(vxlan.VxlanIface, vxlan.TableID) // nolint:wrapcheck  // No need to wrap this error
+	return util.DeleteIfaceAlongWithRoutes(vxlan.VxlanIface, vxlan.TableID) // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
@@ -20,7 +20,7 @@ package cabledriver
 
 import (
 	"github.com/submariner-io/submariner/pkg/event"
-	"github.com/submariner-io/submariner/pkg/util"
+	"github.com/submariner-io/submariner/pkg/netlink"
 	"k8s.io/klog"
 )
 
@@ -43,5 +43,5 @@ func (h *xrfmCleanup) GetNetworkPlugins() []string {
 func (h *xrfmCleanup) TransitionToNonGateway() error {
 	klog.Info("Transitioned to non-Gateway, cleaning up the IPsec xfrm rules")
 
-	return util.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,15 +22,10 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"syscall"
 	"unicode"
 
-	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/log"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/types"
-	nl "github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/klog"
 )
@@ -151,67 +146,4 @@ func EnsureValidName(name string) string {
 
 		return c
 	}, name)
-}
-
-func DeleteXfrmRules() error {
-	netLink := netlink.New()
-
-	currentXfrmPolicyList, err := netLink.XfrmPolicyList(syscall.AF_INET)
-	if err != nil {
-		return errors.Wrap(err, "error retrieving current xfrm policies")
-	}
-
-	if len(currentXfrmPolicyList) > 0 {
-		klog.Infof("Cleaning up %d XFRM policies", len(currentXfrmPolicyList))
-	}
-
-	for i := range currentXfrmPolicyList {
-		// These xfrm rules are not programmed by Submariner, skip them.
-		if currentXfrmPolicyList[i].Dst.String() == "0.0.0.0/0" &&
-			currentXfrmPolicyList[i].Src.String() == "0.0.0.0/0" && currentXfrmPolicyList[i].Proto == 0 {
-			klog.V(log.DEBUG).Infof("Skipping deletion of XFRM policy %s", currentXfrmPolicyList[i])
-			continue
-		}
-
-		klog.V(log.DEBUG).Infof("Deleting XFRM policy %s", currentXfrmPolicyList[i])
-
-		if err = netLink.XfrmPolicyDel(&currentXfrmPolicyList[i]); err != nil {
-			return errors.Wrapf(err, "error deleting XFRM policy %s", currentXfrmPolicyList[i])
-		}
-	}
-
-	return nil
-}
-
-func DeleteIfaceAlongWithRoutes(iface string, tableID int) error {
-	link, err := nl.LinkByName(iface)
-	if err != nil {
-		if !errors.Is(err, nl.LinkNotFoundError{}) {
-			klog.Warningf("Failed to retrieve the vxlan-tunnel interface during transition to non-gateway: %v", err)
-		}
-
-		return nil
-	}
-
-	currentRouteList, err := nl.RouteList(link, syscall.AF_INET)
-
-	if err != nil {
-		klog.Warningf("Unable to cleanup routes, error retrieving routes on the link %s: %v", iface, err)
-	} else {
-		for i := range currentRouteList {
-			klog.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])
-			if currentRouteList[i].Table == tableID {
-				if err = nl.RouteDel(&currentRouteList[i]); err != nil {
-					klog.Errorf("Error removing route %s: %v", currentRouteList[i], err)
-				}
-			}
-		}
-	}
-
-	err = nl.LinkDel(link)
-	if err != nil {
-		return errors.Wrapf(err, "failed to delete the vxlan interface")
-	}
-
-	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -183,7 +183,7 @@ func DeleteXfrmRules() error {
 	return nil
 }
 
-func DeleteVxLANIfaceAlongWithRoutes(iface string, tableID int) error {
+func DeleteIfaceAlongWithRoutes(iface string, tableID int) error {
 	link, err := nl.LinkByName(iface)
 	if err != nil {
 		if !errors.Is(err, nl.LinkNotFoundError{}) {


### PR DESCRIPTION
This PR implements the cleanup for the following cable drivers.
1. Libreswan
2. Wireguard
3. VxLAN

Fixes: https://github.com/submariner-io/submariner/issues/1636
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
