### PR TITLE
Backport: Remove MTU flows as part of uninstall command

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -34,7 +34,7 @@ func (kp *SyncHandler) Stop(uninstall bool) error {
 		return nil
 	}
 
-	klog.Infof("Uinstalling Submariner changes from the node %q", kp.hostname)
+	klog.Infof("Uninstalling Submariner changes from the node %q", kp.hostname)
 	klog.Infof("Flushing route table %d entries", constants.RouteAgentHostNetworkTableID)
 
 	err := kp.netLink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)


### PR DESCRIPTION
Submariner Route-agent programs some iptable rules
to clamp tcp mss to fix MTU issues. This PR ensures
that we delete those flows as part of Submariner
uninstallation.

Fixes: https://github.com/submariner-io/submariner/issues/1719
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit ba449531a369f27541a3d9fcd197e77868c9aac7)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
