### PR TITLE
Delete IP rules as part of uninstall flow

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -140,7 +140,7 @@ func (v *vxlan) createVxlanInterface(activeEndPoint string, port int) error {
 
 	v.vxlanIface.vtepIP = vtepIP
 
-	err = v.netLink.ConfigureIPRule(netlinkAPI.Add, TableID)
+	err = v.netLink.RuleAddIfNotPresent(v.netLink.NewTableRule(TableID))
 	if err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "failed to add ip rule")
 	}
@@ -548,7 +548,7 @@ func (v *vxlan) Cleanup() error {
 		klog.Errorf("unable to delete interface %s and associated routes from table %d", VxlanIface, TableID)
 	}
 
-	err = v.netLink.ConfigureIPRule(netlinkAPI.Delete, TableID)
+	err = v.netLink.RuleDelIfPresent(v.netLink.NewTableRule(TableID))
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete IP rule pointing to %d table", TableID)
 	}

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -140,7 +140,7 @@ func (v *vxlan) createVxlanInterface(activeEndPoint string, port int) error {
 
 	v.vxlanIface.vtepIP = vtepIP
 
-	err = v.netLink.RuleAddIfNotPresent(v.netLink.NewTableRule(TableID))
+	err = v.netLink.RuleAddIfNotPresent(netlinkAPI.NewTableRule(TableID))
 	if err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "failed to add ip rule")
 	}
@@ -548,7 +548,7 @@ func (v *vxlan) Cleanup() error {
 		klog.Errorf("unable to delete interface %s and associated routes from table %d", VxlanIface, TableID)
 	}
 
-	err = v.netLink.RuleDelIfPresent(v.netLink.NewTableRule(TableID))
+	err = v.netLink.RuleDelIfPresent(netlinkAPI.NewTableRule(TableID))
 	if err != nil {
 		return errors.Wrapf(err, "unable to delete IP rule pointing to %d table", TableID)
 	}

--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -44,7 +44,7 @@ func (a *Adapter) RuleAddIfNotPresent(rule *netlink.Rule) error {
 func (a *Adapter) RuleDelIfPresent(rule *netlink.Rule) error {
 	err := a.RuleDel(rule)
 	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "failed to del rule %s", rule)
+		return errors.Wrapf(err, "failed to delete rule %s", rule)
 	}
 
 	return nil

--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -32,10 +32,10 @@ type Adapter struct {
 	Basic
 }
 
-func (a *Adapter) RuleAddIfNotPresent(rule *netlink.Rule) error {
-	err := a.RuleAdd(rule)
+func (a *Adapter) RuleAddIfNotPresent(tableID int) error {
+	err := a.ConfigureIPRule(Add, tableID)
 	if err != nil && !os.IsExist(err) {
-		return errors.Wrapf(err, "failed to add rule %s", rule)
+		return errors.Wrapf(err, "failed to add rule %d", tableID)
 	}
 
 	return nil

--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -32,10 +32,19 @@ type Adapter struct {
 	Basic
 }
 
-func (a *Adapter) RuleAddIfNotPresent(tableID int) error {
-	err := a.ConfigureIPRule(Add, tableID)
+func (a *Adapter) RuleAddIfNotPresent(rule *netlink.Rule) error {
+	err := a.RuleAdd(rule)
 	if err != nil && !os.IsExist(err) {
-		return errors.Wrapf(err, "failed to add rule %d", tableID)
+		return errors.Wrapf(err, "failed to add rule %s", rule)
+	}
+
+	return nil
+}
+
+func (a *Adapter) RuleDelIfPresent(rule *netlink.Rule) error {
+	err := a.RuleDel(rule)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to del rule %s", rule)
 	}
 
 	return nil

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -202,17 +202,6 @@ func (n *basicType) RouteList(link netlink.Link, family int) ([]netlink.Route, e
 	return n.routes[link.Attrs().Index], nil
 }
 
-func (n *basicType) NewTableRule(tableID int) *netlink.Rule {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-
-	rule := netlink.NewRule()
-	rule.Table = tableID
-	rule.Priority = tableID
-
-	return rule
-}
-
 func (n *basicType) RuleAdd(rule *netlink.Rule) error {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -47,7 +47,6 @@ type Basic interface {
 	RouteGet(destination net.IP) ([]netlink.Route, error)
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	FlushRouteTable(tableID int) error
-	NewTableRule(tableID int) *netlink.Rule
 	RuleAdd(rule *netlink.Rule) error
 	RuleDel(rule *netlink.Rule) error
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
@@ -125,14 +124,6 @@ func (n *netlinkType) RouteGet(destination net.IP) ([]netlink.Route, error) {
 
 func (n *netlinkType) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
 	return netlink.RouteList(link, family)
-}
-
-func (n *netlinkType) NewTableRule(tableID int) *netlink.Rule {
-	rule := netlink.NewRule()
-	rule.Table = tableID
-	rule.Priority = tableID
-
-	return rule
 }
 
 func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
@@ -283,4 +274,12 @@ func DeleteXfrmRules() error {
 	}
 
 	return nil
+}
+
+func NewTableRule(tableID int) *netlink.Rule {
+	rule := netlink.NewRule()
+	rule.Table = tableID
+	rule.Priority = tableID
+
+	return rule
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -47,8 +47,7 @@ type Basic interface {
 	RouteGet(destination net.IP) ([]netlink.Route, error)
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	FlushRouteTable(tableID int) error
-	RuleAdd(rule *netlink.Rule) error
-	RuleDel(rule *netlink.Rule) error
+	ConfigureIPRule(operation Operation, tableID int) error
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
@@ -59,7 +58,7 @@ type Basic interface {
 type Interface interface {
 	Basic
 	AddrAddIfNotPresent(link netlink.Link, addr *netlink.Addr) error
-	RuleAddIfNotPresent(rule *netlink.Rule) error
+	RuleAddIfNotPresent(tableID int) error
 	RouteAddOrReplace(route *netlink.Route) error
 	AddDestinationRoutes(destIPs []net.IPNet, gwIP, srcIP net.IP, linkIndex, tableID int) error
 	DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableID int) error
@@ -69,6 +68,13 @@ var NewFunc func() Interface
 
 const (
 	allZeroAddress = "0.0.0.0/0"
+)
+
+type Operation int
+
+const (
+	Add Operation = iota
+	Delete
 )
 
 type netlinkType struct{}
@@ -125,12 +131,25 @@ func (n *netlinkType) RouteList(link netlink.Link, family int) ([]netlink.Route,
 	return netlink.RouteList(link, family)
 }
 
-func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
-	return netlink.RuleAdd(rule)
-}
+func (n *netlinkType) ConfigureIPRule(operation Operation, tableID int) error {
+	rule := netlink.NewRule()
+	rule.Table = tableID
+	rule.Priority = tableID
 
-func (n *netlinkType) RuleDel(rule *netlink.Rule) error {
-	return netlink.RuleDel(rule)
+	switch operation {
+	case Add:
+		err := netlink.RuleAdd(rule)
+		if err != nil && !os.IsExist(err) {
+			return errors.Wrapf(err, "failed to add ip rule %s", rule)
+		}
+	case Delete:
+		err := netlink.RuleDel(rule)
+		if err != nil && !os.IsNotExist(err) {
+			return errors.Wrapf(err, "failed to delete ip rule %s", rule)
+		}
+	}
+
+	return nil
 }
 
 func (n *netlinkType) XfrmPolicyAdd(policy *netlink.XfrmPolicy) error {

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -47,7 +47,9 @@ type Basic interface {
 	RouteGet(destination net.IP) ([]netlink.Route, error)
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	FlushRouteTable(tableID int) error
-	ConfigureIPRule(operation Operation, tableID int) error
+	NewTableRule(tableID int) *netlink.Rule
+	RuleAdd(rule *netlink.Rule) error
+	RuleDel(rule *netlink.Rule) error
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
@@ -58,7 +60,8 @@ type Basic interface {
 type Interface interface {
 	Basic
 	AddrAddIfNotPresent(link netlink.Link, addr *netlink.Addr) error
-	RuleAddIfNotPresent(tableID int) error
+	RuleAddIfNotPresent(rule *netlink.Rule) error
+	RuleDelIfPresent(rule *netlink.Rule) error
 	RouteAddOrReplace(route *netlink.Route) error
 	AddDestinationRoutes(destIPs []net.IPNet, gwIP, srcIP net.IP, linkIndex, tableID int) error
 	DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableID int) error
@@ -68,13 +71,6 @@ var NewFunc func() Interface
 
 const (
 	allZeroAddress = "0.0.0.0/0"
-)
-
-type Operation int
-
-const (
-	Add Operation = iota
-	Delete
 )
 
 type netlinkType struct{}
@@ -131,25 +127,20 @@ func (n *netlinkType) RouteList(link netlink.Link, family int) ([]netlink.Route,
 	return netlink.RouteList(link, family)
 }
 
-func (n *netlinkType) ConfigureIPRule(operation Operation, tableID int) error {
+func (n *netlinkType) NewTableRule(tableID int) *netlink.Rule {
 	rule := netlink.NewRule()
 	rule.Table = tableID
 	rule.Priority = tableID
 
-	switch operation {
-	case Add:
-		err := netlink.RuleAdd(rule)
-		if err != nil && !os.IsExist(err) {
-			return errors.Wrapf(err, "failed to add ip rule %s", rule)
-		}
-	case Delete:
-		err := netlink.RuleDel(rule)
-		if err != nil && !os.IsNotExist(err) {
-			return errors.Wrapf(err, "failed to delete ip rule %s", rule)
-		}
-	}
+	return rule
+}
 
-	return nil
+func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
+	return netlink.RuleAdd(rule)
+}
+
+func (n *netlinkType) RuleDel(rule *netlink.Rule) error {
+	return netlink.RuleDel(rule)
 }
 
 func (n *netlinkType) XfrmPolicyAdd(policy *netlink.XfrmPolicy) error {

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -20,7 +20,6 @@ package kubeproxy
 
 import (
 	"github.com/submariner-io/admiral/pkg/log"
-	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"k8s.io/klog"
 )
@@ -35,7 +34,7 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
 	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
 
-	err := kp.netLink.ConfigureIPRule(netlinkAPI.Delete, constants.RouteAgentHostNetworkTableID)
+	err := kp.netLink.RuleDelIfPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)
@@ -60,7 +59,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 		klog.Fatalf("Unable to create VxLAN interface on gateway node (%s): %v", kp.hostname, err)
 	}
 
-	err = kp.netLink.ConfigureIPRule(netlinkAPI.Add, constants.RouteAgentHostNetworkTableID)
+	err = kp.netLink.RuleAddIfNotPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.Errorf("Unable to add ip rule to table %d on Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -20,6 +20,7 @@ package kubeproxy
 
 import (
 	"github.com/submariner-io/admiral/pkg/log"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"k8s.io/klog"
 )
@@ -34,7 +35,7 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
 	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
 
-	err := kp.configureIPRule(Delete)
+	err := kp.netLink.ConfigureIPRule(netlinkAPI.Delete, constants.RouteAgentHostNetworkTableID)
 	if err != nil {
 		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)
@@ -59,7 +60,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 		klog.Fatalf("Unable to create VxLAN interface on gateway node (%s): %v", kp.hostname, err)
 	}
 
-	err = kp.configureIPRule(Add)
+	err = kp.netLink.ConfigureIPRule(netlinkAPI.Add, constants.RouteAgentHostNetworkTableID)
 	if err != nil {
 		klog.Errorf("Unable to add ip rule to table %d on Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -20,6 +20,7 @@ package kubeproxy
 
 import (
 	"github.com/submariner-io/admiral/pkg/log"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"k8s.io/klog"
 )
@@ -34,7 +35,7 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
 	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
 
-	err := kp.netLink.RuleDelIfPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
+	err := kp.netLink.RuleDelIfPresent(netlinkAPI.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.Errorf("Unable to delete ip rule to table %d on non-Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)
@@ -59,7 +60,7 @@ func (kp *SyncHandler) TransitionToGateway() error {
 		klog.Fatalf("Unable to create VxLAN interface on gateway node (%s): %v", kp.hostname, err)
 	}
 
-	err = kp.netLink.RuleAddIfNotPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
+	err = kp.netLink.RuleAddIfNotPresent(netlinkAPI.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.Errorf("Unable to add ip rule to table %d on Gateway node %s: %v",
 			constants.RouteAgentHostNetworkTableID, kp.hostname, err)

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -303,27 +303,3 @@ func (kp *SyncHandler) updateRoutingRulesForInterClusterSupport(remoteCIDRs []st
 
 	return nil
 }
-
-func (kp *SyncHandler) configureIPRule(operation Operation) error {
-	if kp.cniIface != nil {
-		rule := netlink.NewRule()
-		rule.Table = constants.RouteAgentHostNetworkTableID
-		rule.Priority = constants.RouteAgentHostNetworkTableID
-
-		switch operation {
-		case Add:
-			err := kp.netLink.RuleAdd(rule)
-			if err != nil && !os.IsExist(err) {
-				return errors.Wrapf(err, "failed to add ip rule %s", rule)
-			}
-		case Delete:
-			err := kp.netLink.RuleDel(rule)
-			if err != nil && !os.IsNotExist(err) {
-				return errors.Wrapf(err, "failed to delete ip rule %s", rule)
-			}
-		case Flush:
-		}
-	}
-
-	return nil
-}

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -44,11 +44,7 @@ func (kp *SyncHandler) Stop(uninstall bool) error {
 			constants.RouteAgentHostNetworkTableID, err)
 	}
 
-	rule := netlink.NewRule()
-	rule.Table = constants.RouteAgentHostNetworkTableID
-	rule.Priority = constants.RouteAgentHostNetworkTableID
-
-	err = kp.netLink.RuleDelIfPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
+	err = kp.netLink.RuleDelIfPresent(netlinkAPI.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.V(log.TRACE).Infof("Deleting IP Rule pointing to %d table returned error: %v",
 			constants.RouteAgentHostNetworkTableID, err)

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -44,6 +44,16 @@ func (kp *SyncHandler) Stop(uninstall bool) error {
 			constants.RouteAgentHostNetworkTableID, err)
 	}
 
+	rule := netlink.NewRule()
+	rule.Table = constants.RouteAgentHostNetworkTableID
+	rule.Priority = constants.RouteAgentHostNetworkTableID
+
+	err = kp.netLink.ConfigureIPRule(netlinkAPI.Delete, constants.RouteAgentHostNetworkTableID)
+	if err != nil {
+		klog.V(log.TRACE).Infof("Deleting IP Rule pointing to %d table returned error: %v",
+			constants.RouteAgentHostNetworkTableID, err)
+	}
+
 	deleteVxLANInterface()
 	deleteIPTableChains()
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -48,7 +48,7 @@ func (kp *SyncHandler) Stop(uninstall bool) error {
 	rule.Table = constants.RouteAgentHostNetworkTableID
 	rule.Priority = constants.RouteAgentHostNetworkTableID
 
-	err = kp.netLink.ConfigureIPRule(netlinkAPI.Delete, constants.RouteAgentHostNetworkTableID)
+	err = kp.netLink.RuleDelIfPresent(kp.netLink.NewTableRule(constants.RouteAgentHostNetworkTableID))
 	if err != nil {
 		klog.V(log.TRACE).Infof("Deleting IP Rule pointing to %d table returned error: %v",
 			constants.RouteAgentHostNetworkTableID, err)


### PR DESCRIPTION
Delete IP rules as part of Submariner uninstall datapath cleanup

Fixes: https://github.com/submariner-io/submariner-operator/issues/1913

Signed-off-by: yboaron <yboaron@redhat.com>

