### PR TITLE
Remove cni interface annotation as part of uninstall command

### DIFF
--- a/pkg/routeagent_driver/cni/cni_iface.go
+++ b/pkg/routeagent_driver/cni/cni_iface.go
@@ -96,7 +96,7 @@ func AnnotateNodeWithCNIInterfaceIP(nodeName string, clientSet kubernetes.Interf
 	if setAnnotation {
 		cniIface, err := Discover(clusterCidr[0])
 		if err != nil {
-			return errors.Wrap(err, "Discover returned error")
+			return errors.Wrapf(err, "Error retrieving the CNI interface for %s", clusterCidr[0])
 		}
 
 		cniIPAddress = cniIface.IPAddress

--- a/pkg/routeagent_driver/cni/cni_iface.go
+++ b/pkg/routeagent_driver/cni/cni_iface.go
@@ -86,9 +86,20 @@ func discover(clusterCIDR string) (*Interface, error) {
 }
 
 func AnnotateNodeWithCNIInterfaceIP(nodeName string, clientSet kubernetes.Interface, clusterCidr []string) error {
-	cniIface, err := Discover(clusterCidr[0])
-	if err != nil {
-		return errors.Wrap(err, "Discover returned error")
+	cniIPAddress := ""
+	setAnnotation := true
+
+	if len(clusterCidr) == 0 {
+		setAnnotation = false
+	}
+
+	if setAnnotation {
+		cniIface, err := Discover(clusterCidr[0])
+		if err != nil {
+			return errors.Wrap(err, "Discover returned error")
+		}
+
+		cniIPAddress = cniIface.IPAddress
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -101,7 +112,11 @@ func AnnotateNodeWithCNIInterfaceIP(nodeName string, clientSet kubernetes.Interf
 		if annotations == nil {
 			annotations = map[string]string{}
 		}
-		annotations[constants.CNIInterfaceIP] = cniIface.IPAddress
+		if setAnnotation {
+			annotations[constants.CNIInterfaceIP] = cniIPAddress
+		} else {
+			delete(annotations, constants.CNIInterfaceIP)
+		}
 		node.SetAnnotations(annotations)
 		_, updateErr := clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
 		return updateErr // nolint:wrapcheck // We wrap it below in the enclosing function
@@ -111,7 +126,11 @@ func AnnotateNodeWithCNIInterfaceIP(nodeName string, clientSet kubernetes.Interf
 		return errors.Wrapf(retryErr, "error updatating node %q", nodeName)
 	}
 
-	klog.Infof("Successfully annotated node %q with cniIfaceIP %q", nodeName, cniIface.IPAddress)
+	if setAnnotation {
+		klog.Infof("Successfully annotated node %q with cniIfaceIP %q", nodeName, cniIPAddress)
+	} else {
+		klog.Infof("Successfully removed %q from node %q annotation", constants.CNIInterfaceIP, nodeName)
+	}
 
 	return nil
 }

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -96,6 +96,10 @@ func main() {
 			klog.Warningf("Error stopping handlers: %v", err)
 		}
 
+		if err = annotateNode([]string{}, cfg); err != nil {
+			klog.Warningf("Error removing %q annotation: %v", constants.CNIInterfaceIP, err)
+		}
+
 		return
 	}
 


### PR DESCRIPTION
Submariner Route-agent annotates the cni interface IP in node resource.
This PR ensures that the cni interface IP annotation is deleted as
part of Submariner uninstallation.

Fixes: https://github.com/submariner-io/submariner/issues/1728
Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
