### PR TITLE
Bump E2E-full K8s version 1.20->1.23

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -18,7 +18,6 @@ jobs:
         globalnet: ['', 'globalnet']
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         ovn: ['', 'ovn']
-        k8s_version: ['1.20']
         exclude:
           - ovn: 'ovn'
             globalnet: 'globalnet'
@@ -31,7 +30,6 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
-          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.ovn }}
 
       - name: Post mortem


### PR DESCRIPTION
Use the default Kubernetes version from Shipyard, currently 1.23.

Remove tests for Kubernetes 1.20, as it is End of Life and Submariner
supports all versions upstream-Kubernetes supports and no EOL versions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
