### PR TITLE
Use Dependabot to update GHAs, now supports SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
This is a bit of a test of Dependabot's support for managing SHA-based
versions of GitHub Actions.

In the original press release about Dependabot's support for GHAs,
they say:

> Dependabot creates pull requests that update the action to the latest
released tag (e.g., v2), regardless of if you’re currently on a release
tag, a pre-release tag, or a specific hash.

github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/

But I think SHA-based updates were added as a part of:

https://github.com/dependabot/dependabot-core/issues/2835

I see examples where Dependabot apparently works with SHAs:

https://github.com/systemd/systemd/pull/22638/files
https://github.com/google/go-github/pull/2049/files

And those projects are using config like is proposed here:

https://github.com/systemd/systemd/blob/main/.github/dependabot.yml#L5
https://github.com/google/go-github/blob/master/.github/dependabot.yml#L15

As always, we should be careful about taking updates from third parties
and review theses PRs to update GHAs carefully. Especially until #1740
reduces the permissions of each job to the minimum required.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
