### PR TITLE
Improve logs in Globalnet controller

### DIFF
--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -125,7 +125,8 @@ func NewGlobalIngressIPController(config *syncer.ResourceSyncerConfig, pool *ipa
 func (c *globalIngressIPController) process(from runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
 	ingressIP := from.(*submarinerv1.GlobalIngressIP)
 
-	klog.Infof("Processing %sd %#v", op, ingressIP)
+	klog.Infof("Processing %sd %s/%s, TargetRef: %q, %q, Status: %#v", op, ingressIP.Namespace,
+		ingressIP.Name, ingressIP.Spec.Target, c.getTargetReference(ingressIP), ingressIP.Status)
 
 	switch op {
 	case syncer.Create:
@@ -149,8 +150,6 @@ func (c *globalIngressIPController) onCreate(ingressIP *submarinerv1.GlobalIngre
 
 	key, _ := cache.MetaNamespaceKeyFunc(ingressIP)
 
-	klog.Infof("Allocating global IP for %q", key)
-
 	ips, err := c.pool.Allocate(1)
 	if err != nil {
 		klog.Errorf("Error allocating IP for %q: %v", key, err)
@@ -164,6 +163,8 @@ func (c *globalIngressIPController) onCreate(ingressIP *submarinerv1.GlobalIngre
 
 		return true
 	}
+
+	klog.Infof("Allocated global IP %q for %q", ips, key)
 
 	if ingressIP.Spec.Target == submarinerv1.ClusterIPService {
 		serviceRef := ingressIP.Spec.ServiceRef
@@ -339,8 +340,27 @@ func (c *globalIngressIPController) ensureInternalServiceExists(ingressIP *subma
 
 		_ = deleteService(ingressIP.Namespace, internalSvc, c.services)
 
-		return fmt.Errorf("globalIP assigned to %q does not match with Internal Service ExternalIP", key)
+		return fmt.Errorf("globalIP %q assigned to %q does not match with Internal Service ExternalIP %q",
+			c.getServiceExternalIP(service), key, ingressIP.Status.AllocatedIP)
 	}
 
 	return nil
+}
+
+func (c *globalIngressIPController) getServiceExternalIP(service *corev1.Service) string {
+	if len(service.Spec.ExternalIPs) == 0 {
+		return ""
+	}
+
+	return service.Spec.ExternalIPs[0]
+}
+
+func (c *globalIngressIPController) getTargetReference(giip *submarinerv1.GlobalIngressIP) string {
+	if giip.Spec.Target == submarinerv1.ClusterIPService {
+		return giip.Spec.ServiceRef.Name
+	} else if giip.Spec.Target == submarinerv1.HeadlessServicePod {
+		return giip.Spec.PodRef.Name
+	}
+
+	return ""
 }

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -171,7 +171,8 @@ func (c *serviceExportController) onCreate(serviceExport *mcsv1a1.ServiceExport)
 		},
 	}
 
-	klog.Infof("Creating %#v", ingressIP)
+	klog.Infof("Creating GlobalIngressIP object %s/%s, TargetRef: %q, %q ", serviceExport.Namespace,
+		serviceExport.Name, submarinerv1.ClusterIPService, serviceExport.Name)
 
 	return ingressIP, false
 }


### PR DESCRIPTION
This PR does not fix any issue but improves the log messages
from the Globalnet controller.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
