### PR TITLE
Deflake E2E tests that are accessed via service from external network

### DIFF
--- a/test/external/dataplane/connectivity.go
+++ b/test/external/dataplane/connectivity.go
@@ -21,6 +21,7 @@ package dataplane
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -224,6 +225,9 @@ func testExternalConnectivity(p testParams) {
 		targetIP = podIP
 	case tcp.ServiceIP:
 		targetIP = svcIP
+		// Wait for the service to be ready.
+		// TODO: Improve this by retrying access not a blind 2 sec sleep.
+		time.Sleep(2 * time.Second)
 	}
 
 	By(fmt.Sprintf("Sending an http request from external app %q to %q in the cluster %q",


### PR DESCRIPTION
This PR fixes flaky E2E tests that are accessed via service from external network.

Fixes: #1762