### PR TITLE
Optimize code that looks for iptable chain presence

### DIFF
--- a/pkg/iptables/fake/iptables.go
+++ b/pkg/iptables/fake/iptables.go
@@ -156,6 +156,18 @@ func (i *IPTables) ClearChain(table, chain string) error {
 	return nil
 }
 
+func (i *IPTables) ChainExists(table, chain string) (bool, error) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	chainSet := i.tableChains[table]
+	if chainSet != nil {
+		return chainSet.Contains(chain), nil
+	}
+
+	return false, nil
+}
+
 func (i *IPTables) AddChainsFor(table string, chains ...string) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -36,6 +36,7 @@ type Interface interface {
 	List(table, chain string) ([]string, error)
 	ListChains(table string) ([]string, error)
 	NewChain(table, chain string) error
+	ChainExists(table, chain string) (bool, error)
 	ClearChain(table, chain string) error
 	DeleteChain(table, chain string) error
 }
@@ -73,16 +74,13 @@ func (i *iptablesWrapper) Delete(table, chain string, rulespec ...string) error 
 }
 
 func CreateChainIfNotExists(ipt Interface, table, chain string) error {
-	existingChains, err := ipt.ListChains(table)
-	if err != nil {
-		return errors.Wrap(err, "error listing IP table chains")
+	exists, err := ipt.ChainExists(table, chain)
+	if err == nil && exists {
+		return nil
 	}
 
-	for _, val := range existingChains {
-		if val == chain {
-			// Chain already exists
-			return nil
-		}
+	if err != nil {
+		return errors.Wrapf(err, "error finding IP table chain %q in table %q", chain, table)
 	}
 
 	return errors.Wrap(ipt.NewChain(table, chain), "error creating IP table chain")


### PR DESCRIPTION
Instead of listing all the existing chains and checking
if the required chain is present or not, we can directly
use the iptables library API, chainExists, which is more
optimal way to verify for the chain presence.

Related to: https://github.com/submariner-io/submariner/issues/1749
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
