### PR TITLE
Wrap parameter/return lists as expected by gofumpt

### DIFF
--- a/main.go
+++ b/main.go
@@ -295,7 +295,8 @@ func startHTTPServer() *http.Server {
 }
 
 func startLeaderElection(leaderElectionClient kubernetes.Interface, recorder resourcelock.EventRecorder,
-	run func(ctx context.Context), end func()) error {
+	run func(ctx context.Context), end func(),
+) error {
 	gwLeadershipConfig := leaderConfig{}
 
 	err := envconfig.Process(leadershipConfigEnvPrefix, &gwLeadershipConfig)
@@ -381,7 +382,8 @@ func (c *cleanupHandler) fatal(format string, args ...interface{}) {
 }
 
 func uninstallGateway(cableEngine cableengine.Engine, cableEngineSyncer *syncer.GatewaySyncer,
-	dsSyncer *datastoresyncer.DatastoreSyncer) {
+	dsSyncer *datastoresyncer.DatastoreSyncer,
+) {
 	err := cableEngine.StartEngine()
 	if err != nil {
 		// As we are in the process of cleaning up, ignore any initialization errors.

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -370,7 +370,8 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 }
 
 func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpointInfo *natdiscovery.NATEndpointInfo,
-	leftSubnet, rightSubnet string, rightNATTPort int32) error {
+	leftSubnet, rightSubnet string, rightNATTPort int32,
+) error {
 	// Identifiers are used for authentication, they’re always the private IPs
 	localEndpointIdentifier := i.localEndpoint.Spec.PrivateIP
 	remoteEndpointIdentifier := endpointInfo.Endpoint.Spec.PrivateIP
@@ -414,7 +415,8 @@ func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpoi
 }
 
 func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo *natdiscovery.NATEndpointInfo,
-	leftSubnet, rightSubnet string, lsi, rsi int) error {
+	leftSubnet, rightSubnet string, lsi, rsi int,
+) error {
 	localEndpointIdentifier := fmt.Sprintf("@%s-%d-%d", i.localEndpoint.Spec.PrivateIP, lsi, rsi)
 	remoteEndpointIdentifier := fmt.Sprintf("@%s-%d-%d", endpointInfo.Endpoint.Spec.PrivateIP, rsi, lsi)
 
@@ -453,7 +455,8 @@ func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo 
 }
 
 func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo *natdiscovery.NATEndpointInfo,
-	leftSubnet, rightSubnet string, rightNATTPort int32, lsi, rsi int) error {
+	leftSubnet, rightSubnet string, rightNATTPort int32, lsi, rsi int,
+) error {
 	// Identifiers are used for authentication, they’re always the private IPs.
 	localEndpointIdentifier := fmt.Sprintf("@%s-%d-%d", i.localEndpoint.Spec.PrivateIP, lsi, rsi)
 	remoteEndpointIdentifier := fmt.Sprintf("@%s-%d-%d", endpointInfo.Endpoint.Spec.PrivateIP, rsi, lsi)

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -71,7 +71,8 @@ func init() {
 
 // NewEngine creates a new Engine for the local cluster.
 func NewGatewaySyncer(engine cableengine.Engine, client v1typed.GatewayInterface,
-	version string, healthCheck healthchecker.Interface) *GatewaySyncer {
+	version string, healthCheck healthchecker.Interface,
+) *GatewaySyncer {
 	return &GatewaySyncer{
 		client:      client,
 		engine:      engine,

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -51,7 +51,8 @@ type DatastoreSyncer struct {
 }
 
 func New(syncerConfig *broker.SyncerConfig, localCluster *types.SubmarinerCluster,
-	localEndpoint *types.SubmarinerEndpoint) *DatastoreSyncer {
+	localEndpoint *types.SubmarinerEndpoint,
+) *DatastoreSyncer {
 	// We'll panic if syncerConfig, localCluster or localEndpoint are nil, this is intentional
 	syncerConfig.LocalClusterID = localCluster.Spec.ClusterID
 

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -74,7 +74,8 @@ func (c *baseSyncerController) Start() error {
 }
 
 func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector string,
-	transform func(obj *unstructured.Unstructured) runtime.Object) {
+	transform func(obj *unstructured.Unstructured) runtime.Object,
+) {
 	c.resourceSyncer.Reconcile(func() []runtime.Object {
 		objList, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
@@ -96,7 +97,8 @@ func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, label
 }
 
 func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Federator, obj *unstructured.Unstructured,
-	postReserve func(allocatedIPs []string) error) error {
+	postReserve func(allocatedIPs []string) error,
+) error {
 	var reservedIPs []string
 
 	clearAllocatedIPs := func() {}
@@ -153,7 +155,8 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 }
 
 func (c *baseIPAllocationController) flushRulesAndReleaseIPs(key string, numRequeues int, flushRules func(allocatedIPs []string) error,
-	allocatedIPs ...string) bool {
+	allocatedIPs ...string,
+) bool {
 	if len(allocatedIPs) == 0 {
 		return false
 	}
@@ -205,7 +208,8 @@ func checkStatusChanged(oldStatus, newStatus interface{}, retObj runtime.Object)
 }
 
 func getService(name, namespace string,
-	client dynamic.NamespaceableResourceInterface, scheme *runtime.Scheme) (*corev1.Service, bool, error) {
+	client dynamic.NamespaceableResourceInterface, scheme *runtime.Scheme,
+) (*corev1.Service, bool, error) {
 	obj, err := client.Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil, false, nil
@@ -226,7 +230,8 @@ func getService(name, namespace string,
 }
 
 func createService(svc *corev1.Service,
-	client dynamic.NamespaceableResourceInterface) (*unstructured.Unstructured, error) {
+	client dynamic.NamespaceableResourceInterface,
+) (*unstructured.Unstructured, error) {
 	gnService, err := resourceUtil.ToUnstructured(svc)
 	if err != nil {
 		return nil, err // nolint:wrapcheck  // Let the caller wrap it
@@ -241,7 +246,8 @@ func createService(svc *corev1.Service,
 }
 
 func deleteService(namespace, name string,
-	client dynamic.NamespaceableResourceInterface) error {
+	client dynamic.NamespaceableResourceInterface,
+) error {
 	err := client.Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		klog.Warningf("Could not find Service %s/%s to delete", namespace, name)
@@ -260,7 +266,8 @@ func GetInternalSvcName(name string) string {
 }
 
 func deleteEndpoints(namespace, name string,
-	client dynamic.NamespaceableResourceInterface) error {
+	client dynamic.NamespaceableResourceInterface,
+) error {
 	err := client.Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		klog.Warningf("Could not find Endpoints %s/%s to delete", namespace, name)

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -41,7 +41,8 @@ import (
 )
 
 func NewClusterGlobalEgressIPController(config *syncer.ResourceSyncerConfig, localSubnets []string,
-	pool *ipam.IPPool) (Interface, error) {
+	pool *ipam.IPPool,
+) (Interface, error) {
 	// We'll panic if config is nil, this is intentional
 	var err error
 
@@ -185,7 +186,8 @@ func (c *clusterGlobalEgressIPController) validate(numberOfIPs int, egressIP *su
 }
 
 func (c *clusterGlobalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int, status *submarinerv1.GlobalEgressIPStatus,
-	numRequeues int) bool {
+	numRequeues int,
+) bool {
 	if numberOfIPs == len(status.AllocatedIPs) {
 		klog.V(log.DEBUG).Infof("Update called for %q, but numberOfIPs %d are already allocated", key, numberOfIPs)
 		return false

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -326,7 +326,8 @@ func awaitNoAllocatedIPs(client dynamic.ResourceInterface, name string) {
 }
 
 func (t *testDriverBase) awaitEgressIPStatus(client dynamic.ResourceInterface, name string, expNumIPS int, atIndex int,
-	expCond ...metav1.Condition) {
+	expCond ...metav1.Condition,
+) {
 	awaitStatusConditions(client, name, atIndex, expCond...)
 
 	status := getGlobalEgressIPStatus(client, name)

--- a/pkg/globalnet/controllers/egress_pod_watcher.go
+++ b/pkg/globalnet/controllers/egress_pod_watcher.go
@@ -34,7 +34,8 @@ import (
 )
 
 func startEgressPodWatcher(name, namespace string, namedIPSet ipset.Named, config *watcher.Config,
-	podSelector *metav1.LabelSelector) (*egressPodWatcher, error) {
+	podSelector *metav1.LabelSelector,
+) (*egressPodWatcher, error) {
 	pw := &egressPodWatcher{
 		stopCh:     make(chan struct{}),
 		namedIPSet: namedIPSet,

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -156,7 +156,8 @@ func (c *globalEgressIPController) process(from runtime.Object, numRequeues int,
 }
 
 func (c *globalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int, globalEgressIP *submarinerv1.GlobalEgressIP,
-	numRequeues int) bool {
+	numRequeues int,
+) bool {
 	namedIPSet := c.newNamedIPSet(key)
 
 	requeue := false
@@ -170,7 +171,8 @@ func (c *globalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int,
 
 // nolint:wrapcheck  // No need to wrap these errors.
 func (c *globalEgressIPController) programGlobalEgressRules(key string, allocatedIPs []string, podSelector *metav1.LabelSelector,
-	namedIPSet ipset.Named) error {
+	namedIPSet ipset.Named,
+) error {
 	err := namedIPSet.Create(true)
 	if err != nil {
 		return errors.Wrapf(err, "error creating the IP set chain %q", namedIPSet.Name())
@@ -193,7 +195,8 @@ func (c *globalEgressIPController) programGlobalEgressRules(key string, allocate
 }
 
 func (c *globalEgressIPController) allocateGlobalIPs(key string, numberOfIPs int,
-	globalEgressIP *submarinerv1.GlobalEgressIP, namedIPSet ipset.Named) bool {
+	globalEgressIP *submarinerv1.GlobalEgressIP, namedIPSet ipset.Named,
+) bool {
 	klog.Infof("Allocating %d global IP(s) for %q", numberOfIPs, key)
 
 	if numberOfIPs == 0 {
@@ -315,7 +318,8 @@ func (c *globalEgressIPController) getIPSetName(key string) string {
 }
 
 func (c *globalEgressIPController) createPodWatcher(key string, namedIPSet ipset.Named, numberOfIPs int,
-	globalEgressIP *submarinerv1.GlobalEgressIP) bool {
+	globalEgressIP *submarinerv1.GlobalEgressIP,
+) bool {
 	c.Lock()
 	defer c.Unlock()
 
@@ -355,7 +359,8 @@ func (c *globalEgressIPController) createPodWatcher(key string, namedIPSet ipset
 
 // nolint:wrapcheck  // No need to wrap these errors.
 func (c *globalEgressIPController) flushGlobalEgressRulesAndReleaseIPs(key, ipSetName string, numRequeues int,
-	globalEgressIP *submarinerv1.GlobalEgressIP) bool {
+	globalEgressIP *submarinerv1.GlobalEgressIP,
+) bool {
 	return c.flushRulesAndReleaseIPs(key, numRequeues, func(allocatedIPs []string) error {
 		metrics.RecordDeallocateGlobalEgressIPs(c.pool.GetCIDR(), len(allocatedIPs))
 		if globalEgressIP.Spec.PodSelector != nil {

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -155,7 +155,8 @@ func testGlobalIngressIPCreatedClusterIPSvc(t *globalIngressIPControllerTestDriv
 }
 
 func testGlobalIngressIPCreatedHeadlessSvc(t *globalIngressIPControllerTestDriver, ingressIP *submarinerv1.GlobalIngressIP,
-	awaitIPTableRules, awaitNoIPTableRules func(string), ruleMatch string) {
+	awaitIPTableRules, awaitNoIPTableRules func(string), ruleMatch string,
+) {
 	JustBeforeEach(func() {
 		service := newClusterIPService()
 		t.createService(service)
@@ -345,7 +346,8 @@ func testExistingGlobalIngressIPClusterIPSvc(t *globalIngressIPControllerTestDri
 }
 
 func testExistingGlobalIngressIPHeadlessSvc(t *globalIngressIPControllerTestDriver, ingressIP *submarinerv1.GlobalIngressIP,
-	awaitIPTableRules func(string)) {
+	awaitIPTableRules func(string),
+) {
 	var existing *submarinerv1.GlobalIngressIP
 
 	BeforeEach(func() {

--- a/pkg/globalnet/controllers/iptables/iface.go
+++ b/pkg/globalnet/controllers/iptables/iface.go
@@ -137,7 +137,8 @@ func (i *ipTables) RemoveIngressRulesForHeadlessSvcPod(globalIP, podIP string) e
 }
 
 func (i *ipTables) GetKubeProxyClusterIPServiceChainName(service *corev1.Service,
-	kubeProxyServiceChainPrefix string) (string, bool, error) {
+	kubeProxyServiceChainPrefix string,
+) (string, bool, error) {
 	// CNIs that use kube-proxy with iptables for loadbalancing create an iptables chain for each service
 	// and incoming traffic to the clusterIP Service is directed into the respective chain.
 	// Reference: https://bit.ly/2OPhlwk

--- a/pkg/globalnet/controllers/service_export_controller.go
+++ b/pkg/globalnet/controllers/service_export_controller.go
@@ -35,7 +35,8 @@ import (
 )
 
 func NewServiceExportController(config *syncer.ResourceSyncerConfig, podControllers *IngressPodControllers,
-	endpointsControllers *ServiceExportEndpointsControllers) (Interface, error) {
+	endpointsControllers *ServiceExportEndpointsControllers,
+) (Interface, error) {
 	// We'll panic if config is nil, this is intentional
 	var err error
 

--- a/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/router_submariner_north.go
@@ -98,7 +98,8 @@ func (ovn *SyncHandler) updateSubmarinerRouterRemoteRoutes() error {
 }
 
 func (ovn *SyncHandler) removeRoutesToSubnets(toRemove []string, viaPort string, ovnCommands []*goovn.OvnCommand) ([]*goovn.OvnCommand,
-	error) {
+	error,
+) {
 	for _, subnet := range toRemove {
 		delCmd, err := ovn.nbdb.LRSRDel(submarinerLogicalRouter, subnet, nil, &viaPort, nil)
 		if err != nil {

--- a/pkg/networkplugin-syncer/handlers/ovn/routers.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/routers.go
@@ -49,7 +49,8 @@ func filterRouteSubnetsViaPort(subnetRouteObjs []*goovn.LogicalRouterStaticRoute
 }
 
 func (ovn *SyncHandler) addSubmRoutesToSubnets(toAdd []string, viaPort, nextHop string,
-	ovnCommands []*goovn.OvnCommand) ([]*goovn.OvnCommand, error) {
+	ovnCommands []*goovn.OvnCommand,
+) ([]*goovn.OvnCommand, error) {
 	for _, subnet := range toAdd {
 		addCmd, err := ovn.nbdb.LRSRAdd(submarinerLogicalRouter, subnet, nextHop, &viaPort, nil, nil)
 		if err != nil {

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -94,7 +94,8 @@ func (ovn *Handler) getExistingIPv4HostNetworkRoutes() (stringset.Interface, err
 }
 
 func (ovn *Handler) programRulesForRemoteSubnets(subnets []string, ruleFunc func(rule *netlink.Rule) error,
-	ignoredErrorFunc func(error) bool) error {
+	ignoredErrorFunc func(error) bool,
+) error {
 	for _, remoteSubnet := range subnets {
 		rule, err := ovn.programRule(remoteSubnet, "", constants.RouteAgentHostNetworkTableID)
 		if err != nil {

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -30,7 +30,8 @@ import (
 // handleSubnets builds ip rules, and passes them to the specified netlink function
 //               for provided subnet list
 func (ovn *Handler) handleSubnets(subnets []string, ruleFunc func(rule *netlink.Rule) error,
-	ignoredErrorFunc func(error) bool) error {
+	ignoredErrorFunc func(error) bool,
+) error {
 	for _, subnetToHandle := range subnets {
 		for _, localSubnet := range ovn.localEndpoint.Spec.Subnets {
 			rule, err := ovn.programRule(localSubnet, subnetToHandle, constants.RouteAgentInterClusterNetworkTableID)

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -243,7 +243,8 @@ func GetGlobalnetEgressParams(egressIP GlobalEgressIPType) GlobalnetTestParams {
 }
 
 func CanExecuteNonGatewayConnectivityTest(sourceNode, destNode framework.NetworkPodScheduling,
-	sourceCluster, destCluster framework.ClusterIndex) bool {
+	sourceCluster, destCluster framework.ClusterIndex,
+) bool {
 	if sourceNode == framework.NonGatewayNode &&
 		framework.TestContext.NumNodesInCluster[sourceCluster] == 1 {
 		framework.Skipf("Skipping the test as cluster %q has only a single node...",

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -27,7 +27,8 @@ import (
 )
 
 func (f *Framework) AwaitGatewayWithStatus(cluster framework.ClusterIndex, name string,
-	status submarinerv1.HAStatus) *submarinerv1.Gateway {
+	status submarinerv1.HAStatus,
+) *submarinerv1.Gateway {
 	return toGateway(f.Framework.AwaitGatewayWithStatus(cluster, name, string(status)))
 }
 

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
This is required by golangci-lint 1.45.2; it all involves formatting
wrapped lists of parameters or return types.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
