### PR TITLE
[Backport] Create GN-Mark chain before starting EP watcher

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -116,13 +116,13 @@ func NewGatewayMonitor(spec Specification, localCIDRs []string, config *watcher.
 func (g *gatewayMonitor) Start() error {
 	klog.Info("Starting GatewayMonitor to monitor the active Gateway node in the cluster.")
 
+	if err := g.createGlobalNetMarkingChain(); err != nil {
+		return errors.Wrap(err, "error while calling createGlobalNetMarkingChain")
+	}
+
 	err := g.endpointWatcher.Start(g.stopCh)
 	if err != nil {
 		return errors.Wrap(err, "error starting the Endpoint watcher")
-	}
-
-	if err := g.createGlobalNetMarkingChain(); err != nil {
-		return errors.Wrap(err, "error while calling createGlobalNetMarkingChain")
 	}
 
 	return nil


### PR DESCRIPTION
In the current code, we are starting the endpoint watcher
and later creating the Globalnet marking chain. In a KIND
deployment this was fine, but in an OCP deployment the endpoint
events are generated even before the iptable chain is programmed
because of which we are seeing errors. This PR fixes it by changing
the order.

Related to: https://github.com/submariner-io/submariner/issues/1749
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit feeaf589957c4a1c8abf7e2b511855298aef690f)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
