### PR TITLE
[Backport] Remove globalIP annotation from node as part of uninstall operation

### DIFF
--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -69,6 +69,7 @@ func main() {
 		klog.Info("Uninstalling submariner-globalnet")
 		controllers.UninstallDataPath()
 		controllers.DeleteGlobalnetObjects(submarinerClient, cfg)
+		controllers.RemoveGlobalIPAnnotationOnNode(cfg)
 
 		return
 	}


### PR DESCRIPTION
Remove globalIP annotation from node as part of uninstall operation

Fixes: https://github.com/submariner-io/submariner/issues/1780
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit c047698ccbf1fcc43b2dcd7c0773acc902914f61)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
