### PR TITLE
Verify SUBMARINER-LOCALCIDRS ipset being deleted on uninstall

### DIFF
--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -197,8 +197,16 @@ func (h *mtuHandler) Stop(uninstall bool) error {
 			constants.MangleTable, err)
 	}
 
+	if err := h.localIPSet.Flush(); err != nil {
+		klog.Errorf("Error flushing ipset %q: %v", constants.LocalCIDRIPSet, err)
+	}
+
 	if err := h.localIPSet.Destroy(); err != nil {
 		klog.Errorf("Error deleting ipset %q: %v", constants.LocalCIDRIPSet, err)
+	}
+
+	if err := h.remoteIPSet.Flush(); err != nil {
+		klog.Errorf("Error flushing ipset %q: %v", constants.RemoteCIDRIPSet, err)
 	}
 
 	if err := h.remoteIPSet.Destroy(); err != nil {


### PR DESCRIPTION
It was noticed that SUBMARINER-LOCALCIDRS ipset deletion failed on uninstall flow with [1] error.

The issue can be addressed by flushing the ipset before
destroying it or by a short delay.
This PR applies the first method.

[1]
    ipset v7.11: Set cannot be destroyed: it is in use by a kernel component

Fixes: https://github.com/submariner-io/submariner/issues/1778

Signed-off-by: yboaron <yboaron@redhat.com>
