### PR TITLE
[Backport] Validate globalIP on node with GlobalCIDR of cluster

### DIFF
--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -126,7 +126,7 @@ func testEndpointSyncing() {
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,
-					Annotations: map[string]string{constants.SmGlobalIP: "10.20.30.40"},
+					Annotations: map[string]string{constants.SmGlobalIP: "200.0.0.40"},
 				},
 			}
 
@@ -135,7 +135,7 @@ func testEndpointSyncing() {
 			test.CreateResource(t.localNodes, node)
 			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
 
-			node.Annotations[constants.SmGlobalIP] = "11.21.31.41"
+			node.Annotations[constants.SmGlobalIP] = "200.0.0.100"
 			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
 
 			test.UpdateResource(t.localNodes, node)


### PR DESCRIPTION
This PR validates the globalIP present on the gateway node with
the GlobalCIDR allocated to the Cluster before updating the local
endpoint health-check ip.

Related to: https://github.com/submariner-io/submariner/issues/1780
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 73a1b4ef3dca1f14fcdef72f2c3b7cd0c4661802)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
