### PR TITLE
[Backport] Verify local cidr ipset is updated with local PodCIDRs

### DIFF
--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MTUHandler", func() {
 		ipset.NewFunc = func() ipset.Interface {
 			return ipSet
 		}
-		handler = mtu.NewMTUHandler()
+		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"})
 	})
 
 	AfterEach(func() {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -86,7 +86,7 @@ func main() {
 		ovn.NewHandler(&env, smClientset),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
-		mtu.NewMTUHandler(),
+		mtu.NewMTUHandler(env.ClusterCidr),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}


### PR DESCRIPTION
Verify that the SUBMARINER_LOCALCIDRS ipset is updated with the local
PodCIDRs because SNAT (with GN globalIP) is performed in NAT Postrouting table
which is hit after MANGLE POSTROUTING table.

Partially Fixes: https://github.com/submariner-io/submariner/issues/1774

Signed-off-by: yboaron <yboaron@redhat.com>
(cherry picked from commit 40dd77c56efd2e9000bf481820547616c82e0db6)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
