### PR TITLE
Periodic Public IP watcher for Submariner Gateway

### DIFF
--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -1,0 +1,115 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	v1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog"
+)
+
+type PublicIPWatcherConfig struct {
+	SubmSpec      *types.SubmarinerSpecification
+	Interval      time.Duration
+	K8sClient     kubernetes.Interface
+	Endpoints     v1.EndpointInterface
+	LocalEndpoint types.SubmarinerEndpoint
+}
+
+type PublicIPWatcher struct {
+	config PublicIPWatcherConfig
+}
+
+const DefaultMonitorInterval = 20 * time.Second
+
+func NewPublicIPWatcher(config *PublicIPWatcherConfig) *PublicIPWatcher {
+	controller := &PublicIPWatcher{
+		config: *config,
+	}
+
+	if controller.config.Interval == 0 {
+		controller.config.Interval = DefaultMonitorInterval
+	}
+
+	return controller
+}
+
+func (p *PublicIPWatcher) Run(stopCh <-chan struct{}) {
+	klog.Info("Starting the public IP watcher.")
+
+	go func() {
+		wait.Until(p.syncPublicIP, p.config.Interval, stopCh)
+	}()
+}
+
+func (p *PublicIPWatcher) syncPublicIP() {
+	publicIP, err := getPublicIP(p.config.SubmSpec, p.config.K8sClient, p.config.LocalEndpoint.Spec.BackendConfig)
+	if err != nil {
+		klog.Warningf("Could not determine public IP of the gateway node %q", p.config.LocalEndpoint.Spec.Hostname)
+		return
+	}
+
+	if p.config.LocalEndpoint.Spec.PublicIP != publicIP {
+		klog.Infof("Public IP changed for the Gateway, updating the local endpoint with publicIP %q", publicIP)
+
+		if err := p.updateLocalEndpoint(publicIP); err != nil {
+			klog.Errorf("Error updating the public IP for local endpoint: %v", err)
+			return
+		}
+	}
+}
+
+func (p *PublicIPWatcher) updateLocalEndpoint(publicIP string) error {
+	var ep *submv1.Endpoint
+
+	endpointName, err := util.GetEndpointCRDName(&p.config.LocalEndpoint)
+	if err != nil {
+		return errors.Wrapf(err, "error extracting the submariner Endpoint name from %#v", p.config.LocalEndpoint)
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ep, err = p.config.Endpoints.Get(context.TODO(), endpointName, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "unable to get endpoint %q", endpointName)
+		}
+
+		ep.Spec.PublicIP = publicIP
+
+		_, updateErr := p.config.Endpoints.Update(context.TODO(), ep, metav1.UpdateOptions{})
+		return updateErr // nolint:wrapcheck // We wrap it below in the enclosing function
+	})
+
+	if retryErr != nil {
+		return errors.Wrapf(retryErr, "error updating the public IP of local endpoint %q", endpointName)
+	}
+
+	p.config.LocalEndpoint.Spec = ep.Spec
+
+	return nil
+}

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -1,0 +1,195 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	fakeClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	submarinerClientsetv1 "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	UsingLoadBalancer = "using-loadbalancer"
+	initialIP         = "1.2.3.4"
+	updatedIP         = "4.3.2.1"
+	clusterID         = "eastcluster"
+	interval          = 50 * time.Millisecond
+	testServiceName   = "my-loadbalancer"
+	testNamespace     = "namespace"
+)
+
+var _ = Describe("public ip watcher", func() {
+	var endpointName string
+	var err error
+
+	t := newPublicIPWatcherTestDriver()
+
+	BeforeEach(func() {
+		cableName := fmt.Sprintf("submariner-cable-%s-192-68-10-2", clusterID)
+
+		// Let's create a local endpoint with load-balancer set to true but without any public-ip
+		t.localEPSpec = newEndpointSpec(clusterID, cableName)
+
+		endpointName, err = util.GetEndpointCRDNameFromParams(t.localEPSpec.ClusterID, t.localEPSpec.CableName)
+		Expect(err).To(Succeed())
+	})
+
+	AfterEach(func() {
+		close(t.stopCh)
+	})
+
+	When("using the LoadBalancer mode and the Ingress IP is modified", func() {
+		It("should update the public IP of local endpoint accordingly", func() {
+			// Allow the public-ip watcher to resolve public-ip from the corresponding load-balancer service.
+			time.Sleep(2 * interval)
+
+			// Verify that local endpoint now has public-ip
+			obj := t.getLocalEndpoint(endpointName)
+			Expect(obj.Spec.PublicIP).To(Equal(initialIP))
+
+			// Update the load-balancer ingress ip
+			t.updateLoadbalancerService(testServiceName, testNamespace, updatedIP)
+			time.Sleep(2 * interval)
+
+			// Verify that local endpoint now has the updated public-ip
+			obj = t.getLocalEndpoint(endpointName)
+			Expect(obj.Spec.PublicIP).To(Equal(updatedIP))
+		})
+	})
+})
+
+type publicIPWatcherTestDriver struct {
+	smEndpointClient submarinerClientsetv1.EndpointInterface
+	k8sClient        *fake.Clientset
+	localEPSpec      submarinerv1.EndpointSpec
+	stopCh           chan struct{}
+}
+
+func newPublicIPWatcherTestDriver() *publicIPWatcherTestDriver {
+	t := &publicIPWatcherTestDriver{}
+
+	BeforeEach(func() {
+		t.stopCh = make(chan struct{})
+		t.k8sClient = fake.NewSimpleClientset(loadBalancerService(v1.LoadBalancerIngress{Hostname: "", IP: initialIP}))
+		t.smEndpointClient = fakeClientset.NewSimpleClientset().SubmarinerV1().Endpoints(testNamespace)
+	})
+
+	JustBeforeEach(func() {
+		t.createEndpoint(&t.localEPSpec)
+
+		ipWatcher := endpoint.NewPublicIPWatcher(&endpoint.PublicIPWatcherConfig{
+			SubmSpec: &types.SubmarinerSpecification{
+				ClusterID: clusterID,
+				Namespace: testNamespace,
+				PublicIP:  "lb:" + testServiceName,
+			},
+			Interval:  interval,
+			K8sClient: t.k8sClient,
+			Endpoints: t.smEndpointClient,
+			LocalEndpoint: types.SubmarinerEndpoint{
+				Spec: t.localEPSpec,
+			},
+		})
+
+		ipWatcher.Run(t.stopCh)
+	})
+
+	return t
+}
+
+func (t *publicIPWatcherTestDriver) createEndpoint(spec *submarinerv1.EndpointSpec) *submarinerv1.Endpoint {
+	endpointName, err := util.GetEndpointCRDNameFromParams(spec.ClusterID, spec.CableName)
+	Expect(err).To(Succeed())
+
+	ep := &submarinerv1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: endpointName,
+		},
+		Spec: *spec,
+	}
+
+	obj, err := t.smEndpointClient.Create(context.TODO(), ep, metav1.CreateOptions{})
+	Expect(err).To(Succeed())
+
+	return obj
+}
+
+func (t *publicIPWatcherTestDriver) getLocalEndpoint(name string) *submarinerv1.Endpoint {
+	obj, err := t.smEndpointClient.Get(context.TODO(), name, metav1.GetOptions{})
+	Expect(err).To(Succeed())
+
+	return obj
+}
+
+func newEndpointSpec(clusterID, cableName string) submarinerv1.EndpointSpec {
+	return submarinerv1.EndpointSpec{
+		CableName: cableName,
+		ClusterID: clusterID,
+		PrivateIP: "192-68-10-2",
+		Hostname:  "myhost",
+		Subnets:   []string{"10.1.0.0/24", "100.1.0.0/24"},
+		BackendConfig: map[string]string{
+			UsingLoadBalancer: "true",
+		},
+	}
+}
+
+func (t *publicIPWatcherTestDriver) updateLoadbalancerService(lbservice, ns, ip string) {
+	ingress := []v1.LoadBalancerIngress{{Hostname: "", IP: ip}}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lbservice,
+			Namespace: ns,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: ingress,
+			},
+		},
+	}
+
+	_, err := t.k8sClient.CoreV1().Services(ns).Update(context.TODO(), svc, metav1.UpdateOptions{})
+	Expect(err).To(Succeed())
+}
+
+func loadBalancerService(ingress ...v1.LoadBalancerIngress) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testNamespace,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: ingress,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Currently when the submariner gateway pod comes up, it discovers
the public-ip associated with the gateway node and configures it
in the local endpoint. However, if the public-ip changes, the
connectivity would be lost. This PR implements a periodic watcher
which monitors for any changes to the public IP and updates the
local endpoint when necessary. It works for all the modes like
when using a dedicated gateway node with external-ip as well as
when using a Load-balancer mode of Submariner.

Fixes: https://github.com/submariner-io/submariner/issues/1823
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
