### PR TITLE
Update mtuhandler to support platform running nftables

### DIFF
--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -24,4 +24,5 @@ type Specification struct {
 	ClusterCidr []string
 	ServiceCidr []string
 	Uninstall   bool
+	GlobalCidr  []string
 }

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MTUHandler", func() {
 		ipset.NewFunc = func() ipset.Interface {
 			return ipSet
 		}
-		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"})
+		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"}, false)
 	})
 
 	AfterEach(func() {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -86,7 +86,7 @@ func main() {
 		ovn.NewHandler(&env, smClientset),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
-		mtu.NewMTUHandler(env.ClusterCidr),
+		mtu.NewMTUHandler(env.ClusterCidr, (len(env.GlobalCidr) != 0)),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}


### PR DESCRIPTION
   Submariner MTU handler in route-agent programs iptable rules to
    clamp tcp mss to PMTU in the Mangle table. We noticed that tcp
    mss not being clamped to PMTU when the platform is running nftables
    and Globalnet is enabled.
    
  This PR adds iptables rules that force tcp mss clamping in case
  Globalnet is configured, the mss value is calculated based on
  the MTU of the default interface and the cable driver overhead.


Fixes: https://github.com/submariner-io/submariner/issues/1774

Signed-off-by: yboaron <yboaron@redhat.com>

