### PR TITLE
Configure timeout while resolving public-ip

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -91,8 +91,11 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 func publicAPI(clientset kubernetes.Interface, namespace, value string) (string, error) {
 	url := "https://" + value
 
-	//nolint:gosec // we really need to get from a non-predefined const URL
-	response, err := http.Get(url)
+	httpClient := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	response, err := httpClient.Get(url)
 	if err != nil {
 		return "", errors.Wrapf(err, "retrieving public IP from %s", url)
 	}


### PR DESCRIPTION
While testing use-cases where we modify the external-ip
of the Gateway node, it was seen that public-ip resolution
is sometimes getting stuck for 15 mins. This PR explicitly
configures a 30 secs timeout while resolving the public-ip.

Fixes: https://github.com/submariner-io/submariner/issues/1842
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
