### PR TITLE
Fix connection failure with LB mode + VxLAN Cabledriver

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -132,7 +132,19 @@ func CompareEndpointSpec(left, right *subv1.EndpointSpec) bool {
 
 	// maybe we have to use just reflect.DeepEqual(left, right), but in this case the subnets order will influence.
 	return left.ClusterID == right.ClusterID && left.CableName == right.CableName && left.Hostname == right.Hostname &&
-		left.Backend == right.Backend && equality.Semantic.DeepEqual(left.BackendConfig, right.BackendConfig)
+		left.Backend == right.Backend && isBackendConfigSame(left, right)
+}
+
+func isBackendConfigSame(left, right *subv1.EndpointSpec) bool {
+	if left.BackendConfig[subv1.UsingLoadBalancer] == "true" &&
+		right.BackendConfig[subv1.UsingLoadBalancer] == "true" {
+		// When Gateway pod comes up with loadbalancer mode enabled, it inserts a preferred-server-timestamp in
+		// the BackendConfig when the Gateway pod comes up. So, in loadbalancer mode, we just have to compare
+		// the load-balancer status.
+		return true
+	}
+
+	return equality.Semantic.DeepEqual(left.BackendConfig, right.BackendConfig)
 }
 
 func EnsureValidName(name string) string {


### PR DESCRIPTION
When using Loadbalancer mode with VxLAN cable driver, it was seen that
connections are sometimes not setup. The reason for this is the missing
vxlan-tunnel interface which was deleted by route-agent driver assuming
that the Gateway node migrated.

The reason why route-agent considers it as Gateway migration is because
the local-endpoint is deleted and then re-created. Ideally, the local
endpoint should not be deleted when the Gateway pod comes up, but the
current checks in the code tries to match the entire backendConfig and
when it finds that something does not match with the endpoint stored in
the datastore it deletes and re-creates the endpoint. This PR fixes this
issue by ensuring that local-endpoint is simply updated and not deleted.

Fixes: https://github.com/submariner-io/submariner/issues/1822
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
