### PR TITLE
Refactor constants used externally

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -97,11 +97,6 @@ const (
 	UsingLoadBalancer       = "using-loadbalancer"
 )
 
-const (
-	DefaultNATTDiscoveryPort = "4490"
-	DefaultUDPPort           = "4500"
-)
-
 // Valid PublicIP resolvers.
 const (
 	IPv4         = "ipv4" // ipv4:1.2.3.4

--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -1,0 +1,29 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cni
+
+// Supported network plugins.
+const (
+	Generic       = "generic"
+	CanalFlannel  = "canal-flannel"
+	WeaveNet      = "weave-net"
+	OpenShiftSDN  = "OpenShiftSDN"
+	OVNKubernetes = "OVNKubernetes"
+	Calico        = "calico"
+)

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/node"
+	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/util"
 	v1 "k8s.io/api/core/v1"
@@ -118,7 +119,7 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 	if _, ok := backendConfig[submv1.UDPPortConfig]; !ok {
 		udpPort := os.Getenv("CE_IPSEC_NATTPORT")
 		if udpPort == "" {
-			udpPort = submv1.DefaultUDPPort
+			udpPort = strconv.Itoa(port.ExternalTunnel)
 		}
 
 		backendConfig[submv1.UDPPortConfig] = udpPort
@@ -126,7 +127,7 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 
 	// Enable and publish the natt-discovery-port by default.
 	if _, ok := backendConfig[submv1.NATTDiscoveryPortConfig]; !ok {
-		backendConfig[submv1.NATTDiscoveryPortConfig] = submv1.DefaultNATTDiscoveryPort
+		backendConfig[submv1.NATTDiscoveryPortConfig] = strconv.Itoa(port.NATTDiscovery)
 	}
 
 	// TODO: we should allow the cable drivers to capture and expose BackendConfig settings, instead of doing

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -24,10 +24,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/event/testing"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	k8sV1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,7 +48,7 @@ var _ = Describe("Event Registry", func() {
 			registry = event.NewRegistry("test-registry", npGenericKubeproxyIptables)
 
 			nonMatchingHandlers = []*testing.TestHandler{
-				testing.NewTestHandler("ovn-handler", constants.NetworkPluginOVNKubernetes, allTestEvents),
+				testing.NewTestHandler("ovn-handler", cni.OVNKubernetes, allTestEvents),
 			}
 
 			matchingHandlers = []*testing.TestHandler{

--- a/pkg/networkplugin-syncer/handlers/ovn/handler.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/handler.go
@@ -26,8 +26,8 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -53,7 +53,7 @@ func (ovn *SyncHandler) GetName() string {
 }
 
 func (ovn *SyncHandler) GetNetworkPlugins() []string {
-	return []string{constants.NetworkPluginOVNKubernetes}
+	return []string{cni.OVNKubernetes}
 }
 
 func NewSyncHandler(k8sClientset clientset.Interface, env *environment.Specification) event.Handler {

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -23,11 +23,11 @@ import (
 	"os"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
 	"github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -59,7 +59,7 @@ func main() {
 	networkPlugin := os.Getenv("SUBMARINER_NETWORKPLUGIN")
 
 	if networkPlugin == "" {
-		networkPlugin = constants.NetworkPluginGeneric
+		networkPlugin = cni.Generic
 	}
 
 	registry := event.NewRegistry("networkplugin-syncer", networkPlugin)

--- a/pkg/port/ports.go
+++ b/pkg/port/ports.go
@@ -1,0 +1,25 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package port
+
+const (
+	NATTDiscovery     = 4490
+	ExternalTunnel    = 4500
+	IntraClusterVxLAN = 4800
+)

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -50,14 +50,6 @@ const (
 	// the egress traffic to the corresponding CNIInterfaceIP on that host.
 	RouteAgentHostNetworkTableID = 150
 
-	// Network plugins supported.
-	NetworkPluginGeneric       = "generic"
-	NetworkPluginCanalFlannel  = "canal-flannel"
-	NetworkPluginWeaveNet      = "weave-net"
-	NetworkPluginOpenShiftSDN  = "OpenShiftSDN"
-	NetworkPluginOVNKubernetes = "OVNKubernetes"
-	NetworkPluginCalico        = "calico"
-
 	NATTable    = "nat"
 	FilterTable = "filter"
 )

--- a/pkg/routeagent_driver/handlers/kubeproxy/constants.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/constants.go
@@ -22,7 +22,6 @@ const (
 	VxLANIface         = "vx-submariner"
 	VxInterfaceWorker  = 0
 	VxInterfaceGateway = 1
-	VxLANPort          = 4800
 	VxLANOverhead      = 50
 
 	// Why VxLANVTepNetworkPrefix is 240?

--- a/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/iptables"
+	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	iptcommon "github.com/submariner-io/submariner/pkg/routeagent_driver/iptables"
 	"k8s.io/klog"
@@ -53,7 +54,7 @@ func (kp *SyncHandler) createIPTableChains() error {
 
 	klog.V(log.DEBUG).Infof("Allow VxLAN incoming traffic in %q Chain", constants.SmInputChain)
 
-	ruleSpec := []string{"-p", "udp", "-m", "udp", "--dport", strconv.Itoa(VxLANPort), "-j", "ACCEPT"}
+	ruleSpec := []string{"-p", "udp", "-m", "udp", "--dport", strconv.Itoa(port.IntraClusterVxLAN), "-j", "ACCEPT"}
 
 	if err = ipt.AppendUnique(constants.FilterTable, constants.SmInputChain, ruleSpec...); err != nil {
 		return errors.Wrapf(err, "unable to append iptables rule %q", strings.Join(ruleSpec, " "))

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	cni "github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
@@ -53,7 +53,7 @@ type SyncHandler struct {
 	vxlanDevice      *vxLanIface
 	vxlanGwIP        *net.IP
 	hostname         string
-	cniIface         *cni.Interface
+	cniIface         *cniapi.Interface
 	defaultHostIface *net.Interface
 }
 
@@ -79,8 +79,8 @@ func (kp *SyncHandler) GetName() string {
 
 func (kp *SyncHandler) GetNetworkPlugins() []string {
 	return []string{
-		constants.NetworkPluginGeneric, constants.NetworkPluginCanalFlannel, constants.NetworkPluginWeaveNet,
-		constants.NetworkPluginOpenShiftSDN, constants.NetworkPluginCalico,
+		cni.Generic, cni.CanalFlannel, cni.WeaveNet,
+		cni.OpenShiftSDN, cni.Calico,
 	}
 }
 
@@ -97,7 +97,7 @@ func (kp *SyncHandler) Init() error {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s", kp.hostname)
 	}
 
-	cniIface, err := cni.Discover(kp.localClusterCidr[0])
+	cniIface, err := cniapi.Discover(kp.localClusterCidr[0])
 	if err == nil {
 		// Configure CNI Specific changes
 		kp.cniIface = cniIface

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -24,6 +24,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog"
@@ -64,7 +65,7 @@ func deleteVxLANInterface() {
 		},
 		VxlanId: 100,
 		SrcAddr: nil,
-		Port:    VxLANPort,
+		Port:    port.IntraClusterVxLAN,
 	}
 
 	klog.Infof("Deleting the %q interface", VxLANIface)

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"k8s.io/klog"
@@ -251,7 +252,7 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 			vxlanID:  100,
 			group:    nil,
 			srcAddr:  nil,
-			vtepPort: VxLANPort,
+			vtepPort: port.IntraClusterVxLAN,
 			mtu:      vxlanMtu,
 		}
 
@@ -280,7 +281,7 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 			vxlanID:  100,
 			group:    gatewayNodeIP,
 			srcAddr:  nil,
-			vtepPort: VxLANPort,
+			vtepPort: port.IntraClusterVxLAN,
 			mtu:      vxlanMtu,
 		}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan_internal_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan_internal_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/vishvananda/netlink"
 )
 
@@ -61,7 +62,7 @@ var _ = Describe("Function createVxLanIface", func() {
 				},
 				VxlanId: 100,
 				Group:   net.ParseIP("192.68.1.2"),
-				Port:    VxLANPort,
+				Port:    port.IntraClusterVxLAN,
 			},
 		}
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -27,10 +27,10 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable/wireguard"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"github.com/submariner-io/submariner/pkg/netlink"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"k8s.io/klog"
 )
@@ -69,7 +69,7 @@ func (ovn *Handler) GetName() string {
 }
 
 func (ovn *Handler) GetNetworkPlugins() []string {
-	return []string{constants.NetworkPluginOVNKubernetes}
+	return []string{cni.OVNKubernetes}
 }
 
 func (ovn *Handler) Init() error {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -26,11 +26,12 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	cni "github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
 	"github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cabledriver"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
+	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
@@ -76,7 +77,7 @@ func main() {
 	np := os.Getenv("SUBMARINER_NETWORKPLUGIN")
 
 	if np == "" {
-		np = constants.NetworkPluginGeneric
+		np = cni.Generic
 	}
 
 	registry := event.NewRegistry("routeagent_driver", np)
@@ -144,7 +145,7 @@ func annotateNode(clusterCidr []string, cfg *restclient.Config) error {
 		return fmt.Errorf("error reading the NODE_NAME from the environment")
 	}
 
-	err = cni.AnnotateNodeWithCNIInterfaceIP(nodeName, k8sClientSet, clusterCidr)
+	err = cniapi.AnnotateNodeWithCNIInterfaceIP(nodeName, k8sClientSet, clusterCidr)
 	if err != nil {
 		return errors.Wrap(err, "error annotating node with CNI interface IP")
 	}


### PR DESCRIPTION
- Move `DefaultNATTDiscoveryPort`, `DefaultUDPPort` and `VxLANPort` to _pkg/ports_ module and rename appropriately. The latter avoids consumers pulling in unwanted dependencies due its prior location under _routeagent_driver_.

- Change `DefaultNATTDiscoveryPort` and `DefaultUDPPort` to int  constants so they don't need to be parsed.

- Move the `NetworkPlugin`* constants under _routeagent_driver_ to _pkg/cni_ and rename appropriately.
