### PR TITLE
Update K8s dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,7 @@ updates:
       # protobuf must be handled manually
       - dependency-name: google.golang.org/protobuf
       # K8s dependencies must be handled manually
-      - dependency-name: k8s.io/api
-        versions:
-          - "> 0.17.0"
-      - dependency-name: k8s.io/apimachinery
-        versions:
-          - "> 0.17.0"
-      - dependency-name: k8s.io/client-go
-        versions:
-          - "> 0.17.0"
-      - dependency-name: sigs.k8s.io/controller-runtime
-        versions:
-          - "> 0.3.0"
+      - dependency-name: k8s.io/*
+      - dependency-name: sigs.k8s.io/*
       # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
Ignore all `k8s.io` and `sigs.k8s.io` dependencies and versions.