### PR TITLE
Support override MTU value used in TCP MSS clamping

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -95,6 +95,7 @@ const (
 	PreferredServerConfig   = "preferred-server"
 	PublicIP                = "public-ip"
 	UsingLoadBalancer       = "using-loadbalancer"
+	TCPMssValue             = "submariner.io/tcp-clamp-mss"
 )
 
 // Valid PublicIP resolvers.

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MTUHandler", func() {
 		ipset.NewFunc = func() ipset.Interface {
 			return ipSet
 		}
-		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"}, false)
+		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"}, false, 0)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Currently, when Globalnet is enabled in the cluster,
to address the MTU issues, Submariner clamps the TCP
MSS to a value derived from the default-interface-mtu minus
the tunnel-overhead.

This PR allows users to set MSS clamping value using
node annotation.


To force MSS clamping to a specific value it needs
to annotate the relevant node:
kubectl annotate node <node_name> submariner.io/tcp-mss-clamping=<value>

Fixes: https://github.com/submariner-io/submariner/issues/1858

Signed-off-by: yboaron <yboaron@redhat.com>

