### PR TITLE
Initialize libovsdb clients to any DB

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -124,7 +124,6 @@ func createLibovsdbClient(dbAddress string, tlsConfig *tls.Config, dbModel model
 		// take longer than a normal ovsdb operation. Give it a bit more time so
 		// we don't time out and enter a reconnect loop.
 		libovsdbclient.WithReconnect(connectTimeout, &backoff.ZeroBackOff{}),
-		libovsdbclient.WithLeaderOnly(true),
 		libovsdbclient.WithLogger(&logger),
 		libovsdbclient.WithEndpoint(dbAddress),
 	}


### PR DESCRIPTION
Setup the libovsdb clients with `WithLeaderOnly(false)`
since the submariner clients are not write intensive
and the changes written to a non-leader db should be
mirrored throughout the cluster.

This allows us to not have to track the DB leader in the
cluster saving some overhead.

Fixes #1878 