### PR TITLE
Automated backport of #1882: Initialize libovsdb clients to any DB

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/connection.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/connection.go
@@ -124,7 +124,6 @@ func createLibovsdbClient(dbAddress string, tlsConfig *tls.Config, dbModel model
 		// take longer than a normal ovsdb operation. Give it a bit more time so
 		// we don't time out and enter a reconnect loop.
 		libovsdbclient.WithReconnect(connectTimeout, &backoff.ZeroBackOff{}),
-		libovsdbclient.WithLeaderOnly(true),
 		libovsdbclient.WithLogger(&logger),
 		libovsdbclient.WithEndpoint(dbAddress),
 	}


### PR DESCRIPTION
Backport of #1882 on release-0.13.

#1882: Initialize libovsdb clients to any DB

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.