### PR TITLE
Add grep to Globalnet and RouteAgent images

### DIFF
--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -20,7 +20,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/globalnet \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables iptables-nft ipset
+    iproute iptables iptables-nft ipset grep
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -20,7 +20,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/route-agent \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables iptables-nft ipset openvswitch procps-ng
+    iproute iptables iptables-nft ipset openvswitch procps-ng grep
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE


### PR DESCRIPTION
 In order for iptables-wrapper to work properly we
 need to make sure that grep is included in the image.

  Fixes: https://github.com/submariner-io/submariner/issues/1883