### PR TITLE
Automated backport of #1885: Add grep to Globalnet and RouteAgent images

### DIFF
--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -20,7 +20,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/globalnet \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables iptables-nft ipset
+    iproute iptables iptables-nft ipset grep
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -20,7 +20,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/route-agent \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables iptables-nft ipset openvswitch procps-ng
+    iproute iptables iptables-nft ipset openvswitch procps-ng grep
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE


### PR DESCRIPTION
Backport of #1885 on release-0.13.

#1885: Add grep to Globalnet and RouteAgent images

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.