### PR TITLE
Backport to 0.12: Bump our images to Fedora 36

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:36
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,10 +1,10 @@
-FROM fedora:34
+FROM fedora:36
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft ipset grep && \
+           iproute iptables-legacy iptables-nft ipset grep && \
     dnf -y clean all
 
 COPY package/submariner-globalnet.sh bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,4 +1,4 @@
-FROM fedora:34 
+FROM fedora:36
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,10 +1,10 @@
-FROM fedora:34
+FROM fedora:36
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft ipset openvswitch procps-ng grep && \
+           iproute iptables-legacy iptables-nft ipset openvswitch procps-ng grep && \
     dnf -y clean all
 
 COPY package/submariner-route-agent.sh bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/


### PR DESCRIPTION
34 is now EOL, upgrading to 36 brings continued security support and a
reduction in base image size. As a result, our images are the same
size or smaller:

* network-plugin-syncer: 176MiB, unchanged
* globalnet: 45.5MiB, down from 56.5MiB
* route-agent: 173MiB, down slightly from 176MiB
* gateway: 154MiB, down from 164MiB

The legacy iptables package is now iptables-legacy, install that
instead of iptables.

Depends on #1895
Fixes: #1886
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 69b8ca1c2b4e4491fa1610c91ed6a87e8cd47c80)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
