### PR TITLE
Automated backport of #1885: Add grep to Globalnet and RouteAgent images

### DIFF
--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -4,7 +4,7 @@ ARG TARGETPLATFORM
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft ipset && \
+           iproute iptables iptables-nft ipset grep && \
     dnf -y clean all
 
 COPY package/submariner-globalnet.sh bin/${TARGETPLATFORM}/submariner-globalnet /usr/local/bin/

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -4,7 +4,7 @@ ARG TARGETPLATFORM
 WORKDIR /var/submariner
 
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
-           iproute iptables iptables-nft ipset openvswitch procps-ng && \
+           iproute iptables iptables-nft ipset openvswitch procps-ng grep && \
     dnf -y clean all
 
 COPY package/submariner-route-agent.sh bin/${TARGETPLATFORM}/submariner-route-agent /usr/local/bin/


### PR DESCRIPTION
Backport of #1885 on release-0.12.

#1885: Add grep to Globalnet and RouteAgent images

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.