### PR TITLE
[Backport] Log missing cniInterfaceIP on node

### DIFF
--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -124,6 +124,7 @@ func (n *nodeController) allocateIP(node *corev1.Node, op syncer.Operation) (run
 		// cniIfaceIP of the respective node. Route-agent running on the node annotates the
 		// respective node with the cniIfaceIP. In this API, we check for the presence of this
 		// annotation and process the node event only when the annotation exists.
+		klog.Warningf("%q annotation is missing on the node. Health-check functionality will not work.", routeAgent.CNIInterfaceIP)
 		return nil, false
 	}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -107,8 +107,10 @@ func (kp *SyncHandler) Init() error {
 			return errors.Wrap(err, "error enabling loose mode")
 		}
 	} else {
-		// This is not a fatal error. Hostnetworking to remote cluster support will be broken
-		// but other use-cases can continue to work.
+		// This is not a fatal error. Connectivity and other datapath use-cases will continue
+		// to work, but the following use-cases may not work.
+		// 1. Hostnetworking to remote cluster support will be broken
+		// 2. Health-check verification between the Gateway nodes will be disabled
 		klog.Errorf("Error discovering the CNI interface %v", err)
 	}
 


### PR DESCRIPTION
In some deployments, it was noticed that health-checker
was not triggered and this was because of a missing annotation
on the GW node. RouteAgent is responsible for adding the annotation
and Globalnet Pod after noticing the annotation will allocate a
globalIP and program ingress rules to support health-checker.
This PR includes some additional log message when the annotation
is missing on the node.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 915935fd6d5613e35518c4249f342b42c606a2b6)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
