### PR TITLE
Restart health check pinger in case it failed

### DIFF
--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -29,7 +29,10 @@ import (
 	"k8s.io/klog"
 )
 
-const Privileged = true
+const (
+	Privileged         = true
+	doPingRetryTimeout = 5
+)
 
 var (
 	defaultMaxPacketLossCount uint = 5
@@ -111,8 +114,8 @@ func (p *pingerInfo) Start() {
 			default:
 				err := p.doPing()
 				if err != nil {
-					klog.Errorf("Unable to start pinger for IP %q: %v", p.ip, err)
-					return
+					klog.Errorf("Unable to start pinger for IP %q: %v, retry in %d seconds", p.ip, err, doPingRetryTimeout)
+					time.Sleep(doPingRetryTimeout * time.Second)
 				}
 			}
 		}


### PR DESCRIPTION
When a health check pinger starts running before the
relevant routes configured on GW node, it fails with
[1] error and health check functionality does not work for run remote EP.

This PR restarts the pinger after timeout in case it fails to run.

[1]
E0629 13:34:50.788674       1 pinger.go:114] Unable to start pinger
for IP "242.0.255.254": error running the pinger: write ip4
0.0.0.0->242.0.255.254: sendto: object is remote

Fixes: https://github.com/submariner-io/submariner/issues/1857

Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
