### PR TITLE
Automated backport of #1897: Uninstall support  for ovn

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/uninstall.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/uninstall.go
@@ -1,0 +1,162 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn
+
+import (
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/libovsdbops"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"k8s.io/klog/v2"
+)
+
+func (ovn *SyncHandler) Stop(uninstall bool) error {
+	if !uninstall {
+		return nil
+	}
+
+	klog.Infof("Uninstalling Submariner changes from the node")
+
+	// Delete the submariner logical router, ports and flows
+	staleLRSRPred := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		return item.OutputPort != nil && *item.OutputPort == submarinerUpstreamRPort
+	}
+
+	err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(ovn.nbdb, submarinerLogicalRouter, staleLRSRPred)
+	if err != nil {
+		klog.Errorf("failed to delete ovn static routes for port: %s due to : %v", submarinerUpstreamRPort, err)
+	}
+
+	subLogicalRouter := nbdb.LogicalRouter{
+		Name: submarinerLogicalRouter,
+	}
+
+	subRouterToJoinLrp := nbdb.LogicalRouterPort{
+		Name:     submarinerDownstreamRPort,
+		MAC:      submarinerDownstreamMAC,
+		Networks: []string{submarinerDownstreamNET},
+	}
+
+	err = libovsdbops.DeleteLogicalRouterPorts(ovn.nbdb, &subLogicalRouter, &subRouterToJoinLrp)
+	if err != nil {
+		klog.Errorf("failed to delete router ports from submariner logical router due to %v", err)
+	}
+
+	err = libovsdbops.DeleteLogicalRouter(ovn.nbdb, &subLogicalRouter)
+	if err != nil {
+		klog.Errorf("failed to delete submariner logical router %v", err)
+	}
+
+	// Delete the ports and flows
+	lrpStalePredicate := func(item *nbdb.LogicalRouterPolicy) bool {
+		return item.Priority == ovnRoutePoliciesPrio
+	}
+
+	err = libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(ovn.nbdb, ovnClusterRouter, lrpStalePredicate)
+	if err != nil {
+		klog.Errorf("failed to delete submariner logical route policies due to: %v", err)
+	}
+
+	ovnLogicalRouter := nbdb.LogicalRouter{
+		Name: ovnClusterRouter,
+	}
+
+	ovnRouterToJoinLrp := nbdb.LogicalRouterPort{
+		Name:     ovnClusterSubmarinerRPort,
+		MAC:      ovnClusterSubmarinerMAC,
+		Networks: []string{ovnClusterSubmarinerNET},
+	}
+
+	err = libovsdbops.DeleteLogicalRouterPorts(ovn.nbdb, &ovnLogicalRouter, &ovnRouterToJoinLrp)
+	if err != nil {
+		klog.Errorf("failed to delete ports from ovn logical router due to %v", err)
+	}
+
+	// Delete submariner upstream switch and ports
+	subGatewaySwitch := nbdb.LogicalSwitch{
+		Name: submarinerUpstreamSwitch,
+	}
+
+	subGatewayToLocalNetLsp := nbdb.LogicalSwitchPort{
+		Name:      submarinerUpstreamLocalnetPort,
+		Type:      "localnet",
+		Addresses: []string{"unknown"},
+		Options: map[string]string{
+			"network_name": SubmarinerUpstreamLocalnet,
+		},
+	}
+
+	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subGatewaySwitch, &subGatewayToLocalNetLsp)
+	if err != nil {
+		klog.Errorf("failed to to delete logical gateway ports from submariner upstream switch: %v", err)
+	}
+
+	err = libovsdbops.DeleteLogicalSwitch(ovn.nbdb, submarinerUpstreamSwitch)
+	if err != nil {
+		klog.Errorf("failed to to delete submariner upstream switch %v", err)
+	}
+
+	subGatewayToSubRouterLsp := nbdb.LogicalSwitchPort{
+		Name: submarinerUpstreamSwPort,
+		Type: "router",
+		Options: map[string]string{
+			"router-port": submarinerUpstreamRPort,
+		},
+		Addresses: []string{"router"},
+	}
+
+	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subGatewaySwitch, &subGatewayToSubRouterLsp)
+	if err != nil {
+		klog.Errorf("failed to delete submarinerUpstreamRPort from submariner upstream switch due to : %v", err)
+	}
+
+	// Delete submariner downstream switch and ports
+	subJoinSwitch := nbdb.LogicalSwitch{
+		Name: submarinerDownstreamSwitch,
+	}
+
+	subJoinToSubRouterLsp := nbdb.LogicalSwitchPort{
+		Name: submarinerDownstreamSwPort,
+		Type: "router",
+		Options: map[string]string{
+			"router-port": submarinerDownstreamRPort,
+		},
+		Addresses: []string{"router"},
+	}
+
+	subJointoOvnRouterLsp := nbdb.LogicalSwitchPort{
+		Name: ovnClusterSubmarinerSwPort,
+		Type: "router",
+		Options: map[string]string{
+			"router-port": ovnClusterSubmarinerRPort,
+		},
+		Addresses: []string{"router"},
+	}
+
+	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subJoinSwitch,
+		[]*nbdb.LogicalSwitchPort{&subJoinToSubRouterLsp, &subJointoOvnRouterLsp}...)
+	if err != nil {
+		klog.Errorf("failed to delete ovnClusterSubmarinerSwPort from submariner downstream switch due to : %v", err)
+	}
+
+	err = libovsdbops.DeleteLogicalSwitch(ovn.nbdb, submarinerDownstreamSwitch)
+	if err != nil {
+		klog.Errorf("failed to delete submariner downstream switch due to : %v", err)
+	}
+
+	return nil
+}

--- a/pkg/networkplugin-syncer/handlers/ovn/uninstall.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/uninstall.go
@@ -29,7 +29,7 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 		return nil
 	}
 
-	klog.Infof("Uninstalling Submariner changes from the node")
+	klog.Infof("Uninstalling OVN components")
 
 	// Delete the submariner logical router, ports and flows
 	staleLRSRPred := func(item *nbdb.LogicalRouterStaticRoute) bool {
@@ -38,7 +38,7 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 
 	err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(ovn.nbdb, submarinerLogicalRouter, staleLRSRPred)
 	if err != nil {
-		klog.Errorf("failed to delete ovn static routes for port: %s due to : %v", submarinerUpstreamRPort, err)
+		klog.Errorf("Failed to delete ovn static routes for port: %s due to : %v", submarinerUpstreamRPort, err)
 	}
 
 	subLogicalRouter := nbdb.LogicalRouter{
@@ -53,22 +53,22 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 
 	err = libovsdbops.DeleteLogicalRouterPorts(ovn.nbdb, &subLogicalRouter, &subRouterToJoinLrp)
 	if err != nil {
-		klog.Errorf("failed to delete router ports from submariner logical router due to %v", err)
+		klog.Errorf("Failed to delete router ports from submariner logical router due to %v", err)
 	}
 
 	err = libovsdbops.DeleteLogicalRouter(ovn.nbdb, &subLogicalRouter)
 	if err != nil {
-		klog.Errorf("failed to delete submariner logical router %v", err)
+		klog.Errorf("Failed to delete submariner logical router %v", err)
 	}
 
-	// Delete the ports and flows
+	// Delete the logical router ports and policies
 	lrpStalePredicate := func(item *nbdb.LogicalRouterPolicy) bool {
 		return item.Priority == ovnRoutePoliciesPrio
 	}
 
 	err = libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(ovn.nbdb, ovnClusterRouter, lrpStalePredicate)
 	if err != nil {
-		klog.Errorf("failed to delete submariner logical route policies due to: %v", err)
+		klog.Errorf("Failed to delete submariner logical route policies due to: %v", err)
 	}
 
 	ovnLogicalRouter := nbdb.LogicalRouter{
@@ -83,7 +83,7 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 
 	err = libovsdbops.DeleteLogicalRouterPorts(ovn.nbdb, &ovnLogicalRouter, &ovnRouterToJoinLrp)
 	if err != nil {
-		klog.Errorf("failed to delete ports from ovn logical router due to %v", err)
+		klog.Errorf("Failed to delete ports from ovn logical router due to %v", err)
 	}
 
 	// Delete submariner upstream switch and ports
@@ -102,12 +102,12 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 
 	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subGatewaySwitch, &subGatewayToLocalNetLsp)
 	if err != nil {
-		klog.Errorf("failed to to delete logical gateway ports from submariner upstream switch: %v", err)
+		klog.Errorf("Failed to to delete logical gateway ports from submariner upstream switch: %v", err)
 	}
 
 	err = libovsdbops.DeleteLogicalSwitch(ovn.nbdb, submarinerUpstreamSwitch)
 	if err != nil {
-		klog.Errorf("failed to to delete submariner upstream switch %v", err)
+		klog.Errorf("Failed to to delete submariner upstream switch %v", err)
 	}
 
 	subGatewayToSubRouterLsp := nbdb.LogicalSwitchPort{
@@ -121,7 +121,7 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 
 	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subGatewaySwitch, &subGatewayToSubRouterLsp)
 	if err != nil {
-		klog.Errorf("failed to delete submarinerUpstreamRPort from submariner upstream switch due to : %v", err)
+		klog.Errorf("Failed to delete submarinerUpstreamRPort from submariner upstream switch due to : %v", err)
 	}
 
 	// Delete submariner downstream switch and ports
@@ -150,12 +150,12 @@ func (ovn *SyncHandler) Stop(uninstall bool) error {
 	_, err = libovsdbops.DeleteLogicalSwitchPortsOps(ovn.nbdb, nil, &subJoinSwitch,
 		[]*nbdb.LogicalSwitchPort{&subJoinToSubRouterLsp, &subJointoOvnRouterLsp}...)
 	if err != nil {
-		klog.Errorf("failed to delete ovnClusterSubmarinerSwPort from submariner downstream switch due to : %v", err)
+		klog.Errorf("Failed to delete ovnClusterSubmarinerSwPort from submariner downstream switch due to : %v", err)
 	}
 
 	err = libovsdbops.DeleteLogicalSwitch(ovn.nbdb, submarinerDownstreamSwitch)
 	if err != nil {
-		klog.Errorf("failed to delete submariner downstream switch due to : %v", err)
+		klog.Errorf("Failed to delete submariner downstream switch due to : %v", err)
 	}
 
 	return nil

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -1,0 +1,58 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn
+
+import (
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn/vsctl"
+	"k8s.io/klog"
+)
+
+func (ovn *Handler) Stop(uninstall bool) error {
+	if !uninstall {
+		return nil
+	}
+
+	klog.Infof("Uninstalling Submariner changes from the node")
+
+	err := vsctl.DelInternalPort(ovnK8sSubmarinerBridge, ovnK8sSubmarinerInterface)
+	if err != nil {
+		klog.Errorf("error deleting Submariner port %q due to %v", ovnK8sSubmarinerInterface, err)
+	}
+
+	err = vsctl.DelBridge(ovnK8sSubmarinerBridge)
+	if err != nil {
+		klog.Errorf("error deleting Submariner bridge %q due to %v", ovnK8sSubmarinerBridge, err)
+	}
+
+	if ovn.isGateway {
+		err = ovn.cleanupGatewayDataplane()
+		if err != nil {
+			klog.Errorf("error cleaning the gateway routes to %v", err)
+		}
+	}
+
+	err = ovn.netlink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
+	if err != nil {
+		klog.Errorf("flushing routing table %d returned error: %v",
+			constants.RouteAgentHostNetworkTableID, err)
+	}
+
+	return nil
+}

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -29,28 +29,28 @@ func (ovn *Handler) Stop(uninstall bool) error {
 		return nil
 	}
 
-	klog.Infof("Uninstalling Submariner changes from the node")
+	klog.Infof("Uninstalling OVN components from the node")
 
 	err := vsctl.DelInternalPort(ovnK8sSubmarinerBridge, ovnK8sSubmarinerInterface)
 	if err != nil {
-		klog.Errorf("error deleting Submariner port %q due to %v", ovnK8sSubmarinerInterface, err)
+		klog.Errorf("Error deleting Submariner port %q due to %v", ovnK8sSubmarinerInterface, err)
 	}
 
 	err = vsctl.DelBridge(ovnK8sSubmarinerBridge)
 	if err != nil {
-		klog.Errorf("error deleting Submariner bridge %q due to %v", ovnK8sSubmarinerBridge, err)
+		klog.Errorf("Error deleting Submariner bridge %q due to %v", ovnK8sSubmarinerBridge, err)
 	}
 
 	if ovn.isGateway {
 		err = ovn.cleanupGatewayDataplane()
 		if err != nil {
-			klog.Errorf("error cleaning the gateway routes to %v", err)
+			klog.Errorf("Error cleaning the gateway routes to %v", err)
 		}
 	}
 
 	err = ovn.netlink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
 	if err != nil {
-		klog.Errorf("flushing routing table %d returned error: %v",
+		klog.Errorf("Flushing routing table %d returned error: %v",
 			constants.RouteAgentHostNetworkTableID, err)
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
+++ b/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
@@ -62,10 +62,22 @@ func AddBridge(bridgeName string) error {
 	return err
 }
 
+func DelBridge(bridgeName string) error {
+	_, err := vsctlCmd("del-br", bridgeName)
+
+	return err
+}
+
 func AddInternalPort(bridgeName, portName, macAddress string, mtu int) error {
 	_, err := vsctlCmd("--may-exist", "add-port", bridgeName, portName, "--",
 		"set", "interface", portName, "type=internal", "mtu_request="+fmt.Sprintf("%d", mtu),
 		fmt.Sprintf("mac=%s", strings.ReplaceAll(macAddress, ":", "\\:")))
+
+	return err
+}
+
+func DelInternalPort(bridgeName, portName string) error {
+	_, err := vsctlCmd("--may-exist", "del-port", bridgeName, portName)
 
 	return err
 }

--- a/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
+++ b/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
@@ -77,7 +77,7 @@ func AddInternalPort(bridgeName, portName, macAddress string, mtu int) error {
 }
 
 func DelInternalPort(bridgeName, portName string) error {
-	_, err := vsctlCmd("--may-exist", "del-port", bridgeName, portName)
+	_, err := vsctlCmd("--if-exists", "del-port", bridgeName, portName)
 
 	return err
 }


### PR DESCRIPTION
Backport of #1897 on release-0.13.

#1897: Uninstall support  for ovn

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.