### PR TITLE
Limit the number of open files in dnf_install

### DIFF
--- a/package/dnf_install
+++ b/package/dnf_install
@@ -10,6 +10,9 @@
 
 INSTALL_ROOT=/output/base
 
+# Limit the number of files so that dnf doesn't spend ages processing fds
+ulimit -n 1048576
+
 while getopts a:kr:v: o
 do
     case "$o" in


### PR DESCRIPTION
On recent Fedora systems,

    $ cat /proc/sys/fs/nr_open
    1073741816

which (in some circumstances) causes dnf to spend ages poking all
possible file descriptors. Avoid this by limiting the number of open
files for dnf.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
