### PR TITLE
Automated backport of #1911: Limit the number of open files in dnf_install

### DIFF
--- a/package/dnf_install
+++ b/package/dnf_install
@@ -10,6 +10,9 @@
 
 INSTALL_ROOT=/output/base
 
+# Limit the number of files so that dnf doesn't spend ages processing fds
+ulimit -n 1048576
+
 while getopts a:kr:v: o
 do
     case "$o" in


### PR DESCRIPTION
Backport of #1911 on release-0.13.

#1911: Limit the number of open files in dnf_install

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.