### PR TITLE
Constantly update passive GW object timestamp

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -124,7 +124,7 @@ func (gs *GatewaySyncer) syncGatewayStatusSafe() {
 	} else if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error getting existing Gateway: %w", err))
 		return
-	} else if !reflect.DeepEqual(gatewayObj.Status, existingGw.Status) {
+	} else if (gatewayObj.Status.HAStatus == v1.HAStatusPassive) || !reflect.DeepEqual(gatewayObj.Status, existingGw.Status) {
 		klog.V(log.TRACE).Infof("Gateway already exists - updating %+v", gatewayObj)
 
 		existingGw.Status = gatewayObj.Status


### PR DESCRIPTION
This PR ensures that timestamp annotation of a passive
GW object is constantly updated.

Fixes: https://github.com/submariner-io/submariner/issues/1912

Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
