### PR TITLE
Automated backport of #1916: Constantly update passive GW timestamp

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -124,7 +124,7 @@ func (gs *GatewaySyncer) syncGatewayStatusSafe() {
 	} else if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error getting existing Gateway: %w", err))
 		return
-	} else if !reflect.DeepEqual(gatewayObj.Status, existingGw.Status) {
+	} else if (gatewayObj.Status.HAStatus == v1.HAStatusPassive) || !reflect.DeepEqual(gatewayObj.Status, existingGw.Status) {
 		klog.V(log.TRACE).Infof("Gateway already exists - updating %+v", gatewayObj)
 
 		existingGw.Status = gatewayObj.Status


### PR DESCRIPTION
Backport of #1916 on release-0.13.

#1916: Constantly update passive GW timestamp

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.