### PR TITLE
[Backport] Support override MTU value used in TCP MSS clamping (#1872)

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -95,6 +95,7 @@ const (
 	PreferredServerConfig   = "preferred-server"
 	PublicIP                = "public-ip"
 	UsingLoadBalancer       = "using-loadbalancer"
+	TCPMssValue             = "submariner.io/tcp-clamp-mss"
 )
 
 const (

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -54,9 +54,10 @@ type mtuHandler struct {
 	remoteIPSet      ipset.Named
 	localIPSet       ipset.Named
 	forceMss         forceMssSts
+	tcpMssValue      int
 }
 
-func NewMTUHandler(localClusterCidr []string, isGlobalnet bool) event.Handler {
+func NewMTUHandler(localClusterCidr []string, isGlobalnet bool, tcpMssValue int) event.Handler {
 	forceMss := notNeeded
 	if isGlobalnet {
 		forceMss = needed
@@ -65,6 +66,7 @@ func NewMTUHandler(localClusterCidr []string, isGlobalnet bool) event.Handler {
 	return &mtuHandler{
 		localClusterCidr: localClusterCidr,
 		forceMss:         forceMss,
+		tcpMssValue:      tcpMssValue,
 	}
 }
 
@@ -267,28 +269,55 @@ func (h *mtuHandler) Stop(uninstall bool) error {
 }
 
 func (h *mtuHandler) forceMssClamping(endpoint *submV1.Endpoint) error {
-	defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
-	if err != nil {
-		return errors.Wrapf(err, "Unable to find the default interface on host")
+	tcpMssSrc := "user"
+	tcpMssValue := h.tcpMssValue
+
+	if tcpMssValue == 0 {
+		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
+		if err != nil {
+			return errors.Wrapf(err, "Unable to find the default interface on host")
+		}
+
+		overHeadSize := maxIpsecOverhead
+		if endpoint.Spec.Backend == vxlan.CableDriverName {
+			overHeadSize = vxlan.VxlanOverhead
+		}
+
+		tcpMssValue = defaultHostIface.MTU - overHeadSize
+		tcpMssSrc = "default"
 	}
 
-	overHeadSize := maxIpsecOverhead
-	if endpoint.Spec.Backend == vxlan.CableDriverName {
-		overHeadSize = vxlan.VxlanOverhead
-	}
-
-	klog.Infof("forceMssClamping to: IF_MTU(%d)-Overhead(%d)=%d",
-		defaultHostIface.MTU, overHeadSize, (defaultHostIface.MTU - overHeadSize))
-
+	klog.Infof("forceMssClamping to: %d (%s) ", tcpMssValue, tcpMssSrc)
 	ruleSpecSource := []string{
 		"-m", "set", "--match-set", constants.LocalCIDRIPSet, "src", "-m", "set", "--match-set",
 		constants.RemoteCIDRIPSet, "dst", "-p", "tcp", "-m", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS",
-		"--set-mss", strconv.Itoa(defaultHostIface.MTU - overHeadSize),
+		"--set-mss", strconv.Itoa(tcpMssValue),
 	}
 	ruleSpecDest := []string{
 		"-m", "set", "--match-set", constants.RemoteCIDRIPSet, "src", "-m", "set", "--match-set",
 		constants.LocalCIDRIPSet, "dst", "-p", "tcp", "-m", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS",
-		"--set-mss", strconv.Itoa(defaultHostIface.MTU - overHeadSize),
+		"--set-mss", strconv.Itoa(tcpMssValue),
+	}
+
+	rules, err := h.ipt.List(constants.MangleTable, constants.SmPostRoutingChain)
+	if err != nil {
+		return errors.Wrapf(err, "error listing the rules in %s chain", constants.SmPostRoutingChain)
+	}
+
+	isPresent := false
+
+	for _, rule := range rules {
+		if strings.Contains(rule, strings.Join(ruleSpecSource, " ")) || strings.Contains(rule, strings.Join(ruleSpecDest, " ")) {
+			isPresent = true
+			break
+		}
+	}
+
+	if len(rules) > 0 && !isPresent {
+		if err := h.ipt.ClearChain(constants.MangleTable, constants.SmPostRoutingChain); err != nil {
+			klog.Warningf("Error flushing iptables chain %q of %q table: %v", constants.SmPostRoutingChain,
+				constants.MangleTable, err)
+		}
 	}
 
 	if err := h.ipt.AppendUnique(constants.MangleTable, constants.SmPostRoutingChain, ruleSpecSource...); err != nil {

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("MTUHandler", func() {
 		ipset.NewFunc = func() ipset.Interface {
 			return ipSet
 		}
-		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"}, false)
+		handler = mtu.NewMTUHandler([]string{"10.1.0.0/24"}, false, 0)
 	})
 
 	AfterEach(func() {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -22,22 +22,24 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
 	"github.com/submariner-io/submariner/pkg/event/logger"
+	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cabledriver"
-	"github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
+	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
 	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -68,6 +70,11 @@ func main() {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
+	k8sClientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("Error building clientset: %s", err.Error())
+	}
+
 	smClientset, err := submarinerClientset.NewForConfig(cfg)
 	if err != nil {
 		klog.Fatalf("Error building submariner clientset: %s", err.Error())
@@ -86,7 +93,7 @@ func main() {
 		ovn.NewHandler(&env, smClientset),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
-		mtu.NewMTUHandler(env.ClusterCidr, (len(env.GlobalCidr) != 0)),
+		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(k8sClientSet)),
 	); err != nil {
 		klog.Fatalf("Error registering the handlers: %s", err.Error())
 	}
@@ -96,10 +103,14 @@ func main() {
 			klog.Warningf("Error stopping handlers: %v", err)
 		}
 
+		if err = annotateNode([]string{}, k8sClientSet); err != nil {
+			klog.Warningf("Error removing %q annotation: %v", constants.CNIInterfaceIP, err)
+		}
+
 		return
 	}
 
-	if err = annotateNode(env.ClusterCidr, cfg); err != nil {
+	if err = annotateNode(env.ClusterCidr, k8sClientSet); err != nil {
 		klog.Errorf("Error while annotating the node: %s", err.Error())
 	}
 
@@ -129,21 +140,38 @@ func init() {
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }
 
-func annotateNode(clusterCidr []string, cfg *restclient.Config) error {
-	k8sClientSet, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		klog.Fatalf("Error building clientset: %s", err.Error())
-	}
-
+func annotateNode(clusterCidr []string, k8sClientSet *kubernetes.Clientset) error {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
 	if !ok {
 		return fmt.Errorf("error reading the NODE_NAME from the environment")
 	}
 
-	err = cni.AnnotateNodeWithCNIInterfaceIP(nodeName, k8sClientSet, clusterCidr)
+	err := cniapi.AnnotateNodeWithCNIInterfaceIP(nodeName, k8sClientSet, clusterCidr)
 	if err != nil {
 		return errors.Wrap(err, "error annotating node with CNI interface IP")
 	}
 
 	return nil
+}
+
+func getTCPMssValue(k8sClientSet *kubernetes.Clientset) int {
+	localNode, err := node.GetLocalNode(k8sClientSet)
+	if err != nil {
+		klog.Errorf("Error getting information on the local node: %s", err.Error())
+		return 0
+	}
+
+	tcpMssStr := localNode.GetAnnotations()[v1.TCPMssValue]
+
+	if tcpMssStr == "" {
+		return 0
+	}
+
+	tcpMssValue, err := strconv.Atoi(tcpMssStr)
+	if err != nil {
+		klog.Errorf("Error parsing %q annotation", v1.TCPMssValue)
+		return 0
+	}
+
+	return tcpMssValue
 }


### PR DESCRIPTION
Currently, when Globalnet is enabled in the cluster,
to address the MTU issues, Submariner clamps the TCP
MSS to a value derived from the default-interface-mtu minus
the tunnel-overhead.

This PR allows users to set MSS clamping value using
node annotation.

To force MSS clamping to a specific value it needs
to annotate the relevant node:

kubectl annotate node <node_name> submariner.io/tcp-clamp-mss=<value>

Fixes: https://github.com/submariner-io/submariner/issues/1858

Signed-off-by: yboaron <yboaron@redhat.com>
(cherry picked from commit 233159f96819725f39316a4be7d4eb8735e1c175)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
