### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/pkg/cable/wireguard/README.md
+++ b/pkg/cable/wireguard/README.md
@@ -53,10 +53,10 @@ Currently assuming Linux Kernel WireGuard (`wgtypes.LinuxKernel`).
 
   you probably did not install WireGuard on the Gateway node.
 
-- The e2e tests can be run with WireGuard by setting `DEPLOY_ARGS` before calling `make e2e`
+- The e2e tests can be run with WireGuard by calling `make e2e` with `using=wireguard`:
 
   ```shell
-  export DEPLOY_ARGS="--deploytool operator --deploytool_submariner_args '--cable-driver=wireguard'"
+  make e2e using=wireguard
   ```
 
 - No new `iptables` rules were added, although source NAT needs to be disabled for cross cluster communication. This is similar to disabling

--- a/scripts/e2e/external/utils
+++ b/scripts/e2e/external/utils
@@ -72,22 +72,24 @@ function setup_external() {
 	subm_gw_node_name="${extcluster}-worker"
 	subm_gw_ip=$(get_ip_on_container_network ${subm_gw_node_name} ${EXTERNAL_NET})
 
-	if [[ $GLOBALNET != "true" ]];then
-		# Add route for cluster CIDRs to go via subm_gw_ip
-		for subnet in ${cluster_CIDRs[@]};do
-			docker exec -i ${EXTERNAL_APP} ip r add ${subnet} via ${subm_gw_ip}
-		done
-
-		# Add route for service CIDR to go via subm_gw_ip
-		for subnet in ${service_CIDRs[@]};do
-			docker exec -i ${EXTERNAL_APP} ip r add ${subnet} via ${subm_gw_ip}
-		done
-	else
-		# Add route for global CIDR to go via subm_gw_ip
+	# Add route for global CIDR to go via subm_gw_ip
+	if [[ $GLOBALNET == "true" ]];then
 		for subnet in ${global_CIDRs[@]};do
 			docker exec -i ${EXTERNAL_APP} ip r add ${subnet} via ${subm_gw_ip}
 		done
+
+		return 0
 	fi
+
+	# Add route for cluster CIDRs to go via subm_gw_ip
+	for subnet in ${cluster_CIDRs[@]};do
+		docker exec -i ${EXTERNAL_APP} ip r add ${subnet} via ${subm_gw_ip}
+	done
+
+	# Add route for service CIDR to go via subm_gw_ip
+	for subnet in ${service_CIDRs[@]};do
+		docker exec -i ${EXTERNAL_APP} ip r add ${subnet} via ${subm_gw_ip}
+	done
 }
 
 function add_external_cidrs() {


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
