### PR TITLE
Set ReadHeaderTimeout to 60s to mitigate Slowloris

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.Subma
 }
 
 func startHTTPServer() *http.Server {
-	srv := &http.Server{Addr: ":8080"}
+	srv := &http.Server{Addr: ":8080", ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -142,7 +142,7 @@ func init() {
 }
 
 func startHTTPServer() *http.Server {
-	srv := &http.Server{Addr: ":8081"}
+	srv := &http.Server{Addr: ":8081", ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
 


### PR DESCRIPTION
Go 1.18 added this new timeout and gosec now fails if it's unset.

Leaving this timeout unset exposes the server to a Slowloris attack,
where an attacker keeps many connections open by periodic updates to
HTTP request headers. This can eventually result in being unable to open
new connections because of too many open files.

The 60s value is copied from nginx:
nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout

Relates-to: submariner-io/shipyard#900
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
