### PR TITLE
Use OVSDBTimeout const while creating the client

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/const.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/const.go
@@ -50,8 +50,8 @@ const (
 	ovnClusterSubmarinerIP     = "169.254.254.2"
 	ovnRoutePoliciesPrio       = 20000
 
-	// default ovsdb timout used by ovn-k.
-	OVSDBTimeout   = 10 * time.Second
+	// default ovsdb timeout used by ovn-k.
+	OVSDBTimeout   = 20 * time.Second
 	ovnCert        = "secret://openshift-ovn-kubernetes/ovn-cert/tls.crt"
 	ovnPrivKey     = "secret://openshift-ovn-kubernetes/ovn-cert/tls.key"
 	ovnCABundle    = "configmap://openshift-ovn-kubernetes/ovn-ca/ca-bundle.crt"


### PR DESCRIPTION
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
