### PR TITLE
Make sure redundancy E2E skips inadequate clusters

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -137,23 +137,20 @@ func defaultEndpointType() tcp.EndpointType {
 }
 
 func testGatewayFailOverScenario(f *subFramework.Framework) {
-	if framework.TestContext.NumNodesInCluster[framework.ClusterA] == 1 {
-		framework.Skipf("Skipping the test as cluster %q has only a single node...",
-			framework.TestContext.ClusterIDs[framework.ClusterA])
-		return
-	}
-
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	nonGatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, false)
+	if len(nonGatewayNodes) == 0 {
+		framework.Skipf("Skipping the test as cluster %q doesn't have any suitable non-gateway nodes...", clusterAName)
+		return
+	}
 
 	gatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, true)
 	Expect(gatewayNodes).To(HaveLen(1), fmt.Sprintf("Expected only one gateway node on %q", clusterAName))
 
 	initialGatewayNode := gatewayNodes[0]
 	By(fmt.Sprintf("Found gateway node %q on %q", initialGatewayNode.Name, clusterAName))
-
-	nonGatewayNodes := f.FindNodesByGatewayLabel(framework.ClusterA, false)
-	Expect(len(nonGatewayNodes) > 0).To(BeTrue(), fmt.Sprintf("Expected at least one non-gateway node on %q", clusterAName))
 
 	initialNonGatewayNode := nonGatewayNodes[0]
 	By(fmt.Sprintf("Found non-gateway node %q on %q", initialNonGatewayNode.Name, clusterAName))

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -48,6 +48,11 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
 	nodes := f.FindNodesByGatewayLabel(framework.ClusterA, onGateway)
+	if len(nodes) == 0 && !onGateway {
+		framework.Skipf("Skipping the test as cluster %q doesn't have any suitable non-gateway nodes...", clusterAName)
+		return
+	}
+
 	By(fmt.Sprintf("Found node %q on %q", nodes[0].Name, clusterAName))
 	node := nodes[0]
 


### PR DESCRIPTION
In case an inadequate cluster is given in the first context, skip the
test instead of awkwardly failing.
This will make tests more usable in various scenarios such as 1-worker
clusters.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
