### PR TITLE
Use env vars for metrics ports

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,11 +94,12 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler().Done()
 
-	httpServer := startHTTPServer()
-
 	var submSpec types.SubmarinerSpecification
 
 	fatalOnErr(envconfig.Process("submariner", &submSpec), "Error processing env vars")
+
+	klog.Info("Parsed env variables", submSpec)
+	httpServer := startHTTPServer(&submSpec)
 
 	cfg, err := clientcmd.BuildConfigFromFlags(localMasterURL, localKubeconfig)
 	fatalOnErr(err, "Error building kubeconfig")
@@ -317,8 +318,8 @@ func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.Subma
 	}
 }
 
-func startHTTPServer() *http.Server {
-	srv := &http.Server{Addr: ":8080", ReadHeaderTimeout: 60 * time.Second}
+func startHTTPServer(spec *types.SubmarinerSpecification) *http.Server {
+	srv := &http.Server{Addr: ":" + spec.GwMetricsPort, ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -75,10 +75,11 @@ type Interface interface {
 }
 
 type Specification struct {
-	ClusterID  string
-	Namespace  string
-	GlobalCIDR []string
-	Uninstall  bool
+	ClusterID     string
+	Namespace     string
+	GlobalCIDR    []string
+	GnMetricsPort string `default:"8081"`
+	Uninstall     bool
 }
 
 type baseController struct {

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -79,7 +79,7 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler().Done()
 
-	httpServer := startHTTPServer()
+	httpServer := startHTTPServer(spec)
 
 	err = mcsv1a1.AddToScheme(scheme.Scheme)
 	if err != nil {
@@ -141,8 +141,8 @@ func init() {
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 }
 
-func startHTTPServer() *http.Server {
-	srv := &http.Server{Addr: ":8081", ReadHeaderTimeout: 60 * time.Second}
+func startHTTPServer(spec controllers.Specification) *http.Server {
+	srv := &http.Server{Addr: ":" + spec.GnMetricsPort, ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -47,4 +47,5 @@ type SubmarinerSpecification struct {
 	Uninstall                     bool
 	HealthCheckInterval           uint
 	HealthCheckMaxPacketLossCount uint
+	GwMetricsPort                 string `default:"8080"`
 }


### PR DESCRIPTION
Instead of hardcoded value of 8080/8081, use following
env variables for gateway and globlnet metrics ports:
 * SUBMARINER_GWMETRICSPORT
 * SUBMARINER_GNMETRICSPORT

Refer github.com/submariner-io/enhancements/pull/128

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
