### PR TITLE
Run Anchore scan on merges to devel/release-*

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,29 @@
+---
+name: Reporting
+
+on:
+  push:
+    branches:
+      - devel
+      - release-*
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability Scanning
+    if: github.repository_owner == 'submariner-io'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Run Anchore vulnerability scanner
+        uses: anchore/scan-action@516844f15d82b6cdd0765b87aab79ed3ac006225
+        id: scan
+        with:
+          path: "."
+          fail-build: false
+      - name: Show Anchore scan SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@0c670bbf0414f39666df6ce8e718ec5662c21e03
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Run Anchore Go vulnerability scanning on merges to devel and all release
branches. This will generate reports for those branches for users. The
linting workflow Anchore scan should gate PRs, but the results aren't
consistently representative of what's actually in Submariner and aren't
shown by GH's UIs.

This will cause the GitHub Code Scanning tab to say:

> No code scanning alerts found.
  We'll keep watching out for new ones.

With only on-PR jobs, it instead says something like:

> This branch hasn't been scanned yet.
  Are you looking for the alerts in the pull request #1711?

With neither, it just says:

> Automatically detect vulnerabilities in your code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
