### PR TITLE
Wrapped error is always nil

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/ovn_submariner_infrastructure.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn_submariner_infrastructure.go
@@ -47,7 +47,7 @@ func (ovn *SyncHandler) ensureSubmarinerInfra() error {
 	}
 
 	if len(lbGroups) > 1 {
-		return errors.Wrap(err, "Found more than one ovn load balancer group")
+		return errors.New("found more than one ovn load balancer group")
 	}
 
 	ovnLogicalRouter := nbdb.LogicalRouter{


### PR DESCRIPTION
Use `errors.New`. This was detected by a code scanning tool.
