### PR TITLE
Add CodeQL variant analysis scanning

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -127,6 +127,24 @@ jobs:
       - name: Run packagedoc-lint
         run: make packagedoc-lint
 
+  variant-analysis:
+    name: Variant Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
+        with:
+          languages: go
+      - name: Build code, creating CodeQL database
+        run: make build
+      - name: Run CodeQL variant analysis
+        uses: github/codeql-action/analyze@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
+      - name: Show CodeQL scan SARIF report
+        if: always()
+        run: cat ../results/go.sarif
+
   vulnerability-scan:
     name: Vulnerability Scanning
     runs-on: ubuntu-latest

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -10,6 +10,26 @@ on:
 permissions: {}
 
 jobs:
+  variant-analysis:
+    name: Variant Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
+        with:
+          languages: go
+      - name: Build code, creating CodeQL database
+        run: make build
+      - name: Run CodeQL variant analysis
+        uses: github/codeql-action/analyze@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
+      - name: Show CodeQL scan SARIF report
+        if: always()
+        run: cat ../results/go.sarif
+
   vulnerability-scan:
     name: Vulnerability Scanning
     if: github.repository_owner == 'submariner-io'


### PR DESCRIPTION
This is a different type of static analysis than others we run.

It identified new issues (already fixed) that our other tools missed.

The company that built it was bought by GitHub and the tool is being
integrated into GitHub's security workflow.

Add one unprivileged version of the job to gate PRs and one privileged
version on-merge to report results.

Relates-to: submariner-io/submariner#1970
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
