### PR TITLE
Refactor iptables interface

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -415,27 +415,27 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForPods}
-	if err := iptables.InsertUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, 2, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.InsertUnique("nat", constants.SmGlobalnetEgressChain, 2, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForHeadlessSvcPods}
-	if err := iptables.InsertUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, 3, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.InsertUnique("nat", constants.SmGlobalnetEgressChain, 3, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForHeadlessSvcEPs}
-	if err := iptables.InsertUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, 4, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.InsertUnique("nat", constants.SmGlobalnetEgressChain, 4, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForNamespace}
-	if err := iptables.InsertUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, 5, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.InsertUnique("nat", constants.SmGlobalnetEgressChain, 5, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChainForCluster}
-	if err := iptables.InsertUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, 6, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.InsertUnique("nat", constants.SmGlobalnetEgressChain, 6, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -354,7 +354,7 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 	}
 
 	forwardToSubGlobalNetChain := []string{"-j", constants.SmGlobalnetIngressChain}
-	if err := iptables.PrependUnique(g.ipt, "nat", "PREROUTING", forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.PrependUnique("nat", "PREROUTING", forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error appending iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
@@ -371,7 +371,7 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetEgressChain}
-	if err := iptables.PrependUnique(g.ipt, "nat", routeAgent.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.PrependUnique("nat", routeAgent.SmPostRoutingChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 
@@ -380,7 +380,7 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 	}
 
 	forwardToSubGlobalNetChain = []string{"-j", constants.SmGlobalnetMarkChain}
-	if err := iptables.PrependUnique(g.ipt, "nat", constants.SmGlobalnetEgressChain, forwardToSubGlobalNetChain); err != nil {
+	if err := g.ipt.PrependUnique("nat", constants.SmGlobalnetEgressChain, forwardToSubGlobalNetChain); err != nil {
 		klog.Errorf("error inserting iptables rule %q: %v\n", strings.Join(forwardToSubGlobalNetChain, " "), err)
 	}
 

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -337,7 +337,7 @@ func (g *gatewayMonitor) stopControllers() {
 func (g *gatewayMonitor) createGlobalNetMarkingChain() error {
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetMarkChain)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetMarkChain); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetMarkChain); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetMarkChain)
 	}
 
@@ -349,7 +349,7 @@ func (g *gatewayMonitor) createGlobalNetMarkingChain() error {
 func (g *gatewayMonitor) createGlobalnetChains() error {
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetIngressChain)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetIngressChain); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetIngressChain); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetIngressChain)
 	}
 
@@ -360,13 +360,13 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChain)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChain); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChain); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChain)
 	}
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", routeAgent.SmPostRoutingChain)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", routeAgent.SmPostRoutingChain); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", routeAgent.SmPostRoutingChain); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", routeAgent.SmPostRoutingChain)
 	}
 
@@ -386,31 +386,31 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForPods)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChainForPods); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChainForPods); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChainForPods)
 	}
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForHeadlessSvcPods)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChainForHeadlessSvcPods); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChainForHeadlessSvcPods)
 	}
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForHeadlessSvcEPs)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChainForHeadlessSvcEPs); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChainForHeadlessSvcEPs); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChainForHeadlessSvcEPs)
 	}
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForNamespace)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChainForNamespace); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChainForNamespace); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChainForNamespace)
 	}
 
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmGlobalnetEgressChainForCluster)
 
-	if err := iptables.CreateChainIfNotExists(g.ipt, "nat", constants.SmGlobalnetEgressChainForCluster); err != nil {
+	if err := g.ipt.CreateChainIfNotExists("nat", constants.SmGlobalnetEgressChainForCluster); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmGlobalnetEgressChainForCluster)
 	}
 

--- a/pkg/iptables/adapter.go
+++ b/pkg/iptables/adapter.go
@@ -18,7 +18,13 @@ limitations under the License.
 
 package iptables
 
-import "github.com/pkg/errors"
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	level "github.com/submariner-io/admiral/pkg/log"
+	"k8s.io/klog/v2"
+)
 
 type Adapter struct {
 	Basic
@@ -35,4 +41,45 @@ func (a *Adapter) CreateChainIfNotExists(table, chain string) error {
 	}
 
 	return errors.Wrap(a.NewChain(table, chain), "error creating IP table chain")
+}
+
+func (a *Adapter) InsertUnique(table, chain string, position int, ruleSpec []string) error {
+	rules, err := a.List(table, chain)
+	if err != nil {
+		return errors.Wrapf(err, "error listing the rules in %s chain", chain)
+	}
+
+	isPresentAtRequiredPosition := false
+	numOccurrences := 0
+
+	for index, rule := range rules {
+		if strings.Contains(rule, strings.Join(ruleSpec, " ")) {
+			klog.V(level.DEBUG).Infof("In %s table, iptables rule \"%s\", exists at index %d.", table, strings.Join(ruleSpec, " "), index)
+			numOccurrences++
+
+			if index == position {
+				isPresentAtRequiredPosition = true
+			}
+		}
+	}
+
+	// The required rule is present in the Chain, but either there are multiple occurrences or its
+	// not at the desired location
+	if numOccurrences > 1 || !isPresentAtRequiredPosition {
+		for i := 0; i < numOccurrences; i++ {
+			if err = a.Delete(table, chain, ruleSpec...); err != nil {
+				return errors.Wrapf(err, "error deleting stale IP table rule %q", strings.Join(ruleSpec, " "))
+			}
+		}
+	}
+
+	// The required rule is present only once and is at the desired location
+	if numOccurrences == 1 && isPresentAtRequiredPosition {
+		klog.V(level.DEBUG).Infof("In %s table, iptables rule \"%s\", already exists.", table, strings.Join(ruleSpec, " "))
+		return nil
+	} else if err := a.Insert(table, chain, position, ruleSpec...); err != nil {
+		return errors.Wrapf(err, "error inserting IP table rule %q", strings.Join(ruleSpec, " "))
+	}
+
+	return nil
 }

--- a/pkg/iptables/adapter.go
+++ b/pkg/iptables/adapter.go
@@ -1,0 +1,23 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iptables
+
+type Adapter struct {
+	Basic
+}

--- a/pkg/iptables/adapter.go
+++ b/pkg/iptables/adapter.go
@@ -18,6 +18,21 @@ limitations under the License.
 
 package iptables
 
+import "github.com/pkg/errors"
+
 type Adapter struct {
 	Basic
+}
+
+func (a *Adapter) CreateChainIfNotExists(table, chain string) error {
+	exists, err := a.ChainExists(table, chain)
+	if err == nil && exists {
+		return nil
+	}
+
+	if err != nil {
+		return errors.Wrapf(err, "error finding IP table chain %q in table %q", chain, table)
+	}
+
+	return errors.Wrap(a.NewChain(table, chain), "error creating IP table chain")
 }

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -43,6 +43,7 @@ type Basic interface {
 
 type Interface interface {
 	Basic
+	CreateChainIfNotExists(table, chain string) error
 }
 
 type iptablesWrapper struct {
@@ -75,19 +76,6 @@ func (i *iptablesWrapper) Delete(table, chain string, rulespec ...string) error 
 	}
 
 	return errors.Wrap(err, "error deleting IP table rule")
-}
-
-func CreateChainIfNotExists(ipt Interface, table, chain string) error {
-	exists, err := ipt.ChainExists(table, chain)
-	if err == nil && exists {
-		return nil
-	}
-
-	if err != nil {
-		return errors.Wrapf(err, "error finding IP table chain %q in table %q", chain, table)
-	}
-
-	return errors.Wrap(ipt.NewChain(table, chain), "error creating IP table chain")
 }
 
 func PrependUnique(ipt Interface, table, chain string, ruleSpec []string) error {

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -19,13 +19,8 @@ limitations under the License.
 package iptables
 
 import (
-	"strings"
-
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
-	level "github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/admiral/pkg/stringset"
-	"k8s.io/klog/v2"
 )
 
 type Basic interface {
@@ -46,6 +41,9 @@ type Interface interface {
 	CreateChainIfNotExists(table, chain string) error
 	InsertUnique(table, chain string, position int, ruleSpec []string) error
 	PrependUnique(table, chain string, ruleSpec []string) error
+	// UpdateChainRules ensures that the rules in the list are the ones in rules, without any preference for the order,
+	// any stale rules will be removed from the chain, and any missing rules will be added.
+	UpdateChainRules(table, chain string, rules [][]string) error
 }
 
 type iptablesWrapper struct {
@@ -78,52 +76,4 @@ func (i *iptablesWrapper) Delete(table, chain string, rulespec ...string) error 
 	}
 
 	return errors.Wrap(err, "error deleting IP table rule")
-}
-
-// UpdateChainRules ensures that the rules in the list are the ones in rules, without any preference for the order,
-// any stale rules will be removed from the chain, and any missing rules will be added.
-func UpdateChainRules(ipt Interface, table, chain string, rules [][]string) error {
-	existingRules, err := ipt.List(table, chain)
-	if err != nil {
-		return errors.Wrapf(err, "error listing the rules in table %q, chain %q", table, chain)
-	}
-
-	ruleStrings := stringset.New()
-
-	for _, existingRule := range existingRules {
-		ruleSpec := strings.Split(existingRule, " ")
-		if ruleSpec[0] == "-A" {
-			ruleSpec = ruleSpec[2:] // remove "-A", "$chain"
-			ruleStrings.Add(strings.Trim(strings.Join(ruleSpec, " "), " "))
-		}
-	}
-
-	for _, ruleSpec := range rules {
-		ruleString := strings.Join(ruleSpec, " ")
-
-		if ruleStrings.Contains(ruleString) {
-			ruleStrings.Remove(ruleString)
-		} else {
-			klog.V(level.DEBUG).Infof("Adding iptables rule in %q, %q: %q", table, chain, ruleSpec)
-
-			if err := ipt.Append(table, chain, ruleSpec...); err != nil {
-				return errors.Wrapf(err, "error adding rule to %v to %q, %q", ruleSpec, table, chain)
-			}
-		}
-	}
-
-	// remaining elements should not be there, remove them
-	for _, rule := range ruleStrings.Elements() {
-		klog.V(level.DEBUG).Infof("Deleting stale iptables rule in %q, %q: %q", table, chain, rule)
-		ruleSpec := strings.Split(rule, " ")
-
-		if err := ipt.Delete(table, chain, ruleSpec...); err != nil {
-			// Log and let go, as this is not a fatal error, or something that will make real harm,
-			// it's more harmful to keep retrying. At this point on next update deletion of stale rules
-			// will happen again
-			klog.Warningf("Unable to delete iptables entry from table %q, chain %q: %q", table, chain, rule)
-		}
-	}
-
-	return nil
 }

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type Interface interface {
+type Basic interface {
 	Append(table, chain string, rulespec ...string) error
 	AppendUnique(table, chain string, rulespec ...string) error
 	Delete(table, chain string, rulespec ...string) error
@@ -39,6 +39,10 @@ type Interface interface {
 	ChainExists(table, chain string) (bool, error)
 	ClearChain(table, chain string) error
 	DeleteChain(table, chain string) error
+}
+
+type Interface interface {
+	Basic
 }
 
 type iptablesWrapper struct {
@@ -57,7 +61,7 @@ func New() (Interface, error) {
 		return nil, errors.Wrap(err, "error creating IP tables")
 	}
 
-	return &iptablesWrapper{IPTables: ipt}, nil
+	return &Adapter{Basic: &iptablesWrapper{IPTables: ipt}}, nil
 }
 
 func (i *iptablesWrapper) Delete(table, chain string, rulespec ...string) error {

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -45,6 +45,7 @@ type Interface interface {
 	Basic
 	CreateChainIfNotExists(table, chain string) error
 	InsertUnique(table, chain string, position int, ruleSpec []string) error
+	PrependUnique(table, chain string, ruleSpec []string) error
 }
 
 type iptablesWrapper struct {
@@ -77,20 +78,6 @@ func (i *iptablesWrapper) Delete(table, chain string, rulespec ...string) error 
 	}
 
 	return errors.Wrap(err, "error deleting IP table rule")
-}
-
-func PrependUnique(ipt Interface, table, chain string, ruleSpec []string) error {
-	// Submariner requires certain iptable rules to be programmed at the beginning of an iptables Chain
-	// so that we can preserve the sourceIP for inter-cluster traffic and avoid K8s SDN making changes
-	// to the traffic.
-	// In this API, we check if the required iptable rule is present at the beginning of the chain.
-	// If the rule is already present and there are no stale[1] flows, we simply return. If not, we create one.
-	// [1] Sometimes after we program the rule at the beginning of the chain, K8s SDN might insert some
-	// new rules ahead of the rule that we programmed. In such cases, the rule that we programmed will
-	// not be the first rule to hit and Submariner behavior might get affected. So, we query the rules
-	// in the chain to see if the rule slipped its position, and if so, delete all such occurrences.
-	// We then re-program a new rule at the beginning of the chain as required.
-	return ipt.InsertUnique(table, chain, 1, ruleSpec)
 }
 
 // UpdateChainRules ensures that the rules in the list are the ones in rules, without any preference for the order,

--- a/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
@@ -64,7 +64,7 @@ func (kp *SyncHandler) createIPTableChains() error {
 
 	ruleSpec = []string{"-o", VxLANIface, "-j", "ACCEPT"}
 
-	if err = iptables.PrependUnique(ipt, constants.FilterTable, "FORWARD", ruleSpec); err != nil {
+	if err = ipt.PrependUnique(constants.FilterTable, "FORWARD", ruleSpec); err != nil {
 		return errors.Wrap(err, "unable to insert iptable rule in filter table to allow vxlan traffic")
 	}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/iptables_iface.go
@@ -43,7 +43,7 @@ func (kp *SyncHandler) createIPTableChains() error {
 
 	klog.V(log.DEBUG).Infof("Install/ensure %q chain exists", constants.SmInputChain)
 
-	if err = iptables.CreateChainIfNotExists(ipt, constants.FilterTable, constants.SmInputChain); err != nil {
+	if err = ipt.CreateChainIfNotExists(constants.FilterTable, constants.SmInputChain); err != nil {
 		return errors.Wrap(err, "unable to create SUBMARINER-INPUT chain in iptables")
 	}
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -88,7 +88,7 @@ func (h *mtuHandler) Init() error {
 
 	ipSetIface := ipset.New(utilexec.New())
 
-	if err := iptables.CreateChainIfNotExists(h.ipt, constants.MangleTable, constants.SmPostRoutingChain); err != nil {
+	if err := h.ipt.CreateChainIfNotExists(constants.MangleTable, constants.SmPostRoutingChain); err != nil {
 		return errors.Wrapf(err, "error creating iptables chain %s", constants.SmPostRoutingChain)
 	}
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -104,7 +104,7 @@ func (h *mtuHandler) Init() error {
 		return errors.Wrapf(err, "error creating ipset %q", constants.LocalCIDRIPSet)
 	}
 
-	if err := iptables.PrependUnique(h.ipt, constants.MangleTable, constants.PostRoutingChain,
+	if err := h.ipt.PrependUnique(constants.MangleTable, constants.PostRoutingChain,
 		forwardToSubMarinerPostRoutingChain); err != nil {
 		return errors.Wrapf(err, "error inserting iptables rule %q",
 			strings.Join(forwardToSubMarinerPostRoutingChain, " "))

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -206,7 +206,7 @@ func (ovn *Handler) ensureForwardChains() error {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
-	if err := submiptables.InsertUnique(ovn.ipt, "filter", "FORWARD", 1,
+	if err := ovn.ipt.InsertUnique("filter", "FORWARD", 1,
 		[]string{"-j", forwardingSubmarinerMSSClampChain}); err != nil {
 		return errors.Wrapf(err, "error inserting rule for chain %q", forwardingSubmarinerMSSClampChain)
 	}
@@ -215,7 +215,7 @@ func (ovn *Handler) ensureForwardChains() error {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerFWDChain)
 	}
 
-	return errors.Wrapf(submiptables.InsertUnique(ovn.ipt, "filter", "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
+	return errors.Wrapf(ovn.ipt.InsertUnique("filter", "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
 		"error inserting rule for chain %q", forwardingSubmarinerFWDChain)
 }
 

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	submiptables "github.com/submariner-io/submariner/pkg/iptables"
 	npSyncerOvn "github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	iptcommon "github.com/submariner-io/submariner/pkg/routeagent_driver/iptables"
@@ -157,7 +156,7 @@ func (ovn *Handler) setupForwardingIptables() error {
 func (ovn *Handler) updateNoMasqueradeIPTables() error {
 	rules := ovn.getNoMasqueradRuleSpecs()
 
-	return errors.Wrapf(submiptables.UpdateChainRules(ovn.ipt, "nat", constants.SmPostRoutingChain, rules),
+	return errors.Wrapf(ovn.ipt.UpdateChainRules("nat", constants.SmPostRoutingChain, rules),
 		"error updating %q rules", constants.SmPostRoutingChain)
 }
 
@@ -225,5 +224,5 @@ func (ovn *Handler) updateIPtableChains(table, chain string, ruleGen forwardRule
 		return err
 	}
 
-	return errors.Wrap(submiptables.UpdateChainRules(ovn.ipt, table, chain, ruleSpecs), "error updating chain rules")
+	return errors.Wrap(ovn.ipt.UpdateChainRules(table, chain, ruleSpecs), "error updating chain rules")
 }

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -202,7 +202,7 @@ func (ovn *Handler) initIPtablesChains() error {
 }
 
 func (ovn *Handler) ensureForwardChains() error {
-	if err := submiptables.CreateChainIfNotExists(ovn.ipt, "filter", forwardingSubmarinerMSSClampChain); err != nil {
+	if err := ovn.ipt.CreateChainIfNotExists("filter", forwardingSubmarinerMSSClampChain); err != nil {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
@@ -211,7 +211,7 @@ func (ovn *Handler) ensureForwardChains() error {
 		return errors.Wrapf(err, "error inserting rule for chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
-	if err := submiptables.CreateChainIfNotExists(ovn.ipt, "filter", forwardingSubmarinerFWDChain); err != nil {
+	if err := ovn.ipt.CreateChainIfNotExists("filter", forwardingSubmarinerFWDChain); err != nil {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerFWDChain)
 	}
 

--- a/pkg/routeagent_driver/iptables/iptables.go
+++ b/pkg/routeagent_driver/iptables/iptables.go
@@ -37,7 +37,7 @@ func InitSubmarinerPostRoutingChain(ipt iptables.Interface) error {
 
 	forwardToSubPostroutingRuleSpec := []string{"-j", constants.SmPostRoutingChain}
 
-	if err := iptables.PrependUnique(ipt, "nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
+	if err := ipt.PrependUnique("nat", "POSTROUTING", forwardToSubPostroutingRuleSpec); err != nil {
 		return errors.Wrapf(err, "unable to insert iptable rule in NAT table, POSTROUTING chain")
 	}
 

--- a/pkg/routeagent_driver/iptables/iptables.go
+++ b/pkg/routeagent_driver/iptables/iptables.go
@@ -29,7 +29,7 @@ import (
 func InitSubmarinerPostRoutingChain(ipt iptables.Interface) error {
 	klog.V(log.DEBUG).Infof("Install/ensure %s chain exists", constants.SmPostRoutingChain)
 
-	if err := iptables.CreateChainIfNotExists(ipt, "nat", constants.SmPostRoutingChain); err != nil {
+	if err := ipt.CreateChainIfNotExists("nat", constants.SmPostRoutingChain); err != nil {
 		return errors.Wrapf(err, "unable to create %q chain in iptables", constants.SmPostRoutingChain)
 	}
 


### PR DESCRIPTION
There are several functions, eg `InsertUnique`,  that take an `iptables.Interface` and utilize it to provide higher level functionality. It would be ideal if these functions were part of `iptables.Interface`. However we don't want each implementation to have to implement them.  So, instead, extracted a `Basic` interface with the current methods and added an `Adapter` that implements the full Interface.

See individual commits for details.
