### PR TITLE
OVN Globalnet: Fix missing default route in table 150

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -29,10 +29,10 @@ import (
 
 // handleSubnets builds ip rules, and passes them to the specified netlink function
 //               for provided subnet list
-func (ovn *Handler) handleSubnets(subnets []string, ruleFunc func(rule *netlink.Rule) error,
+func (ovn *Handler) handleSubnets(remoteSubnets []string, ruleFunc func(rule *netlink.Rule) error,
 	ignoredErrorFunc func(error) bool,
 ) error {
-	for _, subnetToHandle := range subnets {
+	for _, subnetToHandle := range remoteSubnets {
 		for _, localSubnet := range ovn.localEndpoint.Spec.Subnets {
 			rule, err := ovn.getRuleSpec(localSubnet, subnetToHandle, constants.RouteAgentInterClusterNetworkTableID)
 			if err != nil {


### PR DESCRIPTION
To support hostNetworking use-case the route-agent handler
programs default route in table 150 with nexthop matching
the nexthop on the ovn-k8s-mp0 interface. Basically, we
want the Submariner managed traffic to be forwarded to the
ovn_cluster_router and pass through the CNI network so that
it reaches the active gateway node in the cluster via the
submariner pipeline.

Fixes: https://github.com/submariner-io/submariner/issues/1982
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
