### PR TITLE
Ensure static routes on submariner_router point to the cluster CIDR

### DIFF
--- a/pkg/networkplugin-syncer/handlers/ovn/ovn_submariner_infrastructure.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn_submariner_infrastructure.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/sbdb"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/stringset"
 	"k8s.io/klog/v2"
 )
 
@@ -221,10 +222,12 @@ func (ovn *SyncHandler) updateSubmarinerRouterRemoteRoutes() error {
 }
 
 func (ovn *SyncHandler) updateSubmarinerRouterLocalRoutes() error {
-	localSubnets := ovn.localEndpointSubnetSet()
+	localSubnets := stringset.New(ovn.localClusterCIDR...)
 
-	klog.V(log.DEBUG).Infof("reconciling south static routes on %q for subnets %v", submarinerLogicalRouter,
+	klog.Infof("reconciling south static routes on %q for subnets %v", submarinerLogicalRouter,
 		localSubnets)
 
+	// For the incoming traffic from remote cluster destined to the local cluster CIDR, configure the next hop
+	// as the ovn_cluster_router port.
 	return ovn.reconcileSubOvnLogicalRouterStaticRoutes(submarinerDownstreamRPort, ovnClusterSubmarinerIP, localSubnets)
 }


### PR DESCRIPTION
Currently we program Logical Static Routes on the submariner_router.
The routes are programmed for both ingress as well as egress direction.
However, for ingress, it was seen that when using Globalnet, it was using
the globalCIDR and not the local clusterCIDR which was creating issues in
datapath connectivity. This PR fixes it and is backward compatible with
non-Globalnet deployments as well.

Fixes: https://github.com/submariner-io/submariner/issues/1984
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
