### PR TITLE
Don't specify images to preload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 IMAGES ?= submariner-gateway submariner-route-agent submariner-globalnet submariner-networkplugin-syncer
 MULTIARCH_IMAGES ?= $(IMAGES)
-PRELOAD_IMAGES = $(IMAGES) submariner-operator
 PLATFORMS ?= linux/amd64,linux/arm64
 
 ifneq (,$(filter ovn,$(USING)))


### PR DESCRIPTION
Shipyard now preloads all built images,
there's no need to explicitly preload any images.

Depends on https://github.com/submariner-io/shipyard/pull/937

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
