### PR TITLE
Cleanup iptable rules programmed by OVN RA plugin

### DIFF
--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	SmInputChain       = "SUBMARINER-INPUT"
 	PostRoutingChain   = "POSTROUTING"
 	InputChain         = "INPUT"
+	ForwardChain       = "FORWARD"
 	MangleTable        = "mangle"
 	RemoteCIDRIPSet    = "SUBMARINER-REMOTECIDRS"
 	LocalCIDRIPSet     = "SUBMARINER-LOCALCIDRS"


### PR DESCRIPTION
After running uninstall on an OVN Cluster, it was seen that iptable chains in NAT as well as FILTER tables are still present on the nodes. This PR fixes it.

Fixes: https://github.com/submariner-io/submariner/issues/1868
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
