### PR TITLE
Update RouteAgentRestart test

### DIFF
--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -48,9 +48,14 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
 	nodes := f.FindNodesByGatewayLabel(framework.ClusterA, onGateway)
+	// Testing GatewayFailover test in "kind" env will require
+	// all nodes to serve as GW nodes due to resources limitation.
+	// It means that current test may fail as will not find non GW worker.
+	// In case required node will not be found, look for any non GW/worker
+	// node. And since the "route agent" pod runs on every node, it will work.
 	if len(nodes) == 0 && !onGateway {
-		framework.Skipf("Skipping the test as cluster %q doesn't have any suitable non-gateway nodes...", clusterAName)
-		return
+		By(fmt.Sprintf("No Non Gateway worker nodes found in %q. Looking for non worker nodes", clusterAName))
+		nodes = f.FindAnyNonGatewayRouteAgentPodNodes(framework.ClusterA)
 	}
 
 	By(fmt.Sprintf("Found node %q on %q", nodes[0].Name, clusterAName))


### PR DESCRIPTION
The following test relates to the e2e in "kind" environment only. Due to refactor of GatewayFailOver test, "kind" environment will have all working nodes serving as gateway nodes.
This is done to save the resources.

As a result, the test will fail because it's looking for a non gateway worker node and it will missing.

Since the RouteAgent pod is running on every cluster node, this change will search for the RouteAgent pod on any cluster node in case the non GW node is not found.

Refactoring details:
https://github.com/submariner-io/submariner/issues/2013

Depends On https://github.com/submariner-io/shipyard/pull/948

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
