### PR TITLE
[Backport] Validate an e2e test-case in reverse direction (#2033)

### DIFF
--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -30,6 +30,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 	var toEndpointType tcp.EndpointType
 	var networking framework.NetworkingType
 	var egressIPType subFramework.GlobalEgressIPType
+	var fromCluster framework.ClusterIndex
+	var toCluster framework.ClusterIndex
 
 	verifyInteraction := func(fromClusterScheduling, toClusterScheduling framework.NetworkPodScheduling) {
 		It("should have sent the expected data from the pod to the other pod", func() {
@@ -47,9 +49,9 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,
-				FromCluster:           framework.ClusterA,
+				FromCluster:           fromCluster,
 				FromClusterScheduling: fromClusterScheduling,
-				ToCluster:             framework.ClusterB,
+				ToCluster:             toCluster,
 				ToClusterScheduling:   toClusterScheduling,
 			}, subFramework.GetGlobalnetEgressParams(egressIPType))
 		})
@@ -60,6 +62,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 			toEndpointType = tcp.GlobalServiceIP
 			networking = framework.PodNetworking
 			egressIPType = subFramework.ClusterSelector
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -80,6 +84,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 			toEndpointType = tcp.GlobalServiceIP
 			networking = framework.PodNetworking
 			egressIPType = subFramework.NameSpaceSelector
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -96,6 +102,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 			toEndpointType = tcp.GlobalServiceIP
 			networking = framework.PodNetworking
 			egressIPType = subFramework.PodSelector
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -112,6 +120,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 			toEndpointType = tcp.GlobalServiceIP
 			networking = framework.HostNetworking
 			egressIPType = subFramework.ClusterSelector
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -128,6 +138,8 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 			toEndpointType = tcp.GlobalPodIP
 			networking = framework.PodNetworking
 			egressIPType = subFramework.ClusterSelector
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -136,6 +148,20 @@ var _ = Describe("[dataplane-globalnet] Basic TCP connectivity tests across over
 
 		When("the pod is on a gateway and the remote service is on a gateway", func() {
 			verifyInteraction(framework.GatewayNode, framework.GatewayNode)
+		})
+	})
+
+	When("a pod connects via TCP to the globalIP of a remote service in reverse direction", func() {
+		BeforeEach(func() {
+			toEndpointType = tcp.GlobalServiceIP
+			networking = framework.PodNetworking
+			egressIPType = subFramework.ClusterSelector
+			fromCluster = framework.ClusterB
+			toCluster = framework.ClusterA
+		})
+
+		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
+			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
 		})
 	})
 })

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -29,6 +29,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 	f := framework.NewFramework("dataplane-conn-nd")
 	var toEndpointType tcp.EndpointType
 	var networking framework.NetworkingType
+	var fromCluster framework.ClusterIndex
+	var toCluster framework.ClusterIndex
 
 	verifyInteraction := func(fromClusterScheduling, toClusterScheduling framework.NetworkPodScheduling) {
 		It("should have sent the expected data from the pod to the other pod", func() {
@@ -46,9 +48,9 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,
-				FromCluster:           framework.ClusterA,
+				FromCluster:           fromCluster,
 				FromClusterScheduling: fromClusterScheduling,
-				ToCluster:             framework.ClusterB,
+				ToCluster:             toCluster,
 				ToClusterScheduling:   toClusterScheduling,
 			})
 		})
@@ -58,6 +60,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 		BeforeEach(func() {
 			toEndpointType = tcp.PodIP
 			networking = framework.PodNetworking
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
@@ -81,6 +85,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 		BeforeEach(func() {
 			toEndpointType = tcp.ServiceIP
 			networking = framework.PodNetworking
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote service is not on a gateway", func() {
@@ -104,6 +110,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 		BeforeEach(func() {
 			toEndpointType = tcp.PodIP
 			networking = framework.HostNetworking
+			fromCluster = framework.ClusterA
+			toCluster = framework.ClusterB
 		})
 
 		When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
@@ -112,6 +120,19 @@ var _ = Describe("[dataplane] Basic TCP connectivity tests across clusters witho
 
 		When("the pod is on a gateway and the remote pod is not on a gateway", func() {
 			verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
+		})
+	})
+
+	When("a pod connects via TCP to a remote pod in reverse direction", func() {
+		BeforeEach(func() {
+			toEndpointType = tcp.PodIP
+			networking = framework.PodNetworking
+			fromCluster = framework.ClusterB
+			toCluster = framework.ClusterA
+		})
+
+		When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
+			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
 		})
 	})
 })


### PR DESCRIPTION
Although not common, in some deployments, we have
seen that e2e tests pass in one direction but fail in the reverse direction. This PR includes an additional test-case which swaps the client/server and validates nonGW to nonGW use-case.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 60f560fc37b7fe791902cf14f9e538254326007d)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
