### PR TITLE
Declare constant for kindnet

### DIFF
--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -24,6 +24,7 @@ const (
 	CanalFlannel  = "canal-flannel"
 	Flannel       = "flannel"
 	WeaveNet      = "weave-net"
+	KindNet       = "kindnet"
 	OpenShiftSDN  = "OpenShiftSDN"
 	OVNKubernetes = "OVNKubernetes"
 	Calico        = "calico"

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -81,6 +81,7 @@ func (kp *SyncHandler) GetNetworkPlugins() []string {
 	return []string{
 		cni.Generic, cni.CanalFlannel, cni.Flannel,
 		cni.WeaveNet, cni.OpenShiftSDN, cni.Calico,
+		cni.KindNet,
 	}
 }
 


### PR DESCRIPTION
Now that we are moving away from weave-net to kindnet CNI as part of KIND deployment, lets create a constant for kindnet and display it instead of showing it as generic CNI.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
