### PR TITLE
Add issues:write permission to broken links GHA

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Raise an Issue to report broken links
         if: ${{ failure() }}
         uses: peter-evans/create-issue-from-file@99b87c35610e986ad2034a7b0518a9b3ebea541b
+        permissions:
+          issues: write
         with:
           title: Broken link detected by periodic linting
           content-filepath: .github/ISSUE_TEMPLATE/broken-link.md


### PR DESCRIPTION
The issue reporting step of the Markdown broken link check GitHub Action is failing due to missing permissions.

> Error: Resource not accessible by integration

There's currently a broken link (twitter-together), but the automation isn't able to raise an issue to let us know. For now, keep the broken link but fix the permissions. If next run is able to report an issue, we'll know the permissions are sorted out and can fix the link.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
