### PR TITLE
Add Sonar unit test coverage reporting

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -10,6 +10,26 @@ on:
 permissions: {}
 
 jobs:
+  unit-coverage:
+    name: Go Unit Test Coverage
+    if: github.repository_owner == 'submariner-io'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Run Go unit tests
+        run: make unit
+
+      - name: Run SonarScan, upload Go test results and coverage
+        uses: sonarsource/sonarcloud-github-action@de2e56b42aa84d0b1c5b622644ac17e505c9a049
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            --debug
+
   vulnerability-scan:
     name: Vulnerability Scanning
     if: github.repository_owner == 'submariner-io'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=submariner-io_submariner
+sonar.projectName=submariner
+sonar.organization=submariner-io
+sonar.sources=.
+sonar.exclusions=**/vendor/**,**/*_test.go,test/e2e/**,test/external/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go,test/e2e/**,test/external/**
+sonar.test.exclusions=**/vendor/**
+sonar.go.tests.reportPaths=**/junit.xml
+sonar.go.coverage.reportPaths=**/unit.coverprofile


### PR DESCRIPTION
Add GHA to run unit tests, generate coverage report, and upload the report to SonarCloud.

Add configuration to ignore code that shouldn't count for coverage.

Relates-to: stolostron/backlog#22706
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
