### PR TITLE
Skip public-ip resolution in air-gapped clusters

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -38,7 +38,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface) (*types.SubmarinerEndpoint, error) {
+func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
+	airGappedDeployment bool,
+) (*types.SubmarinerEndpoint, error) {
 	// We'll panic if submSpec is nil, this is intentional
 	privateIP := GetLocalIP()
 
@@ -86,7 +88,7 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 		},
 	}
 
-	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig)
+	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig, airGappedDeployment)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not determine public IP")
 	}

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -48,7 +48,10 @@ var publicIPMethods = map[string]publicIPResolverFunction{
 
 var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 
-func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface, backendConfig map[string]string) (string, error) {
+func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
+	backendConfig map[string]string, airGapped bool,
+) (string, error) {
+	// If the node is annotated with a public-ip, the same is used as the public-ip of local endpoint.
 	config, ok := backendConfig[v1.PublicIP]
 	if !ok {
 		if submSpec.PublicIP != "" {
@@ -56,6 +59,16 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		} else {
 			config = "api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"
 		}
+	}
+
+	if airGapped {
+		ip, err := resolveIPInAirGappedDeployment(k8sClient, submSpec.Namespace, config, airGapped)
+		if err != nil {
+			klog.Errorf("Error resolving public IP in an air-gapped deployment, using empty value: %s : %s", config, err.Error())
+			return "", nil
+		}
+
+		return ip, nil
 	}
 
 	resolvers := strings.Split(config, ",")
@@ -67,18 +80,13 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 			return "", errors.Errorf("invalid format for %q annotation: %q", v1.GatewayConfigPrefix+v1.PublicIP, config)
 		}
 
-		method, ok := publicIPMethods[parts[0]]
-		if !ok {
-			return "", errors.Errorf("unknown resolver %q in %q annotation: %q", parts[0], v1.GatewayConfigPrefix+v1.PublicIP, config)
-		}
-
-		ip, err := method(k8sClient, submSpec.Namespace, parts[1])
+		ip, err := resolvePublicIP(k8sClient, submSpec.Namespace, parts)
 		if err == nil {
 			return ip, nil
 		}
 
-		// If this resolved failed we log it, but we fall back to the next one
-		klog.Errorf("Error resolving public IP with resolver %s : %s", resolver, err.Error())
+		// If this resolver failed, we log it, but we fall back to the next one
+		klog.Errorf("Error resolving public IP with resolver %s, config: %s : %s", resolver, config, err.Error())
 	}
 
 	if len(resolvers) > 0 {
@@ -86,6 +94,47 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 	}
 
 	return "", nil
+}
+
+func resolveIPInAirGappedDeployment(k8sClient kubernetes.Interface, namespace, config string, airGapped bool) (string, error) {
+	if !airGapped {
+		return "", errors.Errorf("this function should be called only for air-gapped deployments")
+	}
+
+	resolvers := strings.Split(config, ",")
+
+	for _, resolver := range resolvers {
+		resolver = strings.Trim(resolver, " ")
+
+		parts := strings.Split(resolver, ":")
+		if len(parts) != 2 {
+			return "", errors.Errorf("invalid format for %q annotation: %q", v1.GatewayConfigPrefix+v1.PublicIP, config)
+		}
+
+		if parts[0] != v1.IPv4 {
+			continue
+		}
+
+		ip, err := resolvePublicIP(k8sClient, namespace, parts)
+
+		return ip, err
+	}
+
+	return "", nil
+}
+
+func resolvePublicIP(k8sClient kubernetes.Interface, namespace string, parts []string) (string, error) {
+	method, ok := publicIPMethods[parts[0]]
+	if !ok {
+		return "", errors.Errorf("unknown resolver %q in %q annotation", parts[0], v1.GatewayConfigPrefix+v1.PublicIP)
+	}
+
+	ip, err := method(k8sClient, namespace, parts[1])
+	if err == nil {
+		return ip, nil
+	}
+
+	return "", err
 }
 
 func publicAPI(clientset kubernetes.Interface, namespace, value string) (string, error) {

--- a/pkg/endpoint/public_ip_internal_test.go
+++ b/pkg/endpoint/public_ip_internal_test.go
@@ -78,7 +78,7 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return the IP", func() {
 			backendConfig[publicIPConfig] = "lb:" + testServiceName
 			client := fake.NewSimpleClientset(serviceWithIngress(v1.LoadBalancerIngress{Hostname: "", IP: testIP}))
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIP))
 		})
@@ -91,7 +91,7 @@ var _ = Describe("public ip resolvers", func() {
 				Hostname: testIPDNS + ".nip.io",
 				IP:       "",
 			}))
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIPDNS))
 		})
@@ -102,7 +102,7 @@ var _ = Describe("public ip resolvers", func() {
 			loadBalancerRetryConfig.Cap = 1 * time.Second
 			backendConfig[publicIPConfig] = "lb:" + testServiceName
 			client := fake.NewSimpleClientset(serviceWithIngress())
-			_, err := getPublicIP(submSpec, client, backendConfig)
+			_, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -111,7 +111,17 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return the IP", func() {
 			backendConfig[publicIPConfig] = "ipv4:" + testIP
 			client := fake.NewSimpleClientset()
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ip).To(Equal(testIP))
+		})
+	})
+
+	When("an IPv4 entry specified in air-gapped deployment", func() {
+		It("should return the IP and not an empty value", func() {
+			backendConfig[publicIPConfig] = "ipv4:" + testIP
+			client := fake.NewSimpleClientset()
+			ip, err := getPublicIP(submSpec, client, backendConfig, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIP))
 		})
@@ -121,7 +131,7 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return the IP", func() {
 			backendConfig[publicIPConfig] = "dns:" + testIPDNS + ".nip.io"
 			client := fake.NewSimpleClientset()
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIPDNS))
 		})
@@ -131,7 +141,7 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return some IP", func() {
 			backendConfig[publicIPConfig] = "api:api.ipify.org"
 			client := fake.NewSimpleClientset()
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(net.ParseIP(ip)).NotTo(BeNil())
 		})
@@ -141,7 +151,7 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return the first working one", func() {
 			backendConfig[publicIPConfig] = "ipv4:" + testIP + ",dns:" + testIPDNS + ".nip.io"
 			client := fake.NewSimpleClientset()
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIP))
 		})
@@ -151,7 +161,7 @@ var _ = Describe("public ip resolvers", func() {
 		It("should return the first working one", func() {
 			backendConfig[publicIPConfig] = "dns:thisdomaindoesntexistforsure.badbadbad,ipv4:" + testIP
 			client := fake.NewSimpleClientset()
-			ip, err := getPublicIP(submSpec, client, backendConfig)
+			ip, err := getPublicIP(submSpec, client, backendConfig, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip).To(Equal(testIP))
 		})

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -68,7 +68,7 @@ func (p *PublicIPWatcher) Run(stopCh <-chan struct{}) {
 }
 
 func (p *PublicIPWatcher) syncPublicIP() {
-	publicIP, err := getPublicIP(p.config.SubmSpec, p.config.K8sClient, p.config.LocalEndpoint.Spec.BackendConfig)
+	publicIP, err := getPublicIP(p.config.SubmSpec, p.config.K8sClient, p.config.LocalEndpoint.Spec.BackendConfig, false)
 	if err != nil {
 		klog.Warningf("Could not determine public IP of the gateway node %q", p.config.LocalEndpoint.Spec.Hostname)
 		return


### PR DESCRIPTION
When AIR_GAPPED_DEPLOYMENT is set to true as an env' variable on the Gateway pod, this PR does the following.
1. It looks for gateway.submariner.io/public-ip=ipv4:\<address\> annotation on the gateway node. If the annotation is present, its value is used as public-ip in the local endpoint.
2. If the annotation is missing on the gateway node, an empty public-ip is configured in the local endpoint.

In both the above scenarios the gateway pod will avoid making any API/DNS/LB queries to resolve the public-ip associated with the gateway node. Also, the periodic public-ip watcher is disabled for air-gapped deployments.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
