### PR TITLE
Remove space between // and nolint

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -620,5 +620,5 @@ func (i *libreswan) runPluto() error {
 func (i *libreswan) Cleanup() error {
 	logger.Info("Uninstalling the libreswan cable driver")
 
-	return netlink.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules() //nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -469,7 +469,7 @@ func (w *wireguard) keyMismatch(cid string, key *wgtypes.Key) bool {
 func genPsk(psk string) (wgtypes.Key, error) {
 	// Convert spec PSK string to right length byte array, using sha256.Size == wgtypes.KeyLen.
 	pskBytes := sha256.Sum256([]byte(psk))
-	return wgtypes.NewKey(pskBytes[:]) // nolint:wrapcheck // Let the caller wrap it
+	return wgtypes.NewKey(pskBytes[:]) //nolint:wrapcheck // Let the caller wrap it
 }
 
 func (w *wireguard) Cleanup() error {

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -276,7 +276,7 @@ func (i *engine) ListCableConnections() ([]v1.Connection, error) {
 	defer i.Unlock()
 
 	if i.driver != nil {
-		return i.driver.GetConnections() // nolint:wrapcheck  // Let the caller wrap it
+		return i.driver.GetConnections() //nolint:wrapcheck  // Let the caller wrap it
 	}
 	// if no driver, we can safely report that no connections exist.
 	return []v1.Connection{}, nil
@@ -284,7 +284,7 @@ func (i *engine) ListCableConnections() ([]v1.Connection, error) {
 
 func (i *engine) Cleanup() error {
 	if i.driver != nil {
-		return i.driver.Cleanup() // nolint:wrapcheck  // No need to wrap this error
+		return i.driver.Cleanup() //nolint:wrapcheck  // No need to wrap this error
 	}
 
 	return nil

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -28,7 +28,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 )
 
-type Engine struct { // nolint:gocritic // This mutex is exposed but we tweak it in tests
+type Engine struct { //nolint:gocritic // This mutex is exposed but we tweak it in tests
 	sync.Mutex
 	Connections               []v1.Connection
 	ListCableConnectionsError error

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -56,7 +56,7 @@ var (
 	GatewayStaleTimeout   = GatewayUpdateInterval * 3
 )
 
-// nolint:promlinter // Error: "counter metrics should have "_total"". This is already a documented public API and
+//nolint:promlinter // Error: "counter metrics should have "_total"". This is already a documented public API and
 // this doesn't seem a compelling enough reason to change it.
 var gatewaySyncIterations = prometheus.NewCounter(prometheus.CounterOpts{
 	Name: "submariner_gateway_sync_iterations",
@@ -108,7 +108,7 @@ func (gs *GatewaySyncer) SetGatewayStatusError(err error) {
 }
 
 func (gs *GatewaySyncer) gatewayResourceInterface() resource.Interface {
-	// nolint:wrapcheck // These functions are pass-through wrappers for the k8s APIs.
+	//nolint:wrapcheck // These functions are pass-through wrappers for the k8s APIs.
 	return &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return gs.client.Get(ctx, name, options)

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -303,7 +303,7 @@ func (d *DatastoreSyncer) createLocalCluster() error {
 		Spec: d.localCluster.Spec,
 	}
 
-	return d.localFederator.Distribute(cluster) // nolint:wrapcheck  // Let the caller wrap it
+	return d.localFederator.Distribute(cluster) //nolint:wrapcheck  // Let the caller wrap it
 }
 
 func (d *DatastoreSyncer) createOrUpdateLocalEndpoint() error {
@@ -321,5 +321,5 @@ func (d *DatastoreSyncer) createOrUpdateLocalEndpoint() error {
 		Spec: d.localEndpoint.Spec,
 	}
 
-	return d.localFederator.Distribute(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+	return d.localFederator.Distribute(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -191,7 +191,7 @@ func publicLoadBalancerIP(clientset kubernetes.Interface, namespace, loadBalance
 		}
 	})
 
-	return ip, err // nolint:wrapcheck  // No need to wrap here
+	return ip, err //nolint:wrapcheck  // No need to wrap here
 }
 
 func publicDNSIP(clientset kubernetes.Interface, namespace, fqdn string) (string, error) {

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -101,7 +101,7 @@ func (p *PublicIPWatcher) updateLocalEndpoint(publicIP string) error {
 		ep.Spec.PublicIP = publicIP
 
 		_, updateErr := p.config.Endpoints.Update(context.TODO(), ep, metav1.UpdateOptions{})
-		return updateErr // nolint:wrapcheck // We wrap it below in the enclosing function
+		return updateErr //nolint:wrapcheck // We wrap it below in the enclosing function
 	})
 
 	if retryErr != nil {

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -44,7 +44,7 @@ func (c *Controller) handleCreatedEndpoint(obj runtime.Object, numRequeues int) 
 
 func (c *Controller) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) error {
 	if err := c.handlers.LocalEndpointCreated(endpoint); err != nil {
-		return err // nolint:wrapcheck  // Let the caller wrap it
+		return err //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	if endpoint.Spec.Hostname == c.hostname {
@@ -54,7 +54,7 @@ func (c *Controller) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) error {
 		// Verify if this node was a GatewayNode already. If not, it just transitioned to Gateway Node.
 		if !c.isGatewayNode {
 			if err := c.handlers.TransitionToGateway(); err != nil {
-				return err // nolint:wrapcheck  // Let the caller wrap it
+				return err //nolint:wrapcheck  // Let the caller wrap it
 			}
 		}
 
@@ -65,5 +65,5 @@ func (c *Controller) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) error {
 }
 
 func (c *Controller) handleCreatedRemoteEndpoint(endpoint *smv1.Endpoint) error {
-	return c.handlers.RemoteEndpointCreated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+	return c.handlers.RemoteEndpointCreated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -43,7 +43,7 @@ func (c *Controller) handleRemovedEndpoint(obj runtime.Object, numRequeues int) 
 
 func (c *Controller) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) error {
 	if err := c.handlers.LocalEndpointRemoved(endpoint); err != nil {
-		return err // nolint:wrapcheck  // Let the caller wrap it
+		return err //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	c.syncMutex.Lock()
@@ -51,7 +51,7 @@ func (c *Controller) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) error {
 
 	if c.isGatewayNode && endpoint.Spec.Hostname == c.hostname {
 		if err := c.handlers.TransitionToNonGateway(); err != nil {
-			return err // nolint:wrapcheck  // Let the caller wrap it
+			return err //nolint:wrapcheck  // Let the caller wrap it
 		}
 
 		c.isGatewayNode = false
@@ -61,5 +61,5 @@ func (c *Controller) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) error {
 }
 
 func (c *Controller) handleRemovedRemoteEndpoint(endpoint *smv1.Endpoint) error {
-	return c.handlers.RemoteEndpointRemoved(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+	return c.handlers.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/controller/endpoint_updated.go
+++ b/pkg/event/controller/endpoint_updated.go
@@ -42,9 +42,9 @@ func (c *Controller) handleUpdatedEndpoint(obj runtime.Object, numRequeues int) 
 }
 
 func (c *Controller) handleUpdatedLocalEndpoint(endpoint *smv1.Endpoint) error {
-	return c.handlers.LocalEndpointUpdated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+	return c.handlers.LocalEndpointUpdated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }
 
 func (c *Controller) handleUpdatedRemoteEndpoint(endpoint *smv1.Endpoint) error {
-	return c.handlers.RemoteEndpointUpdated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+	return c.handlers.RemoteEndpointUpdated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -85,73 +85,73 @@ func (er *Registry) AddHandlers(eventHandlers ...Handler) error {
 
 func (er *Registry) StopHandlers(uninstall bool) error {
 	return er.invokeHandlers("Stop", func(h Handler) error {
-		return h.Stop(uninstall) // nolint:wrapcheck  // Let the caller wrap it
+		return h.Stop(uninstall) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) TransitionToNonGateway() error {
 	return er.invokeHandlers("TransitionToNonGateway", func(h Handler) error {
-		return h.TransitionToNonGateway() // nolint:wrapcheck  // Let the caller wrap it
+		return h.TransitionToNonGateway() //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) TransitionToGateway() error {
 	return er.invokeHandlers("TransitionToGateway", func(h Handler) error {
-		return h.TransitionToGateway() // nolint:wrapcheck  // Let the caller wrap it
+		return h.TransitionToGateway() //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("LocalEndpointCreated", func(h Handler) error {
-		return h.LocalEndpointCreated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.LocalEndpointCreated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("LocalEndpointUpdated", func(h Handler) error {
-		return h.LocalEndpointUpdated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.LocalEndpointUpdated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("LocalEndpointRemoved", func(h Handler) error {
-		return h.LocalEndpointRemoved(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.LocalEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("RemoteEndpointCreated", func(h Handler) error {
-		return h.RemoteEndpointCreated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.RemoteEndpointCreated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("RemoteEndpointUpdated", func(h Handler) error {
-		return h.RemoteEndpointUpdated(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.RemoteEndpointUpdated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	return er.invokeHandlers("RemoteEndpointRemoved", func(h Handler) error {
-		return h.RemoteEndpointRemoved(endpoint) // nolint:wrapcheck  // Let the caller wrap it
+		return h.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) NodeCreated(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeCreated", func(h Handler) error {
-		return h.NodeCreated(node) // nolint:wrapcheck  // Let the caller wrap it
+		return h.NodeCreated(node) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) NodeUpdated(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeUpdated", func(h Handler) error {
-		return h.NodeUpdated(node) // nolint:wrapcheck  // Let the caller wrap it
+		return h.NodeUpdated(node) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 
 func (er *Registry) NodeRemoved(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeRemoved", func(h Handler) error {
-		return h.NodeRemoved(node) // nolint:wrapcheck  // Let the caller wrap it
+		return h.NodeRemoved(node) //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -69,7 +69,7 @@ func newBaseIPAllocationController(pool *ipam.IPPool, iptIface iptiface.Interfac
 }
 
 func (c *baseSyncerController) Start() error {
-	return c.resourceSyncer.Start(c.stopCh) // nolint:wrapcheck  // Let the caller wrap it
+	return c.resourceSyncer.Start(c.stopCh) //nolint:wrapcheck  // Let the caller wrap it
 }
 
 func (c *baseSyncerController) reconcile(client dynamic.ResourceInterface, labelSelector, fieldSelector string,
@@ -150,7 +150,7 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 
 		logger.Infof("Updating %q: %#v", key, obj)
 
-		return federator.Distribute(obj) // nolint:wrapcheck  // Let the caller wrap it
+		return federator.Distribute(obj) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	return nil
@@ -236,7 +236,7 @@ func createService(svc *corev1.Service,
 ) (*unstructured.Unstructured, error) {
 	gnService, err := resourceUtil.ToUnstructured(svc)
 	if err != nil {
-		return nil, err // nolint:wrapcheck  // Let the caller wrap it
+		return nil, err //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	obj, err := client.Namespace(gnService.GetNamespace()).Create(context.TODO(), gnService, metav1.CreateOptions{})

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -213,7 +213,7 @@ func (c *clusterGlobalEgressIPController) flushClusterGlobalEgressRules(allocate
 func (c *clusterGlobalEgressIPController) deleteClusterGlobalEgressRules(srcIPList []string, snatIP string) error {
 	for _, srcIP := range srcIPList {
 		if err := c.iptIface.RemoveClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
-			return err // nolint:wrapcheck  // Let the caller wrap it
+			return err //nolint:wrapcheck  // Let the caller wrap it
 		}
 	}
 
@@ -228,7 +228,7 @@ func (c *clusterGlobalEgressIPController) programClusterGlobalEgressRules(alloca
 		if err := c.iptIface.AddClusterEgressRules(srcIP, snatIP, globalNetIPTableMark); err != nil {
 			_ = c.deleteClusterGlobalEgressRules(egressRulesProgrammed, snatIP)
 
-			return err // nolint:wrapcheck  // Let the caller wrap it
+			return err //nolint:wrapcheck  // Let the caller wrap it
 		}
 
 		egressRulesProgrammed = append(egressRulesProgrammed, srcIP)

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -314,7 +314,7 @@ func (g *gatewayMonitor) startControllers() error {
 	for _, c := range g.controllers {
 		err = c.Start()
 		if err != nil {
-			return err // nolint:wrapcheck  // Let the caller wrap it
+			return err //nolint:wrapcheck  // Let the caller wrap it
 		}
 	}
 

--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -168,7 +168,7 @@ func (c *globalEgressIPController) onCreateOrUpdate(key string, numberOfIPs int,
 		!c.createPodWatcher(key, namedIPSet, numberOfIPs, globalEgressIP)
 }
 
-// nolint:wrapcheck  // No need to wrap these errors.
+//nolint:wrapcheck  // No need to wrap these errors.
 func (c *globalEgressIPController) programGlobalEgressRules(key string, allocatedIPs []string, podSelector *metav1.LabelSelector,
 	namedIPSet ipset.Named,
 ) error {
@@ -356,7 +356,7 @@ func (c *globalEgressIPController) createPodWatcher(key string, namedIPSet ipset
 	return true
 }
 
-// nolint:wrapcheck  // No need to wrap these errors.
+//nolint:wrapcheck  // No need to wrap these errors.
 func (c *globalEgressIPController) flushGlobalEgressRulesAndReleaseIPs(key, ipSetName string, numRequeues int,
 	globalEgressIP *submarinerv1.GlobalEgressIP,
 ) bool {

--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -79,7 +79,7 @@ func NewGlobalIngressIPController(config *syncer.ResourceSyncerConfig, pool *ipa
 		gip := &submarinerv1.GlobalIngressIP{}
 		_ = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, gip)
 
-		// nolint:wrapcheck  // No need to wrap these errors.
+		//nolint:wrapcheck  // No need to wrap these errors.
 		err = controller.reserveAllocatedIPs(federator, obj, func(reservedIPs []string) error {
 			var target string
 			var tType iptables.TargetType
@@ -283,7 +283,7 @@ func (c *globalIngressIPController) onCreate(ingressIP *submarinerv1.GlobalIngre
 	return false
 }
 
-// nolint:wrapcheck  // No need to wrap these errors.
+//nolint:wrapcheck  // No need to wrap these errors.
 func (c *globalIngressIPController) onDelete(ingressIP *submarinerv1.GlobalIngressIP, numRequeues int) bool {
 	if ingressIP.Status.AllocatedIP == "" {
 		return false

--- a/pkg/globalnet/controllers/iptables/iface.go
+++ b/pkg/globalnet/controllers/iptables/iface.go
@@ -67,7 +67,7 @@ var logger = log.Logger{Logger: logf.Log.WithName("IPTables")}
 func New() (Interface, error) {
 	iptableHandler, err := iptables.New()
 	if err != nil {
-		return nil, err // nolint:wrapcheck  // Let the caller wrap it
+		return nil, err //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	iptableIface := &ipTables{

--- a/pkg/globalnet/controllers/uninstall.go
+++ b/pkg/globalnet/controllers/uninstall.go
@@ -206,7 +206,7 @@ func RemoveGlobalIPAnnotationOnNode(cfg *rest.Config) {
 
 		node.SetAnnotations(annotations)
 		_, updateErr := k8sClientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-		return updateErr // nolint:wrapcheck // We wrap it below in the enclosing function
+		return updateErr //nolint:wrapcheck // We wrap it below in the enclosing function
 	})
 
 	if retryErr != nil {

--- a/pkg/ipset/named.go
+++ b/pkg/ipset/named.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // The functions are simple wrappers so we'll let the caller wrap errors.
+//nolint:wrapcheck // The functions are simple wrappers so we'll let the caller wrap errors.
 package ipset
 
 type Named interface {

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -102,7 +102,7 @@ var errNoNATDiscoveryPort = errors.New("NATT discovery port missing in endpoint"
 func extractNATDiscoveryPort(endPoint *v1.EndpointSpec) (int32, error) {
 	natDiscoveryPort, err := endPoint.GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
 	if err != nil {
-		return natDiscoveryPort, err // nolint:wrapcheck  // No need to wrap this error
+		return natDiscoveryPort, err //nolint:wrapcheck  // No need to wrap this error
 	}
 
 	if natDiscoveryPort == 0 {

--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // Most of the functions are simple wrappers so we'll let the caller wrap errors.
+//nolint:wrapcheck // Most of the functions are simple wrappers so we'll let the caller wrap errors.
 package netlink
 
 import (

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -53,7 +53,7 @@ func (e linkNotFoundError) Error() string {
 }
 
 func (e linkNotFoundError) Is(err error) bool {
-	// nolint:errorlint // The given error should not be wrapped.
+	//nolint:errorlint // The given error should not be wrapped.
 	_, ok := err.(netlink.LinkNotFoundError)
 	return ok
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:wrapcheck // Most of the functions are simple wrappers so we'll let the caller wrap errors.
+//nolint:wrapcheck // Most of the functions are simple wrappers so we'll let the caller wrap errors.
 package netlink
 
 import (
@@ -186,7 +186,7 @@ func setSysctl(path string, contents []byte) error {
 	return os.WriteFile(path, contents, 0o644)
 }
 
-// nolint:wrapcheck // Let the caller wrap external errors
+//nolint:wrapcheck // Let the caller wrap external errors
 func GetDefaultGatewayInterface() (*net.Interface, error) {
 	routes, err := netlink.RouteList(nil, syscall.AF_INET)
 	if err != nil {

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -47,5 +47,5 @@ func (h *vxlanCleanup) GetName() string {
 func (h *vxlanCleanup) TransitionToNonGateway() error {
 	logger.Infof("Cleaning up the routes")
 
-	return netlink.DeleteIfaceAndAssociatedRoutes(vxlan.VxlanIface, vxlan.TableID) // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteIfaceAndAssociatedRoutes(vxlan.VxlanIface, vxlan.TableID) //nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
@@ -42,5 +42,5 @@ func (h *xrfmCleanup) GetNetworkPlugins() []string {
 func (h *xrfmCleanup) TransitionToNonGateway() error {
 	logger.Info("Transitioned to non-Gateway, cleaning up the IPsec xfrm rules")
 
-	return netlink.DeleteXfrmRules() // nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules() //nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/routeagent_driver/cni/cni_iface.go
+++ b/pkg/routeagent_driver/cni/cni_iface.go
@@ -121,7 +121,7 @@ func AnnotateNodeWithCNIInterfaceIP(nodeName string, clientSet kubernetes.Interf
 		}
 		node.SetAnnotations(annotations)
 		_, updateErr := clientSet.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-		return updateErr // nolint:wrapcheck // We wrap it below in the enclosing function
+		return updateErr //nolint:wrapcheck // We wrap it below in the enclosing function
 	})
 
 	if retryErr != nil {

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -54,7 +54,7 @@ var _ = Describe("[dataplane] Gateway status reporting", func() {
 				func() (interface{}, error) {
 					resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
 					if apierrors.IsNotFound(err) {
-						return nil, nil // nolint:nilnil // Returning nil value is intentional
+						return nil, nil //nolint:nilnil // Returning nil value is intentional
 					}
 					return resGw, err
 				},


### PR DESCRIPTION
This is enforced by newer releases of golangci-lint.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
