### PR TITLE
Remove external networks without globalnet from FF

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -22,7 +22,6 @@ jobs:
         cable_driver: ['libreswan', 'wireguard']
         include:
           - external_net: 'external-net'
-          - external_net: 'external-net'
             globalnet: 'globalnet'
     steps:
       - name: Check out the repository


### PR DESCRIPTION
This test consistently fails, has been marked as not required for now. Leaving it in the flake finder may hide tests that inconsistently fail, which is the goal of this job.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
