### PR TITLE
[Backport] Allow setting TCP MSS clamping value also for non GN (#2087)

### DIFF
--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -59,7 +59,7 @@ type mtuHandler struct {
 
 func NewMTUHandler(localClusterCidr []string, isGlobalnet bool, tcpMssValue int) event.Handler {
 	forceMss := notNeeded
-	if isGlobalnet {
+	if isGlobalnet || tcpMssValue != 0 {
 		forceMss = needed
 	}
 


### PR DESCRIPTION
We noticed in some cases MTU issues even when
GN was disabled.

This PR allows the user to force a
particular MSS clamping value also for non GN.

To force a particular MSS clamping value use the
submariner.io/tcp-clamp-mss node annotation on
Gateway nodes.

e.g. kubectl annotate node <node_name> submariner.io/tcp-clamp-mss=<value>

Signed-off-by: Yossi Boaron <yboaron@redhat.com>
(cherry picked from commit 9e47bd067e8a65d9084637e3a19b39201c05034c)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
