### PR TITLE
Automated backport of #2086: Log error message for fdb errors

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -289,7 +289,7 @@ func (v *vxlan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 	err = v.vxlanIface.AddFDB(remoteIP, "00:00:00:00:00:00")
 
 	if err != nil {
-		return endpointInfo.UseIP, fmt.Errorf("failed to add remoteIP %q to the forwarding database", remoteIP)
+		return endpointInfo.UseIP, fmt.Errorf("failed to add remoteIP %q to the forwarding database: %w", remoteIP, err)
 	}
 
 	var ipAddress net.IP


### PR DESCRIPTION
Backport of #2086 on release-0.13.

#2086: Log error message for fdb errors

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.