### PR TITLE
[Backport] Log nodename of connector pod in e2e tests (#2019)

### DIFF
--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -158,6 +158,8 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, egressIPT
 	stdOut, _, err := execCmdInBash(p, cmd, connectorPod.Pod)
 	Expect(err).To(BeNil())
 
+	By(fmt.Sprintf("Connector pod is scheduled on node %q", connectorPod.Pod.Spec.NodeName))
+
 	By(fmt.Sprintf("Waiting for the listener pod %q on node %q to exit, returning what listener sent",
 		listenerPod.Pod.Name, listenerPod.Pod.Spec.NodeName))
 	listenerPod.AwaitFinish()


### PR DESCRIPTION
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 1bfb6b1680a65e00d1763cc86e23650f8a4d6d1b)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
