### PR TITLE
[Backport] Avoid using api.ipify.org as the first resolver for public-ip (#2116)

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -54,7 +54,7 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		if submSpec.PublicIP != "" {
 			config = submSpec.PublicIP
 		} else {
-			config = "api:api.ipify.org,api:api.my-ip.io/ip,api:ip4.seeip.org"
+			config = "api:api.my-ip.io/ip,api:ip4.seeip.org,api:api.ipify.org"
 		}
 	}
 


### PR DESCRIPTION
As we are frequently seeing timeouts/errors with api.ipify.org these days while resolving public-ip, move the resolver to the end of the list.

Fixes: https://github.com/submariner-io/submariner/issues/2115
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 5b881e5ec8862bc1f0c21f3028ecdedc33e9d125)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
