### PR TITLE
Fix golangci-lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 ---
+run:
+  go: '1.18'
 linters-settings:
   gocritic:
     enabled-tags:
@@ -44,7 +46,7 @@ linters:
     - bodyclose
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
-    - deadcode
+    # - deadcode # replaced by unused
     - depguard
     - dogsled
     - dupl
@@ -107,7 +109,7 @@ linters:
     # - scopelint # Deprecated since v1.39.0
     # - sqlclosecheck # We don't use SQL
     - staticcheck
-    - structcheck
+    # - structcheck # replaced by unused
     - stylecheck
     # - tagliatelle # Inconsistent with stylecheck and not as good
     # - tenv # Not relevant for our Ginkgo UTs
@@ -118,9 +120,9 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
+    # - varcheck # replaced by unused
     # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
-    - wastedassign
+    # - wastedassign  # is disabled because of generics
     - whitespace
     - wrapcheck
     - wsl


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

refer the https://github.com/golangci/golangci-lint/issues/2649 and when i run "golangci-lint run"
<img width="643" alt="yanggang@yanggangdeMacook-Pro sub  golangci-lint version" src="https://user-images.githubusercontent.com/12080746/201452778-909f38bc-6f62-4deb-9665-568a39e4ad10.png">
<img width="1365" alt="WARN  runner  The linter 'varcheck' is deprecated (since v1 49 0) due to The owner seems to have abandoned the linter  Replaced" src="https://user-images.githubusercontent.com/12080746/201452779-95f29f1e-3e84-4d75-8ae0-ec9e0d8eb8bc.png">

Maybe we should update the .golangci.yaml. 
After modify the yaml , i run again. the "WARN" message is fixed..
<img width="649" alt="yanggang@yanggangdMacBook-Pro sub ga" src="https://user-images.githubusercontent.com/12080746/201452785-894261ee-39a3-4d16-b7f6-b0de10e01051.png">

