### PR TITLE
[Backport] Revert "Remove TCP MSS clamping rules from filter table (#2016) (#2028)"

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -21,6 +21,7 @@ package ovn
 import (
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/pkg/errors"
 	submiptables "github.com/submariner-io/submariner/pkg/iptables"
@@ -83,6 +84,15 @@ func (ovn *Handler) updateGatewayDataplane() error {
 	return ovn.setupForwardingIptables()
 }
 
+// TODO: if the #1022 workaround needs to be sustained for some time, instead of this we should be calculating
+//       the PMTU with a tool like tracepath between the gateway endpoints, reporting back so we can use such
+//		 information here.
+const (
+	IPTCPOverHead         = 40
+	ExpectedIPSECOverhead = 62
+	MSSFor1500MTU         = 1500 - IPTCPOverHead - ExpectedIPSECOverhead
+)
+
 func (ovn *Handler) getForwardingRuleSpecs() ([][]string, error) {
 	if ovn.cableRoutingInterface == nil {
 		return nil, errors.New("error setting up forwarding iptables, the cable interface isn't discovered yet, " +
@@ -97,13 +107,50 @@ func (ovn *Handler) getForwardingRuleSpecs() ([][]string, error) {
 	return rules, nil
 }
 
+func (ovn *Handler) getMSSClampingRuleSpecs() ([][]string, error) {
+	rules := [][]string{}
+
+	// NOTE: This is a workaround for submariner issues:
+	//   * https://github.com/submariner-io/submariner/issues/1278
+	//   * https://github.com/submariner-io/submariner/issues/1488
+	// TODO: get the kernel to steer the ICMPs back to ovn-k8s-sub0 interface properly, or write a packet
+	//       reflector in the route agent for that type of packets
+	for _, remoteCIDR := range ovn.getRemoteSubnets().Elements() {
+		rules = append(rules,
+			[]string{
+				"-d", remoteCIDR, "-p", "tcp", "-m", "tcp",
+				"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU),
+			},
+			[]string{
+				"-s", remoteCIDR, "-p", "tcp", "-m", "tcp",
+				"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU),
+			})
+	}
+
+	// NOTE: This is a workaround for submariner issue https://github.com/submariner-io/submariner/issues/1022
+	// TODO: work with the core-ovn community to make sure that load balancers propagate ICMPs back to pods
+	for _, serviceCIDR := range ovn.config.ServiceCidr {
+		rules = append(rules, []string{
+			"-o", ovnK8sSubmarinerInterface, "-d", serviceCIDR, "-p", "tcp", "-m", "tcp",
+			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU),
+		})
+	}
+
+	return rules, nil
+}
+
 type forwardRuleSpecGenerator func() ([][]string, error)
 
 const (
-	forwardingSubmarinerFWDChain = "SUBMARINER-FORWARD"
+	forwardingSubmarinerMSSClampChain = "SUBMARINER-FWD-MSSCLAMP"
+	forwardingSubmarinerFWDChain      = "SUBMARINER-FORWARD"
 )
 
 func (ovn *Handler) setupForwardingIptables() error {
+	if err := ovn.updateIPtableChains("filter", forwardingSubmarinerMSSClampChain, ovn.getMSSClampingRuleSpecs); err != nil {
+		return err
+	}
+
 	return ovn.updateIPtableChains("filter", forwardingSubmarinerFWDChain, ovn.getForwardingRuleSpecs)
 }
 
@@ -127,6 +174,10 @@ func (ovn *Handler) getNoMasqueradRuleSpecs() [][]string {
 }
 
 func (ovn *Handler) cleanupForwardingIptables() error {
+	if err := ovn.ipt.ClearChain("filter", forwardingSubmarinerMSSClampChain); err != nil {
+		return errors.Wrapf(err, "error clearing chain %q", forwardingSubmarinerMSSClampChain)
+	}
+
 	return errors.Wrapf(ovn.ipt.ClearChain("filter", forwardingSubmarinerFWDChain),
 		"error clearing chain %q", forwardingSubmarinerFWDChain)
 }
@@ -151,11 +202,20 @@ func (ovn *Handler) initIPtablesChains() error {
 }
 
 func (ovn *Handler) ensureForwardChains() error {
+	if err := submiptables.CreateChainIfNotExists(ovn.ipt, "filter", forwardingSubmarinerMSSClampChain); err != nil {
+		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerMSSClampChain)
+	}
+
+	if err := submiptables.InsertUnique(ovn.ipt, "filter", "FORWARD", 1,
+		[]string{"-j", forwardingSubmarinerMSSClampChain}); err != nil {
+		return errors.Wrapf(err, "error inserting rule for chain %q", forwardingSubmarinerMSSClampChain)
+	}
+
 	if err := submiptables.CreateChainIfNotExists(ovn.ipt, "filter", forwardingSubmarinerFWDChain); err != nil {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerFWDChain)
 	}
 
-	return errors.Wrapf(submiptables.InsertUnique(ovn.ipt, "filter", "FORWARD", 1, []string{"-j", forwardingSubmarinerFWDChain}),
+	return errors.Wrapf(submiptables.InsertUnique(ovn.ipt, "filter", "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
 		"error inserting rule for chain %q", forwardingSubmarinerFWDChain)
 }
 


### PR DESCRIPTION
This reverts commit 9067306e47d64775ce0838fb3985a0aadbe4cd1c. Some of e2e tests fail due to MTU issues for OCP with OVNK as cni, it seems that root cause is [1] PR.
This PR reverts [1].

Signed-off-by: Yossi Boaron <yboaron@redhat.com>

[1]
https://github.com/submariner-io/submariner/pull/2028

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
