### PR TITLE
Automated backport of #2158: Ignore go.sum changes when linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Run codegen
         run: make codegen
+      - name: Ignore go.sum changes
+        run: git checkout go.sum
       - name: Verify generated code matches committed code
         run: git add -A && git diff --staged --exit-code
 
@@ -50,6 +52,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: Recreate Protobuf files
         run: find pkg -name '*.pb.go' -delete -exec make {} \;
+      - name: Ignore go.sum changes
+        run: git checkout go.sum
       - name: Verify generated code matches committed code
         run: git add -A && git diff --staged --exit-code
 


### PR DESCRIPTION
Backport of #2158 on release-0.13.

#2158: Ignore go.sum changes when linting

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.