### PR TITLE
Fix issues with gateway public-ip resolver

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -20,6 +20,7 @@ package endpoint
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -87,6 +88,8 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 			BackendConfig: backendConfig,
 		},
 	}
+
+	rand.Seed(time.Now().UnixNano())
 
 	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig, airGappedDeployment)
 	if err != nil {

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -21,6 +21,7 @@ package endpoint
 import (
 	"context"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"regexp"
@@ -47,6 +48,18 @@ var publicIPMethods = map[string]publicIPResolverFunction{
 
 var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 
+func getPublicIPResolvers() string {
+	serverList := []string{
+		"api:ip4.seeip.org", "api:ipecho.net/plain", "api:ifconfig.me",
+		"api:ipinfo.io/ip", "api:4.ident.me", "api:checkip.amazonaws.com", "api:4.icanhazip.com",
+		"api:myexternalip.com/raw", "api:4.tnedi.me", "api:api.ipify.org",
+	}
+
+	rand.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
+
+	return strings.Join(serverList, ",")
+}
+
 func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
 	backendConfig map[string]string, airGapped bool,
 ) (string, error) {
@@ -56,7 +69,7 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		if submSpec.PublicIP != "" {
 			config = submSpec.PublicIP
 		} else {
-			config = "api:api.my-ip.io/ip,api:ip4.seeip.org,api:api.ipify.org"
+			config = getPublicIPResolvers()
 		}
 	}
 

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -44,7 +44,7 @@ type PublicIPWatcher struct {
 	config PublicIPWatcherConfig
 }
 
-const DefaultMonitorInterval = 20 * time.Second
+const DefaultMonitorInterval = 60 * time.Second
 
 func NewPublicIPWatcher(config *PublicIPWatcherConfig) *PublicIPWatcher {
 	controller := &PublicIPWatcher{


### PR DESCRIPTION
This PR implements changes in the public-ip resolution code

1. Recently we started to notice consistent errors while resolving
   public-ip when using the api.my-ip.io server. This PR removes this
   server entry from the list of resolvers and includes some new set 
   of servers as resolvers.
2. In the current code, we use a fixed sequence for resolving the public-ip.
   Due to this, the same resolver gets used all the time.
   It is only when the resolver fails, the next one from the list will
   be used as the resolver. This PR now randomizes the resolverList
   and we pick a random server everytime the periodic public-ip watcher
   is triggered.
3. The periodic public IP watcher interval is now increased to 60 secs.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
