### PR TITLE
Add GHA to periodically integrate submariner-io/*

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -36,8 +36,9 @@ jobs:
           commit-message: |
             Update submariner-io/* dependencies to latest
 
-            This checks the current status of this repository against the latest
-            version of all the Submariner projects it depends on.
+            This upgrades all our dependencies on other Submariner projects to their
+            latest development snapshots, ensuring the code in the projects remains
+            coherent and that tests of development images verify the latest code.
           signoff: true
           labels: automated, dependencies
 

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -8,6 +8,39 @@ on:
 permissions: {}
 
 jobs:
+  internal-integration:
+    name: Internal Integration
+    if: github.repository_owner == 'submariner-io'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Update internal submariner-io/* dependencies to latest
+        run: |
+          for dep in $(awk '!/module/ && /github.com.submariner-io/ { print $1 }' go.mod)
+            do go get ${dep}@devel
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04
+        with:
+          title: Update submariner-io/* dependencies to latest
+          body: |
+            This checks the current status of this repository against the latest version of all the Submariner projects it depends on.
+            If something fails, the failure should be investigated and at least tracked as an issue blocking the next release.
+            Since some CI only runs periodically, if on-PR CI passes it's still good to merge this update for full integration coverage.
+          commit-message: |
+            Update submariner-io/* dependencies to latest
+
+            This checks the current status of this repository against the latest
+            version of all the Submariner projects it depends on.
+          signoff: true
+          labels: automated, dependencies
+
   markdown-link-check-periodic:
     name: Markdown Links (all files)
     if: github.repository_owner == 'submariner-io'


### PR DESCRIPTION
Add a weekly GitHub action to update all internal Submariner repo dependencies to the latest on devel.

Avoids integration issues just before or during a release and lets us know when there are internal incompatibilities so they can be fixed.

Relates-to: submariner-io/submariner#2125
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
