### PR TITLE
Automated backport of #2164: Fix issues with gateway public-ip resolver

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -20,6 +20,7 @@ package endpoint
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -87,6 +88,8 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 			BackendConfig: backendConfig,
 		},
 	}
+
+	rand.Seed(time.Now().UnixNano())
 
 	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig, airGappedDeployment)
 	if err != nil {

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -21,6 +21,7 @@ package endpoint
 import (
 	"context"
 	"io"
+	"math/rand"
 	"net"
 	"net/http"
 	"regexp"
@@ -47,6 +48,18 @@ var publicIPMethods = map[string]publicIPResolverFunction{
 
 var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 
+func getPublicIPResolvers() string {
+	serverList := []string{
+		"api:ip4.seeip.org", "api:ipecho.net/plain", "api:ifconfig.me",
+		"api:ipinfo.io/ip", "api:4.ident.me", "api:checkip.amazonaws.com", "api:4.icanhazip.com",
+		"api:myexternalip.com/raw", "api:4.tnedi.me", "api:api.ipify.org",
+	}
+
+	rand.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
+
+	return strings.Join(serverList, ",")
+}
+
 func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
 	backendConfig map[string]string, airGapped bool,
 ) (string, error) {
@@ -56,7 +69,7 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		if submSpec.PublicIP != "" {
 			config = submSpec.PublicIP
 		} else {
-			config = "api:api.my-ip.io/ip,api:ip4.seeip.org,api:api.ipify.org"
+			config = getPublicIPResolvers()
 		}
 	}
 

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -44,7 +44,7 @@ type PublicIPWatcher struct {
 	config PublicIPWatcherConfig
 }
 
-const DefaultMonitorInterval = 20 * time.Second
+const DefaultMonitorInterval = 60 * time.Second
 
 func NewPublicIPWatcher(config *PublicIPWatcherConfig) *PublicIPWatcher {
 	controller := &PublicIPWatcher{


### PR DESCRIPTION
Backport of #2164 on release-0.14.

#2164: Fix issues with gateway public-ip resolver

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.