### PR TITLE
Automated backport of #2177: Enable 2 gateways for E2E fail-over test

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -5,3 +5,4 @@ clusters:
   cluster1:
   cluster2:
     nodes: control-plane worker worker
+    gateways: 2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/submariner-io/admiral v0.14.0
-	github.com/submariner-io/shipyard v0.14.0
+	github.com/submariner-io/shipyard v0.14.1-0.20221208073251-0e9e5e48000d
 	github.com/uw-labs/lichen v0.1.7
 	github.com/vishvananda/netlink v1.1.1-0.20210518155637-4cb3795f2ccb
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.14.0 h1:Ac+ZK2WBgEVDryHwKfm4Iof6MVpFbJZuySLYv5ve9dA=
 github.com/submariner-io/admiral v0.14.0/go.mod h1:ZYMMgfRNyaIrcshxN4vfbo5gVAnU0l5HgUdeqNLP/o4=
-github.com/submariner-io/shipyard v0.14.0 h1:oqeT1yxTuUYRDZPVfML6UofpR2kYeZP695dPU7jMO5U=
-github.com/submariner-io/shipyard v0.14.0/go.mod h1:eTF/ewEDwFiyjpBS+ZD7OEK3l3WI3KG/DO8QiwYNI2k=
+github.com/submariner-io/shipyard v0.14.1-0.20221208073251-0e9e5e48000d h1:UXvXQUk3K5jpVgMMaHfP1+izZeJAx2/uew9qbG79NNM=
+github.com/submariner-io/shipyard v0.14.1-0.20221208073251-0e9e5e48000d/go.mod h1:eTF/ewEDwFiyjpBS+ZD7OEK3l3WI3KG/DO8QiwYNI2k=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Backport of #2177 on release-0.14.

#2177: Enable 2 gateways for E2E fail-over test

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.