### PR TITLE
Fix e2e ext-net socket permission denied error

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
           skip: ""  # Override skipping external network tests
+          plugin: "scripts/e2e/external/hook"
 
       - name: Post mortem
         if: failure()

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
           skip: ""  # Override skipping external network tests
-          plugin: "scripts/e2e/external/hook"
+          plugin: scripts/e2e/external/hook
 
       - name: Post mortem
         if: failure()

--- a/scripts/e2e/external/utils
+++ b/scripts/e2e/external/utils
@@ -65,7 +65,7 @@ function setup_external() {
 
     # Create external test container on pseudo-ext network
     docker run --cap-add=NET_ADMIN --name "${EXTERNAL_APP}" --network "${EXTERNAL_NET}" \
-        -d registry.access.redhat.com/ubi7/ubi python -m SimpleHTTPServer 80
+        -d registry.access.redhat.com/ubi7/ubi python -m SimpleHTTPServer 1234
 
     # Add extra routing in external app
     docker exec -i "${EXTERNAL_APP}" yum install -y iproute

--- a/test/external/dataplane/connectivity.go
+++ b/test/external/dataplane/connectivity.go
@@ -21,6 +21,7 @@ package dataplane
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -36,7 +37,7 @@ const (
 	testContainerName = "ext-test-container"
 )
 
-var simpleHTTPServerCommand = []string{"python", "-m", "SimpleHTTPServer", "80"}
+var simpleHTTPServerCommand = []string{"python", "-m", "SimpleHTTPServer", strconv.Itoa(framework.TestPort)}
 
 type testParams struct {
 	Framework         *framework.Framework
@@ -195,7 +196,7 @@ func testExternalConnectivity(p testParams) {
 
 	np := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:          framework.CustomPod,
-		Port:          80,
+		Port:          framework.TestPort,
 		Cluster:       p.Cluster,
 		Scheduling:    p.ClusterScheduling,
 		Networking:    p.Networking,
@@ -229,7 +230,7 @@ func testExternalConnectivity(p testParams) {
 	By(fmt.Sprintf("Sending an http request from external app %q to %q in the cluster %q",
 		dockerIP, targetIP, clusterName))
 
-	command := []string{"curl", "-m", "3", fmt.Sprintf("%s:%d/%s%s", targetIP, 80, p.Framework.Namespace, clusterName)}
+	command := []string{"curl", "-m", "3", fmt.Sprintf("%s:%d/%s%s", targetIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = docker.RunCommandUntil(command...)
 
 	By("Verifying the pod received the request")
@@ -245,7 +246,7 @@ func testExternalConnectivity(p testParams) {
 	By(fmt.Sprintf("Sending an http request from the test pod %q %q in cluster %q to the external app %q",
 		np.Pod.Name, podIP, clusterName, dockerIP))
 
-	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", dockerIP, 80, p.Framework.Namespace, clusterName)}
+	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", dockerIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = np.RunCommand(cmd)
 
 	By("Verifying that external app received request")

--- a/test/external/dataplane/gn_connectivity.go
+++ b/test/external/dataplane/gn_connectivity.go
@@ -301,13 +301,13 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 
 	switch g.ExtEndpointType {
 	case ClusterIP:
-		extSvc = p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", 80)
+		extSvc = p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", framework.TestPort)
 	case Headless:
 		// TODO: move this method to framework
-		extSvc = createHeadlessTCPServiceWithoutSelector(p.Framework, extClusterIdx, "extsvc", "http", 80)
+		extSvc = createHeadlessTCPServiceWithoutSelector(p.Framework, extClusterIdx, "extsvc", "http", framework.TestPort)
 	}
 
-	p.Framework.CreateTCPEndpoints(extClusterIdx, extSvc.Name, "http", dockerIP, 80)
+	p.Framework.CreateTCPEndpoints(extClusterIdx, extSvc.Name, "http", dockerIP, framework.TestPort)
 	p.Framework.CreateServiceExport(extClusterIdx, extSvc.Name)
 
 	// Get globalIPs for the extApp to use later
@@ -323,7 +323,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 
 	np := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:          framework.CustomPod,
-		Port:          80,
+		Port:          framework.TestPort,
 		Cluster:       p.Cluster,
 		Scheduling:    p.ClusterScheduling,
 		Networking:    p.Networking,
@@ -344,7 +344,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	By(fmt.Sprintf("Sending an http request from external app %q to the service %q in the cluster %q",
 		dockerIP, remoteIP, clusterName))
 
-	command := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", remoteIP, 80, p.Framework.Namespace, clusterName)}
+	command := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", remoteIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = docker.RunCommand(command...)
 
 	podLog := np.GetLog()
@@ -381,7 +381,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	By(fmt.Sprintf("Sending an http request from the test pod %q in cluster %q to the external app's ingressGlobalIP %q",
 		np.Pod.Name, clusterName, extIngressGlobalIP))
 
-	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", extIngressGlobalIP, 80, p.Framework.Namespace, clusterName)}
+	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", extIngressGlobalIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = np.RunCommand(cmd)
 	_, dockerLog := docker.GetLog()
 


### PR DESCRIPTION
The e2e, external-net tests, are failing in CI and there seems to be multiple problems. One of them is related to the port 80 that is currently used by the test which is the reason for Permission denied error when the pod is scheduled in a cluster. This PR changes the port to the default port we use in other e2e tests, which is 1234.

Error seen in pod logs:
socket.error: [Errno 13 Permission denied

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
