### PR TITLE
Simplify E2E and Flake Finder GHAs

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -16,37 +16,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator']
-        external_net: ['']
-        globalnet: ['', 'globalnet']
-        cable_driver: ['libreswan', 'wireguard', 'vxlan']
-        ovn: ['', 'ovn']
+        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        extra-toggles: ['', 'globalnet', 'ovn']
         exclude:
-          - ovn: 'ovn'
-            globalnet: 'globalnet'
-          - ovn: 'ovn'
-            cable_driver: 'wireguard'
+          - cable-driver: wireguard
+            extra-toggles: ovn
         include:
-          - external_net: 'external-net'
-          - external_net: 'external-net'
-            globalnet: 'globalnet'
+          - extra-toggles: globalnet, ovn
+          - extra-toggles: external-net
+          - extra-toggles: external-net, globalnet
     steps:
       - name: Check out the repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
 
       - name: Run E2E deployment and tests
-        if: matrix.external_net != 'external-net'
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
-          using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.ovn }}
-
-      - name: Run External Network E2E deployment and tests
-        if: matrix.external_net == 'external-net'
-        uses: submariner-io/shipyard/gh-actions/e2e@devel
-        with:
-          using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
-          skip: ""  # Override skipping external network tests
-          plugin: scripts/e2e/external/hook
+          using: ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
 
       - name: Post mortem
         if: failure()

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -16,29 +16,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator']
-        external_net: ['']
-        globalnet: ['', 'globalnet']
-        cable_driver: ['libreswan', 'wireguard']
+        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        extra-toggles: ['', 'globalnet', 'ovn']
+        exclude:
+          - cable-driver: wireguard
+            extra-toggles: ovn
         include:
-          - external_net: 'external-net'
-            globalnet: 'globalnet'
+          - extra-toggles: globalnet, ovn
+          - extra-toggles: external-net
+          - extra-toggles: external-net, globalnet
     steps:
       - name: Check out the repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
 
       - name: Run E2E deployment and tests
-        if: matrix.external_net != 'external-net'
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
-          using: ${{ matrix.cable_driver }} ${{ matrix.deploytool }} ${{ matrix.globalnet }}
-
-      - name: Run External Network E2E deployment and tests
-        if: matrix.external_net == 'external-net'
-        uses: submariner-io/shipyard/gh-actions/e2e@devel
-        with:
-          using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
-          skip: ""  # Override skipping external network tests
+          using: ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
 
       - name: Post mortem
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export LDFLAGS = -X main.VERSION=$(VERSION)
 
 ifneq (,$(filter external-net,$(_using)))
 export TESTDIR = test/external
-export PLUGIN = scripts/e2e/external/hook
+override export PLUGIN = scripts/e2e/external/hook
 endif
 
 override E2E_ARGS += cluster2 cluster1


### PR DESCRIPTION
Simplify the GHA files to be more concise, making it easier to maintain and add more toggles as necessary.

Should result in a similar job count on E2E, and Flake Finder will now have the same jobs (as it had diverged slightly).

Partially depends on https://github.com/submariner-io/shipyard/pull/1083

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
