### PR TITLE
Automated backport of #2200: Fix e2e ext-net socket permission denied error

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
           skip: ""  # Override skipping external network tests
+          plugin: "scripts/e2e/external/hook"
 
       - name: Post mortem
         if: failure()

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           using: ${{ matrix.external_net }} ${{ matrix.globalnet }}
           skip: ""  # Override skipping external network tests
-          plugin: "scripts/e2e/external/hook"
+          plugin: scripts/e2e/external/hook
 
       - name: Post mortem
         if: failure()

--- a/scripts/e2e/external/utils
+++ b/scripts/e2e/external/utils
@@ -65,7 +65,7 @@ function setup_external() {
 
     # Create external test container on pseudo-ext network
     docker run --cap-add=NET_ADMIN --name "${EXTERNAL_APP}" --network "${EXTERNAL_NET}" \
-        -d registry.access.redhat.com/ubi7/ubi python -m SimpleHTTPServer 80
+        -d registry.access.redhat.com/ubi7/ubi python -m SimpleHTTPServer 1234
 
     # Add extra routing in external app
     docker exec -i "${EXTERNAL_APP}" yum install -y iproute

--- a/test/external/dataplane/connectivity.go
+++ b/test/external/dataplane/connectivity.go
@@ -21,6 +21,7 @@ package dataplane
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -36,7 +37,7 @@ const (
 	testContainerName = "ext-test-container"
 )
 
-var simpleHTTPServerCommand = []string{"python", "-m", "SimpleHTTPServer", "80"}
+var simpleHTTPServerCommand = []string{"python", "-m", "SimpleHTTPServer", strconv.Itoa(framework.TestPort)}
 
 type testParams struct {
 	Framework         *framework.Framework
@@ -195,7 +196,7 @@ func testExternalConnectivity(p testParams) {
 
 	np := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:          framework.CustomPod,
-		Port:          80,
+		Port:          framework.TestPort,
 		Cluster:       p.Cluster,
 		Scheduling:    p.ClusterScheduling,
 		Networking:    p.Networking,
@@ -229,7 +230,7 @@ func testExternalConnectivity(p testParams) {
 	By(fmt.Sprintf("Sending an http request from external app %q to %q in the cluster %q",
 		dockerIP, targetIP, clusterName))
 
-	command := []string{"curl", "-m", "3", fmt.Sprintf("%s:%d/%s%s", targetIP, 80, p.Framework.Namespace, clusterName)}
+	command := []string{"curl", "-m", "3", fmt.Sprintf("%s:%d/%s%s", targetIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = docker.RunCommandUntil(command...)
 
 	By("Verifying the pod received the request")
@@ -245,7 +246,7 @@ func testExternalConnectivity(p testParams) {
 	By(fmt.Sprintf("Sending an http request from the test pod %q %q in cluster %q to the external app %q",
 		np.Pod.Name, podIP, clusterName, dockerIP))
 
-	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", dockerIP, 80, p.Framework.Namespace, clusterName)}
+	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", dockerIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = np.RunCommand(cmd)
 
 	By("Verifying that external app received request")

--- a/test/external/dataplane/gn_connectivity.go
+++ b/test/external/dataplane/gn_connectivity.go
@@ -301,13 +301,13 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 
 	switch g.ExtEndpointType {
 	case ClusterIP:
-		extSvc = p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", 80)
+		extSvc = p.Framework.CreateTCPServiceWithoutSelector(extClusterIdx, "extsvc", "http", framework.TestPort)
 	case Headless:
 		// TODO: move this method to framework
-		extSvc = createHeadlessTCPServiceWithoutSelector(p.Framework, extClusterIdx, "extsvc", "http", 80)
+		extSvc = createHeadlessTCPServiceWithoutSelector(p.Framework, extClusterIdx, "extsvc", "http", framework.TestPort)
 	}
 
-	p.Framework.CreateTCPEndpoints(extClusterIdx, extSvc.Name, "http", dockerIP, 80)
+	p.Framework.CreateTCPEndpoints(extClusterIdx, extSvc.Name, "http", dockerIP, framework.TestPort)
 	p.Framework.CreateServiceExport(extClusterIdx, extSvc.Name)
 
 	// Get globalIPs for the extApp to use later
@@ -323,7 +323,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 
 	np := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:          framework.CustomPod,
-		Port:          80,
+		Port:          framework.TestPort,
 		Cluster:       p.Cluster,
 		Scheduling:    p.ClusterScheduling,
 		Networking:    p.Networking,
@@ -344,7 +344,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	By(fmt.Sprintf("Sending an http request from external app %q to the service %q in the cluster %q",
 		dockerIP, remoteIP, clusterName))
 
-	command := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", remoteIP, 80, p.Framework.Namespace, clusterName)}
+	command := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", remoteIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = docker.RunCommand(command...)
 
 	podLog := np.GetLog()
@@ -381,7 +381,7 @@ func testGlobalNetExternalConnectivity(p testParams, g globalnetTestParams) {
 	By(fmt.Sprintf("Sending an http request from the test pod %q in cluster %q to the external app's ingressGlobalIP %q",
 		np.Pod.Name, clusterName, extIngressGlobalIP))
 
-	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", extIngressGlobalIP, 80, p.Framework.Namespace, clusterName)}
+	cmd := []string{"curl", "-m", "10", fmt.Sprintf("%s:%d/%s%s", extIngressGlobalIP, framework.TestPort, p.Framework.Namespace, clusterName)}
 	_, _ = np.RunCommand(cmd)
 	_, dockerLog := docker.GetLog()
 


### PR DESCRIPTION
Backport of #2200 on release-0.14.

#2200: Fix e2e ext-net socket permission denied error

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.