### PR TITLE
Add FIPS status test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/prometheus-community/pro-bing v0.1.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/submariner-io/admiral v0.15.0-m1.0.20230107102340-0981d1750b04
-	github.com/submariner-io/shipyard v0.15.0-m1.0.20230106040911-f4e8acfd3485
+	github.com/submariner-io/shipyard v0.15.0-m1.0.20230113103004-47fd3c86572c
 	github.com/uw-labs/lichen v0.1.7
 	github.com/vishvananda/netlink v1.1.1-0.20210518155637-4cb3795f2ccb
 	golang.org/x/sys v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/submariner-io/admiral v0.15.0-m1.0.20230107102340-0981d1750b04 h1:GJS8gfoMm+gl6OWDHzSyxFjecqWXMbl7ot7ku4A1o3Q=
 github.com/submariner-io/admiral v0.15.0-m1.0.20230107102340-0981d1750b04/go.mod h1:7M6AzC/PJaVDb/c5BuQIdgklmtyzKGIIxctkOtwLqtA=
-github.com/submariner-io/shipyard v0.15.0-m1.0.20230106040911-f4e8acfd3485 h1:Ju/Z3DjmC/dWX1b1JJECIqNN4qImJrTe2KdchNg9ozI=
-github.com/submariner-io/shipyard v0.15.0-m1.0.20230106040911-f4e8acfd3485/go.mod h1:tAiMbF9sBGHqvWAQyGfJjLzWTmBANJA+e9p+6qVfqO4=
+github.com/submariner-io/shipyard v0.15.0-m1.0.20230113103004-47fd3c86572c h1:5J3CbWyJhfMlLryM4s0bV2dgGtqiBcvqYJt1x8CWHTo=
+github.com/submariner-io/shipyard v0.15.0-m1.0.20230113103004-47fd3c86572c/go.mod h1:tAiMbF9sBGHqvWAQyGfJjLzWTmBANJA+e9p+6qVfqO4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/dataplane/fips_status.go
+++ b/test/e2e/dataplane/fips_status.go
@@ -1,0 +1,64 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
+)
+
+var _ = Describe("[dataplane] FIPS", func() {
+	f := subFramework.NewFramework("fips-gateway-status")
+
+	When("FIPS mode is enabled for the active gateway node", func() {
+		It("should use FIPS mode in the libreswan cable driver", func() {
+			testFIPSGatewayStatus(f)
+		})
+	})
+})
+
+func testFIPSGatewayStatus(f *subFramework.Framework) {
+	By(fmt.Sprintln("Find a cluster with FIPS enabled"))
+
+	fipsCluster := f.FindFIPSEnabledCluster()
+
+	if fipsCluster == -1 {
+		framework.Skipf("No cluster found with FIPS enabled, skipping the test...")
+	}
+
+	fipsClusterName := framework.TestContext.ClusterIDs[fipsCluster]
+	By(fmt.Sprintf("Found enabled FIPS on cluster %q", fipsClusterName))
+
+	submEndpoint := f.AwaitSubmarinerEndpoint(fipsCluster, subFramework.NoopCheckEndpoint)
+
+	if submEndpoint.Spec.Backend != "libreswan" {
+		framework.Skipf(fmt.Sprintf("Cluster %q is not using the libreswan cable driver, skipping the test...", fipsClusterName))
+	}
+
+	By(fmt.Sprintf("Locate active gateway pod on cluster %q", fipsClusterName))
+
+	gwPod := f.AwaitActiveGatewayPod(fipsCluster, nil)
+	Expect(gwPod).ToNot(BeNil(), "Did not find an active gateway pod")
+
+	f.TestGatewayNodeFIPSMode(fipsCluster, gwPod.Name)
+}


### PR DESCRIPTION
Add FIPS status test to verify submariner gateway mode. When OCP cluster deployed with FIPS mode [1], submariner gateway should support FIPS mode and run with this mode enabled for libreswan.

Currently, FIPS is not supported on pure k8s.
It is supported on OCP clusters.
[1] - https://docs.openshift.com/container-platform/4.10/installing/installing-fips.html

Depends On https://github.com/submariner-io/shipyard/pull/1096

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
