### PR TITLE
Automated backport of #1941: Add constant for Flannel CNI
#2036: Declare constant for kindnet

### DIFF
--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -24,6 +24,7 @@ const (
 	CanalFlannel  = "canal-flannel"
 	Flannel       = "flannel"
 	WeaveNet      = "weave-net"
+	KindNet       = "kindnet"
 	OpenShiftSDN  = "OpenShiftSDN"
 	OVNKubernetes = "OVNKubernetes"
 	Calico        = "calico"

--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -22,6 +22,7 @@ package cni
 const (
 	Generic       = "generic"
 	CanalFlannel  = "canal-flannel"
+	Flannel       = "flannel"
 	WeaveNet      = "weave-net"
 	OpenShiftSDN  = "OpenShiftSDN"
 	OVNKubernetes = "OVNKubernetes"

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -79,8 +79,8 @@ func (kp *SyncHandler) GetName() string {
 
 func (kp *SyncHandler) GetNetworkPlugins() []string {
 	return []string{
-		cni.Generic, cni.CanalFlannel, cni.WeaveNet,
-		cni.OpenShiftSDN, cni.Calico,
+		cni.Generic, cni.CanalFlannel, cni.Flannel,
+		cni.WeaveNet, cni.OpenShiftSDN, cni.Calico,
 	}
 }
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -81,6 +81,7 @@ func (kp *SyncHandler) GetNetworkPlugins() []string {
 	return []string{
 		cni.Generic, cni.CanalFlannel, cni.Flannel,
 		cni.WeaveNet, cni.OpenShiftSDN, cni.Calico,
+		cni.KindNet,
 	}
 }
 


### PR DESCRIPTION
Backport of #1941 #2036 on release-0.13. Needed for https://github.com/submariner-io/subctl/pull/470.

#1941: Add constant for Flannel CNI
#2036: Declare constant for kindnet

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.