### PR TITLE
Skip IPv6 node addresses while adding fdb entries

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/submariner-io/admiral/pkg/log"
 	k8sV1 "k8s.io/api/core/v1"
+	k8snet "k8s.io/utils/net"
 )
 
 func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
@@ -33,7 +34,8 @@ func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
 	defer kp.syncHandlerMutex.Unlock()
 
 	for i, addr := range node.Status.Addresses {
-		if addr.Type == k8sV1.NodeInternalIP {
+		// Revisit when IPv6 support is added.
+		if addr.Type == k8sV1.NodeInternalIP && k8snet.IsIPv4String(node.Status.Addresses[i].Address) {
 			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address, Add)
 			break
 		}


### PR DESCRIPTION
In a dual-stack environment, a node is configured
with both IPv4 as well as IPv6 addresses. Currently, Submariner supports only IPv4 environements, so we should skip processing any IPv6 addresses on the node.

Partially Fixes: https://github.com/submariner-io/submariner/issues/1739
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
