### PR TITLE
Move FIPS E2E test to new compliance category

### DIFF
--- a/test/e2e/compliance/fips.go
+++ b/test/e2e/compliance/fips.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package dataplane
+package compliance
 
 import (
 	"fmt"
@@ -27,7 +27,7 @@ import (
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 )
 
-var _ = Describe("[dataplane] FIPS", func() {
+var _ = Describe("[compliance] FIPS", func() {
 	f := subFramework.NewFramework("fips-gateway-status")
 
 	When("FIPS mode is enabled for the active gateway node", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/submariner-io/shipyard/test/e2e"
 	_ "github.com/submariner-io/submariner/test/e2e/cluster"
+	_ "github.com/submariner-io/submariner/test/e2e/compliance"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
 )


### PR DESCRIPTION
...rather than as part of the `dataplane` category so it's not automatically run by `subctl verify` as a connectivity test.

Fixes https://github.com/submariner-io/submariner/issues/2251
