### PR TITLE
Modifying the argument passed to the clientcmd.BuildConfigFromFlags method

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -97,7 +97,7 @@ func New(config *Config) (*Controller, error) {
 
 	var cfg *restclient.Config
 	if config.Client == nil {
-		cfg, err = clientcmd.BuildConfigFromFlags(config.MasterURL, config.MasterURL)
+		cfg, err = clientcmd.BuildConfigFromFlags(config.MasterURL, config.Kubeconfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "error building config from flags")
 		}


### PR DESCRIPTION
Do we need to change `clientcmd.BuildConfigFromFlags(config.MasterURL, config.MasterURL)` to `clientcmd.BuildConfigFromFlags(config.MasterURL, config.Kubeconfig)`

Signed-off-by: hanweisen <hanweisen_yewu@cmss.chinamobile.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
