### PR TITLE
Submariner support for Dual Stack networks

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
 	"github.com/submariner-io/submariner/pkg/cableengine/syncer"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
@@ -322,8 +323,8 @@ func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.Subma
 		Spec: subv1.ClusterSpec{
 			ClusterID:   submSpec.ClusterID,
 			ColorCodes:  []string{"blue"}, // This is a fake value, used only for upgrade purposes
-			ServiceCIDR: submSpec.ServiceCidr,
-			ClusterCIDR: submSpec.ClusterCidr,
+			ServiceCIDR: cidr.GetIPv4Subnets(submSpec.ServiceCidr),
+			ClusterCIDR: cidr.GetIPv4Subnets(submSpec.ClusterCidr),
 			GlobalCIDR:  submSpec.GlobalCidr,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -323,8 +323,8 @@ func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.Subma
 		Spec: subv1.ClusterSpec{
 			ClusterID:   submSpec.ClusterID,
 			ColorCodes:  []string{"blue"}, // This is a fake value, used only for upgrade purposes
-			ServiceCIDR: cidr.GetIPv4Subnets(submSpec.ServiceCidr),
-			ClusterCIDR: cidr.GetIPv4Subnets(submSpec.ClusterCidr),
+			ServiceCIDR: cidr.ExtractIPv4Subnets(submSpec.ServiceCidr),
+			ClusterCIDR: cidr.ExtractIPv4Subnets(submSpec.ClusterCidr),
 			GlobalCIDR:  submSpec.GlobalCidr,
 		},
 	}

--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -87,8 +87,9 @@ func IsOverlapping(cidrList []string, cidr string) (bool, error) {
 	return false, nil
 }
 
-func GetIPv4Subnets(cidrList []string) ([]string) {
+func GetIPv4Subnets(cidrList []string) []string {
 	var ipv4Cidrs []string
+
 	for _, subnet := range cidrList {
 		if k8snet.IsIPv4CIDRString(subnet) {
 			ipv4Cidrs = append(ipv4Cidrs, subnet)

--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -87,7 +87,7 @@ func IsOverlapping(cidrList []string, cidr string) (bool, error) {
 	return false, nil
 }
 
-func GetIPv4Subnets(cidrList []string) []string {
+func ExtractIPv4Subnets(cidrList []string) []string {
 	var ipv4Cidrs []string
 
 	for _, subnet := range cidrList {

--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -84,4 +85,15 @@ func IsOverlapping(cidrList []string, cidr string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func GetIPv4Subnets(cidrList []string) ([]string) {
+	var ipv4Cidrs []string
+	for _, subnet := range cidrList {
+		if k8snet.IsIPv4CIDRString(subnet) {
+			ipv4Cidrs = append(ipv4Cidrs, subnet)
+		}
+	}
+
+	return ipv4Cidrs
 }

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -64,8 +64,8 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 		localSubnets = submSpec.GlobalCidr
 		globalnetEnabled = true
 	} else {
-		localSubnets = append(localSubnets, cidr.GetIPv4Subnets(submSpec.ServiceCidr)...)
-		localSubnets = append(localSubnets, cidr.GetIPv4Subnets(submSpec.ClusterCidr)...)
+		localSubnets = append(localSubnets, cidr.ExtractIPv4Subnets(submSpec.ServiceCidr)...)
+		localSubnets = append(localSubnets, cidr.ExtractIPv4Subnets(submSpec.ClusterCidr)...)
 	}
 
 	backendConfig, err := getBackendConfig(gwNode)

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/stringset"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/submariner-io/submariner/pkg/types"
@@ -63,8 +64,8 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 		localSubnets = submSpec.GlobalCidr
 		globalnetEnabled = true
 	} else {
-		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
-		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
+		localSubnets = append(localSubnets, cidr.GetIPv4Subnets(submSpec.ServiceCidr)...)
+		localSubnets = append(localSubnets, cidr.GetIPv4Subnets(submSpec.ClusterCidr)...)
 	}
 
 	backendConfig, err := getBackendConfig(gwNode)

--- a/pkg/endpoint/local_ip.go
+++ b/pkg/endpoint/local_ip.go
@@ -23,7 +23,8 @@ import (
 )
 
 func GetLocalIPForDestination(dst string) string {
-	conn, err := net.Dial("udp", dst+":53")
+	// Revisit when IPv6 support is added.
+	conn, err := net.Dial("udp4", dst+":53")
 	logger.FatalOnError(err, "Error getting local IP")
 
 	defer conn.Close()

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	cni "github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
@@ -62,8 +63,8 @@ var logger = log.Logger{Logger: logf.Log.WithName("KubeProxy")}
 
 func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 	return &SyncHandler{
-		localClusterCidr:        localClusterCidr,
-		localServiceCidr:        localServiceCidr,
+		localClusterCidr:        cidr.GetIPv4Subnets(localClusterCidr),
+		localServiceCidr:        cidr.GetIPv4Subnets(localServiceCidr),
 		localCableDriver:        "",
 		remoteSubnets:           stringset.NewSynchronized(),
 		remoteSubnetGw:          map[string]net.IP{},

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -63,8 +63,8 @@ var logger = log.Logger{Logger: logf.Log.WithName("KubeProxy")}
 
 func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 	return &SyncHandler{
-		localClusterCidr:        cidr.GetIPv4Subnets(localClusterCidr),
-		localServiceCidr:        cidr.GetIPv4Subnets(localServiceCidr),
+		localClusterCidr:        cidr.ExtractIPv4Subnets(localClusterCidr),
+		localServiceCidr:        cidr.ExtractIPv4Subnets(localServiceCidr),
 		localCableDriver:        "",
 		remoteSubnets:           stringset.NewSynchronized(),
 		remoteSubnetGw:          map[string]net.IP{},

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable/vxlan"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/ipset"
 	"github.com/submariner-io/submariner/pkg/iptables"
@@ -68,7 +69,7 @@ func NewMTUHandler(localClusterCidr []string, isGlobalnet bool, tcpMssValue int)
 	}
 
 	return &mtuHandler{
-		localClusterCidr: localClusterCidr,
+		localClusterCidr: cidr.GetIPv4Subnets(localClusterCidr),
 		forceMss:         forceMss,
 		tcpMssValue:      tcpMssValue,
 	}

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -69,7 +69,7 @@ func NewMTUHandler(localClusterCidr []string, isGlobalnet bool, tcpMssValue int)
 	}
 
 	return &mtuHandler{
-		localClusterCidr: cidr.GetIPv4Subnets(localClusterCidr),
+		localClusterCidr: cidr.ExtractIPv4Subnets(localClusterCidr),
 		forceMss:         forceMss,
 		tcpMssValue:      tcpMssValue,
 	}


### PR DESCRIPTION
This PR includes the following changes.

1. Support in mtu_handler to skip processing IPv6 addresses.
2. Local privateIP resolution code now uses only IPv4 addresses while creating an endpoint.
3. Support in Submariner Gateway pod for dual-stack clusters
4. Support in Submariner Route-agent pod for dual-stack clusters

Partially Fixes: https://github.com/submariner-io/submariner/issues/1739
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
