### PR TITLE
Use an atomic Bool for isGatewayNode

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -20,6 +20,7 @@ package controllers
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/stringset"
@@ -90,16 +91,16 @@ type baseController struct {
 
 type gatewayMonitor struct {
 	*baseController
-	syncerConfig    *syncer.ResourceSyncerConfig
-	endpointWatcher watcher.Interface
-	spec            Specification
-	ipt             iptables.Interface
-	isGatewayNode   bool
-	nodeName        string
-	syncMutex       sync.Mutex
-	localSubnets    []string
-	remoteSubnets   stringset.Interface
-	controllers     []Interface
+	syncerConfig     *syncer.ResourceSyncerConfig
+	endpointWatcher  watcher.Interface
+	spec             Specification
+	ipt              iptables.Interface
+	isGatewayNode    atomic.Bool
+	nodeName         string
+	localSubnets     []string
+	remoteSubnets    stringset.Interface
+	controllersMutex sync.Mutex // Protects controllers
+	controllers      []Interface
 }
 
 type baseSyncerController struct {


### PR DESCRIPTION
This allows the manual synchronization to be removed.

syncMutex is repurposed to protect controllers; we want to ensure that
startControllers() finishes before stopControllers() can be called,
and that stopControllers() is never called twice in parallel.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
