### PR TITLE
Use pointer utility functions instead of temporaries

### DIFF
--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/utils/pointer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -142,13 +143,11 @@ func NewDriver(localEndpoint *types.SubmarinerEndpoint, localCluster *types.Subm
 		return nil, errors.Wrapf(err, "error parsing %q from local endpoint", v1.UDPPortConfig)
 	}
 
-	portInt := int(port)
-
 	// Configure the device - still not up.
 	peerConfigs := make([]wgtypes.PeerConfig, 0)
 	cfg := wgtypes.Config{
 		PrivateKey:   &priv,
-		ListenPort:   &portInt,
+		ListenPort:   pointer.Int(int(port)),
 		FirewallMark: nil,
 		ReplacePeers: true,
 		Peers:        peerConfigs,

--- a/pkg/globalnet/controllers/cluster_egressip_controller.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 )
 
 func NewClusterGlobalEgressIPController(config *syncer.ResourceSyncerConfig, localSubnets []string,
@@ -59,13 +60,12 @@ func NewClusterGlobalEgressIPController(config *syncer.ResourceSyncerConfig, loc
 
 	federator := federate.NewUpdateStatusFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll)
 
-	numberOfIPs := DefaultNumberOfClusterEgressIPs
 	defaultEgressIP := &submarinerv1.ClusterGlobalEgressIP{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.ClusterGlobalEgressIPName,
 		},
 		Spec: submarinerv1.ClusterGlobalEgressIPSpec{
-			NumberOfIPs: &numberOfIPs,
+			NumberOfIPs: pointer.Int(DefaultNumberOfClusterEgressIPs),
 		},
 	}
 

--- a/pkg/networkplugin-syncer/handlers/ovn/ovn_logical_router_policy.go
+++ b/pkg/networkplugin-syncer/handlers/ovn/ovn_logical_router_policy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/stringset"
+	"k8s.io/utils/pointer"
 )
 
 func (ovn *SyncHandler) reconcileSubOvnLogicalRouterPolicies(remoteSubnets stringset.Interface) error {
@@ -63,7 +64,6 @@ func (ovn *SyncHandler) reconcileSubOvnLogicalRouterPolicies(remoteSubnets strin
 // database as an StringSet, and based on the known remote endpoints it will return the elements that need
 // to be added and removed.
 func buildLRPsFromSubnets(subnetsToAdd []string) []*nbdb.LogicalRouterPolicy {
-	tmpDownstreamIP := submarinerDownstreamIP
 	toAdd := []*nbdb.LogicalRouterPolicy{}
 
 	for _, subnet := range subnetsToAdd {
@@ -71,7 +71,7 @@ func buildLRPsFromSubnets(subnetsToAdd []string) []*nbdb.LogicalRouterPolicy {
 			Priority: ovnRoutePoliciesPrio,
 			Action:   "reroute",
 			Match:    "ip4.dst == " + subnet,
-			Nexthop:  &tmpDownstreamIP,
+			Nexthop:  pointer.String(submarinerDownstreamIP),
 			ExternalIDs: map[string]string{
 				"submariner": "true",
 			},


### PR DESCRIPTION
This allows struct contents to be expressed within the struct construction, and helps readability.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
