### PR TITLE
Use the new sets.Clear() function

### DIFF
--- a/pkg/ipset/fake/ipset.go
+++ b/pkg/ipset/fake/ipset.go
@@ -78,7 +78,7 @@ func (i *IPSet) FlushSet(set string) error {
 		return nil
 	}
 
-	entries.Delete(entries.UnsortedList()...)
+	entries.Clear()
 
 	return nil
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -33,7 +33,7 @@ import (
 
 func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks []string, operation Operation) {
 	if operation == Flush {
-		kp.routeCacheGWNode.Delete(kp.routeCacheGWNode.UnsortedList()...)
+		kp.routeCacheGWNode.Clear()
 
 		err := kp.netLink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
 		if err != nil {


### PR DESCRIPTION
This depends on the release of K8s 1.27.

Depends on https://github.com/submariner-io/submariner/pull/2426

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
