### PR TITLE
Use a package-private random number generator

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -20,7 +20,6 @@ package endpoint
 
 import (
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -89,8 +88,6 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 			BackendConfig: backendConfig,
 		},
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig, airGappedDeployment)
 	if err != nil {

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -51,6 +51,9 @@ var publicIPMethods = map[string]publicIPResolverFunction{
 
 var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 
+//nolint:gosec // This is only used to shuffle the list of resolvers
+var randgen = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 func getPublicIPResolvers() string {
 	serverList := []string{
 		"api:ip4.seeip.org", "api:ipecho.net/plain", "api:ifconfig.me",
@@ -58,7 +61,7 @@ func getPublicIPResolvers() string {
 		"api:myexternalip.com/raw", "api:4.tnedi.me", "api:api.ipify.org",
 	}
 
-	rand.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
+	randgen.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
 
 	return strings.Join(serverList, ",")
 }


### PR DESCRIPTION
The global rand.Seed() is deprecated, and package-private generators should be used instead. This will be enforced by our golangci-lint configuration when we upgrade to Go 1.20.

gosec complains about the use of math/rand rather than crypto/rand, but we don't need cryptographically-secure random number generation to shuffle the list of public IP resolvers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
