### PR TITLE
[Backport] Fix issues with gateway public-ip resolver (#2164)

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -20,6 +20,7 @@ package endpoint
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -86,6 +87,8 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 			BackendConfig: backendConfig,
 		},
 	}
+
+	rand.Seed(time.Now().UnixNano())
 
 	publicIP, err := getPublicIP(submSpec, k8sClient, backendConfig)
 	if err != nil {

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -46,7 +46,7 @@ type PublicIPWatcher struct {
 	config PublicIPWatcherConfig
 }
 
-const DefaultMonitorInterval = 20 * time.Second
+const DefaultMonitorInterval = 60 * time.Second
 
 func NewPublicIPWatcher(config *PublicIPWatcherConfig) *PublicIPWatcher {
 	controller := &PublicIPWatcher{


### PR DESCRIPTION
This PR implements changes in the public-ip resolution code

1. Recently we started to notice consistent errors while resolving public-ip when using the api.my-ip.io server. This PR removes this server entry from the list of resolvers and includes some new set of servers as resolvers.
2. In the current code, we use a fixed sequence for resolving the public-ip. Due to this, the same resolver gets used all the time. It is only when the resolver fails, the next one from the list will be used as the resolver. This PR now randomizes the resolverList and we pick a random server everytime the periodic public-ip watcher is triggered.
3. The periodic public IP watcher interval is now increased to 60 secs.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 8ec47c68cf1eefbb30ce7423240e45a7f6cfe99f)

Conflicts:
  pkg/endpoint/local_endpoint.go
  pkg/endpoint/public_ip.go

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
