### PR TITLE
[Backport] Public-ip resolver, change err log to debug (#2201)

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,8 +94,8 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 			return ip, nil
 		}
 
-		// If this resolved failed we log it, but we fall back to the next one
-		klog.Errorf("Error resolving public IP with resolver %s : %s", resolver, err.Error())
+		// If this resolver failed, we log it, but we fall back to the next one
+		klog.V(log.DEBUG).Infof("Error resolving public IP with resolver %s, config: %s: %v", resolver, config, err)
 	}
 
 	if len(resolvers) > 0 {

--- a/pkg/endpoint/public_ip_internal_test.go
+++ b/pkg/endpoint/public_ip_internal_test.go
@@ -129,7 +129,7 @@ var _ = Describe("public ip resolvers", func() {
 
 	When("an API entry specified", func() {
 		It("should return some IP", func() {
-			backendConfig[publicIPConfig] = "api:api.ipify.org"
+			backendConfig[publicIPConfig] = "api:4.icanhazip.com/"
 			client := fake.NewSimpleClientset()
 			ip, err := getPublicIP(submSpec, client, backendConfig)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Now that the code uses a list of external servers in a random manner, even if there is an error from one of the resolver, the code continues to use the other resolvers until all of them return errors. So instead of logging an error for an individual server, just log it as a debug message.

This PR also changes the unit test case to use one of the most robust external servers.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 28cd912c0b60857eb6e4f225305d55fd91c20b73)

Conflicts:
  pkg/endpoint/public_ip.go

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
