### PR TITLE
Ensure Gateway resource is deleted on shutdown

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -83,10 +83,8 @@ func NewGatewaySyncer(engine cableengine.Engine, client v1typed.GatewayInterface
 }
 
 func (gs *GatewaySyncer) Run(stopCh <-chan struct{}) {
-	go func() {
-		wait.Until(gs.syncGatewayStatus, GatewayUpdateInterval, stopCh)
-		gs.CleanupGatewayEntry()
-	}()
+	wait.Until(gs.syncGatewayStatus, GatewayUpdateInterval, stopCh)
+	gs.CleanupGatewayEntry()
 
 	logger.Info("CableEngine syncer started")
 }

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -560,7 +560,7 @@ func (t *testDriver) run() {
 	go informer.Run(t.stopInformer)
 	Expect(cache.WaitForCacheSync(t.stopInformer, informer.HasSynced)).To(BeTrue())
 
-	t.syncer.Run(t.stopSyncer)
+	go t.syncer.Run(t.stopSyncer)
 
 	Expect(t.healthChecker.Start(t.stopSyncer)).To(Succeed())
 }


### PR DESCRIPTION
The submariner `Gateway` resource is deleted by the syncer when the `syncGatewayStatus` loop exits but it's run asynchronously from the main function so, due to timing, it may not get deleted on shutdown. This can result in an intermittent gateway failover [E2E failure](https://github.com/submariner-io/submariner/actions/runs/4516418150/jobs/7954723307) b/c, after deleting the active gateway pod, it ensures the `Gateway` is [fully connected](https://github.com/submariner-io/submariner/blob/ee08287d2f0051af782f6b00c5d78fab696de905/test/e2e/redundancy/gateway_failover.go#L107), assuming it's a new instance. But, if the prior `Gateway` was not deleted, then it will observe the fully connected state of the prior stale `Gateway`. This can lead to subsequent timing failures where it is assumed the gateway is fully active.

Ensure that the `Gateway` is deleted by running the `Gateway` syncer synchronously from main and waiting for it to complete on shutdown.
