### PR TITLE
Add profiling endpoints to the metrics servers

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"strings"
 	"sync"
@@ -346,6 +347,7 @@ func startHTTPServer(spec *types.SubmarinerSpecification) *http.Server {
 	srv := &http.Server{Addr: ":" + spec.MetricsPort, ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/debug", pprof.Profile)
 
 	go func() {
 		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -135,6 +136,7 @@ func startHTTPServer(spec controllers.Specification) *http.Server {
 	srv := &http.Server{Addr: ":" + spec.MetricsPort, ReadHeaderTimeout: 60 * time.Second}
 
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/debug", pprof.Profile)
 
 	go func() {
 		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
This provides simple access to profiling information in the gateway and globalnet binaries. Forwarding the port locally provides access to a web-based interface, http://localhost:6060/debug/pprof/ (if the port is forwarded to :6060), which can be used directly or with tools such as https://github.com/google/pprof.

![Screenshot from 2023-03-27 15-31-31](https://user-images.githubusercontent.com/2128935/227952659-93344e54-9b3f-487c-b80f-4293e414683e.png)

![Screenshot from 2023-03-27 15-34-38](https://user-images.githubusercontent.com/2128935/227953714-fc97dd81-f8a6-4516-83a9-99bbb221abf5.png)

![Screenshot from 2023-03-27 15-30-13](https://user-images.githubusercontent.com/2128935/227952280-c51d9c36-00b5-495b-990b-bb1639522ac2.png)

If this is deemed useful we can generalise it to other binaries which don't already provide metrics.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
