### PR TITLE
Automated backport of #2354: Improve public IP resolver logging

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,7 +74,9 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		}
 	}
 
+	var wrappedErr error
 	resolvers := strings.Split(config, ",")
+
 	for _, resolver := range resolvers {
 		resolver = strings.Trim(resolver, " ")
 
@@ -95,11 +96,15 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		}
 
 		// If this resolver failed, we log it, but we fall back to the next one
-		klog.V(log.DEBUG).Infof("Error resolving public IP with resolver %s, config: %s: %v", resolver, config, err)
+		if wrappedErr == nil {
+			wrappedErr = errors.Wrapf(err, "\nResolver[%q]", resolver)
+		} else {
+			wrappedErr = errors.Wrapf(wrappedErr, "\nResolver[%q]: %v", resolver, err.Error())
+		}
 	}
 
 	if len(resolvers) > 0 {
-		return "", errors.Errorf("Unable to resolve public IP by any of the resolver methods: %s", resolvers)
+		return "", errors.Errorf("Unable to resolve public IP by any of the resolver methods: %v", wrappedErr)
 	}
 
 	return "", nil

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -32,6 +32,7 @@ import (
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -74,8 +75,8 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		}
 	}
 
-	var wrappedErr error
 	resolvers := strings.Split(config, ",")
+	errs := make([]error, 0, len(resolvers))
 
 	for _, resolver := range resolvers {
 		resolver = strings.Trim(resolver, " ")
@@ -96,15 +97,11 @@ func getPublicIP(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.I
 		}
 
 		// If this resolver failed, we log it, but we fall back to the next one
-		if wrappedErr == nil {
-			wrappedErr = errors.Wrapf(err, "\nResolver[%q]", resolver)
-		} else {
-			wrappedErr = errors.Wrapf(wrappedErr, "\nResolver[%q]: %v", resolver, err.Error())
-		}
+		errs = append(errs, errors.Wrapf(err, "\nResolver[%q]", resolver))
 	}
 
 	if len(resolvers) > 0 {
-		return "", errors.Errorf("Unable to resolve public IP by any of the resolver methods: %v", wrappedErr)
+		return "", errors.Wrapf(k8serrors.NewAggregate(errs), "Unable to resolve public IP by any of the resolver methods")
 	}
 
 	return "", nil

--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -71,7 +71,7 @@ func (p *PublicIPWatcher) Run(stopCh <-chan struct{}) {
 func (p *PublicIPWatcher) syncPublicIP() {
 	publicIP, err := getPublicIP(p.config.SubmSpec, p.config.K8sClient, p.config.LocalEndpoint.Spec.BackendConfig)
 	if err != nil {
-		klog.Warningf("Could not determine public IP of the gateway node %q", p.config.LocalEndpoint.Spec.Hostname)
+		klog.Warningf("Could not determine public IP of the gateway node %q: %v", p.config.LocalEndpoint.Spec.Hostname, err)
 		return
 	}
 


### PR DESCRIPTION
Backport of #2354 on release-0.13.

#2354: Improve public IP resolver logging

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.