### PR TITLE
Automated backport of #2349: Bump tim-actions/get-pr-commits for Node.js update

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get PR commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@c64db31d359214d244884dd68f971a110b29ab83
+        uses: tim-actions/get-pr-commits@8673d84c368f480628607dbe21c88545811ef23a
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Verify no "Apply suggestions from code review" commits'
-        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
+        uses: tim-actions/commit-message-checker-with-regex@e16b08b1a7f5cafeb1f8167de05bf1d40239eb5d
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^(?!.*(apply suggestions from code review))'
@@ -24,7 +24,7 @@ jobs:
           error: 'Commits addressing code review feedback should typically be squashed into the commits under review'
 
       - name: 'Verify no "fixup!" commits'
-        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
+        uses: tim-actions/commit-message-checker-with-regex@e16b08b1a7f5cafeb1f8167de05bf1d40239eb5d
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^(?!fixup!)'


### PR DESCRIPTION
Backport of #2349 on release-0.13.

#2349: Bump tim-actions/get-pr-commits for Node.js update

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.