### PR TITLE
Define status subresource in globalnet CRDs

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -196,6 +196,7 @@ func (c *Connection) SetStatus(status ConnectionStatus, messageFormat string, a 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName="geip"
+// +kubebuilder:subresource:status
 
 // GlobalEgressIP defines a policy for allocating GlobalIPs for selected pods in the namespace of the GlobalEgressIP object.
 type GlobalEgressIP struct {
@@ -254,6 +255,7 @@ type GlobalEgressIPList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope="Cluster",shortName="cgeip"
+// +kubebuilder:subresource:status
 // ClusterGlobalEgressIP defines a policy for allocating GlobalIPs at the cluster level to be used when no GlobalEgressIP
 // applies.
 type ClusterGlobalEgressIP struct {
@@ -290,6 +292,7 @@ type ClusterGlobalEgressIPList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName="giip"
 // +kubebuilder:printcolumn:JSONPath=".status.allocatedIP",name="IP",description="Global IP Allocated",type="string"
+// +kubebuilder:subresource:status
 
 type GlobalIngressIP struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
`GlobalEgressIP`, `ClusterGlobalEgressIP` and `GlobalEgressIP` follow the spec-status separation paradigm so it makes sense to define status as an actual subresource. The controllers for each already use the `StatusUpdateFederator` to specifically only update the status field.

This will need to be backported to 0.15 to unblock rc0 as globalnet E2E is failing. The main reason is that **admiral** `CreateOrUpdate`  doesn't properly handle CRDs that have the status field but don't define it as a subresource. While we need to fix that, it made it apparent that the globalnet CRDs really should define the subresource. 

