### PR TITLE
Fix stale iptable rule and globalip leak

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -123,10 +123,11 @@ type globalEgressIPController struct {
 }
 
 type egressPodWatcher struct {
-	stopCh      chan struct{}
-	ipSetName   string
-	namedIPSet  ipset.Named
-	podSelector *metav1.LabelSelector
+	stopCh       chan struct{}
+	ipSetName    string
+	namedIPSet   ipset.Named
+	podSelector  *metav1.LabelSelector
+	allocatedIPs []string
 }
 
 type clusterGlobalEgressIPController struct {


### PR DESCRIPTION
In this PR, the Globalnet controller, caches the AllocatedIPs for a globalEgressIP object and refers to it when the delete notification is seen (when the AllocatedIPs field is empty), which is sometimes noticed when the globalEgressIP object is created and immediately deleted.

Fixes: https://github.com/submariner-io/submariner/issues/2388

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
