### PR TITLE
Automated backport of #2389: Fix stale iptable rule and globalip leak

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -122,10 +122,11 @@ type globalEgressIPController struct {
 }
 
 type egressPodWatcher struct {
-	stopCh      chan struct{}
-	ipSetName   string
-	namedIPSet  ipset.Named
-	podSelector *metav1.LabelSelector
+	stopCh       chan struct{}
+	ipSetName    string
+	namedIPSet   ipset.Named
+	podSelector  *metav1.LabelSelector
+	allocatedIPs []string
 }
 
 type clusterGlobalEgressIPController struct {


### PR DESCRIPTION
Backport of #2389 on release-0.14.

#2389: Fix stale iptable rule and globalip leak

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.