### PR TITLE
Automated backport of #2389: Fix stale iptable rule and globalip leak

### DIFF
--- a/pkg/globalnet/controllers/global_egressip_controller.go
+++ b/pkg/globalnet/controllers/global_egressip_controller.go
@@ -292,6 +292,12 @@ func (c *globalEgressIPController) onDelete(numRequeues int, globalEgressIP *sub
 
 	namedIPSet := c.newNamedIPSet(key)
 
+	if len(globalEgressIP.Status.AllocatedIPs) == 0 && len(podWatcher.allocatedIPs) > 0 {
+		// Refer to issue for more details: https://github.com/submariner-io/submariner/issues/2388
+		klog.Warningf("Using the cached allocatedIPs %q to delete the iptables rules for key %q", podWatcher.allocatedIPs, key)
+		globalEgressIP.Status.AllocatedIPs = podWatcher.allocatedIPs
+	}
+
 	requeue := c.flushGlobalEgressRulesAndReleaseIPs(key, namedIPSet.Name(), numRequeues, globalEgressIP)
 	if requeue {
 		return requeue
@@ -305,7 +311,11 @@ func (c *globalEgressIPController) onDelete(numRequeues int, globalEgressIP *sub
 		}
 	}
 
-	klog.Infof("Successfully deleted all the iptables/ipset rules for %q ", key)
+	if numRequeues >= maxRequeues {
+		klog.Infof("Failed to delete all the iptables/ipset rules for %q even after %d retries", key, numRequeues)
+	} else {
+		klog.Infof("Successfully deleted all the iptables/ipset rules for %q ", key)
+	}
 
 	return false
 }
@@ -351,6 +361,7 @@ func (c *globalEgressIPController) createPodWatcher(key string, namedIPSet ipset
 
 	c.podWatchers[key] = podWatcher
 	podWatcher.podSelector = globalEgressIP.Spec.PodSelector
+	podWatcher.allocatedIPs = globalEgressIP.Status.AllocatedIPs
 
 	klog.Infof("Started pod watcher for %q", key)
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -119,10 +119,11 @@ type globalEgressIPController struct {
 }
 
 type egressPodWatcher struct {
-	stopCh      chan struct{}
-	ipSetName   string
-	namedIPSet  ipset.Named
-	podSelector *metav1.LabelSelector
+	stopCh       chan struct{}
+	ipSetName    string
+	namedIPSet   ipset.Named
+	podSelector  *metav1.LabelSelector
+	allocatedIPs []string
 }
 
 type clusterGlobalEgressIPController struct {


### PR DESCRIPTION
Backport of #2389 on release-0.13.

#2389: Fix stale iptable rule and globalip leak

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.