### PR TITLE
Fix data race in syncer_test

### DIFF
--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -60,6 +60,7 @@ const (
 
 func init() {
 	kzerolog.AddFlags(nil)
+	utilruntime.Must(submarinerv1.AddToScheme(kubeScheme.Scheme))
 }
 
 var _ = BeforeSuite(func() {
@@ -511,8 +512,6 @@ func (t *testDriver) run() {
 	utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers, func(err error) {
 		t.handledError <- err
 	})
-
-	Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())
 
 	scheme := runtime.NewScheme()
 	Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c0002e5c20 by goroutine 417:
  runtime.mapassign()
      /usr/lib/golang/src/runtime/map.go:578 +0x0
  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddUnversionedTypes()
      k8s.io/apimachinery@v0.26.3/pkg/runtime/scheme.go:129
  ...
  pkg/cableengine/syncer_test.(*testDriver).run()
      pkg/cableengine/syncer/syncer_test.go:515

Previous read at 0x00c0002e5c20 by goroutine 405:
  runtime.mapaccess2()
      /usr/lib/golang/src/runtime/map.go:456 +0x0
  k8s.io/apimachinery/pkg/runtime.(*Scheme).ObjectKinds()
      k8s.io/apimachinery@v0.26.3/pkg/runtime/scheme.go:268
  ...
  pkg/util/create_or_update.go:176
      pkg/util.maybeCreateOrUpdate.func1()
```

The offending write is:

  `Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())`

`AddToScheme` should be done once in an `init` function.

