### PR TITLE
Support packet-size as part of Globalnet e2e

### DIFF
--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -151,7 +151,8 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, egressIPT
 		Command:       []string{"sleep", "600"},
 	})
 
-	cmd := []string{"sh", "-c", "for j in $(seq 50); do echo [dataplane] connector says " + connectorPod.Config.Data + "; done" +
+	cmd := []string{"sh", "-c", "for j in $(seq 1 " + strconv.Itoa(int(connectorPod.Config.NumOfDataBufs)) + "); do echo" +
+		" [dataplane] connector says " + connectorPod.Config.Data + "; done" +
 		" | for i in $(seq " + strconv.Itoa(int(p.ConnectionAttempts)) + ");" +
 		" do if nc -v " + remoteIP + " " + strconv.Itoa(connectorPod.Config.Port) + " -w " + strconv.Itoa(int(p.ConnectionTimeout)) + ";" +
 		" then break; else sleep " + strconv.Itoa(int(p.ConnectionTimeout/2)) + "; fi; done"}


### PR DESCRIPTION
The following PR in Shipyard[*] includes support for packet-size which works for non-Globalnet deployments. Globalnet on the other hand uses a CustomPod and this PR includes the necessary support.

* https://github.com/submariner-io/shipyard/pull/1140

Fixes: https://github.com/submariner-io/subctl/pull/551

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
