### PR TITLE
Automated backport of #2416: Fix data race in syncer_test

### DIFF
--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -60,6 +60,7 @@ const (
 
 func init() {
 	kzerolog.AddFlags(nil)
+	utilruntime.Must(submarinerv1.AddToScheme(kubeScheme.Scheme))
 }
 
 var _ = BeforeSuite(func() {
@@ -511,8 +512,6 @@ func (t *testDriver) run() {
 	utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers, func(err error) {
 		t.handledError <- err
 	})
-
-	Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())
 
 	scheme := runtime.NewScheme()
 	Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())


### PR DESCRIPTION
Backport of #2416 on release-0.15.

#2416: Fix data race in syncer_test

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.