### PR TITLE
Fix connection issues with RHEL9 GW nodes

### DIFF
--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -257,6 +257,10 @@ func (n *basicType) EnableLooseModeReversePathFilter(_ string) error {
 	return nil
 }
 
+func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
+	return []byte("2"), nil
+}
+
 func (n *basicType) ConfigureTCPMTUProbe(_, _ string) error {
 	return nil
 }


### PR DESCRIPTION
When a RHEL-9 node is used as a Submariner Gateway node, it was seen that immediately after creating the interface if we configure the rp_filter setting its getting overwritten. However, if we add a small delay for the interface to come up and then configure the rp_filter it works fine. This is still to be considred as a temporary work-around until a proper root cause is identified.

Fixes: https://github.com/submariner-io/submariner/issues/2422

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
