### PR TITLE
Ignore comments in proto-generated code

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Ignore go.sum changes
         run: git checkout go.sum
       - name: Verify generated code matches committed code
-        run: git add -A && git diff --staged --exit-code
+        run: git add -A && git diff -I'^//' --staged --exit-code
 
   gitlint:
     name: Commit Message(s)


### PR DESCRIPTION
This avoids false positives when one of the protoc components is upgraded without any actual code changes (the comments indicating the version used to generate the code change).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
