### PR TITLE
Automated backport of #2399: Fix race when out-of-order RemoteEndpoint events are seen

### DIFF
--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -24,14 +24,16 @@ import (
 	"github.com/submariner-io/admiral/pkg/stringset"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	k8sV1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Registry struct {
-	name          string
-	networkPlugin string
-	eventHandlers []Handler
+	name                    string
+	networkPlugin           string
+	eventHandlers           []Handler
+	remoteEndpointTimeStamp map[string]v1.Time
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("EventRegistry")}
@@ -40,9 +42,10 @@ var logger = log.Logger{Logger: logf.Log.WithName("EventRegistry")}
 // Handlers that match the given networkPlugin name.
 func NewRegistry(name, networkPlugin string) *Registry {
 	return &Registry{
-		name:          name,
-		networkPlugin: networkPlugin,
-		eventHandlers: []Handler{},
+		name:                    name,
+		networkPlugin:           networkPlugin,
+		eventHandlers:           []Handler{},
+		remoteEndpointTimeStamp: map[string]v1.Time{},
 	}
 }
 
@@ -122,9 +125,23 @@ func (er *Registry) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (er *Registry) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
-	return er.invokeHandlers("RemoteEndpointCreated", func(h Handler) error {
+	lastProcessedTime, ok := er.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
+
+	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
+		logger.Infof("Ignoring new remote %#v since a later endpoint was already"+
+			"processed", endpoint)
+		return nil
+	}
+
+	err := er.invokeHandlers("RemoteEndpointCreated", func(h Handler) error {
 		return h.RemoteEndpointCreated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})
+
+	if err == nil {
+		er.remoteEndpointTimeStamp[endpoint.Spec.ClusterID] = endpoint.CreationTimestamp
+	}
+
+	return err
 }
 
 func (er *Registry) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
@@ -134,6 +151,16 @@ func (er *Registry) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 }
 
 func (er *Registry) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	lastProcessedTime, ok := er.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
+
+	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
+		logger.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
+			"processed", endpoint)
+		return nil
+	}
+
+	delete(er.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
+
 	return er.invokeHandlers("RemoteEndpointRemoved", func(h Handler) error {
 		return h.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	})

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -20,6 +20,7 @@ package event_test
 
 import (
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,6 +99,41 @@ var _ = Describe("Event Registry", func() {
 						ev.Handler = h.Name
 						Expect(allTestEvents).To(Receive(Equal(ev)))
 					}
+				}
+			})
+		})
+
+		When("the RemoteEndpointCreated notification is fired out of order", func() {
+			It("should skip processing the stale event", func() {
+				now := time.Now()
+				aFewSecondsLater := now.Add(2 * time.Second)
+				staleEndpoint := &submV1.Endpoint{
+					ObjectMeta: v1meta.ObjectMeta{Name: "endpoint1", CreationTimestamp: v1meta.NewTime(now)},
+					Spec:       submV1.EndpointSpec{ClusterID: "eastCluster"},
+				}
+				latestEndpoint := &submV1.Endpoint{
+					ObjectMeta: v1meta.ObjectMeta{Name: "endpoint1", CreationTimestamp: v1meta.NewTime(aFewSecondsLater)},
+					Spec:       submV1.EndpointSpec{ClusterID: "eastCluster"},
+				}
+
+				event := testing.TestEvent{
+					Name:      testing.EvRemoteEndpointCreated,
+					Parameter: latestEndpoint,
+				}
+
+				err := registry.RemoteEndpointCreated(latestEndpoint)
+				Expect(err).To(Succeed())
+
+				for _, h := range matchingHandlers {
+					event.Handler = h.Name
+					Expect(allTestEvents).To(Receive(Equal(event)))
+				}
+
+				err = registry.RemoteEndpointCreated(staleEndpoint)
+				Expect(err).To(Succeed())
+
+				for range matchingHandlers {
+					Expect(allTestEvents).NotTo(Receive(Equal(event)))
 				}
 			})
 		})

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -104,14 +104,6 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
 
-	lastProcessedTime, ok := kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
-
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring new remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
-
 	for _, inputCidrBlock := range endpoint.Spec.Subnets {
 		if !kp.remoteSubnets.Contains(inputCidrBlock) {
 			kp.remoteSubnets.Add(inputCidrBlock)
@@ -131,8 +123,6 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Add)
 	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Add)
 
-	kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID] = endpoint.CreationTimestamp
-
 	return nil
 }
 
@@ -143,16 +133,6 @@ func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
-
-	lastProcessedTime, ok := kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
-
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
-
-	delete(kp.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
 
 	for _, inputCidrBlock := range endpoint.Spec.Subnets {
 		kp.remoteSubnets.Remove(inputCidrBlock)

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -30,7 +30,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
 	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -44,7 +43,6 @@ type SyncHandler struct {
 	remoteSubnetGw          map[string]net.IP
 	remoteVTEPs             stringset.Interface
 	routeCacheGWNode        stringset.Interface
-	remoteEndpointTimeStamp map[string]v1.Time
 
 	syncHandlerMutex     sync.Mutex
 	isGatewayNode        bool
@@ -67,7 +65,6 @@ func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 		localCableDriver:        "",
 		remoteSubnets:           stringset.NewSynchronized(),
 		remoteSubnetGw:          map[string]net.IP{},
-		remoteEndpointTimeStamp: map[string]v1.Time{},
 		remoteVTEPs:             stringset.NewSynchronized(),
 		routeCacheGWNode:        stringset.NewSynchronized(),
 		isGatewayNode:           false,

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -139,14 +139,6 @@ func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
 
-	existingEndPoint, ok := ovn.remoteEndpoints[endpoint.Spec.ClusterID]
-
-	if ok && existingEndPoint.CreationTimestamp.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring new remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
-
 	ovn.remoteEndpoints[endpoint.Name] = endpoint
 
 	err := ovn.updateHostNetworkDataplane()
@@ -194,14 +186,6 @@ func (ovn *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 func (ovn *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
-
-	existingEndPoint, ok := ovn.remoteEndpoints[endpoint.Spec.ClusterID]
-
-	if ok && existingEndPoint.CreationTimestamp.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
 
 	delete(ovn.remoteEndpoints, endpoint.Name)
 


### PR DESCRIPTION
Backport of #2399 on release-0.14.

#2399: Fix race when out-of-order RemoteEndpoint events are seen

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.