### PR TITLE
Automated backport of #2399: Fix race when out-of-order RemoteEndpoint events are seen

### DIFF
--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -20,6 +20,7 @@ package event_test
 
 import (
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,6 +99,41 @@ var _ = Describe("Event Registry", func() {
 						ev.Handler = h.Name
 						Expect(allTestEvents).To(Receive(Equal(ev)))
 					}
+				}
+			})
+		})
+
+		When("the RemoteEndpointCreated notification is fired out of order", func() {
+			It("should skip processing the stale event", func() {
+				now := time.Now()
+				aFewSecondsLater := now.Add(2 * time.Second)
+				staleEndpoint := &submV1.Endpoint{
+					ObjectMeta: v1meta.ObjectMeta{Name: "endpoint1", CreationTimestamp: v1meta.NewTime(now)},
+					Spec:       submV1.EndpointSpec{ClusterID: "eastCluster"},
+				}
+				latestEndpoint := &submV1.Endpoint{
+					ObjectMeta: v1meta.ObjectMeta{Name: "endpoint1", CreationTimestamp: v1meta.NewTime(aFewSecondsLater)},
+					Spec:       submV1.EndpointSpec{ClusterID: "eastCluster"},
+				}
+
+				event := testing.TestEvent{
+					Name:      testing.EvRemoteEndpointCreated,
+					Parameter: latestEndpoint,
+				}
+
+				err := registry.RemoteEndpointCreated(latestEndpoint)
+				Expect(err).To(Succeed())
+
+				for _, h := range matchingHandlers {
+					event.Handler = h.Name
+					Expect(allTestEvents).To(Receive(Equal(event)))
+				}
+
+				err = registry.RemoteEndpointCreated(staleEndpoint)
+				Expect(err).To(Succeed())
+
+				for range matchingHandlers {
+					Expect(allTestEvents).NotTo(Receive(Equal(event)))
 				}
 			})
 		})

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -105,14 +105,6 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
 
-	lastProcessedTime, ok := kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
-
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		klog.Infof("Ignoring new remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
-
 	for _, inputCidrBlock := range endpoint.Spec.Subnets {
 		if !kp.remoteSubnets.Contains(inputCidrBlock) {
 			kp.remoteSubnets.Add(inputCidrBlock)
@@ -132,8 +124,6 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Add)
 	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Add)
 
-	kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID] = endpoint.CreationTimestamp
-
 	return nil
 }
 
@@ -144,16 +134,6 @@ func (kp *SyncHandler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
 func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	kp.syncHandlerMutex.Lock()
 	defer kp.syncHandlerMutex.Unlock()
-
-	lastProcessedTime, ok := kp.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
-
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		klog.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
-	}
-
-	delete(kp.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
 
 	for _, inputCidrBlock := range endpoint.Spec.Subnets {
 		kp.remoteSubnets.Remove(inputCidrBlock)

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -29,7 +29,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
 	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
@@ -39,11 +38,10 @@ type SyncHandler struct {
 	localClusterCidr []string
 	localServiceCidr []string
 
-	remoteSubnets           stringset.Interface
-	remoteSubnetGw          map[string]net.IP
-	remoteVTEPs             stringset.Interface
-	routeCacheGWNode        stringset.Interface
-	remoteEndpointTimeStamp map[string]v1.Time
+	remoteSubnets    stringset.Interface
+	remoteSubnetGw   map[string]net.IP
+	remoteVTEPs      stringset.Interface
+	routeCacheGWNode stringset.Interface
 
 	syncHandlerMutex     sync.Mutex
 	isGatewayNode        bool
@@ -59,17 +57,16 @@ type SyncHandler struct {
 
 func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 	return &SyncHandler{
-		localClusterCidr:        localClusterCidr,
-		localServiceCidr:        localServiceCidr,
-		localCableDriver:        "",
-		remoteSubnets:           stringset.NewSynchronized(),
-		remoteSubnetGw:          map[string]net.IP{},
-		remoteEndpointTimeStamp: map[string]v1.Time{},
-		remoteVTEPs:             stringset.NewSynchronized(),
-		routeCacheGWNode:        stringset.NewSynchronized(),
-		isGatewayNode:           false,
-		wasGatewayPreviously:    false,
-		netLink:                 netlink.New(),
+		localClusterCidr:     localClusterCidr,
+		localServiceCidr:     localServiceCidr,
+		localCableDriver:     "",
+		remoteSubnets:        stringset.NewSynchronized(),
+		remoteSubnetGw:       map[string]net.IP{},
+		remoteVTEPs:          stringset.NewSynchronized(),
+		routeCacheGWNode:     stringset.NewSynchronized(),
+		isGatewayNode:        false,
+		wasGatewayPreviously: false,
+		netLink:              netlink.New(),
 	}
 }
 


### PR DESCRIPTION
Backport of #2399 on release-0.13.

#2399: Fix race when out-of-order RemoteEndpoint events are seen

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.