### PR TITLE
Fix vxlan cable driver issue on RHEL-9 Gateway nodes

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -151,9 +151,9 @@ func (v *vxlan) createVxlanInterface(activeEndPoint string, port int) error {
 		return errors.Wrap(err, "failed to add ip rule")
 	}
 
-	err = v.netLink.EnableLooseModeReversePathFilter(VxlanIface)
+	err = v.netLink.EnsureLooseModeIsConfigured(VxlanIface)
 	if err != nil {
-		return errors.Wrap(err, "unable to update vxlan rp_filter proc entry")
+		return errors.Wrap(err, "error while validating loose mode")
 	}
 
 	logger.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on %s", VxlanIface)

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -257,6 +257,10 @@ func (n *basicType) EnableLooseModeReversePathFilter(_ string) error {
 	return nil
 }
 
+func (n *basicType) EnsureLooseModeIsConfigured(_ string) error {
+	return nil
+}
+
 func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
 	return []byte("2"), nil
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -19,14 +19,11 @@ limitations under the License.
 package kubeproxy
 
 import (
-	"bytes"
 	goerrors "errors"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -274,7 +271,7 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 			}
 		}
 
-		err = kp.ensureLooseModeIsConfigured(VxLANIface)
+		err = kp.netLink.EnsureLooseModeIsConfigured(VxLANIface)
 		if err != nil {
 			return errors.Wrap(err, "error while validating loose mode")
 		}
@@ -303,28 +300,4 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 	}
 
 	return nil
-}
-
-func (kp *SyncHandler) ensureLooseModeIsConfigured(iface string) error {
-	for i := 0; i < 10; i++ {
-		// Revisit: This is a temporary work-around to fix https://github.com/submariner-io/submariner/issues/2422
-		// Allow the vx-submariner interface to get initialized.
-		time.Sleep(100 * time.Millisecond)
-
-		rpFilterSetting, err := kp.netLink.GetReversePathFilter(iface)
-		if err == nil {
-			if bytes.Equal(rpFilterSetting, []byte("2")) {
-				return nil
-			}
-		} else {
-			logger.Warningf("Error retrieving reverse path filter for %q: %v", iface, err)
-		}
-
-		err = kp.netLink.EnableLooseModeReversePathFilter(iface)
-		if err != nil {
-			return errors.Wrapf(err, "error enabling loose mode on iface %q", iface)
-		}
-	}
-
-	return fmt.Errorf("loose mode not configured on iface %q", iface)
 }


### PR DESCRIPTION
Similar to the fix done as part of #2422 for the intra-cluster vxlan tunnel (i.e., vx-submariner iface), we run into the same issues when using the vxlan cable driver. This PR fixes it by adding a small delay after creating the vxlan-tunnel iface on the Gateway node.

Fixes: https://github.com/submariner-io/submariner/issues/2422

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
