### PR TITLE
Automated backport of #2423: Fix connection issues with RHEL9 GW nodes

### DIFF
--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -257,6 +257,10 @@ func (n *basicType) EnableLooseModeReversePathFilter(interfaceName string) error
 	return nil
 }
 
+func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
+	return []byte("2"), nil
+}
+
 func (n *basicType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
 	return nil
 }


### PR DESCRIPTION
Backport of #2423 on release-0.14.

#2423: Fix connection issues with RHEL9 GW nodes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.