### PR TITLE
Automated backport of #2423: Fix connection issues with RHEL9 GW nodes

### DIFF
--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -244,6 +244,10 @@ func (n *basicType) EnableLooseModeReversePathFilter(interfaceName string) error
 	return nil
 }
 
+func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
+	return []byte("2"), nil
+}
+
 func (n *basicType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
 	return nil
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -53,6 +53,7 @@ type Basic interface {
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
 	EnableLooseModeReversePathFilter(interfaceName string) error
+	GetReversePathFilter(interfaceName string) ([]byte, error)
 	ConfigureTCPMTUProbe(mtuProbe, baseMss string) error
 }
 
@@ -150,6 +151,20 @@ func (n *netlinkType) EnableLooseModeReversePathFilter(interfaceName string) err
 	// Enable loose mode (rp_filter=2) reverse path filtering on the vxlan interface.
 	err := setSysctl("/proc/sys/net/ipv4/conf/"+interfaceName+"/rp_filter", []byte("2"))
 	return errors.Wrapf(err, "unable to update rp_filter proc entry for interface %q", interfaceName)
+}
+
+func (n *netlinkType) GetReversePathFilter(interfaceName string) ([]byte, error) {
+	path := "/proc/sys/net/ipv4/conf/" + interfaceName + "/rp_filter"
+
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read proc entry for interface %q", interfaceName)
+	}
+
+	// Ignore leading and terminating newlines
+	existing = bytes.Trim(existing, "\n")
+
+	return existing, nil
 }
 
 func (n *netlinkType) FlushRouteTable(tableID int) error {

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -314,7 +314,7 @@ func (kp *SyncHandler) ensureLooseModeIsConfigured(iface string) error {
 				return nil
 			}
 		} else {
-			logger.Warningf("Error retrieving reverse path filter for %q: %v", iface, err)
+			klog.Warningf("Error retrieving reverse path filter for %q: %v", iface, err)
 		}
 
 		err = kp.netLink.EnableLooseModeReversePathFilter(iface)

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -19,11 +19,14 @@ limitations under the License.
 package kubeproxy
 
 import (
+	"bytes"
 	goerrors "errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -268,9 +271,9 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 			}
 		}
 
-		err = kp.netLink.EnableLooseModeReversePathFilter(VxLANIface)
+		err = kp.ensureLooseModeIsConfigured(VxLANIface)
 		if err != nil {
-			return errors.Wrap(err, "error enabling loose mode")
+			return errors.Wrap(err, "error while validating loose mode")
 		}
 
 		klog.V(log.DEBUG).Infof("Successfully configured reverse path filter to loose mode on %q", VxLANIface)
@@ -297,4 +300,28 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 	}
 
 	return nil
+}
+
+func (kp *SyncHandler) ensureLooseModeIsConfigured(iface string) error {
+	for i := 0; i < 10; i++ {
+		// Revisit: This is a temporary work-around to fix https://github.com/submariner-io/submariner/issues/2422
+		// Allow the vx-submariner interface to get initialized.
+		time.Sleep(100 * time.Millisecond)
+
+		rpFilterSetting, err := kp.netLink.GetReversePathFilter(iface)
+		if err == nil {
+			if bytes.Equal(rpFilterSetting, []byte("2")) {
+				return nil
+			}
+		} else {
+			logger.Warningf("Error retrieving reverse path filter for %q: %v", iface, err)
+		}
+
+		err = kp.netLink.EnableLooseModeReversePathFilter(iface)
+		if err != nil {
+			return errors.Wrapf(err, "error enabling loose mode on iface %q", iface)
+		}
+	}
+
+	return fmt.Errorf("loose mode not configured on iface %q", iface)
 }


### PR DESCRIPTION
Backport of #2423 on release-0.13.

#2423: Fix connection issues with RHEL9 GW nodes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.