### PR TITLE
Log connection status in Submariner gateway pod

### DIFF
--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -157,6 +157,11 @@ func (p *pingerInfo) doPing() error {
 			p.Lock()
 			defer p.Unlock()
 
+			if p.connectionStatus != ConnectionError {
+				logger.Errorf(fmt.Errorf("more than %d packets lost", p.maxPacketLossCount),
+					"Failed to successfully ping the remote endpoint IP %q", p.ip)
+			}
+
 			p.connectionStatus = ConnectionError
 			p.failureMsg = fmt.Sprintf("Failed to successfully ping the remote endpoint IP %q", p.ip)
 
@@ -167,6 +172,10 @@ func (p *pingerInfo) doPing() error {
 	pinger.OnRecv = func(packet *probing.Packet) {
 		p.Lock()
 		defer p.Unlock()
+
+		if p.connectionStatus != Connected {
+			logger.Infof("Ping to remote endpoint IP %q is successful", p.ip)
+		}
 
 		p.connectionStatus = Connected
 		p.failureMsg = ""


### PR DESCRIPTION
Currently, in the gateway pod after a connection is initiated to a remote cluster, we are not logging if the health-checker is able/un-able to successfully ping a remote cluster. The only way to know this would be to look at the output of gateways.submariner.io CR (or the output of diagnose connections). This PR logs the appropriate success/failure messages during the changes in the connection status.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
