### PR TITLE
Automated backport of #2437: Log connection status in Submariner gateway pod

### DIFF
--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -157,6 +157,11 @@ func (p *pingerInfo) doPing() error {
 			p.Lock()
 			defer p.Unlock()
 
+			if p.connectionStatus != ConnectionError {
+				logger.Errorf(fmt.Errorf("more than %d packets lost", p.maxPacketLossCount),
+					"Failed to successfully ping the remote endpoint IP %q", p.ip)
+			}
+
 			p.connectionStatus = ConnectionError
 			p.failureMsg = fmt.Sprintf("Failed to successfully ping the remote endpoint IP %q", p.ip)
 
@@ -167,6 +172,10 @@ func (p *pingerInfo) doPing() error {
 	pinger.OnRecv = func(packet *ping.Packet) {
 		p.Lock()
 		defer p.Unlock()
+
+		if p.connectionStatus != Connected {
+			logger.Infof("Ping to remote endpoint IP %q is successful", p.ip)
+		}
 
 		p.connectionStatus = Connected
 		p.failureMsg = ""


### PR DESCRIPTION
Backport of #2437 on release-0.14.

#2437: Log connection status in Submariner gateway pod

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.