### PR TITLE
Bump to Fedora 38

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=37
+ARG FEDORA_VERSION=38
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=37
+ARG FEDORA_VERSION=38
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=37
+ARG FEDORA_VERSION=38
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=37
+ARG FEDORA_VERSION=38
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder


### PR DESCRIPTION
Image size changes (since 37):

* networkplugin-syncer: 156 → 161 MiB
* globalnet: unchanged (45.2 MiB)
* route-agent: 154 → 159 MiB
* gateway: 161 → 160 MiB

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
