### PR TITLE
Automated backport of #2433: Fix vxlan cable driver issue on RHEL-9 Gateway nodes

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -145,9 +145,9 @@ func (v *vxlan) createVxlanInterface(activeEndPoint string, port int) error {
 		return errors.Wrap(err, "failed to add ip rule")
 	}
 
-	err = v.netLink.EnableLooseModeReversePathFilter(VxlanIface)
+	err = v.netLink.EnsureLooseModeIsConfigured(VxlanIface)
 	if err != nil {
-		return errors.Wrap(err, "unable to update vxlan rp_filter proc entry")
+		return errors.Wrap(err, "error while validating loose mode")
 	}
 
 	klog.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on %s", VxlanIface)

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -244,6 +244,10 @@ func (n *basicType) EnableLooseModeReversePathFilter(interfaceName string) error
 	return nil
 }
 
+func (n *basicType) EnsureLooseModeIsConfigured(_ string) error {
+	return nil
+}
+
 func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
 	return []byte("2"), nil
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -53,6 +54,7 @@ type Basic interface {
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
 	EnableLooseModeReversePathFilter(interfaceName string) error
+	EnsureLooseModeIsConfigured(interfaceName string) error
 	GetReversePathFilter(interfaceName string) ([]byte, error)
 	ConfigureTCPMTUProbe(mtuProbe, baseMss string) error
 }
@@ -151,6 +153,30 @@ func (n *netlinkType) EnableLooseModeReversePathFilter(interfaceName string) err
 	// Enable loose mode (rp_filter=2) reverse path filtering on the vxlan interface.
 	err := setSysctl("/proc/sys/net/ipv4/conf/"+interfaceName+"/rp_filter", []byte("2"))
 	return errors.Wrapf(err, "unable to update rp_filter proc entry for interface %q", interfaceName)
+}
+
+func (n *netlinkType) EnsureLooseModeIsConfigured(interfaceName string) error {
+	for i := 0; i < 10; i++ {
+		// Revisit: This is a temporary work-around to fix https://github.com/submariner-io/submariner/issues/2422
+		// Allow the interface to get initialized.
+		time.Sleep(100 * time.Millisecond)
+
+		rpFilterSetting, err := n.GetReversePathFilter(interfaceName)
+		if err == nil {
+			if bytes.Equal(rpFilterSetting, []byte("2")) {
+				return nil
+			}
+		} else {
+			klog.Warningf("Error retrieving reverse path filter for %q: %v", interfaceName, err)
+		}
+
+		err = n.EnableLooseModeReversePathFilter(interfaceName)
+		if err != nil {
+			return errors.Wrapf(err, "error enabling loose mode on iface %q", interfaceName)
+		}
+	}
+
+	return fmt.Errorf("loose mode not configured on iface %q", interfaceName)
 }
 
 func (n *netlinkType) GetReversePathFilter(interfaceName string) ([]byte, error) {

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -19,14 +19,11 @@ limitations under the License.
 package kubeproxy
 
 import (
-	"bytes"
 	goerrors "errors"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -271,7 +268,7 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 			}
 		}
 
-		err = kp.ensureLooseModeIsConfigured(VxLANIface)
+		err = kp.netLink.EnsureLooseModeIsConfigured(VxLANIface)
 		if err != nil {
 			return errors.Wrap(err, "error while validating loose mode")
 		}
@@ -302,26 +299,3 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 	return nil
 }
 
-func (kp *SyncHandler) ensureLooseModeIsConfigured(iface string) error {
-	for i := 0; i < 10; i++ {
-		// Revisit: This is a temporary work-around to fix https://github.com/submariner-io/submariner/issues/2422
-		// Allow the vx-submariner interface to get initialized.
-		time.Sleep(100 * time.Millisecond)
-
-		rpFilterSetting, err := kp.netLink.GetReversePathFilter(iface)
-		if err == nil {
-			if bytes.Equal(rpFilterSetting, []byte("2")) {
-				return nil
-			}
-		} else {
-			klog.Warningf("Error retrieving reverse path filter for %q: %v", iface, err)
-		}
-
-		err = kp.netLink.EnableLooseModeReversePathFilter(iface)
-		if err != nil {
-			return errors.Wrapf(err, "error enabling loose mode on iface %q", iface)
-		}
-	}
-
-	return fmt.Errorf("loose mode not configured on iface %q", iface)
-}


### PR DESCRIPTION
Backport of #2433 on release-0.13.

#2433: Fix vxlan cable driver issue on RHEL-9 Gateway nodes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.