### PR TITLE
Automated backport of #2450: Release notes for race condition fix in routeagent handlers

### DIFF
--- a/release-notes/20230426-race-endpoints.md
+++ b/release-notes/20230426-race-endpoints.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+Submariner now handles out of order remote endpoint notifications properly in various
+handlers associated with route-agent.


### PR DESCRIPTION
Backport of #2450 on release-0.13.

#2450: Release notes for race condition fix in routeagent handlers

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.