### PR TITLE
Automated backport of #2451: Release notes for stale iptable rule and globalIP leak

### DIFF
--- a/release-notes/20230426-globalip-leak.md
+++ b/release-notes/20230426-globalip-leak.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+Includes fix for stale IPtable rules along with globalIP leak which can sometimes happen
+when a GlobalEgressIP is created and immediately deleted as part of stress testing.


### PR DESCRIPTION
Backport of #2451 on release-0.13.

#2451: Release notes for stale iptable rule and globalIP leak

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.