### PR TITLE
Automated backport of #2452: Release notes for RHEL-9 rp_filter setting

### DIFF
--- a/release-notes/20230426-rhel9-fix.md
+++ b/release-notes/20230426-rhel9-fix.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+Submariner now ensures that reverse path filtering setting is properly applied
+on the `vx-submariner` and `vxlan-tunnel` interfaces after they are created.
+This fix was necessary for RHEL9 nodes where the setting was sometimes getting
+overwritten.


### PR DESCRIPTION
Backport of #2452 on release-0.15.

#2452: Release notes for RHEL-9 rp_filter setting

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.