### PR TITLE
Use case-insensitive comparision when checking the CNI name

### DIFF
--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -19,6 +19,8 @@ limitations under the License.
 package event
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -43,7 +45,7 @@ var logger = log.Logger{Logger: logf.Log.WithName("EventRegistry")}
 func NewRegistry(name, networkPlugin string) *Registry {
 	return &Registry{
 		name:                    name,
-		networkPlugin:           networkPlugin,
+		networkPlugin:           strings.ToLower(networkPlugin),
 		eventHandlers:           []Handler{},
 		remoteEndpointTimeStamp: map[string]v1.Time{},
 	}
@@ -58,7 +60,7 @@ func (er *Registry) addHandler(eventHandler Handler) error {
 	evNetworkPlugins := sets.New[string]()
 
 	for _, np := range eventHandler.GetNetworkPlugins() {
-		evNetworkPlugins.Insert(np)
+		evNetworkPlugins.Insert(strings.ToLower(np))
 	}
 
 	if evNetworkPlugins.Has(AnyNetworkPlugin) || evNetworkPlugins.Has(er.networkPlugin) {
@@ -69,7 +71,8 @@ func (er *Registry) addHandler(eventHandler Handler) error {
 		er.eventHandlers = append(er.eventHandlers, eventHandler)
 		logger.Infof("Event handler %q added to registry %q.", eventHandler.GetName(), er.name)
 	} else {
-		logger.V(log.DEBUG).Infof("Event handler %q ignored for registry %q.", eventHandler.GetName(), er.name)
+		logger.V(log.DEBUG).Infof("Event handler %q ignored for registry %q as networkPlugin is %q.",
+			eventHandler.GetName(), er.name, er.networkPlugin)
 	}
 
 	return nil


### PR DESCRIPTION
The existing code currently performs a case-sensitive comparison for the CNI name in the route-agent handlers. However, it has been observed that in certain OCP deployments, the CNI is sometimes configured as "OpenshiftSDN" instead of the expected "OpenShiftSDN". This PR modifies the checks to use case-insensitive comparision for the CNI names.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
