### PR TITLE
Rework status Conditions for Globalnet resources

### DIFF
--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -322,6 +322,7 @@ func testServiceWithoutSelector() {
 
 		Context("and then original endpoints is deleted", func() {
 			It("should delete the cloned endpoints", func() {
+				t.awaitEndpoints(controllers.GetInternalSvcName(endpoints.Name))
 				t.deleteEndpoints(endpoints)
 				t.awaitNoEndpoints(controllers.GetInternalSvcName(endpoints.Name))
 			})


### PR DESCRIPTION
The status `Conditions` are appended to preserve the history however this is contrary to the intended design where each condition type should be unique and only the last status is preserved. Instead of appending, use `meta.SetStatusCondition`. Also trim existing conditions on upgrade to contain only the last one.

Fixes https://github.com/submariner-io/submariner/issues/2463
