### PR TITLE
Basic framework for the OVN IC handler in route-agent

### DIFF
--- a/pkg/routeagent_driver/handlers/ovnic/handler.go
+++ b/pkg/routeagent_driver/handlers/ovnic/handler.go
@@ -1,0 +1,101 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovnic
+
+import (
+	"sync"
+
+	"github.com/submariner-io/admiral/pkg/log"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Handler struct {
+	event.HandlerBase
+	mutex           sync.Mutex
+	config          *environment.Specification
+	smClient        clientset.Interface
+	localEndpoint   *submV1.Endpoint
+	remoteEndpoints map[string]*submV1.Endpoint
+}
+
+var logger = log.Logger{Logger: logf.Log.WithName("OVN-IC")}
+
+func NewHandler(env *environment.Specification, smClientSet clientset.Interface) *Handler {
+	return &Handler{
+		config:          env,
+		smClient:        smClientSet,
+		remoteEndpoints: map[string]*submV1.Endpoint{},
+	}
+}
+
+func (ovn *Handler) GetName() string {
+	return "ovn-ic-handler"
+}
+
+func (ovn *Handler) GetNetworkPlugins() []string {
+	// TODO: Once we have the necessary controllers implemented for OVN-IC support, the network plugin name
+	// should be updated, until then, we do not want this handler to be registered even for OVN deployments.
+	return []string{"OVN-IC"}
+}
+
+func (ovn *Handler) Init() error {
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	logger.Infof("A new Endpoint for the local cluster has been created: %#v", endpoint.Spec)
+	ovn.localEndpoint = endpoint
+
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	logger.Infof("A new Endpoint for the local cluster has been updated: %#v", endpoint.Spec)
+	ovn.localEndpoint = endpoint
+
+	return nil
+}
+
+func (ovn *Handler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
+	logger.Infof("A new Endpoint for the local cluster has been deleted: %#v", endpoint.Spec)
+
+	if ovn.localEndpoint.Name == endpoint.Name {
+		ovn.localEndpoint = nil
+	}
+
+	return nil
+}
+
+func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	logger.Infof("A new Endpoint for the remote cluster has been created: %#v", endpoint.Spec)
+	return nil
+}

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovnic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -96,6 +97,7 @@ func main() {
 		eventlogger.NewHandler(),
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
 		ovn.NewHandler(&env, smClientset),
+		ovnic.NewHandler(&env, smClientset),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
 		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(k8sClientSet)),


### PR DESCRIPTION
This is a skeleton code for the OVN IC handler in Route agent pod. Subsequent PRs will add the necessary functionality.

Related to: https://github.com/submariner-io/submariner/issues/2496
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
