### PR TITLE
Avoid cableEngine cleanup when the gateway pod is restarted

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,10 +207,6 @@ func main() {
 
 	<-components.stopCh
 
-	if err := components.cableEngine.Cleanup(); err != nil {
-		logger.Error(nil, "Error cleaning up cableEngine resources before removing Gateway")
-	}
-
 	logger.Info("All controllers stopped or exited. Stopping main loop")
 
 	if err := httpServer.Shutdown(context.TODO()); err != nil {


### PR DESCRIPTION
In the current code, it was seen that when the submariner-gateway pod gets restarted, there is a brief datapath disruption until the new pod comes online. The cleanup code in submariner-gateway pod is not required as its handled by the route-agent code when there is any transition in the active Gateway of the cluster.

This PR removes the cleanup code from submariner-gateway pod which fixes the issue with VxLAN Cable Driver, but Libreswan Cable Driver seems to have some other issue[s] which needs to be addressed separately.

![Screenshot from 2023-05-26 17-01-59](https://github.com/submariner-io/submariner/assets/6574656/f4825998-d776-4ff9-81ec-978a95a5dc98)


Partially fixes: https://github.com/submariner-io/submariner/issues/2498
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
