### PR TITLE
Automated backport of #2499: Avoid cableEngine cleanup when the gateway pod is restarted

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,10 +207,6 @@ func main() {
 
 	<-components.stopCh
 
-	if err := components.cableEngine.Cleanup(); err != nil {
-		logger.Error(nil, "Error cleaning up cableEngine resources before removing Gateway")
-	}
-
 	logger.Info("All controllers stopped or exited. Stopping main loop")
 
 	if err := httpServer.Shutdown(context.TODO()); err != nil {


### PR DESCRIPTION
Backport of #2499 on release-0.15.

#2499: Avoid cableEngine cleanup when the gateway pod is restarted

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.