### PR TITLE
Add config syncer to reprogram routes in case of an accidental delete

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -47,6 +47,7 @@ type Handler struct {
 	isGateway             bool
 	netlink               netlink.Interface
 	ipt                   iptables.Interface
+	stopCh                chan struct{}
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("OVN")}
@@ -64,6 +65,7 @@ func NewHandler(env *environment.Specification, smClientSet clientset.Interface)
 		remoteEndpoints: map[string]*submV1.Endpoint{},
 		netlink:         netlink.New(),
 		ipt:             ipt,
+		stopCh:          make(chan struct{}),
 	}
 }
 
@@ -80,6 +82,8 @@ func (ovn *Handler) Init() error {
 	if err != nil {
 		return err
 	}
+
+	ovn.startRouteConfigSyncer(ovn.stopCh)
 
 	return ovn.ensureSubmarinerNodeBridge()
 }

--- a/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
+++ b/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
@@ -1,0 +1,156 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn
+
+import (
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	iptcommon "github.com/submariner-io/submariner/pkg/routeagent_driver/iptables"
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func (ovn *Handler) startRouteConfigSyncer(stop chan struct{}) {
+	logger.Info("Starting route config syncer")
+	// Start monitoring routes
+	go wait.Until(func() {
+		err := ovn.monitorRoutingTable(stop)
+		if err != nil {
+			logger.Errorf(err, "error starting monitorRoutingTable for interface: %q", OVNK8sMgmntIntfName)
+		}
+	}, time.Second, stop)
+}
+
+func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
+	iface, err := netlink.LinkByName(OVNK8sMgmntIntfName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to find interface: %q", OVNK8sMgmntIntfName)
+	}
+
+	addrCh := make(chan netlink.AddrUpdate)
+	doneCh := make(chan struct{})
+
+	err = netlink.AddrSubscribe(addrCh, doneCh)
+	if err != nil {
+		return errors.Wrapf(err, "failed to subscribe to address updates")
+	}
+
+	defer close(doneCh)
+
+	var prevIP net.IP
+
+	assignPrevIP := func() {
+		addrs, err := netlink.AddrList(iface, netlink.FAMILY_V4)
+		if err != nil {
+			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
+		} else if len(addrs) > 0 {
+			prevIP = addrs[0].IP
+		}
+	}
+
+	handleAddressChange := func(addrUpdate netlink.AddrUpdate) {
+		if addrUpdate.LinkIndex != iface.Attrs().Index {
+			return
+		}
+
+		if !addrUpdate.NewAddr {
+			// Address deleted
+			prevIP = nil
+			return
+		}
+
+		addrs, err := netlink.AddrList(iface, netlink.FAMILY_V4)
+		if err != nil {
+			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
+			return
+		}
+
+		if len(addrs) == 0 {
+			return
+		}
+
+		newIP := addrs[0].IP
+		// If the new IP address is not nil and different from the previous IP address,
+		// which mean an IP address is assigned to the interface. When ovnkube-node pod restarts
+		// the IP address is first cleared and then assigned again.
+		if newIP != nil && !newIP.Equal(prevIP) {
+			err := ovn.handleInterfaceAddressChange()
+			if err != nil {
+				logger.Errorf(err, "error handling interface address addition: %s", newIP.String())
+
+				prevIP = nil // Reset previous IP to nil in case of error
+			} else {
+				prevIP = newIP
+			}
+		}
+	}
+
+	assignPrevIP()
+
+	for {
+		select {
+		case <-stop:
+			return nil
+		case addrUpdate := <-addrCh:
+			handleAddressChange(addrUpdate)
+		}
+	}
+}
+
+func (ovn *Handler) handleInterfaceAddressChange() error {
+	backoff := wait.Backoff{
+		Cap:      3 * time.Minute,
+		Duration: 5 * time.Second,
+		Factor:   1.2,
+		Steps:    24,
+	}
+
+	var err error
+
+	retryErr := retry.OnError(backoff, func(err error) bool {
+		logger.Infof("Waiting for interface %q to be ready: %v", OVNK8sMgmntIntfName, err)
+		return true
+	}, func() error {
+		ovn.mutex.Lock()
+		defer ovn.mutex.Unlock()
+		if ovn.isGateway {
+			err = ovn.updateGatewayDataplane()
+			if err != nil {
+				return errors.Wrap(err, "error syncing gateway routes")
+			}
+		}
+
+		err = ovn.updateHostNetworkDataplane()
+		if err != nil {
+			return errors.Wrap(err, "error syncing host network routes")
+		}
+
+		if err := iptcommon.InitSubmarinerPostRoutingChain(ovn.ipt); err != nil {
+			return errors.Wrapf(err, "error syncing IPtable %q chain", constants.PostRoutingChain)
+		}
+
+		return nil
+	})
+
+	return errors.Wrap(retryErr, "error syncing the config even after multiple retries")
+}

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -26,6 +26,8 @@ import (
 )
 
 func (ovn *Handler) Stop(uninstall bool) error {
+	close(ovn.stopCh)
+
 	if !uninstall {
 		return nil
 	}


### PR DESCRIPTION
Add config syncer to reprogram routes in case of an
accidental delete

If ovnkube-node pods restarts some of the interfaces are deleted
which leads to route delete. The syncer add the routes
and iptable rules in case of an accidental delete.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
