### PR TITLE
Fix pluto crash when remote endpoint is unstable

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -416,7 +416,8 @@ func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpoi
 		"--host", endpointInfo.UseIP,
 		"--client", rightSubnet,
 
-		"--ikeport", strconv.Itoa(int(rightNATTPort)))
+		"--ikeport", strconv.Itoa(int(rightNATTPort)),
+		"--dpdaction=hold")
 
 	logger.Infof("Executing whack with args: %v", args)
 
@@ -458,7 +459,8 @@ func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo 
 		// Right-hand side.
 		"--id", remoteEndpointIdentifier,
 		"--host", "%any",
-		"--client", rightSubnet)
+		"--client", rightSubnet,
+		"--dpdaction=hold")
 
 	logger.Infof("Executing whack with args: %v", args)
 
@@ -499,7 +501,8 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 		"--host", endpointInfo.UseIP,
 		"--client", rightSubnet,
 
-		"--ikeport", strconv.Itoa(int(rightNATTPort)))
+		"--ikeport", strconv.Itoa(int(rightNATTPort)),
+		"--dpdaction=hold")
 
 	logger.Infof("Executing whack with args: %v", args)
 


### PR DESCRIPTION
Currently, submariner-gateway pod while invoking the whack commands does not set any dpdaction flags. So the default dpdaction of disabled was applied. While using this action, when the remote endpoint is not responding within a certain duration, some problematic code path in Libreswan was getting executed and leading to crash. The proper fix would be to use an updated Libreswan, but as a workaround we can explicitly set the dpdaction=hold to avoid hitting the problematic code paths.

Related PR in libreswan:
https://github.com/libreswan/libreswan/commit/c7a6113a85d27fcf8018b05f62905548e37f33f0

Fixes: https://github.com/submariner-io/submariner/issues/2516
Co-authored-by: Yossi Boaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
