### PR TITLE
Automated backport of #2499: Avoid cableEngine cleanup when the gateway pod is restarted

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,10 +248,6 @@ func main() {
 
 	<-stopCh
 
-	if err := cableEngine.Cleanup(); err != nil {
-		klog.Errorf("error cleaning up cableEngine resources before removing Gateway")
-	}
-
 	klog.Info("All controllers stopped or exited. Stopping main loop")
 
 	if err := httpServer.Shutdown(context.TODO()); err != nil {


### PR DESCRIPTION
Backport of #2499 on release-0.13.

#2499: Avoid cableEngine cleanup when the gateway pod is restarted

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.