### PR TITLE
Use EnsureNoResource in globalnet tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-community/pro-bing v0.1.0
 	github.com/prometheus/client_golang v1.15.1
-	github.com/submariner-io/admiral v0.16.0-m0
+	github.com/submariner-io/admiral v0.16.0-m0.0.20230602131053-613bd96ec5a2
 	github.com/submariner-io/shipyard v0.16.0-m0
 	github.com/uw-labs/lichen v0.1.7
 	github.com/vishvananda/netlink v1.2.1-beta.2

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/submariner-io/admiral v0.16.0-m0 h1:WVzyoaE6zkPzkhUBiEoS3twK6ccXHDHkRNJ1O81VI/w=
-github.com/submariner-io/admiral v0.16.0-m0/go.mod h1:42+8VT+tHo03Cgt8mYh69AJrS3pptKSU5BRckONw+vE=
+github.com/submariner-io/admiral v0.16.0-m0.0.20230602131053-613bd96ec5a2 h1:3Z3EoAK+07Ro6UW9RTpB3aehzz4U2dwTh9rq1s/Vg30=
+github.com/submariner-io/admiral v0.16.0-m0.0.20230602131053-613bd96ec5a2/go.mod h1:42+8VT+tHo03Cgt8mYh69AJrS3pptKSU5BRckONw+vE=
 github.com/submariner-io/shipyard v0.16.0-m0 h1:5pw0gTYVGqCLLe3zSEikmqDRScaOriwTcWwYh+HWsZg=
 github.com/submariner-io/shipyard v0.16.0-m0/go.mod h1:wgnJxga0mr5ujphMnTK6dfz0w0OCqbRVe/fwO+wu2C0=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/onsi/gomega/format"
 	fakeDynClient "github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
@@ -397,7 +399,6 @@ func (t *testDriverBase) awaitService(name string) *corev1.Service {
 }
 
 func (t *testDriverBase) awaitNoService(name string) {
-	time.Sleep(300 * time.Millisecond)
 	test.AwaitNoResource(t.services, name)
 }
 
@@ -411,8 +412,11 @@ func (t *testDriverBase) awaitEndpoints(name string) *corev1.Endpoints {
 }
 
 func (t *testDriverBase) awaitNoEndpoints(name string) {
-	time.Sleep(300 * time.Millisecond)
 	test.AwaitNoResource(t.endpoints, name)
+}
+
+func (t *testDriverBase) ensureNoEndpoints(name string) {
+	testutil.EnsureNoResource(resource.ForDynamic(t.endpoints), name)
 }
 
 func (t *testDriverBase) awaitEndpointsHasIP(name, ip string) {
@@ -490,11 +494,14 @@ func getGlobalIngressIP(t *testDriverBase, name string,
 }
 
 func (t *testDriverBase) awaitNoGlobalIngressIP(name string) {
-	time.Sleep(300 * time.Millisecond)
 	test.AwaitNoResource(t.globalIngressIPs, name)
 }
 
-func (t *testDriverBase) awaitNoGlobalIngressIPs() {
+func (t *testDriverBase) ensureNoGlobalIngressIP(name string) {
+	testutil.EnsureNoResource(resource.ForDynamic(t.globalIngressIPs), name)
+}
+
+func (t *testDriverBase) ensureNoGlobalIngressIPs() {
 	Consistently(func() []unstructured.Unstructured {
 		list, _ := t.globalIngressIPs.List(context.TODO(), metav1.ListOptions{})
 		return list.Items

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Endpoint monitoring", func() {
 				awaitNoAllocatedIPs(t.globalEgressIPs, globalEgressIPName)
 
 				t.createServiceExport(t.createService(newClusterIPService()))
-				t.awaitNoGlobalIngressIP(serviceName)
+				t.ensureNoGlobalIngressIP(serviceName)
 			})
 		})
 	})

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -24,10 +24,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
-	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/ipam"
@@ -80,7 +78,7 @@ func testClusterIPService() {
 		})
 
 		It("should eventually create a GlobalIngressIP", func() {
-			testutil.EnsureNoResource(resource.ForDynamic(t.globalIngressIPs), service.Name)
+			t.ensureNoGlobalIngressIP(service.Name)
 			t.createService(service)
 			t.awaitGlobalIngressIP(service.Name)
 		})
@@ -93,7 +91,7 @@ func testClusterIPService() {
 		})
 
 		It("should not create a GlobalIngressIP", func() {
-			t.awaitNoGlobalIngressIP(service.Name)
+			t.ensureNoGlobalIngressIP(service.Name)
 		})
 	})
 
@@ -152,7 +150,7 @@ func testHeadlessService() {
 		})
 
 		It("should eventually create a GlobalIngressIP", func() {
-			t.awaitNoGlobalIngressIPs()
+			t.ensureNoGlobalIngressIPs()
 
 			backendPod.Status.Phase = corev1.PodRunning
 			test.UpdateResource(t.pods.Namespace(namespace), backendPod)
@@ -167,7 +165,7 @@ func testHeadlessService() {
 		})
 
 		It("should eventually create a GlobalIngressIP", func() {
-			t.awaitNoGlobalIngressIPs()
+			t.ensureNoGlobalIngressIPs()
 
 			backendPod.Status.PodIP = "154.67.82.2"
 			test.UpdateResource(t.pods.Namespace(namespace), backendPod)
@@ -197,7 +195,7 @@ func testHeadlessService() {
 
 			// Ensure GlobalIngressIPs are no longer created for the service.
 			t.createPod(newHeadlessServicePod(service.Name))
-			t.awaitNoGlobalIngressIPs()
+			t.ensureNoGlobalIngressIPs()
 		})
 	})
 
@@ -207,7 +205,7 @@ func testHeadlessService() {
 		})
 
 		It("should not create a GlobalIngressIP", func() {
-			t.awaitNoGlobalIngressIPs()
+			t.ensureNoGlobalIngressIPs()
 		})
 	})
 
@@ -388,8 +386,7 @@ func testServiceWithoutSelector() {
 
 				t.start()
 
-				time.Sleep(50 * time.Millisecond)
-				t.awaitNoEndpoints(controllers.GetInternalSvcName(endpoints.Name))
+				t.ensureNoEndpoints(controllers.GetInternalSvcName(endpoints.Name))
 			})
 		})
 	})


### PR DESCRIPTION
...instead of `AwaitNoResource` where appropriate. Also update the **admiral** version to get the latest changes to `AwaitNoResource`.
