### PR TITLE
Fix race in GN pod for out-of-order RemoteEndpoint events

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -91,16 +91,17 @@ type baseController struct {
 
 type gatewayMonitor struct {
 	*baseController
-	syncerConfig     *syncer.ResourceSyncerConfig
-	endpointWatcher  watcher.Interface
-	spec             Specification
-	ipt              iptables.Interface
-	isGatewayNode    atomic.Bool
-	nodeName         string
-	localSubnets     []string
-	remoteSubnets    sets.Set[string]
-	controllersMutex sync.Mutex // Protects controllers
-	controllers      []Interface
+	syncerConfig            *syncer.ResourceSyncerConfig
+	endpointWatcher         watcher.Interface
+	remoteEndpointTimeStamp map[string]metav1.Time
+	spec                    Specification
+	ipt                     iptables.Interface
+	isGatewayNode           atomic.Bool
+	nodeName                string
+	localSubnets            []string
+	remoteSubnets           sets.Set[string]
+	controllersMutex        sync.Mutex // Protects controllers
+	controllers             []Interface
 }
 
 type baseSyncerController struct {


### PR DESCRIPTION
When there is a gateway migration in a remote cluster or if there is any stale endpoint on the Broker associated with the remoteCluster, the events might come in out of order which can create issues for datapath connectivity. This PR includes the necessary checks in Globalnet pod to ignore any stale events.

Related to: https://github.com/submariner-io/submariner/pull/2399
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
