### PR TITLE
Automated backport of #2532: Fix race in GN pod for out-of-order RemoteEndpoint events

### DIFF
--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -90,16 +90,17 @@ type baseController struct {
 
 type gatewayMonitor struct {
 	*baseController
-	syncerConfig    *syncer.ResourceSyncerConfig
-	endpointWatcher watcher.Interface
-	spec            Specification
-	ipt             iptables.Interface
-	isGatewayNode   bool
-	nodeName        string
-	syncMutex       sync.Mutex
-	localSubnets    []string
-	remoteSubnets   stringset.Interface
-	controllers     []Interface
+	syncerConfig            *syncer.ResourceSyncerConfig
+	endpointWatcher         watcher.Interface
+	remoteEndpointTimeStamp map[string]metav1.Time
+	spec                    Specification
+	ipt                     iptables.Interface
+	isGatewayNode           bool
+	nodeName                string
+	syncMutex               sync.Mutex
+	localSubnets            []string
+	remoteSubnets           stringset.Interface
+	controllers             []Interface
 }
 
 type baseSyncerController struct {


### PR DESCRIPTION
Backport of #2532 on release-0.14.

#2532: Fix race in GN pod for out-of-order RemoteEndpoint events

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.