### PR TITLE
Disable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ linters:
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
     - decorder
-    - depguard
+    # - depguard # depguard now denies by default, it should only be enabled if we actually use it
     - dogsled
     - dupl
     - dupword


### PR DESCRIPTION
Newer versions of depguard, as used in golangci-lint 1.53.0 and later, deny imports by default. As a result, depguard should only be enabled if it's going to be used, which isn't the case currently in Submariner projects.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
