### PR TITLE
Automated backport of #2550: Pass functions to Eventually

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -150,7 +150,8 @@ var _ = Describe("Controller", func() {
 
 			latencyInfo1 := newLatencyInfo()
 			pingerMap[healthCheckIP1].SetLatencyInfo(latencyInfo1)
-			Eventually(healthChecker.GetLatencyInfo(&endpoint1.Spec)).Should(Equal(latencyInfo1))
+			Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint1.Spec) }).
+				Should(Equal(latencyInfo1))
 
 			latencyInfo2 := &healthchecker.LatencyInfo{
 				ConnectionStatus: healthchecker.ConnectionError,
@@ -164,7 +165,8 @@ var _ = Describe("Controller", func() {
 			}
 
 			pingerMap[healthCheckIP2].SetLatencyInfo(latencyInfo2)
-			Eventually(healthChecker.GetLatencyInfo(&endpoint2.Spec)).Should(Equal(latencyInfo2))
+			Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint2.Spec) }).
+				Should(Equal(latencyInfo2))
 		})
 	})
 
@@ -182,7 +184,8 @@ var _ = Describe("Controller", func() {
 
 			Expect(endpoints.Delete(context.TODO(), endpoint.Name, metav1.DeleteOptions{})).To(Succeed())
 			pingerMap[healthCheckIP1].AwaitStop()
-			Eventually(healthChecker.GetLatencyInfo(&endpoint.Spec)).Should(BeNil())
+			Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint.Spec) }).
+				Should(BeNil())
 		})
 	})
 
@@ -208,7 +211,8 @@ var _ = Describe("Controller", func() {
 
 				latencyInfo := newLatencyInfo()
 				pingerMap[healthCheckIP3].SetLatencyInfo(latencyInfo)
-				Eventually(healthChecker.GetLatencyInfo(&endpoint.Spec)).Should(Equal(latencyInfo))
+				Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint.Spec) }).
+					Should(Equal(latencyInfo))
 			})
 		})
 


### PR DESCRIPTION
Backport of #2550 on release-0.13.

#2550: Pass functions to Eventually

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.