### PR TITLE
Automated backport of #2551: Add a few missing Expect() assertions

### DIFF
--- a/pkg/globalnet/controllers/cluster_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller_test.go
@@ -303,7 +303,8 @@ var _ = Describe("ClusterGlobalEgressIP controller", func() {
 		JustBeforeEach(func() {
 			t.awaitClusterGlobalEgressIPStatusAllocated(1)
 			allocatedIPs = getGlobalEgressIPStatus(t.clusterGlobalEgressIPs, constants.ClusterGlobalEgressIPName).AllocatedIPs
-			Expect(t.clusterGlobalEgressIPs.Delete(context.TODO(), constants.ClusterGlobalEgressIPName, metav1.DeleteOptions{}))
+			Expect(t.clusterGlobalEgressIPs.Delete(context.TODO(), constants.ClusterGlobalEgressIPName, metav1.DeleteOptions{})).
+				To(Succeed())
 		})
 
 		It("should release the previously allocated IPs", func() {

--- a/pkg/natdiscovery/natdiscovery_internal_test.go
+++ b/pkg/natdiscovery/natdiscovery_internal_test.go
@@ -82,7 +82,8 @@ var _ = When("a remote Endpoint is added", func() {
 
 		Context("and the private IP responds after the public IP within the grace period", func() {
 			It("should notify with the private IP NATEndpointInfo settings", func() {
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
@@ -90,7 +91,8 @@ var _ = When("a remote Endpoint is added", func() {
 					UseIP:    t.remoteEndpoint.Spec.PublicIP,
 				})))
 
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
@@ -104,7 +106,8 @@ var _ = When("a remote Endpoint is added", func() {
 			It("should notify with the public IP NATEndpointInfo settings", func() {
 				atomic.StoreInt64(&publicToPrivateFailoverTimeout, 0)
 
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
@@ -112,7 +115,8 @@ var _ = When("a remote Endpoint is added", func() {
 					UseIP:    t.remoteEndpoint.Spec.PublicIP,
 				})))
 
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Consistently(t.readyChannel).ShouldNot(Receive())
 			})
@@ -120,7 +124,8 @@ var _ = When("a remote Endpoint is added", func() {
 
 		Context("and the private IP responds first", func() {
 			It("should notify with the private IP NATEndpointInfo settings", func() {
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
@@ -128,7 +133,8 @@ var _ = When("a remote Endpoint is added", func() {
 					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
 				})))
 
-				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr))
+				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr)).
+					To(Succeed())
 
 				Consistently(t.readyChannel).ShouldNot(Receive())
 			})


### PR DESCRIPTION
Backport of #2551 on release-0.15.

#2551: Add a few missing Expect() assertions

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.