### PR TITLE
Nexodus cable driver

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,8 +115,7 @@ func main() {
 	kzerolog.InitK8sLogging()
 
 	versions.Log(&logger)
-
-	logger.Info("Starting the submariner gateway engine")
+	logger.Info("Starting the submariner gateway engine with custom nexodus cable driver (WIP)")
 
 	components := &componentsType{
 		// set up signals so we handle the first shutdown signal gracefully

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -23,7 +23,7 @@ COPY package/dnf_install /
 # kmod is required so that libreswan can load modules
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/gateway \
     glibc bash glibc-minimal-langpack coreutils-single \
-    libcurl-minimal iproute libreswan kmod
+    libcurl-minimal iproute libreswan kmod wireguard-tools
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE

--- a/pkg/cable/nexodus/nexodus.go
+++ b/pkg/cable/nexodus/nexodus.go
@@ -1,0 +1,106 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nexodus
+
+import (
+	"github.com/submariner-io/admiral/pkg/log"
+	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var logger = log.Logger{Logger: logf.Log.WithName("nexodus")}
+
+const (
+	cableDriverName   = "nexodus"
+	DefaultDeviceName = "wg0"
+)
+
+type nexodus struct {
+	localEndpoint types.SubmarinerEndpoint
+	localCluster  types.SubmarinerCluster
+	connections   []v1.Connection
+}
+
+func init() {
+	cable.AddDriver(cableDriverName, NewNexodus)
+}
+
+func NewNexodus(localEndpoint *types.SubmarinerEndpoint, localCluster *types.SubmarinerCluster) (cable.Driver, error) {
+	v := nexodus{
+		localEndpoint: *localEndpoint,
+		localCluster:  *localCluster,
+		connections:   []v1.Connection{},
+	}
+
+	return &v, nil
+}
+
+func (n *nexodus) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
+	// We'll panic if endpointInfo is nil, this is intentional
+	endpoint := &endpointInfo.Endpoint
+	n.connections = append(n.connections,
+		v1.Connection{Endpoint: endpoint.Spec, Status: v1.Connected, UsingIP: endpointInfo.UseIP, UsingNAT: endpointInfo.UseNAT})
+
+	logger.V(log.DEBUG).Infof("Connect request made to remote endpoint %s", endpoint.Spec.ClusterID)
+
+	return endpointInfo.UseIP, nil
+}
+
+func (n *nexodus) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpoint) error {
+	n.connections = removeConnectionForEndpoint(n.connections, remoteEndpoint)
+
+	logger.V(log.DEBUG).Infof("Disconnect from remote endpoint %#v", remoteEndpoint.Spec.ClusterID)
+
+	return nil
+}
+
+func removeConnectionForEndpoint(connections []v1.Connection, endpoint *types.SubmarinerEndpoint) []v1.Connection {
+	for j := range connections {
+		if connections[j].Endpoint.CableName == endpoint.Spec.CableName {
+			copy(connections[j:], connections[j+1:])
+			return connections[:len(connections)-1]
+		}
+	}
+
+	return connections
+}
+
+func (n *nexodus) GetConnections() ([]v1.Connection, error) {
+	return n.connections, nil
+}
+
+func (n *nexodus) GetActiveConnections() ([]v1.Connection, error) {
+	return n.connections, nil
+}
+
+func (n *nexodus) Init() error {
+	return nil
+}
+
+func (n *nexodus) GetName() string {
+	return cableDriverName
+}
+
+func (n *nexodus) Cleanup() error {
+	logger.Infof("Uninstalling the nexodus cable driver")
+	return nil
+}

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -34,6 +34,7 @@ import (
 
 	// Add supported drivers.
 	_ "github.com/submariner-io/submariner/pkg/cable/libreswan"
+	_ "github.com/submariner-io/submariner/pkg/cable/nexodus"
 	_ "github.com/submariner-io/submariner/pkg/cable/vxlan"
 	_ "github.com/submariner-io/submariner/pkg/cable/wireguard"
 )

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/cable/nexodus"
 	"github.com/submariner-io/submariner/pkg/cable/wireguard"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
@@ -114,12 +115,19 @@ func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation, 
 	}
 
 	ifaceIndex := kp.defaultHostIface.Index
-	// TODO: Add support for this in the CableDrivers themselves.
-	if kp.localCableDriver == "wireguard" {
+
+	switch kp.localCableDriver {
+	case "wireguard":
 		if wg, err := net.InterfaceByName(wireguard.DefaultDeviceName); err == nil {
 			ifaceIndex = wg.Index
 		} else {
-			logger.Errorf(nil, "Wireguard interface %s not found on the node.", wireguard.DefaultDeviceName)
+			return errors.Wrapf(err, "wireguard interface %s not found on the node", wireguard.DefaultDeviceName)
+		}
+	case "nexodus":
+		if wg, err := net.InterfaceByName(nexodus.DefaultDeviceName); err == nil {
+			ifaceIndex = wg.Index
+		} else {
+			return errors.Wrapf(err, "nexodus interface %s not found on the node", nexodus.DefaultDeviceName)
 		}
 	}
 

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -62,8 +62,8 @@ func main() {
 	kzerolog.InitK8sLogging()
 
 	versions.Log(&logger)
+	logger.Info("Starting submariner-route-agent using the event framework with nexodus cable driver support for OVNK (WIP)")
 
-	logger.Info("Starting submariner-route-agent using the event framework")
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler().Done()
 


### PR DESCRIPTION
This WIP PR can be used to try out nexodus as one of the 
cable-drivers in Submariner.

To try this PR, one has to build the associated submariner-gateway
and submariner-routeagent images, push them to some private repo and 
use `image-override` options while joining the cluster. 
Also, the cable-driver should be explicitly specified as `nexodus`.

```
subctl join --cable-driver nexodus --image-override="submariner-gateway=quay.io/sridhargaddam/submariner-gateway:nexodus" --image-override=submariner-routeagent=quay.io/sridhargaddam/submariner-route-agent:nexodus ./broker-info.subm
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
