### PR TITLE
Consider Pluto status on Libreswan GetConnections

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -280,6 +280,10 @@ func (i *libreswan) GetActiveConnections() ([]subv1.Connection, error) {
 
 // GetConnections() returns an array of the existing connections, including status and endpoint info.
 func (i *libreswan) GetConnections() ([]subv1.Connection, error) {
+	if !i.plutoStarted {
+		return []subv1.Connection{}, nil
+	}
+
 	if err := i.refreshConnectionStatus(); err != nil {
 		return []subv1.Connection{}, err
 	}


### PR DESCRIPTION
To reduce the downtime of the data path in case the gateway pod is restarted, we start Pluto only when Liberswan connects to the first remote endpoint.
Which means if 0 remote endpoints are defined Pluto is not running.

The GetConnections function returns the connections status retrieved from 'whack --trafficstatus' command and its called periodically regardless of Pluto status.

This PR updates GetConnections also to support the case when Pluto is not running

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
