### PR TITLE
Backport 0.15: log submariner component's version on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,12 @@ endif
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e /)
-export LDFLAGS = -X main.VERSION=$(VERSION)
-
+GIT_COMMIT_HASH := $(shell git show -s --format='format:%H')
+GIT_COMMIT_DATE := $(shell git show -s --format='format:%cI')
+VERSIONS_MODULE := github.com/submariner-io/submariner/pkg/versions
+export LDFLAGS = -X $(VERSIONS_MODULE).version=$(VERSION) \
+                 -X $(VERSIONS_MODULE).gitCommitHash=$(GIT_COMMIT_HASH) \
+                 -X $(VERSIONS_MODULE).gitCommitDate=$(GIT_COMMIT_DATE)
 ifneq (,$(filter external-net,$(_using)))
 export TESTDIR = test/external
 override export PLUGIN = scripts/e2e/external/hook

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/pod"
 	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -104,7 +105,6 @@ const (
 )
 
 var (
-	VERSION            = "not-compiled-properly"
 	logger             = log.Logger{Logger: logf.Log.WithName("main")}
 	lastBadCertificate atomic.Value
 )
@@ -113,6 +113,8 @@ func main() {
 	kzerolog.AddFlags(nil)
 	flag.Parse()
 	kzerolog.InitK8sLogging()
+
+	versions.Log(&logger)
 
 	logger.Info("Starting the submariner gateway engine")
 
@@ -185,7 +187,7 @@ func main() {
 	components.cableEngineSyncer = syncer.NewGatewaySyncer(
 		components.cableEngine,
 		submarinerClient.SubmarinerV1().Gateways(components.submSpec.Namespace),
-		VERSION, components.cableHealthChecker)
+		versions.Submariner(), components.cableHealthChecker)
 
 	if components.submSpec.Uninstall {
 		logger.Info("Uninstalling the submariner gateway engine")

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cidr"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
+	"github.com/submariner-io/submariner/pkg/versions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
@@ -53,6 +54,8 @@ func main() {
 	kzerolog.AddFlags(nil)
 	flag.Parse()
 	kzerolog.InitK8sLogging()
+
+	versions.Log(&logger)
 
 	var spec controllers.Specification
 

--- a/pkg/networkplugin-syncer/main.go
+++ b/pkg/networkplugin-syncer/main.go
@@ -31,6 +31,7 @@ import (
 	eventlogger "github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/networkplugin-syncer/handlers/ovn"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
+	"github.com/submariner-io/submariner/pkg/versions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,6 +49,8 @@ func main() {
 	kzerolog.AddFlags(nil)
 	flag.Parse()
 	kzerolog.InitK8sLogging()
+
+	versions.Log(&logger)
 
 	logger.Info("Starting submariner-networkplugin-syncer")
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	"github.com/submariner-io/submariner/pkg/versions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -58,6 +59,8 @@ func main() {
 	kzerolog.AddFlags(nil)
 	flag.Parse()
 	kzerolog.InitK8sLogging()
+
+	versions.Log(&logger)
 
 	logger.Info("Starting submariner-route-agent using the event framework")
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/versions/version.go
+++ b/pkg/versions/version.go
@@ -1,0 +1,45 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versions
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/submariner-io/admiral/pkg/log"
+)
+
+var (
+	version       = "devel"
+	gitCommitHash string
+	gitCommitDate string
+)
+
+func Log(logger *log.Logger) {
+	logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logger.Info(fmt.Sprintf("Go Arch: %s", runtime.GOARCH))
+	logger.Info(fmt.Sprintf("Git Commit Hash: %s", gitCommitHash))
+	logger.Info(fmt.Sprintf("Git Commit Date: %s", gitCommitDate))
+	logger.Info(fmt.Sprintf("Submariner Version: %s", version))
+}
+
+// Submariner returns the version info of submariner.
+func Submariner() string {
+	return version
+}


### PR DESCRIPTION
Signed-off-by: cyclinder <qifeng.guo@daocloud.io>
(cherry picked from commit fb660d93634eb7b42d17b1d4834a13aec1864476)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
