### PR TITLE
Automated backport of #2614: Consider Pluto status on Libreswan GetConnections

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -277,6 +277,10 @@ func (i *libreswan) GetActiveConnections() ([]subv1.Connection, error) {
 
 // GetConnections() returns an array of the existing connections, including status and endpoint info.
 func (i *libreswan) GetConnections() ([]subv1.Connection, error) {
+	if !i.plutoStarted {
+		return []subv1.Connection{}, nil
+	}
+
 	if err := i.refreshConnectionStatus(); err != nil {
 		return []subv1.Connection{}, err
 	}


### PR DESCRIPTION
Backport of #2614 on release-0.14.

#2614: Consider Pluto status on Libreswan GetConnections

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.