### PR TITLE
Backport of #2263: Skip endpoints from Broker with overlapping CIDRs

### DIFF
--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/util"
 	k8sv1 "k8s.io/api/core/v1"
@@ -182,6 +183,7 @@ func (d *DatastoreSyncer) createSyncer() (*broker.Syncer, error) {
 			LocalSourceNamespace: d.syncerConfig.LocalNamespace,
 			LocalResourceType:    &submarinerv1.Endpoint{},
 			LocalTransform:       d.shouldSyncEndpoint,
+			BrokerTransform:      d.shouldSyncRemoteEndpoint,
 			BrokerResourceType:   &submarinerv1.Endpoint{},
 		},
 	}
@@ -209,6 +211,27 @@ func (d *DatastoreSyncer) shouldSyncCluster(obj runtime.Object, numRequeues int,
 	}
 
 	return nil, false
+}
+
+func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, numRequeues int,
+	op resourceSyncer.Operation,
+) (runtime.Object, bool) {
+	endpoint := obj.(*submarinerv1.Endpoint)
+
+	for _, localSubnet := range d.localEndpoint.Spec.Subnets {
+		overlap, err := cidr.IsOverlapping(endpoint.Spec.Subnets, localSubnet)
+		if err != nil {
+			klog.Errorf("Unable to validate if remote CIDR overlaps with local CIDR: %v", err)
+			return nil, false
+		}
+
+		if overlap {
+			klog.Errorf("Skip processing the remote endpoint %#v as subnets are overlapping", endpoint)
+			return nil, false
+		}
+	}
+
+	return obj, false
 }
 
 func (d *DatastoreSyncer) ensureExclusiveEndpoint(syncer *broker.Syncer) error {


### PR DESCRIPTION
Currently, we have validations in route-agent,
network-plugin-syncer which will check if CIDRs
overlap when processing an endpoint. However, there is no such check in the cableDriver code. Because of this the IPsec tunnels are configured even for cluster when the CIDR overlaps. This will not affect the pods on other nodes, but has an effect on the Gateway node.

This PR fixes this issue by ensuring that we do not sync any endpoint from the Broker cluster if its CIDR overlaps with the local cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
