### PR TITLE
Change the node_handler log to trace

### DIFF
--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -62,7 +62,7 @@ func (d *DatastoreSyncer) areNodesEquivalent(obj1, obj2 *unstructured.Unstructur
 	existingGlobalIP := obj1.GetAnnotations()[constants.SmGlobalIP]
 	newGlobalIP := obj2.GetAnnotations()[constants.SmGlobalIP]
 
-	logger.V(log.DEBUG).Infof("areNodesEquivalent called for %q, existingGlobalIP %q, newGlobalIP %q",
+	logger.V(log.TRACE).Infof("areNodesEquivalent called for %q, existingGlobalIP %q, newGlobalIP %q",
 		obj1.GetName(), existingGlobalIP, newGlobalIP)
 
 	return existingGlobalIP == newGlobalIP


### PR DESCRIPTION
As the log from areNodesEquivalent is getting printed at regular intervals change it to trace.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
