### PR TITLE
Fix golangci-lint 1.54.2 errors

### DIFF
--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -63,7 +63,7 @@ func (w *wireguard) GetConnections() ([]v1.Connection, error) {
 
 func (w *wireguard) connectionByKey(key *wgtypes.Key) (*v1.Connection, error) {
 	for cid, con := range w.connections {
-		if k, err := keyFromSpec(&con.Endpoint); err == nil {
+		if k, err := keyFromSpec(&con.Endpoint); err == nil { //nolint:gosec // Implicit aliasing OK here
 			if key.String() == k.String() {
 				return con, nil
 			}

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -53,7 +53,6 @@ func (e linkNotFoundError) Error() string {
 }
 
 func (e linkNotFoundError) Is(err error) bool {
-	//nolint:errorlint // The given error should not be wrapped.
 	_, ok := err.(netlink.LinkNotFoundError)
 	return ok
 }


### PR DESCRIPTION
Ignore this one as the aliasing is OK here:

```
pkg/cable/wireguard/getconnections.go:66:28: G601: Implicit memory aliasing in for loop. (gosec)
		if k, err := keyFromSpec(&con.Endpoint); err == nil {
```

```
pkg/netlink/fake/netlink.go:56:2: directive `//nolint:errorlint // The given error should not be wrapped.` is unused for linter "errorlint" (nolintlint)
	//nolint:errorlint // The given error should not be wrapped.
```
