### PR TITLE
Automated backport of #2651: Enable forwarding on the submariner interfaces

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -159,6 +159,11 @@ func (v *vxlan) createVxlanInterface(activeEndPoint string, port int) error {
 		return errors.Wrap(err, "failed to configure vxlan interface ipaddress on the Gateway Node")
 	}
 
+	err = v.netLink.EnableForwarding(VxlanIface)
+	if err != nil {
+		return errors.Wrapf(err, "error enabling forwarding on the %q iface", VxlanIface)
+	}
+
 	return nil
 }
 

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -261,6 +261,10 @@ func (n *basicType) EnsureLooseModeIsConfigured(_ string) error {
 	return nil
 }
 
+func (n *basicType) EnableForwarding(_ string) error {
+	return nil
+}
+
 func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
 	return []byte("2"), nil
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -55,6 +55,7 @@ type Basic interface {
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
 	EnableLooseModeReversePathFilter(interfaceName string) error
 	EnsureLooseModeIsConfigured(interfaceName string) error
+	EnableForwarding(interfaceName string) error
 	GetReversePathFilter(interfaceName string) ([]byte, error)
 	ConfigureTCPMTUProbe(mtuProbe, baseMss string) error
 }
@@ -179,6 +180,11 @@ func (n *netlinkType) EnsureLooseModeIsConfigured(interfaceName string) error {
 	}
 
 	return fmt.Errorf("loose mode not configured on iface %q", interfaceName)
+}
+
+func (n *netlinkType) EnableForwarding(interfaceName string) error {
+	err := setSysctl("/proc/sys/net/ipv4/conf/"+interfaceName+"/forwarding", []byte("1"))
+	return errors.Wrapf(err, "unable to update forwarding on interface %q", interfaceName)
 }
 
 func (n *netlinkType) GetReversePathFilter(interfaceName string) ([]byte, error) {

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -299,5 +299,10 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 		return errors.Wrap(err, "failed to configure vxlan interface ipaddress on the Gateway Node")
 	}
 
+	err = kp.netLink.EnableForwarding(VxLANIface)
+	if err != nil {
+		return errors.Wrapf(err, "error enabling forwarding on the %q iface", VxLANIface)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Backport of #2651 on release-0.14.

#2651: Enable forwarding on the submariner interfaces

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.