### PR TITLE
Upgrade changes for OVN IC

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -88,6 +88,8 @@ func (ovn *Handler) GetNetworkPlugins() []string {
 }
 
 func (ovn *Handler) Init() error {
+	ovn.LegacyCleanup()
+
 	err := ovn.initIPtablesChains()
 	if err != nil {
 		return err

--- a/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
+++ b/pkg/routeagent_driver/handlers/ovn/vsctl/vsctl.go
@@ -65,7 +65,7 @@ func AddBridge(bridgeName string) error {
 }
 
 func DelBridge(bridgeName string) error {
-	_, err := vsctlCmd("del-br", bridgeName)
+	_, err := vsctlCmd("--if-exists", "del-br", bridgeName)
 
 	return err
 }


### PR DESCRIPTION
When a submariner installation upgrades from legacy non-OVN-IC version to an OVN-IC version, cleanup resources created by legacy installation.

Fixes https://github.com/submariner-io/enhancements/issues/193