### PR TITLE
Ignore endpoint events after retrying couple of times

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -54,6 +54,10 @@ type Controller struct {
 	isGatewayNode bool
 }
 
+// If the handler cannot recover from a failure, even after retrying for maximum requeue attempts,
+// it's best to disregard the event. This prevents the logs from being flooded with repetitive errors.
+const maxRequeues = 20
+
 type Config struct {
 	// Registry is the event handler registry where controller events will be sent.
 	Registry *event.Registry

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -23,10 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *Controller) handleCreatedEndpoint(obj runtime.Object, _ int) bool {
+func (c *Controller) handleCreatedEndpoint(obj runtime.Object, requeueCount int) bool {
 	var err error
 
 	endpoint := obj.(*smv1.Endpoint)
+
+	if requeueCount > maxRequeues {
+		logger.Errorf(nil, "Ignoring create event for endpoint %q, as its requeued for more than %d times",
+			endpoint.Spec.ClusterID, maxRequeues)
+		return false
+	}
 
 	if endpoint.Spec.ClusterID != c.env.ClusterID {
 		err = c.handleCreatedRemoteEndpoint(endpoint)

--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -23,8 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *Controller) handleRemovedEndpoint(obj runtime.Object, _ int) bool {
+func (c *Controller) handleRemovedEndpoint(obj runtime.Object, requeueCount int) bool {
 	endpoint := obj.(*smv1.Endpoint)
+
+	if requeueCount > maxRequeues {
+		logger.Errorf(nil, "Ignoring delete event for endpoint %q, as its requeued for more than %d times",
+			endpoint.Spec.ClusterID, maxRequeues)
+		return false
+	}
 
 	var err error
 	if endpoint.Spec.ClusterID != c.env.ClusterID {

--- a/pkg/event/controller/endpoint_updated.go
+++ b/pkg/event/controller/endpoint_updated.go
@@ -23,8 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *Controller) handleUpdatedEndpoint(obj runtime.Object, _ int) bool {
+func (c *Controller) handleUpdatedEndpoint(obj runtime.Object, requeueCount int) bool {
 	endpoint := obj.(*smv1.Endpoint)
+
+	if requeueCount > maxRequeues {
+		logger.Errorf(nil, "Ignoring update event for endpoint %q, as its requeued for more than %d times",
+			endpoint.Spec.ClusterID, maxRequeues)
+		return false
+	}
 
 	var err error
 	if endpoint.Spec.ClusterID != c.env.ClusterID {


### PR DESCRIPTION
If the endpoint handlers cannot recover from a failure, even after retrying 20 times, it's best to disregard the event. This prevents the logs from being flooded with repetitive errors.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
