### PR TITLE
Automated backport of #2599: libreswan: Present --dpddelay if --dpdaction is specified

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -173,7 +173,7 @@ func retrieveActiveConnectionStats() (map[string]int, map[string]int, error) {
 	defer cancel()
 
 	// Retrieve active tunnels from the daemon
-	cmd := exec.CommandContext(ctx, "/usr/libexec/ipsec/whack", "--trafficstatus")
+	cmd := exec.CommandContext(ctx, "/usr/sbin/ipsec", "whack", "--trafficstatus")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -312,7 +312,8 @@ func whack(args ...string) error {
 			ctx, cancel := context.WithTimeout(context.TODO(), whackTimeout)
 			defer cancel()
 
-			cmd := exec.CommandContext(ctx, "/usr/libexec/ipsec/whack", args...)
+			fullArgs := append([]string{"whack"}, args...)
+			cmd := exec.CommandContext(ctx, "/usr/sbin/ipsec", fullArgs...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -45,6 +45,7 @@ import (
 const (
 	cableDriverName = "libreswan"
 	whackTimeout    = 5 * time.Second
+	dpdDelay        = 30 // seconds
 )
 
 var logger = log.Logger{Logger: logf.Log.WithName("libreswan")}
@@ -427,7 +428,8 @@ func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpoi
 		"--client", rightSubnet,
 
 		"--ikeport", strconv.Itoa(int(rightNATTPort)),
-		"--dpdaction=hold")
+		"--dpdaction=hold",
+		"--dpddelay", strconv.Itoa(dpdDelay))
 
 	logger.Infof("Executing whack with args: %v", args)
 
@@ -470,7 +472,8 @@ func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo 
 		"--id", remoteEndpointIdentifier,
 		"--host", "%any",
 		"--client", rightSubnet,
-		"--dpdaction=hold")
+		"--dpdaction=hold",
+		"--dpddelay", strconv.Itoa(dpdDelay))
 
 	logger.Infof("Executing whack with args: %v", args)
 
@@ -512,7 +515,8 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 		"--client", rightSubnet,
 
 		"--ikeport", strconv.Itoa(int(rightNATTPort)),
-		"--dpdaction=hold")
+		"--dpdaction=hold",
+		"--dpddelay", strconv.Itoa(dpdDelay))
 
 	logger.Infof("Executing whack with args: %v", args)
 


### PR DESCRIPTION
Backport of #2599 on release-0.15.

#2599: libreswan: Present --dpddelay if --dpdaction is specified

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.