### PR TITLE
Fix e2e failures seen with OCP OVN-IC deployments

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -103,8 +103,8 @@ func (ovn *Handler) getForwardingRuleSpecs() ([][]string, error) {
 	}
 
 	rules := [][]string{
-		{"-i", ovnK8sSubmarinerInterface, "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"},
-		{"-i", ovn.cableRoutingInterface.Name, "-o", ovnK8sSubmarinerInterface, "-j", "ACCEPT"},
+		{"-i", OVNK8sMgmntIntfName, "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"},
+		{"-i", ovn.cableRoutingInterface.Name, "-o", OVNK8sMgmntIntfName, "-j", "ACCEPT"},
 	}
 
 	return rules, nil


### PR DESCRIPTION
When a client pod attempts to establish a connection with a service in the remote cluster, it has been observed that the response traffic is being discarded at the local Gateway node. The return traffic is getting dropped because of some DROP rules in the FORWARDing chain of the filter table (which seems to have been added recently in the OVN OCP deployments).

Submariner normally has rules to allow such traffic, but with the new architecture designed to support OVN-IC deployments, we no longer use the ovn-k8s-sub0 iface and simply use the ovn-k8s-mp0 interface. This PR updates the firewall rules accordingly to allow the return traffic on the Gateway node.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
