### PR TITLE
Automated backport of #2681: Fix e2e failures seen with OCP OVN-IC deployments

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -103,8 +103,8 @@ func (ovn *Handler) getForwardingRuleSpecs() ([][]string, error) {
 	}
 
 	rules := [][]string{
-		{"-i", ovnK8sSubmarinerInterface, "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"},
-		{"-i", ovn.cableRoutingInterface.Name, "-o", ovnK8sSubmarinerInterface, "-j", "ACCEPT"},
+		{"-i", OVNK8sMgmntIntfName, "-o", ovn.cableRoutingInterface.Name, "-j", "ACCEPT"},
+		{"-i", ovn.cableRoutingInterface.Name, "-o", OVNK8sMgmntIntfName, "-j", "ACCEPT"},
 	}
 
 	return rules, nil


### PR DESCRIPTION
Backport of #2681 on release-0.16.

#2681: Fix e2e failures seen with OCP OVN-IC deployments

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.