### PR TITLE
Automated backport of #2682: Refactor the ovn network discovery code

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -32,4 +32,5 @@ const (
 	defaultOVNOpenshiftUnixSocket = "unix:/var/run/ovn-ic/ovnnb_db.sock"
 	ovnNBDBDefaultPort            = 6641
 	defaultOpenshiftOVNNBDB       = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
+	ovnPodLabel                   = "app=ovnkube-node"
 )


### PR DESCRIPTION
Backport of #2682 on release-0.16.

#2682: Refactor the ovn network discovery code

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.