### PR TITLE
Fix flaky datastore syncer unit test

### DIFF
--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -120,19 +120,21 @@ func testEndpointSyncing() {
 	})
 
 	When("the local Node's global IP is updated", func() {
-		It("should update the local Endpoint's HealthCheckIP", func() {
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+		var node *corev1.Node
 
-			node := &corev1.Node{
+		BeforeEach(func() {
+			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        nodeName,
 					Annotations: map[string]string{constants.SmGlobalIP: "200.0.0.40"},
 				},
 			}
 
-			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
-
 			test.CreateResource(t.localNodes, node)
+		})
+
+		It("should update the local Endpoint's HealthCheckIP", func() {
+			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
 			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
 
 			node.Annotations[constants.SmGlobalIP] = "200.0.0.100"


### PR DESCRIPTION
```
[FAIL] Endpoint syncing when the local Node's global IP is updated
   [It] should update the local Endpoint's HealthCheckIP

[FAILED] Timed out after 5.000s.
  Expected success, but got an error:
    <*errors.errorString | 0xc0014e7a50>:
    resource "east-submariner-cable-east-192-68-1-2" was found but not verified
    {
      ...
    }

```
This is a timing issue with the `Node` creation due to concurrency issue in the fake client. To workaround it, create the Node prior to creating the datastore syncer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
