### PR TITLE
Retry IPsec connections when there are any whack errors

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -308,7 +308,7 @@ func whack(args ...string) error {
 	var err error
 
 	for i := 0; i < 3; i++ {
-		err := func() error {
+		err = func() error {
 			ctx, cancel := context.WithTimeout(context.TODO(), whackTimeout)
 			defer cancel()
 


### PR DESCRIPTION
In the current code, when 'whack' encounters an error, we only log a warning message without hanlding the error case. As a result, in cases where there is an issue connecting to a remote endpoint, the caller is left unaware that connection attempts have failed, and no retries are initiated. This PR fixes it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
