### PR TITLE
Automated backport of #2710: Retry IPsec connections when there are any whack errors

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -302,7 +302,7 @@ func whack(args ...string) error {
 	var err error
 
 	for i := 0; i < 3; i++ {
-		err := func() error {
+		err = func() error {
 			ctx, cancel := context.WithTimeout(context.TODO(), whackTimeout)
 			defer cancel()
 


### PR DESCRIPTION
Backport of #2710 on release-0.13.

#2710: Retry IPsec connections when there are any whack errors

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.