### PR TITLE
Allow the route agent to wait for node readiness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/api v0.27.5
 	k8s.io/apimachinery v0.27.5
 	k8s.io/client-go v0.27.5
+	k8s.io/component-helpers v0.27.5
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.15.1
 	sigs.k8s.io/mcs-api v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -804,6 +804,8 @@ k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRV
 k8s.io/code-generator v0.18.4/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.18.4/go.mod h1:7jr/Ef5PGmKwQhyAz/pjByxJbC58mhKAhiaDu0vXfPk=
+k8s.io/component-helpers v0.27.5 h1:V966SPo7cVdxkKs0tfuHao7GNSM8H+krlg3rKGiKjeo=
+k8s.io/component-helpers v0.27.5/go.mod h1:DysJsLaHI3yPgDi1KF7dROTf7gm7BPQgxIbuXYd8sQk=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -23,6 +23,7 @@ type Specification struct {
 	Namespace   string
 	ClusterCidr []string
 	ServiceCidr []string
-	Uninstall   bool
 	GlobalCidr  []string
+	Uninstall   bool
+	WaitForNode bool
 }

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -134,13 +134,7 @@ func main() {
 	}
 
 	if env.Uninstall {
-		if err := registry.StopHandlers(true); err != nil {
-			logger.Warningf("Error stopping handlers: %v", err)
-		}
-
-		if err = annotateNode([]string{}, k8sClientSet); err != nil {
-			logger.Warningf("Error removing %q annotation: %v", constants.CNIInterfaceIP, err)
-		}
+		uninstall(k8sClientSet, registry)
 
 		return
 	}
@@ -210,4 +204,14 @@ func getTCPMssValue(k8sClientSet *kubernetes.Clientset) int {
 	}
 
 	return tcpMssValue
+}
+
+func uninstall(k8sClientSet *kubernetes.Clientset, registry *event.Registry) {
+	if err := registry.StopHandlers(true); err != nil {
+		logger.Warningf("Error stopping handlers: %v", err)
+	}
+
+	if err := annotateNode([]string{}, k8sClientSet); err != nil {
+		logger.Warningf("Error removing %q annotation: %v", constants.CNIInterfaceIP, err)
+	}
 }


### PR DESCRIPTION
In order to ensure that host path mounts don't interfere with socket
creation, the route agent pods need to wait for the node to be ready
(which includes CNI readiness) before starting. This adds a variant of
the route agent, invoked using the SUBMARINER_WAITFORNODE environment
variable, to do just that (similar in style to the uninstallation
command).

This will be put to use in the operator; the corresponding change will
have full details of the issue being fixed.