### PR TITLE
Remove the MTU workaround used for OVN load-balancers

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -141,15 +141,6 @@ func (ovn *Handler) getMSSClampingRuleSpecs() ([][]string, error) {
 			})
 	}
 
-	// NOTE: This is a workaround for submariner issue https://github.com/submariner-io/submariner/issues/1022
-	// TODO: work with the core-ovn community to make sure that load balancers propagate ICMPs back to pods
-	for _, serviceCIDR := range ovn.config.ServiceCidr {
-		rules = append(rules, []string{
-			"-o", ovnK8sSubmarinerInterface, "-d", serviceCIDR, "-p", "tcp", "-m", "tcp",
-			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(MSSFor1500MTU),
-		})
-	}
-
 	return rules, nil
 }
 


### PR DESCRIPTION
With the following update[*], OVN now forwards ICMP packets to OVN Loadbalancers, facilitating end-to-end PMTUD. As a result, the workaround used in the OVN route-agent handler may no longer be necessary.

[*] https://github.com/ovn-org/ovn-kubernetes/pull/3762

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
