### PR TITLE
Split stop and uninstall in RA handlers

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -159,7 +159,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 func (c *Controller) Stop() {
 	logger.Info("Event controller stopping")
 
-	if err := c.handlers.StopHandlers(false); err != nil {
+	if err := c.handlers.StopHandlers(); err != nil {
 		logger.Warningf("In Event Controller, StopHandlers returned error: %v", err)
 	}
 }

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -35,9 +35,11 @@ type Handler interface {
 	// GetNetworkPlugin returns the kubernetes network plugin that this handler supports.
 	GetNetworkPlugins() []string
 
-	// Stop is called once during shutdown to let the handler perform any cleanup. The uninstall flag indicates
-	// whether or not Submariner is being completely uninstalled from the system.
-	Stop(uninstall bool) error
+	// Stop is called once during shutdown to let the handler perform any cleanup.
+	Stop() error
+
+	// Uninstall is called once after shutdown to let the handler process a Submariner uninstallation.
+	Uninstall() error
 
 	// TransitionToNonGateway is called once for each transition of the local node from Gateway to a non-Gateway.
 	TransitionToNonGateway() error
@@ -80,7 +82,11 @@ func (ev *HandlerBase) Init() error {
 	return nil
 }
 
-func (ev *HandlerBase) Stop(_ bool) error {
+func (ev *HandlerBase) Stop() error {
+	return nil
+}
+
+func (ev *HandlerBase) Uninstall() error {
 	return nil
 }
 

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -91,9 +91,15 @@ func (er *Registry) AddHandlers(eventHandlers ...Handler) error {
 	return nil
 }
 
-func (er *Registry) StopHandlers(uninstall bool) error {
+func (er *Registry) StopHandlers() error {
 	return er.invokeHandlers("Stop", func(h Handler) error {
-		return h.Stop(uninstall) //nolint:wrapcheck  // Let the caller wrap it
+		return h.Stop() //nolint:wrapcheck  // Let the caller wrap it
+	})
+}
+
+func (er *Registry) Uninstall() error {
+	return er.invokeHandlers("Uninstall", func(h Handler) error {
+		return h.Uninstall() //nolint:wrapcheck  // Let the caller wrap it
 	})
 }
 

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -145,7 +145,8 @@ func allEvents(registry *event.Registry) map[testing.TestEvent]func() error {
 	node := &k8sV1.Node{ObjectMeta: v1meta.ObjectMeta{Name: "node1"}}
 
 	return map[testing.TestEvent]func() error{
-		{Name: testing.EvStop, Parameter: false}:                     func() error { return registry.StopHandlers(false) },
+		{Name: testing.EvStop}:                                       func() error { return registry.StopHandlers() },
+		{Name: testing.EvUninstall}:                                  func() error { return registry.Uninstall() },
 		{Name: testing.EvTransitionToGateway}:                        registry.TransitionToGateway,
 		{Name: testing.EvTransitionToNonGateway}:                     registry.TransitionToNonGateway,
 		{Name: testing.EvNodeCreated, Parameter: node}:               func() error { return registry.NodeCreated(node) },

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -87,10 +87,15 @@ const (
 	EvNodeUpdated            = "NodeUpdated"
 	EvNodeRemoved            = "NodeRemoved"
 	EvStop                   = "Stop"
+	EvUninstall              = "Uninstall"
 )
 
-func (t *TestHandler) Stop(uninstall bool) error {
-	return t.addEvent(EvStop, uninstall)
+func (t *TestHandler) Stop() error {
+	return t.addEvent(EvStop, nil)
+}
+
+func (t *TestHandler) Uninstall() error {
+	return t.addEvent(EvUninstall, nil)
 }
 
 func (t *TestHandler) TransitionToNonGateway() error {

--- a/pkg/routeagent_driver/handlers/calico/ippool_handler.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler.go
@@ -128,8 +128,8 @@ func (h *calicoIPPoolHandler) TransitionToGateway() error {
 	return errorutils.NewAggregate(retErrors)
 }
 
-func (h *calicoIPPoolHandler) Stop(uninstall bool) error {
-	if !uninstall || !h.isGateway.Load() {
+func (h *calicoIPPoolHandler) Uninstall() error {
+	if !h.isGateway.Load() {
 		return nil
 	}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -29,11 +29,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func (kp *SyncHandler) Stop(uninstall bool) error {
-	if !uninstall {
-		return nil
-	}
-
+func (kp *SyncHandler) Uninstall() error {
 	logger.Infof("Uninstalling Submariner changes from the node %q", kp.hostname)
 	logger.Infof("Flushing route table %d entries", constants.RouteAgentHostNetworkTableID)
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -238,11 +238,7 @@ func (h *mtuHandler) newNamedIPSet(key string, ipSetIface ipset.Interface) ipset
 	}, ipSetIface)
 }
 
-func (h *mtuHandler) Stop(uninstall bool) error {
-	if !uninstall {
-		return nil
-	}
-
+func (h *mtuHandler) Uninstall() error {
 	logger.Infof("Flushing iptable entries in %q chain of %q table", constants.SmPostRoutingChain, constants.MangleTable)
 
 	if err := h.ipt.ClearChain(constants.MangleTable, constants.SmPostRoutingChain); err != nil {

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -25,15 +25,15 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func (ovn *Handler) Stop(uninstall bool) error {
+func (ovn *Handler) Stop() error {
 	ovn.gatewayRouteController.stop()
 	ovn.nonGatewayRouteController.stop()
 	close(ovn.stopCh)
 
-	if !uninstall {
-		return nil
-	}
+	return nil
+}
 
+func (ovn *Handler) Uninstall() error {
 	logger.Infof("Uninstalling OVN components from the node")
 
 	err := ovn.cleanupRoutes()

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -216,8 +216,12 @@ func getTCPMssValue(k8sClientSet *kubernetes.Clientset) int {
 }
 
 func uninstall(k8sClientSet *kubernetes.Clientset, registry *event.Registry) {
-	if err := registry.StopHandlers(true); err != nil {
+	if err := registry.StopHandlers(); err != nil {
 		logger.Warningf("Error stopping handlers: %v", err)
+	}
+
+	if err := registry.Uninstall(); err != nil {
+		logger.Warningf("Error uninstalling handlers: %v", err)
 	}
 
 	if err := annotateNode([]string{}, k8sClientSet); err != nil {


### PR DESCRIPTION
Only one stop handler actually stops anything, all the others are only used for uninstallation. This separates the two operations to make the functions' role clear.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
