### PR TITLE
Fix log message from nodeHandler

### DIFF
--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -21,7 +21,6 @@ package datastoresyncer
 import (
 	"net"
 
-	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -62,8 +61,9 @@ func (d *DatastoreSyncer) areNodesEquivalent(obj1, obj2 *unstructured.Unstructur
 	existingGlobalIP := obj1.GetAnnotations()[constants.SmGlobalIP]
 	newGlobalIP := obj2.GetAnnotations()[constants.SmGlobalIP]
 
-	logger.V(log.TRACE).Infof("areNodesEquivalent called for %q, existingGlobalIP %q, newGlobalIP %q",
-		obj1.GetName(), existingGlobalIP, newGlobalIP)
+	if existingGlobalIP != newGlobalIP {
+		logger.Infof("Global IP for node %q changed from %q to %q", obj1.GetName(), existingGlobalIP, newGlobalIP)
+	}
 
 	return existingGlobalIP == newGlobalIP
 }


### PR DESCRIPTION
When debug is turned on in the Gateway pod, we are logging the globalIP assigned to the node at regular intervals. These repeated log messages do not add any significant value. Hence this PR updates the API to log only when there is a change in the globalIP assigned to the node.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
