### PR TITLE
Process stale globalIPs present on non-Gateway nodes

### DIFF
--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -154,6 +154,9 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 		return federator.Distribute(obj) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
+	logger.Infof("Successfully reserved GlobalIPs %q for %s \"%s/%s\"", reservedIPs, obj.GetKind(),
+		obj.GetNamespace(), obj.GetName())
+
 	return nil
 }
 

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -216,7 +216,8 @@ func updateNodeAnnotation(node runtime.Object, globalIP string) runtime.Object {
 
 func (n *nodeController) onNodeUpdated(oldObj, newObj *unstructured.Unstructured) bool {
 	if oldObj.GetName() != n.nodeName {
-		return true
+		// We return false here as we want the event to be processed for any stale globalIPs
+		return false
 	}
 
 	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[routeAgent.CNIInterfaceIP]

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -98,8 +98,11 @@ func (n *nodeController) process(from runtime.Object, _ int, op syncer.Operation
 	// If the event corresponds to a different node which has globalIP annotation, release the globalIP back to Pool.
 	if node.Name != n.nodeName {
 		if existingGlobalIP := node.GetAnnotations()[constants.SmGlobalIP]; existingGlobalIP != "" {
+			logger.Infof("Processing %sd non-gateway node %q - releasing GlobalIP %q", op, node.Name, existingGlobalIP)
+
 			if op == syncer.Delete {
 				_ = n.pool.Release(existingGlobalIP)
+
 				return nil, false
 			}
 
@@ -186,6 +189,8 @@ func (n *nodeController) reserveAllocatedIP(federator federate.Federator, obj *u
 
 		return errors.Wrap(federator.Distribute(updateNodeAnnotation(obj, "")), "error updating the Node global IP annotation")
 	}
+
+	logger.Infof("Successfully reserved allocated GlobalIP %q for node %q", existingGlobalIP, obj.GetName())
 
 	return nil
 }


### PR DESCRIPTION
In certain deployments, due to timing issues, globalIP annotation on non-Gateway nodes were not removed. 
As a result, there's a chance that globalIPs for exported services might unintentionally be updated with new globalIPs when such nodes become active gateway nodes. This PR fixes this issue and also improves logging in some of the globalnet controllers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
