### PR TITLE
Automated backport of #2739: Improve logging in Globalnet controllers

### DIFF
--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -154,6 +154,9 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 		return federator.Distribute(obj) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
+	logger.Infof("Successfully reserved GlobalIPs %q for %s \"%s/%s\"", reservedIPs, obj.GetKind(),
+		obj.GetNamespace(), obj.GetName())
+
 	return nil
 }
 

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -216,7 +216,8 @@ func updateNodeAnnotation(node runtime.Object, globalIP string) runtime.Object {
 
 func (n *nodeController) onNodeUpdated(oldObj, newObj *unstructured.Unstructured) bool {
 	if oldObj.GetName() != n.nodeName {
-		return true
+		// We return false here as we want the event to be processed for any stale globalIPs
+		return false
 	}
 
 	oldCNIIfaceIPOnNode := oldObj.GetAnnotations()[routeAgent.CNIInterfaceIP]

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -98,8 +98,11 @@ func (n *nodeController) process(from runtime.Object, _ int, op syncer.Operation
 	// If the event corresponds to a different node which has globalIP annotation, release the globalIP back to Pool.
 	if node.Name != n.nodeName {
 		if existingGlobalIP := node.GetAnnotations()[constants.SmGlobalIP]; existingGlobalIP != "" {
+			logger.Infof("Processing %sd non-gateway node %q - releasing GlobalIP %q", op, node.Name, existingGlobalIP)
+
 			if op == syncer.Delete {
 				_ = n.pool.Release(existingGlobalIP)
+
 				return nil, false
 			}
 
@@ -186,6 +189,8 @@ func (n *nodeController) reserveAllocatedIP(federator federate.Federator, obj *u
 
 		return errors.Wrap(federator.Distribute(updateNodeAnnotation(obj, "")), "error updating the Node global IP annotation")
 	}
+
+	logger.Infof("Successfully reserved allocated GlobalIP %q for node %q", existingGlobalIP, obj.GetName())
 
 	return nil
 }


### PR DESCRIPTION
Backport of #2739 on release-0.16.

#2739: Improve logging in Globalnet controllers

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.