### PR TITLE
Automated backport of #2743: Use leader election in globalnet controller

### DIFF
--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -315,17 +315,6 @@ func getGlobalEgressIPStatus(client dynamic.ResourceInterface, name string) *sub
 	return status
 }
 
-func awaitNoAllocatedIPs(client dynamic.ResourceInterface, name string) {
-	Consistently(func() int {
-		status := getGlobalEgressIPStatus(client, name)
-		if status == nil {
-			return 0
-		}
-
-		return len(status.AllocatedIPs)
-	}, 200*time.Millisecond).Should(Equal(0))
-}
-
 func (t *testDriverBase) awaitEgressIPStatus(client dynamic.ResourceInterface, name string, expNumIPS int, expCond ...metav1.Condition) {
 	t.awaitStatusConditions(client, name, expCond...)
 

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -46,7 +46,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -119,14 +118,7 @@ func newTestDriverBase() *testDriverBase {
 	Expect(submarinerv1.AddToScheme(t.scheme)).To(Succeed())
 	Expect(corev1.AddToScheme(t.scheme)).To(Succeed())
 
-	// TODO: Remove this workaround for https://github.com/kubernetes/client-go/issues/949 once
-	// admiral has been updated
-	t.scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"},
-		&unstructured.UnstructuredList{})
-
 	t.dynClient = fakeDynClient.NewDynamicClient(t.scheme)
-
-	t.watches = fakeDynClient.NewWatchReactor(&t.dynClient.Fake)
 
 	t.globalEgressIPs = t.dynClient.Resource(*test.GetGroupVersionResourceFor(t.restMapper, &submarinerv1.GlobalEgressIP{})).
 		Namespace(namespace)

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -26,14 +26,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	routeAgent "github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 const (
@@ -46,12 +52,12 @@ const (
 var _ = Describe("Endpoint monitoring", func() {
 	t := newGatewayMonitorTestDriver()
 
-	var endpointName string
+	var endpoint *submarinerv1.Endpoint
 
-	When("a local Endpoint is created", func() {
+	When("a local gateway Endpoint corresponding to the controller host is created", func() {
 		JustBeforeEach(func() {
 			t.createNode(nodeName, "", "")
-			endpointName = t.createEndpoint(newEndpointSpec(clusterID, t.hostName, localCIDR))
+			endpoint = t.createEndpoint(newEndpointSpec(clusterID, t.hostName, localCIDR))
 			t.createIPTableChain("nat", kubeProxyIPTableChainName)
 		})
 
@@ -63,6 +69,8 @@ var _ = Describe("Endpoint monitoring", func() {
 		})
 
 		It("should start the controllers", func() {
+			t.awaitLeaderLockAcquired()
+
 			t.awaitClusterGlobalEgressIPStatusAllocated(controllers.DefaultNumberOfClusterEgressIPs)
 
 			t.createGlobalEgressIP(newGlobalEgressIP(globalEgressIPName, nil, nil))
@@ -80,20 +88,21 @@ var _ = Describe("Endpoint monitoring", func() {
 			t.awaitHeadlessGlobalIngressIP(service.Name, backendPod.Name)
 		})
 
-		Context("and then removed", func() {
+		Context("and then removed and recreated", func() {
 			JustBeforeEach(func() {
+				t.awaitLeaderLockAcquired()
 				t.awaitClusterGlobalEgressIPStatusAllocated(controllers.DefaultNumberOfClusterEgressIPs)
 
-				Expect(t.endpoints.Delete(context.TODO(), endpointName, metav1.DeleteOptions{})).To(Succeed())
+				By("Deleting the Endpoint")
+
+				Expect(t.endpoints.Delete(context.TODO(), endpoint.Name, metav1.DeleteOptions{})).To(Succeed())
 			})
 
-			It("should remove the appropriate IP table chains", func() {
+			It("should stop and restart the controllers", func() {
+				t.awaitLeaderLockReleased()
+
 				t.ipt.AwaitNoChain("nat", constants.SmGlobalnetIngressChain)
 				t.ipt.AwaitNoChain("nat", constants.SmGlobalnetEgressChain)
-				t.ipt.AwaitNoChain("nat", constants.SmGlobalnetMarkChain)
-			})
-
-			It("should stop the controllers", func() {
 				t.ipt.AwaitNoChain("nat", constants.SmGlobalnetMarkChain)
 
 				time.Sleep(300 * time.Millisecond)
@@ -102,16 +111,126 @@ var _ = Describe("Endpoint monitoring", func() {
 
 				t.createServiceExport(t.createService(newClusterIPService()))
 				t.ensureNoGlobalIngressIP(serviceName)
+
+				By("Recreating the Endpoint")
+
+				time.Sleep(300 * time.Millisecond)
+				t.createEndpoint(newEndpointSpec(clusterID, t.hostName, localCIDR))
+
+				t.awaitLeaderLockAcquired()
+				t.awaitGlobalEgressIPStatusAllocated(globalEgressIPName, 1)
+				t.awaitIngressIPStatusAllocated(serviceName)
 			})
+		})
+
+		Context("and then updated", func() {
+			BeforeEach(func() {
+				t.leaderElectionConfig.LeaseDuration = time.Hour * 3
+				t.leaderElectionConfig.RenewDeadline = time.Hour * 2
+				t.leaderElectionConfig.RetryPeriod = time.Hour
+			})
+
+			JustBeforeEach(func() {
+				t.awaitLeaderLockAcquired()
+				t.awaitClusterGlobalEgressIPStatusAllocated(controllers.DefaultNumberOfClusterEgressIPs)
+
+				// Since the RenewDeadline and RetryPeriod are set very high and the leader lock has been acquired, leader election should
+				// not try to renew the leader lock at this point, but we'll wait a bit more just in case to give it plenty of time. After
+				// that and after we update the Endpoint below, any updates to the leader lock means it tried to re-acquire it.
+				time.Sleep(time.Millisecond * 500)
+				t.kubeClient.ClearActions()
+
+				By("Updating the Endpoint")
+
+				endpoint.Annotations = map[string]string{"foo": "bar"}
+				test.UpdateResource(t.endpoints, endpoint)
+			})
+
+			It("should not try to re-acquire the leader lock", func() {
+				testutil.EnsureNoActionsForResource(&t.kubeClient.Fake, "leases", "update")
+			})
+		})
+
+		Context("and then a local gateway Endpoint corresponding to another host is created", func() {
+			JustBeforeEach(func() {
+				t.awaitLeaderLockAcquired()
+				t.ipt.AwaitChain("nat", constants.SmGlobalnetIngressChain)
+
+				By("Creating other Endpoint")
+
+				t.createEndpoint(newEndpointSpec(clusterID, t.hostName+"-other", localCIDR))
+			})
+
+			It("should stop the controllers", func() {
+				t.awaitLeaderLockReleased()
+
+				t.ipt.AwaitNoChain("nat", constants.SmGlobalnetIngressChain)
+			})
+		})
+
+		Context("and then renewal of the leader lock fails", func() {
+			var leasesReactor *fake.FailOnActionReactor
+
+			BeforeEach(func() {
+				t.leaderElectionConfig.RenewDeadline = time.Millisecond * 200
+				t.leaderElectionConfig.RetryPeriod = time.Millisecond * 20
+
+				leasesReactor = fake.FailOnAction(&t.kubeClient.Fake, "leases", "update", nil, false)
+				leasesReactor.Fail(false)
+			})
+
+			JustBeforeEach(func() {
+				t.awaitLeaderLockAcquired()
+				t.awaitClusterGlobalEgressIPStatusAllocated(controllers.DefaultNumberOfClusterEgressIPs)
+
+				By("Setting leases resource updates to fail")
+
+				leasesReactor.Fail(true)
+			})
+
+			It("should re-acquire the leader lock", func() {
+				// Wait enough time for the renewal deadline to be reached
+				time.Sleep(t.leaderElectionConfig.RenewDeadline + 100)
+
+				By("Ensuring controllers are still running")
+
+				t.createServiceExport(t.createService(newClusterIPService()))
+				t.awaitIngressIPStatusAllocated(serviceName)
+
+				now := metav1.NewTime(time.Now())
+
+				By("Setting leases resource updates to succeed")
+
+				leasesReactor.Fail(false)
+
+				By("Ensuring lease was renewed")
+
+				Eventually(func() int64 {
+					return t.getLeaderElectionRecord().RenewTime.UnixNano()
+				}).Should(BeNumerically(">=", now.UnixNano()), "Lease was not renewed")
+			})
+		})
+	})
+
+	Context("and a local gateway Endpoint corresponding to another host is created", func() {
+		JustBeforeEach(func() {
+			endpoint = t.createEndpoint(newEndpointSpec(clusterID, t.hostName+"-other", localCIDR))
+		})
+
+		It("should not start the controllers", func() {
+			t.ensureLeaderLockNotAcquired()
+
+			t.createServiceExport(t.createService(newClusterIPService()))
+			t.ensureNoGlobalIngressIP(serviceName)
 		})
 	})
 
 	When("a remote Endpoint with non-overlapping CIDRs is created then removed", func() {
 		It("should add/remove appropriate IP table rule(s)", func() {
-			endpointName := t.createEndpoint(newEndpointSpec(remoteClusterID, t.hostName, remoteCIDR))
+			endpoint := t.createEndpoint(newEndpointSpec(remoteClusterID, t.hostName, remoteCIDR))
 			t.ipt.AwaitRule("nat", constants.SmGlobalnetMarkChain, ContainSubstring(remoteCIDR))
 
-			Expect(t.endpoints.Delete(context.TODO(), endpointName, metav1.DeleteOptions{})).To(Succeed())
+			Expect(t.endpoints.Delete(context.TODO(), endpoint.Name, metav1.DeleteOptions{})).To(Succeed())
 			t.ipt.AwaitNoRule("nat", constants.SmGlobalnetMarkChain, ContainSubstring(remoteCIDR))
 		})
 	})
@@ -127,8 +246,10 @@ var _ = Describe("Endpoint monitoring", func() {
 
 type gatewayMonitorTestDriver struct {
 	*testDriverBase
-	endpoints dynamic.ResourceInterface
-	hostName  string
+	endpoints            dynamic.ResourceInterface
+	hostName             string
+	kubeClient           *k8sfake.Clientset
+	leaderElectionConfig controllers.LeaderElectionConfig
 }
 
 func newGatewayMonitorTestDriver() *gatewayMonitorTestDriver {
@@ -139,6 +260,10 @@ func newGatewayMonitorTestDriver() *gatewayMonitorTestDriver {
 
 		t.endpoints = t.dynClient.Resource(*test.GetGroupVersionResourceFor(t.restMapper, &submarinerv1.Endpoint{})).
 			Namespace(namespace)
+
+		t.kubeClient = k8sfake.NewSimpleClientset()
+
+		t.leaderElectionConfig = controllers.LeaderElectionConfig{}
 	})
 
 	JustBeforeEach(func() {
@@ -160,14 +285,20 @@ func (t *gatewayMonitorTestDriver) start() {
 	t.hostName, err = os.Hostname()
 	Expect(err).To(Succeed())
 
-	t.controller, err = controllers.NewGatewayMonitor(controllers.Specification{
-		ClusterID:  clusterID,
-		Namespace:  namespace,
-		GlobalCIDR: []string{localCIDR},
-	}, localSubnets, &watcher.Config{
-		RestMapper: t.restMapper,
-		Client:     t.dynClient,
-		Scheme:     t.scheme,
+	t.controller, err = controllers.NewGatewayMonitor(&controllers.GatewayMonitorConfig{
+		Config: watcher.Config{
+			RestMapper: t.restMapper,
+			Client:     t.dynClient,
+			Scheme:     t.scheme,
+		},
+		Spec: controllers.Specification{
+			ClusterID:  clusterID,
+			Namespace:  namespace,
+			GlobalCIDR: []string{localCIDR},
+		},
+		LocalCIDRs:           localSubnets,
+		KubeClient:           t.kubeClient,
+		LeaderElectionConfig: t.leaderElectionConfig,
 	})
 
 	Expect(err).To(Succeed())
@@ -176,25 +307,71 @@ func (t *gatewayMonitorTestDriver) start() {
 	t.ipt.AwaitChain("nat", constants.SmGlobalnetMarkChain)
 }
 
-func (t *gatewayMonitorTestDriver) createEndpoint(spec *submarinerv1.EndpointSpec) string {
+func (t *gatewayMonitorTestDriver) createEndpoint(spec *submarinerv1.EndpointSpec) *submarinerv1.Endpoint {
 	endpointName, err := spec.GenerateName()
 	Expect(err).To(Succeed())
 
-	test.CreateResource(t.endpoints, &submarinerv1.Endpoint{
+	endpoint := &submarinerv1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: endpointName,
 		},
 		Spec: *spec,
-	})
+	}
 
-	return endpointName
+	obj := test.CreateResource(t.endpoints, endpoint)
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, endpoint)
+	Expect(err).To(Succeed())
+
+	return endpoint
+}
+
+func (t *gatewayMonitorTestDriver) getLeaderElectionRecord() *resourcelock.LeaderElectionRecord {
+	lock, err := resourcelock.New(resourcelock.LeasesResourceLock, namespace, controllers.LeaderElectionLockName,
+		t.kubeClient.CoreV1(), t.kubeClient.CoordinationV1(), resourcelock.ResourceLockConfig{})
+	Expect(err).To(Succeed())
+
+	le, _, err := lock.Get(context.Background())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	Expect(err).To(Succeed())
+
+	return le
+}
+
+func (t *gatewayMonitorTestDriver) awaitLeaderLockAcquired() {
+	Eventually(func() string {
+		le := t.getLeaderElectionRecord()
+		if le == nil {
+			return ""
+		}
+
+		return le.HolderIdentity
+	}, 3).ShouldNot(BeEmpty(), "Leader lock was not acquired")
+}
+
+func (t *gatewayMonitorTestDriver) ensureLeaderLockNotAcquired() {
+	Consistently(func() any {
+		return t.getLeaderElectionRecord()
+	}, 300*time.Millisecond).Should(BeNil(), "Leader lock was acquired")
+}
+
+func (t *gatewayMonitorTestDriver) awaitLeaderLockReleased() {
+	Eventually(func() string {
+		le := t.getLeaderElectionRecord()
+		Expect(le).ToNot(BeNil(), "LeaderElectionRecord not found")
+
+		return le.HolderIdentity
+	}, 3).Should(BeEmpty(), "Leader lock was not released")
 }
 
 func newEndpointSpec(clusterID, hostname, subnet string) *submarinerv1.EndpointSpec {
 	return &submarinerv1.EndpointSpec{
-		CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
+		CableName: fmt.Sprintf("submariner-cable-%s-%s", clusterID, hostname),
 		ClusterID: clusterID,
-		PrivateIP: "192-68-1-2",
+		PrivateIP: "192.68.1.2",
 		Hostname:  hostname,
 		Subnets:   []string{subnet},
 	}

--- a/pkg/globalnet/controllers/global_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_egressip_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	fakeDynClient "github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -592,6 +593,8 @@ func newGlobalEgressIPControllerTestDriver() *globalEgressIPControllerTestDriver
 
 		t.pool, err = ipam.NewIPPool(t.globalCIDR)
 		Expect(err).To(Succeed())
+
+		t.watches = fakeDynClient.NewWatchReactor(&t.dynClient.Fake)
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
Backport of #2743 on release-0.16.

#2743: Use leader election in globalnet controller

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.