### PR TITLE
Automated backport of #2748: Refactor bulk of main.go to a new gateway package

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,17 +23,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"flag"
-	"fmt"
 	"net/http"
 	"net/http/pprof"
-	"os"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	extErrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
@@ -43,28 +38,17 @@ import (
 	admversion "github.com/submariner-io/admiral/pkg/version"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cableengine"
-	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
-	"github.com/submariner-io/submariner/pkg/cableengine/syncer"
-	"github.com/submariner-io/submariner/pkg/cidr"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
-	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
-	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
-	"github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/gateway"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
-	"github.com/submariner-io/submariner/pkg/pod"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/versions"
-	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/tools/record"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
@@ -88,25 +72,7 @@ type leaderConfig struct {
 	RetryPeriod   int64
 }
 
-type componentsType struct {
-	restConfig         *rest.Config
-	cableHealthChecker healthchecker.Interface
-	cableEngineSyncer  *syncer.GatewaySyncer
-	cableEngine        cableengine.Engine
-	publicIPWatcher    *endpoint.PublicIPWatcher
-	datastoreSyncer    *datastoresyncer.DatastoreSyncer
-	gatewayPod         *pod.GatewayPod
-	submSpec           types.SubmarinerSpecification
-	stopCh             <-chan struct{}
-	waitGroup          sync.WaitGroup
-}
-
-const (
-	leadershipConfigEnvPrefix = "leadership"
-	defaultLeaseDuration      = 10 // In Seconds
-	defaultRenewDeadline      = 5  // In Seconds
-	defaultRetryPeriod        = 2  // In Seconds
-)
+const leadershipConfigEnvPrefix = "leadership"
 
 var (
 	logger             = log.Logger{Logger: logf.Log.WithName("main")}
@@ -127,17 +93,15 @@ func main() {
 
 	versions.Log(&logger)
 
-	logger.Info("Starting the submariner gateway engine")
+	gwLeadershipConfig := leaderConfig{}
+	logger.FatalfOnError(envconfig.Process(leadershipConfigEnvPrefix, &gwLeadershipConfig), "Error processing %s env vars",
+		leadershipConfigEnvPrefix)
 
-	components := &componentsType{
-		// set up signals so we handle the first shutdown signal gracefully
-		stopCh: signals.SetupSignalHandler().Done(),
-	}
+	submSpec := types.SubmarinerSpecification{}
+	logger.FatalOnError(envconfig.Process("submariner", &submSpec), "Error processing env vars")
 
-	logger.FatalOnError(envconfig.Process("submariner", &components.submSpec), "Error processing env vars")
-
-	logger.Info("Parsed env variables", components.submSpec)
-	httpServer := startHTTPServer(&components.submSpec)
+	logger.Info("Parsed env variables", submSpec)
+	httpServer := startHTTPServer(&submSpec)
 
 	var err error
 
@@ -154,220 +118,48 @@ func main() {
 		// The generic handler has already logged the error, no need to repeat if we don't want extra detail
 	})
 
-	components.restConfig, err = clientcmd.BuildConfigFromFlags(localMasterURL, localKubeconfig)
+	restConfig, err := clientcmd.BuildConfigFromFlags(localMasterURL, localKubeconfig)
 	logger.FatalOnError(err, "Error building kubeconfig")
 
-	submarinerClient, err := submarinerClientset.NewForConfig(components.restConfig)
+	submarinerClient, err := submarinerClientset.NewForConfig(restConfig)
 	logger.FatalOnError(err, "Error creating submariner clientset")
 
-	k8sClient, err := kubernetes.NewForConfig(components.restConfig)
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
 	logger.FatalOnError(err, "Error creating Kubernetes clientset")
+
+	leClient, err := kubernetes.NewForConfig(rest.AddUserAgent(restConfig, "leader-election"))
+	logger.FatalOnError(err, "Error creating leader election kubernetes clientset")
 
 	logger.FatalOnError(subv1.AddToScheme(scheme.Scheme), "Error adding submariner types to the scheme")
 
-	logger.Info("Creating the cable engine")
+	gw, err := gateway.New(&gateway.Config{
+		LeaderElectionConfig: gateway.LeaderElectionConfig{
+			LeaseDuration: time.Duration(gwLeadershipConfig.LeaseDuration) * time.Second,
+			RenewDeadline: time.Duration(gwLeadershipConfig.RenewDeadline) * time.Second,
+			RetryPeriod:   time.Duration(gwLeadershipConfig.RetryPeriod) * time.Second,
+		},
+		Spec: submSpec,
+		SyncerConfig: broker.SyncerConfig{
+			LocalRestConfig: restConfig,
+		},
+		WatcherConfig: watcher.Config{
+			RestConfig: restConfig,
+		},
+		SubmarinerClient:     submarinerClient,
+		KubeClient:           k8sClient,
+		LeaderElectionClient: leClient,
+		NewCableEngine:       cableengine.NewEngine,
+		NewNATDiscovery:      natdiscovery.New,
+	})
+	logger.FatalOnError(err, "Error creating gateway instance")
 
-	localCluster := submarinerClusterFrom(&components.submSpec)
+	err = gw.Run(signals.SetupSignalHandler().Done())
 
-	if components.submSpec.CableDriver == "" {
-		components.submSpec.CableDriver = cable.GetDefaultCableDriver()
-	}
-
-	components.submSpec.CableDriver = strings.ToLower(components.submSpec.CableDriver)
-
-	airGapped := isAirGappedDeployment()
-	logger.Infof("AIR_GAPPED_DEPLOYMENT is set to %t", airGapped)
-
-	localEndpoint, err := endpoint.GetLocal(&components.submSpec, k8sClient, airGapped)
-	logger.FatalOnError(err, "Error creating local endpoint object")
-
-	components.cableEngine = cableengine.NewEngine(localCluster, localEndpoint)
-
-	natDiscovery, err := natdiscovery.New(localEndpoint)
-	logger.FatalOnError(err, "Error creating the NAT discovery handler")
-
-	logger.Info("Creating the datastore syncer")
-
-	components.datastoreSyncer = datastoresyncer.New(&broker.SyncerConfig{
-		LocalRestConfig: components.restConfig,
-		LocalNamespace:  components.submSpec.Namespace,
-	}, localCluster, localEndpoint)
-
-	components.initCableHealthChecker()
-
-	components.cableEngineSyncer = syncer.NewGatewaySyncer(
-		components.cableEngine,
-		submarinerClient.SubmarinerV1().Gateways(components.submSpec.Namespace),
-		versions.Submariner(), components.cableHealthChecker)
-
-	if components.submSpec.Uninstall {
-		logger.Info("Uninstalling the submariner gateway engine")
-
-		components.uninstallGateway()
-
-		return
-	}
-
-	components.cableEngine.SetupNATDiscovery(natDiscovery)
-
-	logger.FatalOnError(natDiscovery.Run(components.stopCh), "Error starting NAT discovery server")
-
-	components.gatewayPod, err = pod.NewGatewayPod(k8sClient)
-	logger.FatalOnError(err, "Error creating a handler to update the gateway pod")
-
-	components.runAsync(components.cableEngineSyncer.Run)
-
-	if !airGapped {
-		components.initPublicIPWatcher(k8sClient, submarinerClient, localEndpoint)
-	}
-
-	leClient, err := kubernetes.NewForConfig(rest.AddUserAgent(components.restConfig, "leader-election"))
-	if err != nil {
-		components.fatal("Error creating leader election kubernetes clientset: %s", err)
-	}
-
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(logger.V(log.DEBUG).Infof)
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "submariner-controller"})
-
-	go func() {
-		if err = startLeaderElection(leClient, recorder, components.becameLeader, components.lostLeader); err != nil {
-			components.fatal("Error starting leader election: %v", err)
-		}
-	}()
-
-	<-components.stopCh
-
-	logger.Info("All controllers stopped or exited. Stopping main loop")
-
-	if err := httpServer.Shutdown(context.TODO()); err != nil {
+	if err := httpServer.Shutdown(context.Background()); err != nil {
 		logger.Errorf(err, "Error shutting down metrics HTTP server")
 	}
 
-	components.waitGroup.Wait()
-}
-
-func isAirGappedDeployment() bool {
-	return os.Getenv("AIR_GAPPED_DEPLOYMENT") == "true"
-}
-
-func (c *componentsType) becameLeader(context.Context) {
-	if err := c.cableEngine.StartEngine(); err != nil {
-		c.fatal("Error starting the cable engine: %v", err)
-	}
-
-	var wg sync.WaitGroup
-
-	wg.Add(5)
-
-	go func() {
-		defer wg.Done()
-
-		if err := c.gatewayPod.SetHALabels(subv1.HAStatusActive); err != nil {
-			c.fatal("Error updating pod label: %s", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-
-		watcherConfig := &watcher.Config{RestConfig: c.restConfig}
-		if err := tunnel.StartController(c.cableEngine, c.submSpec.Namespace, watcherConfig, c.stopCh); err != nil {
-			c.fatal("Error running the tunnel controller: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-
-		if err := c.datastoreSyncer.Start(c.stopCh); err != nil {
-			c.fatal("Error running the datastore syncer: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-
-		if c.cableHealthChecker != nil {
-			if err := c.cableHealthChecker.Start(c.stopCh); err != nil {
-				logger.Errorf(err, "Error starting healthChecker")
-			}
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-
-		if c.publicIPWatcher != nil {
-			c.publicIPWatcher.Run(c.stopCh)
-		}
-	}()
-
-	wg.Wait()
-	<-c.stopCh
-}
-
-func (c *componentsType) lostLeader() {
-	if err := c.gatewayPod.SetHALabels(subv1.HAStatusPassive); err != nil {
-		logger.Warningf("Error updating pod label: %s", err)
-	}
-
-	c.cableEngineSyncer.CleanupGatewayEntry()
-	logger.Fatalf("Leader election lost, shutting down")
-}
-
-func (c *componentsType) initCableHealthChecker() {
-	var err error
-
-	if !c.submSpec.HealthCheckEnabled {
-		logger.Info("The CableEngine HealthChecker is disabled")
-	} else {
-		c.cableHealthChecker, err = healthchecker.New(&healthchecker.Config{
-			WatcherConfig:      &watcher.Config{RestConfig: c.restConfig},
-			EndpointNamespace:  c.submSpec.Namespace,
-			ClusterID:          c.submSpec.ClusterID,
-			PingInterval:       c.submSpec.HealthCheckInterval,
-			MaxPacketLossCount: c.submSpec.HealthCheckMaxPacketLossCount,
-		})
-		if err != nil {
-			logger.Errorf(err, "Error creating healthChecker")
-		}
-	}
-}
-
-func (c *componentsType) initPublicIPWatcher(k8sClient kubernetes.Interface, submarinerClient *submarinerClientset.Clientset,
-	localEndpoint *types.SubmarinerEndpoint,
-) {
-	publicIPConfig := &endpoint.PublicIPWatcherConfig{
-		SubmSpec:      &c.submSpec,
-		K8sClient:     k8sClient,
-		Endpoints:     submarinerClient.SubmarinerV1().Endpoints(c.submSpec.Namespace),
-		LocalEndpoint: *localEndpoint,
-	}
-
-	c.publicIPWatcher = endpoint.NewPublicIPWatcher(publicIPConfig)
-}
-
-func (c *componentsType) runAsync(run func(<-chan struct{})) {
-	c.waitGroup.Add(1)
-
-	go func() {
-		defer c.waitGroup.Done()
-		run(c.stopCh)
-	}()
-}
-
-func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.SubmarinerCluster {
-	return &types.SubmarinerCluster{
-		ID: submSpec.ClusterID,
-		Spec: subv1.ClusterSpec{
-			ClusterID:   submSpec.ClusterID,
-			ColorCodes:  []string{"blue"}, // This is a fake value, used only for upgrade purposes
-			ServiceCIDR: cidr.ExtractIPv4Subnets(submSpec.ServiceCidr),
-			ClusterCIDR: cidr.ExtractIPv4Subnets(submSpec.ClusterCidr),
-			GlobalCIDR:  submSpec.GlobalCidr,
-		},
-	}
+	logger.FatalOnError(err, "Error running the gateway")
 }
 
 func startHTTPServer(spec *types.SubmarinerSpecification) *http.Server {
@@ -383,103 +175,4 @@ func startHTTPServer(spec *types.SubmarinerSpecification) *http.Server {
 	}()
 
 	return srv
-}
-
-func startLeaderElection(leaderElectionClient kubernetes.Interface, recorder resourcelock.EventRecorder,
-	run func(ctx context.Context), end func(),
-) error {
-	gwLeadershipConfig := leaderConfig{}
-
-	err := envconfig.Process(leadershipConfigEnvPrefix, &gwLeadershipConfig)
-	if err != nil {
-		return extErrors.Wrapf(err, "error processing environment config for %s", leadershipConfigEnvPrefix)
-	}
-
-	// Use default values when GatewayLeadership environment variables are not configured
-	if gwLeadershipConfig.LeaseDuration == 0 {
-		gwLeadershipConfig.LeaseDuration = defaultLeaseDuration
-	}
-
-	if gwLeadershipConfig.RenewDeadline == 0 {
-		gwLeadershipConfig.RenewDeadline = defaultRenewDeadline
-	}
-
-	if gwLeadershipConfig.RetryPeriod == 0 {
-		gwLeadershipConfig.RetryPeriod = defaultRetryPeriod
-	}
-
-	logger.Infof("Gateway leader election config values: %#v", gwLeadershipConfig)
-
-	id, err := os.Hostname()
-	if err != nil {
-		return extErrors.Wrap(err, "error getting hostname")
-	}
-
-	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	)
-
-	namespace, _, err := kubeconfig.Namespace()
-	if err != nil {
-		namespace = "submariner"
-		logger.Infof("Could not obtain a namespace to use for the leader election lock - the error was: %v. Using the default %q namespace.",
-			err, namespace)
-	} else {
-		logger.Infof("Using namespace %q for the leader election lock", namespace)
-	}
-
-	// Lock required for leader election
-	rl, err := resourcelock.New(resourcelock.LeasesResourceLock, namespace, "submariner-gateway-lock",
-		leaderElectionClient.CoreV1(), leaderElectionClient.CoordinationV1(), resourcelock.ResourceLockConfig{
-			Identity:      id + "-submariner-gateway",
-			EventRecorder: recorder,
-		})
-	if err != nil {
-		return extErrors.Wrap(err, "error creating leader election resource lock")
-	}
-
-	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: time.Duration(gwLeadershipConfig.LeaseDuration) * time.Second,
-		RenewDeadline: time.Duration(gwLeadershipConfig.RenewDeadline) * time.Second,
-		RetryPeriod:   time.Duration(gwLeadershipConfig.RetryPeriod) * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: run,
-			OnStoppedLeading: end,
-		},
-	})
-
-	return nil
-}
-
-func (c *componentsType) fatal(format string, args ...interface{}) {
-	err := fmt.Errorf(format, args...)
-	c.cableEngineSyncer.SetGatewayStatusError(err)
-
-	if err := c.gatewayPod.SetHALabels(subv1.HAStatusPassive); err != nil {
-		logger.Warningf("Error updating pod label: %s", err)
-	}
-
-	logger.Fatal(err.Error())
-}
-
-func (c *componentsType) uninstallGateway() {
-	err := c.cableEngine.StartEngine()
-	if err != nil {
-		// As we are in the process of cleaning up, ignore any initialization errors.
-		logger.Errorf(err, "Error starting the cable driver")
-	}
-
-	// The Gateway object has to be deleted before invoking the cableEngine.Cleanup
-	c.cableEngineSyncer.CleanupGatewayEntry()
-
-	err = c.cableEngine.Cleanup()
-	if err != nil {
-		logger.Errorf(err, "Error while cleaning up of cable drivers")
-	}
-
-	dsErr := c.datastoreSyncer.Cleanup()
-
-	logger.FatalOnError(dsErr, "Error cleaning up the datastore")
 }

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -38,6 +38,7 @@ type Engine struct { //nolint:gocritic // This mutex is exposed but we tweak it 
 	ErrOnInstallCable         error
 	removeCable               chan *v1.EndpointSpec
 	ErrOnRemoveCable          error
+	StartErr                  error
 }
 
 var _ cableengine.Engine = &Engine{}
@@ -52,7 +53,7 @@ func New() *Engine {
 }
 
 func (e *Engine) StartEngine() error {
-	return nil
+	return e.StartErr
 }
 
 func (e *Engine) InstallCable(endpoint *v1.Endpoint) error {

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -86,7 +86,7 @@ func (gs *GatewaySyncer) Run(stopCh <-chan struct{}) {
 	wait.Until(gs.syncGatewayStatus, GatewayUpdateInterval, stopCh)
 	gs.CleanupGatewayEntry()
 
-	logger.Info("CableEngine syncer started")
+	logger.Info("CableEngine syncer stopped")
 }
 
 func (gs *GatewaySyncer) syncGatewayStatus() {

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -48,7 +48,9 @@ func GetLocal(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Inte
 	privateIP := GetLocalIP()
 
 	gwNode, err := node.GetLocalNode(k8sClient)
-	logger.FatalfOnError(err, "Error getting information on the local node")
+	if err != nil {
+		return nil, errors.Wrap(err, "getting information on the local node")
+	}
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -1,0 +1,371 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cableengine"
+	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
+	"github.com/submariner-io/submariner/pkg/cableengine/syncer"
+	"github.com/submariner-io/submariner/pkg/cidr"
+	submclientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
+	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
+	"github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/pod"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/submariner-io/submariner/pkg/versions"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	defaultLeaseDuration = 10 * time.Second
+	defaultRenewDeadline = 5 * time.Second
+	defaultRetryPeriod   = 2 * time.Second
+)
+
+type Interface interface {
+	Run(<-chan struct{}) error
+}
+
+type LeaderElectionConfig struct {
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+}
+
+type Config struct {
+	LeaderElectionConfig
+	Spec                 types.SubmarinerSpecification
+	SyncerConfig         broker.SyncerConfig
+	WatcherConfig        watcher.Config
+	SubmarinerClient     submclientset.Interface
+	KubeClient           kubernetes.Interface
+	LeaderElectionClient kubernetes.Interface
+	NewCableEngine       func(localCluster *types.SubmarinerCluster, localEndpoint *types.SubmarinerEndpoint) cableengine.Engine
+	NewNATDiscovery      func(localEndpoint *types.SubmarinerEndpoint) (natdiscovery.Interface, error)
+}
+
+type gatewayType struct {
+	Config
+	airGapped          bool
+	cableHealthChecker healthchecker.Interface
+	cableEngineSyncer  *syncer.GatewaySyncer
+	cableEngine        cableengine.Engine
+	publicIPWatcher    *endpoint.PublicIPWatcher
+	datastoreSyncer    *datastoresyncer.DatastoreSyncer
+	natDiscovery       natdiscovery.Interface
+	gatewayPod         *pod.GatewayPod
+	hostName           string
+	localEndpoint      *types.SubmarinerEndpoint
+	stopCh             <-chan struct{}
+	fatalError         chan error
+	waitGroup          sync.WaitGroup
+	recorder           record.EventRecorder
+}
+
+var logger = log.Logger{Logger: logf.Log.WithName("Gateway")}
+
+func New(config *Config) (Interface, error) {
+	logger.Info("Initializing the gateway engine")
+
+	g := &gatewayType{
+		Config:     *config,
+		fatalError: make(chan error),
+	}
+
+	if g.LeaseDuration == 0 {
+		g.LeaseDuration = defaultLeaseDuration
+	}
+
+	if g.RenewDeadline == 0 {
+		g.RenewDeadline = defaultRenewDeadline
+	}
+
+	if g.RetryPeriod == 0 {
+		g.RetryPeriod = defaultRetryPeriod
+	}
+
+	var err error
+
+	g.hostName, err = os.Hostname()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting hostname")
+	}
+
+	logger.Info("Creating the cable engine")
+
+	localCluster := submarinerClusterFrom(&g.Spec)
+
+	if g.Spec.CableDriver == "" {
+		g.Spec.CableDriver = cable.GetDefaultCableDriver()
+	}
+
+	g.Spec.CableDriver = strings.ToLower(g.Spec.CableDriver)
+
+	g.airGapped = os.Getenv("AIR_GAPPED_DEPLOYMENT") == "true"
+	logger.Infof("AIR_GAPPED_DEPLOYMENT is set to %t", g.airGapped)
+
+	g.localEndpoint, err = endpoint.GetLocal(&g.Spec, g.KubeClient, g.airGapped)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating local endpoint object")
+	}
+
+	g.cableEngine = g.NewCableEngine(localCluster, g.localEndpoint)
+
+	g.natDiscovery, err = g.NewNATDiscovery(g.localEndpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating the NAT discovery handler")
+	}
+
+	logger.Info("Creating the datastore syncer")
+
+	g.SyncerConfig.LocalNamespace = g.Spec.Namespace
+
+	g.datastoreSyncer = datastoresyncer.New(&g.SyncerConfig, localCluster, g.localEndpoint)
+
+	g.initCableHealthChecker()
+
+	g.cableEngineSyncer = syncer.NewGatewaySyncer(
+		g.cableEngine,
+		g.SubmarinerClient.SubmarinerV1().Gateways(g.Spec.Namespace),
+		versions.Submariner(), g.cableHealthChecker)
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(logger.V(log.DEBUG).Infof)
+	g.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "submariner-controller"})
+
+	return g, nil
+}
+
+func (g *gatewayType) Run(stopCh <-chan struct{}) error {
+	if g.Spec.Uninstall {
+		logger.Info("Uninstalling the submariner gateway engine")
+
+		g.uninstall()
+
+		return nil
+	}
+
+	logger.Info("Starting the gateway engine")
+
+	g.stopCh = stopCh
+
+	g.cableEngine.SetupNATDiscovery(g.natDiscovery)
+
+	err := g.natDiscovery.Run(g.stopCh)
+	if err != nil {
+		return errors.Wrap(err, "error starting NAT discovery server")
+	}
+
+	g.gatewayPod, err = pod.NewGatewayPod(g.KubeClient)
+	if err != nil {
+		return errors.Wrap(err, "error creating a handler to update the gateway pod")
+	}
+
+	g.runAsync(g.cableEngineSyncer.Run)
+
+	if !g.airGapped {
+		g.initPublicIPWatcher()
+	}
+
+	err = g.startLeaderElection()
+	if err != nil {
+		return errors.Wrap(err, "error starting leader election")
+	}
+
+	select {
+	case <-g.stopCh:
+	case fatalErr := <-g.fatalError:
+		g.cableEngineSyncer.SetGatewayStatusError(fatalErr)
+
+		if err := g.gatewayPod.SetHALabels(subv1.HAStatusPassive); err != nil {
+			logger.Warningf("Error updating pod label: %s", err)
+		}
+
+		return fatalErr
+	}
+
+	g.waitGroup.Wait()
+
+	logger.Info("Gateway engine stopped")
+
+	return nil
+}
+
+func (g *gatewayType) runAsync(run func(<-chan struct{})) {
+	g.waitGroup.Add(1)
+
+	go func() {
+		defer g.waitGroup.Done()
+		run(g.stopCh)
+	}()
+}
+
+func (g *gatewayType) startLeaderElection() error {
+	rl, err := resourcelock.New(resourcelock.LeasesResourceLock, g.Spec.Namespace, "submariner-gateway-lock",
+		g.LeaderElectionClient.CoreV1(), g.LeaderElectionClient.CoordinationV1(), resourcelock.ResourceLockConfig{
+			Identity:      g.hostName + "-submariner-gateway",
+			EventRecorder: g.recorder,
+		})
+	if err != nil {
+		return errors.Wrap(err, "error creating leader election resource lock")
+	}
+
+	go leaderelection.RunOrDie(context.Background(), leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: g.LeaseDuration,
+		RenewDeadline: g.RenewDeadline,
+		RetryPeriod:   g.RetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: g.onStartedLeading,
+			OnStoppedLeading: g.onStoppedLeading,
+		},
+	})
+
+	return nil
+}
+
+func (g *gatewayType) onStartedLeading(_ context.Context) {
+	if err := g.cableEngine.StartEngine(); err != nil {
+		g.fatalError <- errors.Wrap(err, "error starting the cable engine")
+		return
+	}
+
+	go func() {
+		if err := g.gatewayPod.SetHALabels(subv1.HAStatusActive); err != nil {
+			g.fatalError <- errors.Wrap(err, "error updating pod label")
+		}
+	}()
+
+	go func() {
+		watcherConfig := g.WatcherConfig
+		if err := tunnel.StartController(g.cableEngine, g.Spec.Namespace, &watcherConfig, g.stopCh); err != nil {
+			g.fatalError <- errors.Wrap(err, "error running the tunnel controller")
+		}
+	}()
+
+	go func() {
+		if err := g.datastoreSyncer.Start(g.stopCh); err != nil {
+			g.fatalError <- errors.Wrap(err, "error running the datastore syncer")
+		}
+	}()
+
+	if g.cableHealthChecker != nil {
+		go func() {
+			if err := g.cableHealthChecker.Start(g.stopCh); err != nil {
+				logger.Errorf(err, "Error starting healthChecker")
+			}
+		}()
+	}
+
+	if g.publicIPWatcher != nil {
+		go func() {
+			g.publicIPWatcher.Run(g.stopCh)
+		}()
+	}
+}
+
+func (g *gatewayType) onStoppedLeading() {
+	g.cableEngineSyncer.CleanupGatewayEntry()
+
+	g.fatalError <- errors.New("leader election lost, shutting down")
+}
+
+func (g *gatewayType) initPublicIPWatcher() {
+	publicIPConfig := &endpoint.PublicIPWatcherConfig{
+		SubmSpec:      &g.Spec,
+		K8sClient:     g.KubeClient,
+		Endpoints:     g.SubmarinerClient.SubmarinerV1().Endpoints(g.Spec.Namespace),
+		LocalEndpoint: *g.localEndpoint,
+	}
+
+	g.publicIPWatcher = endpoint.NewPublicIPWatcher(publicIPConfig)
+}
+
+func (g *gatewayType) initCableHealthChecker() {
+	var err error
+
+	if !g.Spec.HealthCheckEnabled {
+		logger.Info("The CableEngine HealthChecker is disabled")
+	} else {
+		watcherConfig := g.WatcherConfig
+		g.cableHealthChecker, err = healthchecker.New(&healthchecker.Config{
+			WatcherConfig:      &watcherConfig,
+			EndpointNamespace:  g.Spec.Namespace,
+			ClusterID:          g.Spec.ClusterID,
+			PingInterval:       g.Spec.HealthCheckInterval,
+			MaxPacketLossCount: g.Spec.HealthCheckMaxPacketLossCount,
+		})
+		if err != nil {
+			logger.Errorf(err, "Error creating healthChecker")
+		}
+	}
+}
+
+func (g *gatewayType) uninstall() {
+	err := g.cableEngine.StartEngine()
+	if err != nil {
+		// As we are in the process of cleaning up, ignore any initialization errors.
+		logger.Errorf(err, "Error starting the cable driver")
+	}
+
+	// The Gateway object has to be deleted before invoking the cableEngine.Cleanup
+	g.cableEngineSyncer.CleanupGatewayEntry()
+
+	err = g.cableEngine.Cleanup()
+	if err != nil {
+		logger.Errorf(err, "Error while cleaning up of cable drivers")
+	}
+
+	dsErr := g.datastoreSyncer.Cleanup()
+
+	logger.FatalOnError(dsErr, "Error cleaning up the datastore")
+}
+
+func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.SubmarinerCluster {
+	return &types.SubmarinerCluster{
+		ID: submSpec.ClusterID,
+		Spec: subv1.ClusterSpec{
+			ClusterID:   submSpec.ClusterID,
+			ColorCodes:  []string{"blue"}, // This is a fake value, used only for upgrade purposes
+			ServiceCIDR: cidr.ExtractIPv4Subnets(submSpec.ServiceCidr),
+			ClusterCIDR: cidr.ExtractIPv4Subnets(submSpec.ClusterCidr),
+			GlobalCIDR:  submSpec.GlobalCidr,
+		},
+	}
+}

--- a/pkg/gateway/gateway_suite_test.go
+++ b/pkg/gateway/gateway_suite_test.go
@@ -1,0 +1,43 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+	Expect(submarinerv1.AddToScheme(scheme.Scheme)).To(Succeed())
+})
+
+func TestGateway(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway Suite")
+}

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -1,0 +1,270 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/fake"
+	. "github.com/submariner-io/admiral/pkg/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cableengine"
+	enginefake "github.com/submariner-io/submariner/pkg/cableengine/fake"
+	submfake "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	"github.com/submariner-io/submariner/pkg/gateway"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ = Describe("Run", func() {
+	t := newTestDriver()
+
+	It("should start the controllers", func() {
+		t.awaitEndpoint()
+		t.awaitHAStatus(submarinerv1.HAStatusActive)
+		t.awaitGateway()
+	})
+
+	When("starting the Cable Engine fails", func() {
+		BeforeEach(func() {
+			t.expectedRunErr = errors.New("mock Cable Engine Start error")
+			t.cableEngine.StartErr = t.expectedRunErr
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("renewal of the leader lock fails", func() {
+		var leasesReactor *fake.FailOnActionReactor
+
+		BeforeEach(func() {
+			t.config.RenewDeadline = time.Millisecond * 200
+			t.config.RetryPeriod = time.Millisecond * 20
+
+			t.expectedRunErr = errors.New("leader election lost")
+			leasesReactor = fake.FailOnAction(&t.kubeClient.Fake, "leases", "update", nil, false)
+			leasesReactor.Fail(false)
+		})
+
+		It("should return an error", func() {
+			t.awaitHAStatus(submarinerv1.HAStatusActive)
+
+			By("Setting leases resource updates to fail")
+
+			leasesReactor.Fail(true)
+		})
+	})
+})
+
+type testDriver struct {
+	config         gateway.Config
+	localPodName   string
+	nodeName       string
+	endpoints      dynamic.NamespaceableResourceInterface
+	expectedRunErr error
+	cableEngine    *enginefake.Engine
+	kubeClient     *k8sfake.Clientset
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		t.expectedRunErr = nil
+
+		restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{}, &submarinerv1.Cluster{}, &submarinerv1.Gateway{}, &corev1.Node{})
+
+		dynClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+		t.kubeClient = k8sfake.NewSimpleClientset()
+
+		t.cableEngine = enginefake.New()
+
+		t.config = gateway.Config{
+			Spec: types.SubmarinerSpecification{
+				ClusterCidr:        []string{"169.254.1.0/24"},
+				GlobalCidr:         []string{"224.0.0.0/16"},
+				ServiceCidr:        []string{"169.254.2.0/24"},
+				ClusterID:          "east",
+				Namespace:          "submariner",
+				PublicIP:           "ipv4:1.2.3.4",
+				HealthCheckEnabled: true,
+			},
+			SyncerConfig: broker.SyncerConfig{
+				LocalClient:     dynClient,
+				BrokerClient:    dynClient,
+				BrokerNamespace: "broker-ns",
+				RestMapper:      restMapper,
+			},
+			WatcherConfig: watcher.Config{
+				RestMapper: restMapper,
+				Client:     dynClient,
+			},
+			SubmarinerClient:     submfake.NewSimpleClientset(),
+			KubeClient:           t.kubeClient,
+			LeaderElectionClient: t.kubeClient,
+			NewCableEngine: func(_ *types.SubmarinerCluster, ep *types.SubmarinerEndpoint) cableengine.Engine {
+				t.cableEngine.LocalEndPoint = ep
+				return t.cableEngine
+			},
+			NewNATDiscovery: func(_ *types.SubmarinerEndpoint) (natdiscovery.Interface, error) {
+				return &fakeNATDiscovery{}, nil
+			},
+		}
+
+		t.endpoints = t.config.SyncerConfig.LocalClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{}))
+
+		t.localPodName = "local-pod"
+		t.nodeName = "raiders"
+
+		os.Setenv("SUBMARINER_NAMESPACE", t.config.Spec.Namespace)
+		os.Setenv("NODE_NAME", t.nodeName)
+		os.Setenv("POD_NAME", t.localPodName)
+
+		_, err := t.config.KubeClient.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: t.nodeName,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).To(Succeed())
+
+		_, err = t.config.KubeClient.CoreV1().Pods(t.config.Spec.Namespace).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: t.localPodName,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		gw, err := gateway.New(&t.config)
+		Expect(err).To(Succeed())
+
+		stopCh := make(chan struct{})
+		runCompleted := make(chan error, 1)
+
+		DeferCleanup(func() {
+			if t.expectedRunErr == nil {
+				close(stopCh)
+			}
+
+			err := func() error {
+				timeout := 5 * time.Second
+				select {
+				case err := <-runCompleted:
+					return errors.WithMessage(err, "Run returned an error")
+				case <-time.After(timeout):
+					return fmt.Errorf("Run did not complete after %v", timeout)
+				}
+			}()
+
+			if t.expectedRunErr == nil {
+				Expect(err).To(Succeed())
+				t.awaitNoGateway()
+			} else {
+				Expect(err).To(ContainErrorSubstring(t.expectedRunErr))
+				t.awaitHAStatus(submarinerv1.HAStatusPassive)
+				t.awaitGatewayStatusError(t.expectedRunErr.Error())
+			}
+		})
+
+		go func() {
+			runCompleted <- gw.Run(stopCh)
+		}()
+	})
+
+	return t
+}
+
+func (t *testDriver) awaitEndpoint() {
+	Eventually(func() int {
+		l, err := t.endpoints.Namespace(t.config.Spec.Namespace).List(context.Background(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+
+		return len(l.Items)
+	}, 3).Should(Equal(1))
+}
+
+func (t *testDriver) awaitHAStatus(status submarinerv1.HAStatus) {
+	Eventually(func() string {
+		pod, err := t.config.KubeClient.CoreV1().Pods(t.config.Spec.Namespace).Get(context.Background(), t.localPodName, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+
+		return pod.Labels["gateway.submariner.io/status"]
+	}, 3).Should(Equal(string(status)))
+}
+
+func (t *testDriver) awaitGateway() {
+	Eventually(func() int {
+		l, err := t.config.SubmarinerClient.SubmarinerV1().Gateways(t.config.Spec.Namespace).List(context.Background(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+
+		return len(l.Items)
+	}, 3).Should(Equal(1))
+}
+
+func (t *testDriver) awaitNoGateway() {
+	Eventually(func() int {
+		l, err := t.config.SubmarinerClient.SubmarinerV1().Gateways(t.config.Spec.Namespace).List(context.Background(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+
+		return len(l.Items)
+	}, 3).Should(BeZero())
+}
+
+func (t *testDriver) awaitGatewayStatusError(s string) {
+	Eventually(func() string {
+		l, err := t.config.SubmarinerClient.SubmarinerV1().Gateways(t.config.Spec.Namespace).List(context.Background(), metav1.ListOptions{})
+		Expect(err).To(Succeed())
+		Expect(l.Items).To(HaveLen(1))
+
+		return l.Items[0].Status.StatusFailure
+	}, 3).Should(ContainSubstring(s))
+}
+
+type fakeNATDiscovery struct{}
+
+func (n *fakeNATDiscovery) Run(_ <-chan struct{}) error {
+	return nil
+}
+
+func (n *fakeNATDiscovery) AddEndpoint(_ *submarinerv1.Endpoint) {
+}
+
+func (n *fakeNATDiscovery) RemoveEndpoint(_ string) {
+}
+
+func (n *fakeNATDiscovery) GetReadyChannel() chan *natdiscovery.NATEndpointInfo {
+	return make(chan *natdiscovery.NATEndpointInfo, 100)
+}


### PR DESCRIPTION
Backport of #2748 on release-0.16.

#2748: Refactor bulk of main.go to a new gateway package

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.