### PR TITLE
Delete Calico IPPools when Submariner uninstalled

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/ippool_handler.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler.go
@@ -129,10 +129,6 @@ func (h *calicoIPPoolHandler) TransitionToGateway() error {
 }
 
 func (h *calicoIPPoolHandler) Uninstall() error {
-	if !h.isGateway.Load() {
-		return nil
-	}
-
 	logger.Info("Uninstalling Calico IPPools used for Submariner")
 
 	labelSelector := labels.SelectorFromSet(map[string]string{submarinerIPPool: "true"}).String()


### PR DESCRIPTION
All Calico IPPools created by Submariner should be deleted when Submariner is uninstalled.

This PR updates Calico IPPools handler Uninstall function to delete all IPPools regardless of isGateway field status.

Fixes: https://github.com/submariner-io/submariner/issues/2764

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
