### PR TITLE
Remove release-notes files

### DIFF
--- a/release-notes/20221103-mss-clamp.md
+++ b/release-notes/20221103-mss-clamp.md
@@ -1,2 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-It is now possible to customize the default TCP MSS clamping value set by Submariner also for non-Globalnet deployments.

--- a/release-notes/20230306-dual-stack.md
+++ b/release-notes/20230306-dual-stack.md
@@ -1,4 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Submariner can now be installed on a dual-stack Kubernetes cluster. Currently, it does not
-support IPv6, but connectivity and service-discovery would continue to work normally using
-IPv4 addresses.

--- a/release-notes/20230426-globalip-leak.md
+++ b/release-notes/20230426-globalip-leak.md
@@ -1,3 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Includes fix for stale IPtable rules along with globalIP leak which can sometimes happen
-when a GlobalEgressIP is created and immediately deleted as part of stress testing.

--- a/release-notes/20230426-race-endpoints.md
+++ b/release-notes/20230426-race-endpoints.md
@@ -1,3 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Submariner now handles out of order remote endpoint notifications properly in various
-handlers associated with route-agent.

--- a/release-notes/20230426-rhel9-fix.md
+++ b/release-notes/20230426-rhel9-fix.md
@@ -1,5 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Submariner now ensures that reverse path filtering setting is properly applied
-on the `vx-submariner` and `vxlan-tunnel` interfaces after they are created.
-This fix was necessary for RHEL9 nodes where the setting was sometimes getting
-overwritten.

--- a/release-notes/20230508-ovn-gw-node.md
+++ b/release-notes/20230508-ovn-gw-node.md
@@ -1,2 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Fixed issues while spawning Gateway nodes during cloud prepare for clusters deployed on OpenStack environment running OVN-Kubernetes CNI.


### PR DESCRIPTION
We're no longer checking in such files to the projects, also once the notes were merged into the web-site doc, the files no longer serve any purpose.
