### PR TITLE
Fix race condtion when mutliple local endpoints are created

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	cni "github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
@@ -39,6 +40,7 @@ type SyncHandler struct {
 	localCableDriver string
 	localClusterCidr []string
 	localServiceCidr []string
+	localEndpoint    *submV1.Endpoint
 
 	remoteSubnets    set.Set[string]
 	remoteSubnetGw   map[string]net.IP


### PR DESCRIPTION
There is a race condition when the worker nodes get restarted one by one. More than one submariner endpoint is created in one cluster as two gateways tries to be the leader. One yields later and this triggers a endpoint delete event. This causes routes to be cleared in both local and remote cluster. Later an endpoint update even comes for the active gateway, and we are using the update event in the fix

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
