### PR TITLE
Only update local Endpoint when setting HealthCheckIP

### DIFF
--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -26,12 +26,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -133,15 +136,29 @@ func testEndpointSyncing() {
 			test.CreateResource(t.localNodes, node)
 		})
 
-		It("should update the local Endpoint's HealthCheckIP", func() {
+		JustBeforeEach(func() {
 			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
 			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+		})
 
+		It("should update the local Endpoint's HealthCheckIP", func() {
 			node.Annotations[constants.SmGlobalIP] = "200.0.0.100"
 			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
 
 			test.UpdateResource(t.localNodes, node)
 			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+		})
+
+		Context("but the local Endpoint no longer exists", func() {
+			It("should not recreate the local Endpoint", func() {
+				Expect(t.localEndpoints.Delete(context.Background(), getEndpointName(&t.localEndpoint.Spec), metav1.DeleteOptions{})).
+					To(Succeed())
+
+				node.Annotations[constants.SmGlobalIP] = "200.0.0.100"
+				test.UpdateResource(t.localNodes, node)
+
+				testutil.EnsureNoResource[runtime.Object](resource.ForDynamic(t.localEndpoints), getEndpointName(&t.localEndpoint.Spec))
+			})
 		})
 	})
 }

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -75,7 +75,7 @@ func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIPOfNode string) 
 		prevHealthCheckIP := d.localEndpoint.Spec.HealthCheckIP
 		d.localEndpoint.Spec.HealthCheckIP = globalIPOfNode
 
-		if err := d.createOrUpdateLocalEndpoint(); err != nil {
+		if err := d.createOrUpdateLocalEndpoint(d.updateFederator); err != nil {
 			logger.Warningf("Error updating the local submariner Endpoint with HealthcheckIP: %v", err)
 
 			d.localEndpoint.Spec.HealthCheckIP = prevHealthCheckIP


### PR DESCRIPTION
When setting the `HealthCheckIP` from the `Node` global IP, it was doing a create-or-update operation but we really want to just update. It was observed in a leader election fail-over scenario where a local `Endpoint` was recreated on `Node` update after the `Endpoint` had been deleted, which caused issues (see https://issues.redhat.com/browse/ACM-8274).
