### PR TITLE
Automated backport of #2772: Only update local Endpoint when setting HealthCheckIP

### DIFF
--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -75,7 +75,7 @@ func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIPOfNode string) 
 		prevHealthCheckIP := d.localEndpoint.Spec.HealthCheckIP
 		d.localEndpoint.Spec.HealthCheckIP = globalIPOfNode
 
-		if err := d.createOrUpdateLocalEndpoint(); err != nil {
+		if err := d.createOrUpdateLocalEndpoint(d.updateFederator); err != nil {
 			logger.Warningf("Error updating the local submariner Endpoint with HealthcheckIP: %v", err)
 
 			d.localEndpoint.Spec.HealthCheckIP = prevHealthCheckIP


### PR DESCRIPTION
Backport of #2772 on release-0.16.

#2772: Only update local Endpoint when setting HealthCheckIP

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.