### PR TITLE
Automated backport of #2766: Delete Calico IPPools when Submariner uninstalled

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/ippool_handler.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler.go
@@ -129,7 +129,7 @@ func (h *calicoIPPoolHandler) TransitionToGateway() error {
 }
 
 func (h *calicoIPPoolHandler) Stop(uninstall bool) error {
-	if !uninstall || !h.isGateway.Load() {
+	if !uninstall {
 		return nil
 	}
 


### PR DESCRIPTION
Backport of #2766 on release-0.16.

#2766: Delete Calico IPPools when Submariner uninstalled

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.