### PR TITLE
Automated backport of #2778: Pass ctx to datastoreSyncer Start method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/projectcalico/api v0.0.0-20230602153125-fb7148692637
 	github.com/prometheus-community/pro-bing v0.3.0
 	github.com/prometheus/client_golang v1.16.0
-	github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c
-	github.com/submariner-io/shipyard v0.16.1-0.20231025063959-1e68200a75e6
+	github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca
+	github.com/submariner-io/shipyard v0.16.1-0.20231031115937-e306910cd742
 	github.com/uw-labs/lichen v0.1.7
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/sys v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -506,10 +506,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c h1:zy5mZZrB885JAuLPqpb/RoGhtd9N9tUCFE5OGAZEzWw=
-github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
-github.com/submariner-io/shipyard v0.16.1-0.20231025063959-1e68200a75e6 h1:UbExEBgaVP9q4XTNYlw3DnMb/RWXLSFdxWedxfstoN0=
-github.com/submariner-io/shipyard v0.16.1-0.20231025063959-1e68200a75e6/go.mod h1:op6JLbiJv3dteWxde6GpG5zp0oljZWVDU1FXmB1j6cs=
+github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca h1:O3gUAdYldm4LQJD/IpqaFcOlJVf9ikM+uBWsfVADmjg=
+github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
+github.com/submariner-io/shipyard v0.16.1-0.20231031115937-e306910cd742 h1:IxgmM0WOPYnYkBc1eNQdiMu9ozGax8FV0PYhHFHPbuE=
+github.com/submariner-io/shipyard v0.16.1-0.20231031115937-e306910cd742/go.mod h1:op6JLbiJv3dteWxde6GpG5zp0oljZWVDU1FXmB1j6cs=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/main.go
+++ b/main.go
@@ -144,9 +144,12 @@ func main() {
 	})
 	logger.FatalOnError(err, "Error creating gateway instance")
 
-	err = gw.Run(signals.SetupSignalHandler().Done())
+	err = gw.Run(signals.SetupSignalHandler())
 
-	if err := httpServer.Shutdown(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	if err := httpServer.Shutdown(ctx); err != nil {
 		logger.Errorf(err, "Error shutting down metrics HTTP server")
 	}
 

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -189,7 +189,7 @@ func testGatewaySyncing() {
 			statusErr := errors.New("fake error")
 			t.expectedGateway.Status.StatusFailure = statusErr.Error()
 
-			t.syncer.SetGatewayStatusError(statusErr)
+			t.syncer.SetGatewayStatusError(context.Background(), statusErr)
 			t.awaitGatewayUpdated(t.expectedGateway)
 		})
 	})

--- a/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_cluster_sync_test.go
@@ -134,7 +134,7 @@ func testClusterCleanup() {
 	})
 
 	It("should remove local Clusters from the remote datastore", func() {
-		Expect(t.syncer.Cleanup()).To(Succeed())
+		Expect(t.syncer.Cleanup(context.Background())).To(Succeed())
 
 		test.AwaitNoResource(t.brokerClusters, clusterID)
 
@@ -143,7 +143,7 @@ func testClusterCleanup() {
 	})
 
 	It("should remove all Clusters from the local datastore", func() {
-		Expect(t.syncer.Cleanup()).To(Succeed())
+		Expect(t.syncer.Cleanup(context.Background())).To(Succeed())
 
 		test.AwaitNoResource(t.localClusters, clusterID)
 		test.AwaitNoResource(t.localClusters, otherClusterID)

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -262,7 +262,7 @@ func testEndpointCleanup() {
 	})
 
 	It("should remove local Endpoints from the remote datastore", func() {
-		Expect(t.syncer.Cleanup()).To(Succeed())
+		Expect(t.syncer.Cleanup(context.Background())).To(Succeed())
 
 		test.AwaitNoResource(t.brokerEndpoints, existingLocalEndpoint.GetName())
 
@@ -271,7 +271,7 @@ func testEndpointCleanup() {
 	})
 
 	It("should remove all Endpoints from the local datastore", func() {
-		Expect(t.syncer.Cleanup()).To(Succeed())
+		Expect(t.syncer.Cleanup(context.Background())).To(Succeed())
 
 		test.AwaitNoResource(t.localEndpoints, existingLocalEndpoint.GetName())
 		test.AwaitNoResource(t.localEndpoints, existingRemoteEndpoint.GetName())

--- a/pkg/controllers/datastoresyncer/node_handler.go
+++ b/pkg/controllers/datastoresyncer/node_handler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package datastoresyncer
 
 import (
+	"context"
 	"net"
 
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
@@ -75,7 +76,7 @@ func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIPOfNode string) 
 		prevHealthCheckIP := d.localEndpoint.Spec.HealthCheckIP
 		d.localEndpoint.Spec.HealthCheckIP = globalIPOfNode
 
-		if err := d.createOrUpdateLocalEndpoint(d.updateFederator); err != nil {
+		if err := d.createOrUpdateLocalEndpoint(context.TODO(), d.updateFederator); err != nil {
 			logger.Warningf("Error updating the local submariner Endpoint with HealthcheckIP: %v", err)
 
 			d.localEndpoint.Spec.HealthCheckIP = prevHealthCheckIP

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -302,12 +302,12 @@ func newTestDriver() *testDriver {
 		gw, err := gateway.New(&t.config)
 		Expect(err).To(Succeed())
 
-		stopCh := make(chan struct{})
+		ctx, stop := context.WithCancel(context.Background())
 		runCompleted := make(chan error, 1)
 
 		DeferCleanup(func() {
 			if t.expectedRunErr == nil {
-				close(stopCh)
+				stop()
 			}
 
 			err := func() error {
@@ -334,7 +334,7 @@ func newTestDriver() *testDriver {
 		})
 
 		go func() {
-			runCompleted <- gw.Run(stopCh)
+			runCompleted <- gw.Run(ctx)
 		}()
 	})
 

--- a/pkg/globalnet/controllers/base_controllers.go
+++ b/pkg/globalnet/controllers/base_controllers.go
@@ -151,7 +151,7 @@ func (c *baseIPAllocationController) reserveAllocatedIPs(federator federate.Fede
 
 		logger.Infof("Updating %q: %#v", key, obj)
 
-		return federator.Distribute(obj) //nolint:wrapcheck  // Let the caller wrap it
+		return federator.Distribute(context.TODO(), obj) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	logger.Infof("Successfully reserved GlobalIPs %q for %s \"%s/%s\"", reservedIPs, obj.GetKind(),

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -187,7 +187,8 @@ func (n *nodeController) reserveAllocatedIP(federator federate.Federator, obj *u
 	if err != nil {
 		logger.Warningf("Could not reserve allocated GlobalIP for Node %q: %v", obj.GetName(), err)
 
-		return errors.Wrap(federator.Distribute(updateNodeAnnotation(obj, "")), "error updating the Node global IP annotation")
+		return errors.Wrap(federator.Distribute(context.TODO(), updateNodeAnnotation(obj, "")),
+			"error updating the Node global IP annotation")
 	}
 
 	logger.Infof("Successfully reserved allocated GlobalIP %q for node %q", existingGlobalIP, obj.GetName())

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -45,7 +45,7 @@ type GatewayPod struct {
 
 var logger = log.Logger{Logger: logf.Log.WithName("Pod")}
 
-func NewGatewayPod(k8sClient kubernetes.Interface) (*GatewayPod, error) {
+func NewGatewayPod(ctx context.Context, k8sClient kubernetes.Interface) (*GatewayPod, error) {
 	gp := &GatewayPod{
 		namespace: os.Getenv("SUBMARINER_NAMESPACE"),
 		node:      os.Getenv("NODE_NAME"),
@@ -65,7 +65,7 @@ func NewGatewayPod(k8sClient kubernetes.Interface) (*GatewayPod, error) {
 		return nil, errors.New("POD_NAME environment variable missing")
 	}
 
-	if err := gp.SetHALabels(context.Background(), submV1.HAStatusPassive); err != nil {
+	if err := gp.SetHALabels(ctx, submV1.HAStatusPassive); err != nil {
 		logger.Warningf("Error updating pod label: %s", err)
 	}
 


### PR DESCRIPTION
Backport of #2778 on release-0.16.

#2778: Pass ctx to datastoreSyncer Start method

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.