### PR TITLE
Remove OVN Handler localEndpoint field

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -48,7 +48,6 @@ type Handler struct {
 	dynamicClient             dynamic.Interface
 	watcherConfig             *watcher.Config
 	cableRoutingInterface     *net.Interface
-	localEndpoint             *submV1.Endpoint
 	remoteEndpoints           map[string]*submV1.Endpoint
 	isGateway                 bool
 	netlink                   netlink.Interface
@@ -148,28 +147,7 @@ func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
 
-	ovn.localEndpoint = endpoint
 	ovn.cableRoutingInterface = routingInterface
-
-	return nil
-}
-
-func (ovn *Handler) LocalEndpointUpdated(endpoint *submV1.Endpoint) error {
-	ovn.mutex.Lock()
-	defer ovn.mutex.Unlock()
-
-	ovn.localEndpoint = endpoint
-
-	return nil
-}
-
-func (ovn *Handler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
-	ovn.mutex.Lock()
-	defer ovn.mutex.Unlock()
-
-	if ovn.localEndpoint.Name == endpoint.Name {
-		ovn.localEndpoint = nil
-	}
 
 	return nil
 }

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -111,10 +111,6 @@ func (ovn *Handler) programRulesForRemoteSubnets(subnets []string, ruleFunc func
 }
 
 func (ovn *Handler) getNextHopOnK8sMgmtIntf() (*net.IP, error) {
-	if ovn.localEndpoint == nil {
-		return nil, fmt.Errorf("missing localEndpoint info")
-	}
-
 	link, err := netlink.LinkByName(OVNK8sMgmntIntfName)
 
 	if err != nil && !errors.Is(err, netlink.LinkNotFoundError{}) {


### PR DESCRIPTION
This is a remnant from when the local subnets were obtained from the local `Endpoint`. They're now obtained from the local CIDRs passed via the env. Maintaining this field is actually problematic b/c `LocalEndpointRemoved` checks the `Name` before setting it to nil. On `TransitionToGateway`, which usually follows `LocalEndpointRemoved`, `getNextHopOnK8sMgmtIntf` returns an error b/c `localEndpoint` is nil by that point and the resulting retry causes a panic in `LocalEndpointRemoved`. This is a latent issue which, at worst, would cause a route agent pod restart.

