### PR TITLE
Extend the event.Handler API to provide common state info to implementations

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -49,7 +49,7 @@ type Controller struct {
 
 	handlers *event.Registry
 
-	syncMutex     *sync.Mutex
+	syncMutex     sync.Mutex
 	hostname      string
 	isGatewayNode bool
 }
@@ -84,9 +84,8 @@ func New(config *Config) (*Controller, error) {
 	}
 
 	ctl := Controller{
-		handlers:  config.Registry,
-		syncMutex: &sync.Mutex{},
-		hostname:  hostname,
+		handlers: config.Registry,
+		hostname: hostname,
 	}
 
 	err = envconfig.Process("submariner", &ctl.env)

--- a/pkg/event/controller/controller_test.go
+++ b/pkg/event/controller/controller_test.go
@@ -20,8 +20,8 @@ package controller_test
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,137 +45,244 @@ const (
 )
 
 var _ = Describe("Event controller", func() {
-	var (
-		endpoints       dynamic.ResourceInterface
-		nodes           dynamic.ResourceInterface
-		node            *corev1.Node
-		endpoint        *submV1.Endpoint
-		hostname        string
-		testEvents      chan testing.TestEvent
-		stopCh          chan struct{}
-		registry        *event.Registry
-		eventController *controller.Controller
-	)
+	t := newTestDriver()
+
+	When("a Node is created, updated and deleted", func() {
+		It("should correctly notify the handler", func() {
+			node := &corev1.Node{
+				ObjectMeta: v1.ObjectMeta{
+					Name: t.hostname,
+				},
+			}
+
+			obj := test.CreateResource(t.nodes, node)
+			node.Namespace = obj.GetNamespace()
+
+			t.awaitEvent(testing.EvNodeCreated, node)
+
+			node.Labels = map[string]string{"labeled-i-am": "i-am"}
+			test.UpdateResource(t.nodes, node)
+
+			t.awaitEvent(testing.EvNodeUpdated, node)
+
+			Expect(t.nodes.Delete(context.TODO(), node.GetName(), v1.DeleteOptions{})).To(Succeed())
+
+			t.awaitEvent(testing.EvNodeRemoved, node)
+			t.ensureNoEvents()
+		})
+	})
+
+	When("a local Endpoint on this host is created, updated and deleted", func() {
+		It("should correctly notify the handler", func() {
+			t.testLocalEndpoint()
+		})
+	})
+
+	When("remote Endpoints are created, updated and deleted", func() {
+		It("should correctly notify the handler", func() {
+			t.testRemoteEndpoints()
+		})
+	})
+
+	When("the handler returns an error from an event notification", func() {
+		It("should retry the event", func() {
+			t.handler.FailOnEvent(testing.EvLocalEndpointCreated, testing.EvLocalEndpointUpdated, testing.EvLocalEndpointRemoved,
+				testing.EvTransitionToGateway, testing.EvTransitionToNonGateway, testing.EvRemoteEndpointCreated,
+				testing.EvRemoteEndpointUpdated, testing.EvRemoteEndpointRemoved)
+
+			t.testLocalEndpoint()
+			t.testRemoteEndpoints()
+		})
+	})
+})
+
+type testDriver struct {
+	endpoints       dynamic.ResourceInterface
+	nodes           dynamic.ResourceInterface
+	hostname        string
+	testEvents      chan testing.TestEvent
+	stopCh          chan struct{}
+	eventController *controller.Controller
+	handler         *TestHandler
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+	t.hostname, _ = os.Hostname()
 
 	BeforeEach(func() {
-		stopCh = make(chan struct{})
-		testEvents = make(chan testing.TestEvent, 1000)
-		testHandler := testing.NewTestHandler(testHandlerName, event.AnyNetworkPlugin, testEvents)
-		registry = event.NewRegistry("test-registry", "test-plugin")
-		Expect(registry.AddHandlers(testHandler)).To(Succeed())
-		hostname, _ = os.Hostname()
-		node = NewNode(hostname)
+		t.stopCh = make(chan struct{})
+
+		t.testEvents = make(chan testing.TestEvent, 1000)
+		t.handler = &TestHandler{
+			TestHandler: &testing.TestHandler{
+				Name:          testHandlerName,
+				NetworkPlugin: event.AnyNetworkPlugin,
+				Events:        t.testEvents,
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
 		_ = submV1.AddToScheme(scheme.Scheme)
+
+		registry := event.NewRegistry("test-registry", "test-plugin")
+		Expect(registry.AddHandlers(t.handler)).To(Succeed())
 
 		config := controller.Config{
 			RestMapper: test.GetRESTMapperFor(&corev1.Node{}, &submV1.Endpoint{}),
 			Client:     dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
 			Registry:   registry,
 		}
+
 		os.Setenv("SUBMARINER_NAMESPACE", testNamespace)
 		os.Setenv("SUBMARINER_CLUSTERID", testLocalClusterID)
 
-		nodes = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &corev1.Node{}))
-		endpoints = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper,
+		t.nodes = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &corev1.Node{}))
+		t.endpoints = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper,
 			&submV1.Endpoint{})).Namespace(testNamespace)
 
 		var err error
 
-		eventController, err = controller.New(&config)
+		t.eventController, err = controller.New(&config)
 
 		Expect(err).To(Succeed())
-		Expect(eventController.Start(stopCh)).To(Succeed())
+		Expect(t.eventController.Start(t.stopCh)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		close(stopCh)
-		eventController.Stop()
+		close(t.stopCh)
+		t.eventController.Stop()
 	})
 
-	When("a Node is created, updated and deleted", func() {
-		It("should notify the appropriate handler of each event", func() {
-			obj := test.CreateResource(nodes, node)
-			node.Namespace = obj.GetNamespace()
-			node.ResourceVersion = obj.GetResourceVersion()
-			node.UID = obj.GetUID()
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvNodeCreated, Parameter: node})))
-			Consistently(testEvents).ShouldNot(Receive())
-
-			node.Labels = map[string]string{"labeled-i-am": "i-am"}
-
-			test.UpdateResource(nodes, node)
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvNodeUpdated, Parameter: node})))
-			Consistently(testEvents).ShouldNot(Receive())
-
-			Expect(nodes.Delete(context.TODO(), node.GetName(), v1.DeleteOptions{})).To(Succeed())
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvNodeRemoved, Parameter: node})))
-			Consistently(testEvents).ShouldNot(Receive())
-		})
-	})
-
-	When("a Local Endpoint is created on this host, updated and deleted", func() {
-		It("should notify the appropriate handlers of each event", func() {
-			endpoint = NewEndpoint(testLocalClusterID, hostname)
-			obj := test.CreateResource(endpoints, endpoint)
-			endpoint.Namespace = obj.GetNamespace()
-			endpoint.ResourceVersion = obj.GetResourceVersion()
-			endpoint.UID = obj.GetUID()
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvLocalEndpointCreated, Parameter: endpoint})))
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvTransitionToGateway})))
-			Consistently(testEvents).ShouldNot(Receive())
-
-			endpoint.Labels = map[string]string{"labeled-i-am": "i-am"}
-
-			test.UpdateResource(endpoints, endpoint)
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvLocalEndpointUpdated, Parameter: endpoint})))
-			Consistently(testEvents).ShouldNot(Receive())
-
-			Expect(endpoints.Delete(context.TODO(), endpoint.GetName(), v1.DeleteOptions{})).To(Succeed())
-
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvLocalEndpointRemoved, Parameter: endpoint})))
-			Eventually(testEvents).Should(Receive(Equal(
-				testing.TestEvent{Handler: testHandlerName, Name: testing.EvTransitionToNonGateway})))
-			Consistently(testEvents).ShouldNot(Receive())
-		})
-	})
-})
-
-func NewNode(name string) *corev1.Node {
-	return &corev1.Node{
-		ObjectMeta: v1.ObjectMeta{
-			Name:            name,
-			UID:             uuid.NewUUID(),
-			ResourceVersion: "10",
-		},
-		Spec: corev1.NodeSpec{},
-	}
+	return t
 }
 
-func NewEndpoint(clusterID, hostname string) *submV1.Endpoint {
-	return &submV1.Endpoint{
+func (t *testDriver) createEndpoint(clusterID string) *submV1.Endpoint {
+	endpoint := &submV1.Endpoint{
 		ObjectMeta: v1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%s", clusterID, hostname),
-			UID:             uuid.NewUUID(),
-			ResourceVersion: "10",
+			Name: string(uuid.NewUUID()),
 		},
 		Spec: submV1.EndpointSpec{
 			ClusterID: clusterID,
-			Hostname:  hostname,
+			Hostname:  t.hostname,
 		},
 	}
+
+	Expect(scheme.Scheme.Convert(test.CreateResource(t.endpoints, endpoint), endpoint, nil)).To(Succeed())
+
+	return endpoint
+}
+
+func (t *testDriver) awaitEvent(name string, param interface{}) {
+	Eventually(t.testEvents).Should(Receive(Equal(
+		testing.TestEvent{Handler: testHandlerName, Name: name, Parameter: param})))
+}
+
+func (t *testDriver) ensureNoEvents() {
+	Consistently(t.testEvents).ShouldNot(Receive())
+}
+
+func (t *testDriver) testLocalEndpoint() {
+	By("Create local Endpoint")
+
+	endpoint := t.createEndpoint(testLocalClusterID)
+
+	t.awaitEvent(testing.EvLocalEndpointCreated, endpoint)
+	t.awaitEvent(testing.EvTransitionToGateway, nil)
+
+	t.createEndpoint(testLocalClusterID)
+	Consistently(t.testEvents).ShouldNot(Receive(Equal(
+		testing.TestEvent{Handler: testHandlerName, Name: testing.EvTransitionToGateway})))
+
+	By("Update local Endpoint")
+
+	endpoint.Labels = map[string]string{"labeled-i-am": "i-am"}
+	test.UpdateResource(t.endpoints, endpoint)
+
+	t.awaitEvent(testing.EvLocalEndpointUpdated, endpoint)
+
+	By("Delete local Endpoint")
+
+	Expect(t.endpoints.Delete(context.TODO(), endpoint.GetName(), v1.DeleteOptions{})).To(Succeed())
+
+	t.awaitEvent(testing.EvLocalEndpointRemoved, endpoint)
+	t.awaitEvent(testing.EvTransitionToNonGateway, nil)
+	t.ensureNoEvents()
+}
+
+func (t *testDriver) testRemoteEndpoints() {
+	By("Create first remote Endpoint")
+
+	endpoint1 := t.createEndpoint("remote-cluster1")
+
+	t.awaitEvent(testing.EvRemoteEndpointCreated, endpoint1)
+	Expect(t.handler.remoteEndpoints.Load()).To(Equal([]submV1.Endpoint{*endpoint1}))
+
+	By("Create second remote Endpoint")
+
+	endpoint2 := t.createEndpoint("remote-cluster2")
+
+	t.awaitEvent(testing.EvRemoteEndpointCreated, endpoint2)
+	Expect(t.handler.remoteEndpoints.Load()).To(ContainElements(*endpoint1, *endpoint2))
+
+	By("Update first remote Endpoint")
+
+	endpoint1.Labels = map[string]string{"labeled-i-am": "i-am"}
+	test.UpdateResource(t.endpoints, endpoint1)
+
+	t.awaitEvent(testing.EvRemoteEndpointUpdated, endpoint1)
+
+	By("Delete second remote Endpoint")
+
+	Expect(t.endpoints.Delete(context.TODO(), endpoint2.GetName(), v1.DeleteOptions{})).To(Succeed())
+
+	t.awaitEvent(testing.EvRemoteEndpointRemoved, endpoint2)
+	Expect(t.handler.remoteEndpoints.Load()).To(Equal([]submV1.Endpoint{*endpoint1}))
+
+	By("Delete first remote Endpoint")
+
+	Expect(t.endpoints.Delete(context.TODO(), endpoint1.GetName(), v1.DeleteOptions{})).To(Succeed())
+
+	t.awaitEvent(testing.EvRemoteEndpointRemoved, endpoint1)
+	Expect(t.handler.remoteEndpoints.Load()).To(BeEmpty())
+	t.ensureNoEvents()
+}
+
+type TestHandler struct {
+	*testing.TestHandler
+	remoteEndpoints atomic.Value
+}
+
+func (t *TestHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	defer GinkgoRecover()
+	Expect(t.State().IsOnGateway()).To(BeTrue())
+
+	return t.TestHandler.LocalEndpointCreated(endpoint)
+}
+
+func (t *TestHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	defer GinkgoRecover()
+	Expect(t.State().IsOnGateway()).To(BeFalse())
+
+	return t.TestHandler.LocalEndpointRemoved(endpoint)
+}
+
+func (t *TestHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	t.storeRemoteEndpoints()
+	return t.TestHandler.RemoteEndpointCreated(endpoint)
+}
+
+func (t *TestHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	t.storeRemoteEndpoints()
+	return t.TestHandler.RemoteEndpointRemoved(endpoint)
+}
+
+func (t *TestHandler) storeRemoteEndpoints() {
+	eps := t.State().GetRemoteEndpoints()
+	if eps == nil {
+		eps = []submV1.Endpoint{}
+	}
+
+	t.remoteEndpoints.Store(eps)
 }

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -34,6 +34,9 @@ func (c *Controller) handleCreatedEndpoint(obj runtime.Object, requeueCount int)
 		return false
 	}
 
+	c.syncMutex.Lock()
+	defer c.syncMutex.Unlock()
+
 	if endpoint.Spec.ClusterID != c.env.ClusterID {
 		err = c.handleCreatedRemoteEndpoint(endpoint)
 	} else {
@@ -53,9 +56,6 @@ func (c *Controller) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) error {
 	}
 
 	if endpoint.Spec.Hostname == c.hostname {
-		c.syncMutex.Lock()
-		defer c.syncMutex.Unlock()
-
 		// Verify if this node was a GatewayNode already. If not, it just transitioned to Gateway Node.
 		if !c.isGatewayNode {
 			if err := c.handlers.TransitionToGateway(); err != nil {

--- a/pkg/event/controller/endpoint_updated.go
+++ b/pkg/event/controller/endpoint_updated.go
@@ -32,6 +32,9 @@ func (c *Controller) handleUpdatedEndpoint(obj runtime.Object, requeueCount int)
 		return false
 	}
 
+	c.syncMutex.Lock()
+	defer c.syncMutex.Unlock()
+
 	var err error
 	if endpoint.Spec.ClusterID != c.env.ClusterID {
 		err = c.handleUpdatedRemoteEndpoint(endpoint)

--- a/pkg/event/controller/endpoint_updated.go
+++ b/pkg/event/controller/endpoint_updated.go
@@ -54,5 +54,6 @@ func (c *Controller) handleUpdatedLocalEndpoint(endpoint *smv1.Endpoint) error {
 }
 
 func (c *Controller) handleUpdatedRemoteEndpoint(endpoint *smv1.Endpoint) error {
+	c.handlerState.remoteEndpoints.Store(endpoint.Name, endpoint)
 	return c.handlers.RemoteEndpointUpdated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/controller/node_handlers.go
+++ b/pkg/event/controller/node_handlers.go
@@ -27,6 +27,9 @@ import (
 func (c *Controller) handleRemovedNode(obj runtime.Object, _ int) bool {
 	node := obj.(*k8sv1.Node)
 
+	c.syncMutex.Lock()
+	defer c.syncMutex.Unlock()
+
 	if err := c.handlers.NodeRemoved(node); err != nil {
 		logger.Error(err, "Error handling removed Node")
 		return true
@@ -38,6 +41,9 @@ func (c *Controller) handleRemovedNode(obj runtime.Object, _ int) bool {
 func (c *Controller) handleCreatedNode(obj runtime.Object, _ int) bool {
 	node := obj.(*k8sv1.Node)
 
+	c.syncMutex.Lock()
+	defer c.syncMutex.Unlock()
+
 	if err := c.handlers.NodeCreated(node); err != nil {
 		logger.Error(err, "Error handling created Node")
 		return true
@@ -48,6 +54,9 @@ func (c *Controller) handleCreatedNode(obj runtime.Object, _ int) bool {
 
 func (c *Controller) handleUpdatedNode(obj runtime.Object, _ int) bool {
 	node := obj.(*k8sv1.Node)
+
+	c.syncMutex.Lock()
+	defer c.syncMutex.Unlock()
 
 	if err := c.handlers.NodeUpdated(node); err != nil {
 		logger.Error(err, "Error handling updated Node")

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -91,6 +91,13 @@ func (er *Registry) AddHandlers(eventHandlers ...Handler) error {
 	return nil
 }
 
+func (er *Registry) SetHandlerState(handlerState HandlerState) {
+	_ = er.invokeHandlers("SetHandlerState", func(h Handler) error {
+		h.SetState(handlerState)
+		return nil
+	})
+}
+
 func (er *Registry) StopHandlers() error {
 	return er.invokeHandlers("Stop", func(h Handler) error {
 		return h.Stop() //nolint:wrapcheck  // Let the caller wrap it

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Event Registry", func() {
 
 		BeforeEach(func() {
 			allTestEvents = make(chan testing.TestEvent, 1000)
-			registry = event.NewRegistry("test-registry", npGenericKubeproxyIptables)
 
 			nonMatchingHandlers = []*testing.TestHandler{
 				testing.NewTestHandler("ovn-handler", cni.OVNKubernetes, allTestEvents),
@@ -57,8 +56,10 @@ var _ = Describe("Event Registry", func() {
 				testing.NewTestHandler("wildcard-handler", event.AnyNetworkPlugin, allTestEvents),
 			}
 
-			err := registry.AddHandlers(logger.NewHandler(), matchingHandlers[0], nonMatchingHandlers[0], matchingHandlers[1],
-				matchingHandlers[2])
+			var err error
+
+			registry, err = event.NewRegistry("test-registry", npGenericKubeproxyIptables, logger.NewHandler(), matchingHandlers[0],
+				nonMatchingHandlers[0], matchingHandlers[1], matchingHandlers[2])
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -144,8 +145,7 @@ var _ = Describe("Event Registry", func() {
 	When("SetHandlerState is called on the registry", func() {
 		It("should invoke SetState on the handlers", func() {
 			h := testing.NewTestHandler("test", event.AnyNetworkPlugin, nil)
-			registry := event.NewRegistry("test-registry", event.AnyNetworkPlugin)
-			err := registry.AddHandlers(h)
+			registry, err := event.NewRegistry("test-registry", event.AnyNetworkPlugin, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			registry.SetHandlerState(&testing.TestHandlerState{Gateway: true})

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package event_test
 
 import (
-	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -89,14 +88,17 @@ var _ = Describe("Event Registry", func() {
 
 		When("one handler returns an error", func() {
 			It("should invoke subsequent matching handlers", func() {
-				matchingHandlers[0].FailOnEvent = errors.New("mock handler error")
+				events := allEvents(registry)
+				for ev := range events {
+					matchingHandlers[0].FailOnEvent(ev.Name)
+				}
 
-				for ev, f := range allEvents(registry) {
+				for ev, f := range events {
 					err := f()
 					Expect(err).To(HaveOccurred())
 
-					for _, h := range matchingHandlers {
-						ev.Handler = h.Name
+					for i := 1; i < len(matchingHandlers); i++ {
+						ev.Handler = matchingHandlers[i].Name
 						Expect(allTestEvents).To(Receive(Equal(ev)))
 					}
 				}

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -138,6 +138,26 @@ var _ = Describe("Event Registry", func() {
 			})
 		})
 	})
+
+	When("SetHandlerState is called on the registry", func() {
+		It("should invoke SetState on the handlers", func() {
+			h := testing.NewTestHandler("test", event.AnyNetworkPlugin, nil)
+			registry := event.NewRegistry("test-registry", event.AnyNetworkPlugin)
+			err := registry.AddHandlers(h)
+			Expect(err).NotTo(HaveOccurred())
+
+			registry.SetHandlerState(&testing.TestHandlerState{Gateway: true})
+			Expect(h.State().IsOnGateway()).To(BeTrue())
+		})
+	})
+
+	When("SetState has not been called for a handler", func() {
+		Specify("State should return a valid instance", func() {
+			h := testing.NewTestHandler("test", event.AnyNetworkPlugin, nil)
+			hc := h.State()
+			Expect(hc).ToNot(BeNil())
+		})
+	})
 })
 
 func allEvents(registry *event.Registry) map[testing.TestEvent]func() error {

--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -1,0 +1,140 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/event/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	Namespace      = "test-namespace"
+	LocalClusterID = "local-cluster"
+)
+
+func init() {
+	utilruntime.Must(submV1.AddToScheme(scheme.Scheme))
+}
+
+type ControllerSupport struct {
+	Hostname  string
+	endpoints dynamic.ResourceInterface
+	nodes     dynamic.ResourceInterface
+}
+
+func NewControllerSupport() *ControllerSupport {
+	c := &ControllerSupport{}
+	c.Hostname, _ = os.Hostname()
+
+	return c
+}
+
+func (c *ControllerSupport) Start(handler event.Handler) {
+	stopCh := make(chan struct{})
+
+	registry := event.NewRegistry("test-registry", handler.GetNetworkPlugins()[0])
+	Expect(registry.AddHandlers(handler)).To(Succeed())
+
+	config := controller.Config{
+		RestMapper: test.GetRESTMapperFor(&corev1.Node{}, &submV1.Endpoint{}),
+		Client:     dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
+		Registry:   registry,
+	}
+
+	os.Setenv("SUBMARINER_NAMESPACE", Namespace)
+	os.Setenv("SUBMARINER_CLUSTERID", LocalClusterID)
+
+	c.nodes = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &corev1.Node{}))
+	c.endpoints = config.Client.Resource(*test.GetGroupVersionResourceFor(config.RestMapper, &submV1.Endpoint{})).Namespace(Namespace)
+
+	eventController, err := controller.New(&config)
+
+	Expect(err).To(Succeed())
+	Expect(eventController.Start(stopCh)).To(Succeed())
+
+	DeferCleanup(func() {
+		close(stopCh)
+		eventController.Stop()
+	})
+}
+
+func NewEndpoint(clusterID, hostname string, subnets ...string) *submV1.Endpoint {
+	return &submV1.Endpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(uuid.NewUUID()),
+		},
+		Spec: submV1.EndpointSpec{
+			ClusterID: clusterID,
+			Hostname:  hostname,
+			Subnets:   subnets,
+		},
+	}
+}
+
+func (c *ControllerSupport) CreateLocalHostEndpoint() *submV1.Endpoint {
+	return c.CreateEndpoint(NewEndpoint(LocalClusterID, c.Hostname))
+}
+
+func (c *ControllerSupport) CreateEndpoint(endpoint *submV1.Endpoint) *submV1.Endpoint {
+	Expect(scheme.Scheme.Convert(test.CreateResource(c.endpoints, endpoint), endpoint, nil)).To(Succeed())
+	return endpoint
+}
+
+func (c *ControllerSupport) UpdateEndpoint(endpoint *submV1.Endpoint) {
+	test.UpdateResource(c.endpoints, endpoint)
+}
+
+func (c *ControllerSupport) DeleteEndpoint(name string) {
+	Expect(c.endpoints.Delete(context.TODO(), name, metav1.DeleteOptions{})).To(Succeed())
+}
+
+func NewNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func (c *ControllerSupport) CreateNode(node *corev1.Node) *corev1.Node {
+	Expect(scheme.Scheme.Convert(test.CreateResource(c.nodes, node), node, nil)).To(Succeed())
+	return node
+}
+
+func (c *ControllerSupport) UpdateNode(node *corev1.Node) {
+	test.UpdateResource(c.nodes, node)
+}
+
+func (c *ControllerSupport) DeleteNode(name string) {
+	Expect(c.nodes.Delete(context.TODO(), name, metav1.DeleteOptions{})).To(Succeed())
+}

--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -62,8 +62,8 @@ func NewControllerSupport() *ControllerSupport {
 func (c *ControllerSupport) Start(handler event.Handler) {
 	stopCh := make(chan struct{})
 
-	registry := event.NewRegistry("test-registry", handler.GetNetworkPlugins()[0])
-	Expect(registry.AddHandlers(handler)).To(Succeed())
+	registry, err := event.NewRegistry("test-registry", handler.GetNetworkPlugins()[0], handler)
+	Expect(err).To(Succeed())
 
 	config := controller.Config{
 		RestMapper: test.GetRESTMapperFor(&corev1.Node{}, &submV1.Endpoint{}),

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -30,6 +30,15 @@ type TestEvent struct {
 	Parameter interface{}
 }
 
+type TestHandlerState struct {
+	event.DefaultHandlerState
+	Gateway bool
+}
+
+func (c *TestHandlerState) IsOnGateway() bool {
+	return c.Gateway
+}
+
 type TestHandler struct {
 	event.HandlerBase
 	Name          string

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -211,7 +211,11 @@ func (n *basicType) RouteList(link netlink.Link, _ int) ([]netlink.Route, error)
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	return n.routes[link.Attrs().Index], nil
+	r := n.routes[link.Attrs().Index]
+	to := make([]netlink.Route, len(r))
+	copy(to, r)
+
+	return to, nil
 }
 
 func (n *basicType) RuleAdd(rule *netlink.Rule) error {

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -314,6 +314,20 @@ func (n *basicType) RuleDel(rule *netlink.Rule) error {
 	return nil
 }
 
+func (n *basicType) RuleList(family int) ([]netlink.Rule, error) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	var rules []netlink.Rule
+	for _, r := range n.rules { //nolint:gocritic // Ignore range value copy
+		if r.Family == family {
+			rules = append(rules, r)
+		}
+	}
+
+	return rules, nil
+}
+
 func (n *basicType) XfrmPolicyAdd(_ *netlink.XfrmPolicy) error {
 	return nil
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -41,6 +41,9 @@ type Basic interface {
 	LinkByName(name string) (netlink.Link, error)
 	LinkSetUp(link netlink.Link) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	AddrDel(link netlink.Link, addr *netlink.Addr) error
+	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	AddrSubscribe(addrCh chan netlink.AddrUpdate, doneCh chan struct{}) error
 	NeighAppend(neigh *netlink.Neigh) error
 	NeighDel(neigh *netlink.Neigh) error
 	RouteAdd(route *netlink.Route) error
@@ -106,6 +109,18 @@ func (n *netlinkType) LinkSetUp(link netlink.Link) error {
 
 func (n *netlinkType) AddrAdd(link netlink.Link, addr *netlink.Addr) error {
 	return netlink.AddrAdd(link, addr)
+}
+
+func (n *netlinkType) AddrDel(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrDel(link, addr)
+}
+
+func (n *netlinkType) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	return netlink.AddrList(link, family)
+}
+
+func (n *netlinkType) AddrSubscribe(addrCh chan netlink.AddrUpdate, doneCh chan struct{}) error {
+	return netlink.AddrSubscribe(addrCh, doneCh)
 }
 
 func (n *netlinkType) NeighAppend(neigh *netlink.Neigh) error {

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -53,6 +53,7 @@ type Basic interface {
 	FlushRouteTable(tableID int) error
 	RuleAdd(rule *netlink.Rule) error
 	RuleDel(rule *netlink.Rule) error
+	RuleList(family int) ([]netlink.Rule, error)
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
@@ -153,6 +154,10 @@ func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
 
 func (n *netlinkType) RuleDel(rule *netlink.Rule) error {
 	return netlink.RuleDel(rule)
+}
+
+func (n *netlinkType) RuleList(family int) ([]netlink.Rule, error) {
+	return netlink.RuleList(family)
 }
 
 func (n *netlinkType) XfrmPolicyAdd(policy *netlink.XfrmPolicy) error {

--- a/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
+++ b/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
@@ -1,0 +1,39 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package calico_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	calicoapi "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+	Expect(calicoapi.AddToScheme(scheme.Scheme)).To(Succeed())
+})
+
+func TestCalico(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Calico Suite")
+}

--- a/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
@@ -1,0 +1,159 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package calico_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	calicoapi "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	calicocs "github.com/projectcalico/api/pkg/client/clientset_generated/clientset"
+	calicocsfake "github.com/projectcalico/api/pkg/client/clientset_generated/clientset/fake"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/event/testing"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/calico"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("IPPool Handler", func() {
+	t := testing.NewControllerSupport()
+
+	var (
+		calicoClient *calicocsfake.Clientset
+		handler      event.Handler
+	)
+
+	BeforeEach(func() {
+		calicoClient = calicocsfake.NewSimpleClientset()
+		fake.AddDeleteCollectionReactor(&calicoClient.Fake)
+
+		calico.NewClient = func(_ *rest.Config) (calicocs.Interface, error) {
+			return calicoClient, nil
+		}
+	})
+
+	JustBeforeEach(func() {
+		handler = calico.NewCalicoIPPoolHandler(nil)
+		t.Start(handler)
+	})
+
+	When("remote Endpoints are created and deleted", func() {
+		It("should create and delete IPPools", func() {
+			subnets1 := []string{"192.0.2.0/24", "192.0.3.0/24"}
+			remoteEP1 := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", subnets1...))
+			ensureNoIPPools(calicoClient, subnets1...)
+
+			localEP := t.CreateLocalHostEndpoint()
+			awaitIPPools(calicoClient, subnets1...)
+
+			// Ensure it handles existing IPPools.
+			Expect(handler.RemoteEndpointCreated(remoteEP1)).To(Succeed())
+
+			subnets2 := []string{"192.0.4.0/24"}
+			remoteEP2 := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", subnets2...))
+			awaitIPPools(calicoClient, subnets2...)
+
+			t.DeleteEndpoint(remoteEP1.Name)
+			awaitNoIPPools(calicoClient, subnets1...)
+
+			t.DeleteEndpoint(localEP.Name)
+
+			t.DeleteEndpoint(remoteEP2.Name)
+			ensureIPPools(calicoClient, subnets2...)
+		})
+	})
+
+	Context("on Uninstall", func() {
+		It("should delete all IPPools", func() {
+			_, err := calicoClient.ProjectcalicoV3().IPPools().Create(context.Background(), &calicoapi.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool1",
+					Labels: map[string]string{calico.SubmarinerIPPool: "true"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+
+			_, err = calicoClient.ProjectcalicoV3().IPPools().Create(context.Background(), &calicoapi.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "pool2",
+					Labels: map[string]string{calico.SubmarinerIPPool: "true"},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+
+			Expect(handler.Uninstall()).To(Succeed())
+
+			list, err := calicoClient.ProjectcalicoV3().IPPools().List(context.Background(), metav1.ListOptions{
+				LabelSelector: calico.SubmarinerIPPool + "=true",
+			})
+			Expect(err).To(Succeed())
+			Expect(list.Items).To(BeEmpty())
+		})
+	})
+})
+
+func getIPPoolCIDRs(client calicocs.Interface) []string {
+	list, err := client.ProjectcalicoV3().IPPools().List(context.Background(), metav1.ListOptions{
+		LabelSelector: calico.SubmarinerIPPool + "=true",
+	})
+	Expect(err).To(Succeed())
+
+	cidrs := make([]string, len(list.Items))
+	for i := range list.Items {
+		cidrs[i] = list.Items[i].Spec.CIDR
+	}
+
+	return cidrs
+}
+
+func ensureNoIPPools(client calicocs.Interface, subnets ...string) {
+	Consistently(func() []string {
+		return getIPPoolCIDRs(client)
+	}).ShouldNot(ContainElements(toAny(subnets)...))
+}
+
+func ensureIPPools(client calicocs.Interface, subnets ...string) {
+	Consistently(func() []string {
+		return getIPPoolCIDRs(client)
+	}).Should(ContainElements(toAny(subnets)...))
+}
+
+func awaitIPPools(client calicocs.Interface, subnets ...string) {
+	Eventually(func() []string {
+		return getIPPoolCIDRs(client)
+	}).Should(ContainElements(toAny(subnets)...))
+}
+
+func awaitNoIPPools(client calicocs.Interface, subnets ...string) {
+	Eventually(func() []string {
+		return getIPPoolCIDRs(client)
+	}).ShouldNot(ContainElements(toAny(subnets)...))
+}
+
+func toAny(s []string) []any {
+	ia := make([]any, len(s))
+	for i := range s {
+		ia[i] = s[i]
+	}
+
+	return ia
+}

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -26,9 +26,6 @@ import (
 
 func (kp *SyncHandler) TransitionToNonGateway() error {
 	logger.V(log.DEBUG).Info("The current node is no longer a Gateway")
-	kp.syncHandlerMutex.Lock()
-	defer kp.syncHandlerMutex.Unlock()
-	kp.isGatewayNode = false
 
 	kp.cleanVxSubmarinerRoutes()
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
@@ -46,13 +43,7 @@ func (kp *SyncHandler) TransitionToNonGateway() error {
 func (kp *SyncHandler) TransitionToGateway() error {
 	logger.V(log.DEBUG).Info("The current node has become a Gateway")
 
-	kp.syncHandlerMutex.Lock()
-	defer kp.syncHandlerMutex.Unlock()
-
 	kp.cleanVxSubmarinerRoutes()
-
-	kp.isGatewayNode = true
-	kp.wasGatewayPreviously = true
 
 	logger.Infof("Creating the vxlan interface: %s on the gateway node", VxLANIface)
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -45,7 +45,7 @@ func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks [
 		return
 	}
 
-	if !kp.isGatewayNode || kp.cniIface == nil {
+	if !kp.State().IsOnGateway() || kp.cniIface == nil {
 		return
 	}
 
@@ -270,7 +270,7 @@ func (kp *SyncHandler) removeUnknownRoutes(vxlanGw net.IP, currentRouteList []ne
 }
 
 func (kp *SyncHandler) updateRoutingRulesForInterClusterSupport(remoteCIDRs []string, operation Operation) error {
-	if kp.isGatewayNode {
+	if kp.State().IsOnGateway() {
 		logger.V(log.DEBUG).Info("On GWNode, in updateRoutingRulesForInterClusterSupport ignoring")
 		// These rules are required only on the nonGatewayNode.
 		return nil

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -253,7 +253,7 @@ func testGatewayTransition() {
 		})
 
 		It("should add a routing rule for the RouteAgentHostNetworkTableID", func() {
-			t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID)
+			t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID, "", "")
 		})
 
 		It("should add host networking routing rules for the remote subnets", func() {
@@ -284,12 +284,12 @@ func testGatewayTransition() {
 
 		Context("and then to non-gateway", func() {
 			JustBeforeEach(func() {
-				t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID)
+				t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID, "", "")
 				t.DeleteEndpoint(localHostEP.Name)
 			})
 
 			It("should remove the routing rule for the RouteAgentHostNetworkTableID", func() {
-				t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID)
+				t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", "")
 			})
 
 			It("should remove host networking routing rules for the remote subnets", func() {
@@ -339,11 +339,11 @@ func testUninstall() {
 	Context("on Uninstall", func() {
 		It("should clean up dataplane artifacts", func() {
 			t.CreateLocalHostEndpoint()
-			t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID)
+			t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID, "", "")
 
 			Expect(t.handler.Uninstall()).To(Succeed())
 
-			t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID)
+			t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", "")
 			t.netLink.AwaitNoLink(kubeproxy.VxLANIface)
 			t.verifyNoHostNetworkingRoutes()
 		})

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -78,7 +78,7 @@ func testEndpoints() {
 			})
 
 			It("should remove them", func() {
-				t.netLink.AwaitNoRoutes(t.vxLanInterfaceIndex, remoteSubnet1)
+				t.netLink.AwaitNoDstRoutes(t.vxLanInterfaceIndex, 0, remoteSubnet1)
 			})
 		})
 
@@ -267,7 +267,7 @@ func testGatewayTransition() {
 			})
 
 			It("should remove them", func() {
-				t.netLink.AwaitNoRoutes(t.vxLanInterfaceIndex, remoteSubnet1)
+				t.netLink.AwaitNoDstRoutes(t.vxLanInterfaceIndex, 0, remoteSubnet1)
 			})
 		})
 
@@ -410,21 +410,21 @@ func newTestDriver() *testDriver {
 }
 
 func (t *testDriver) verifyVxLANRoutes() {
-	t.netLink.AwaitRoutes(t.netLink.AwaitLink(kubeproxy.VxLANIface).Attrs().Index, t.remoteEndpoint.Spec.Subnets...)
+	t.netLink.AwaitDstRoutes(t.netLink.AwaitLink(kubeproxy.VxLANIface).Attrs().Index, 0, t.remoteEndpoint.Spec.Subnets...)
 }
 
 func (t *testDriver) verifyNoVxLANRoutes() {
 	time.Sleep(200 * time.Millisecond)
-	t.netLink.AwaitNoRoutes(t.vxLanInterfaceIndex, t.remoteEndpoint.Spec.Subnets...)
+	t.netLink.AwaitNoDstRoutes(t.vxLanInterfaceIndex, 0, t.remoteEndpoint.Spec.Subnets...)
 }
 
 func (t *testDriver) verifyHostNetworkingRoutes() {
-	t.netLink.AwaitRoutes(t.hostInterfaceIndex, t.remoteEndpoint.Spec.Subnets...)
+	t.netLink.AwaitDstRoutes(t.hostInterfaceIndex, constants.RouteAgentHostNetworkTableID, t.remoteEndpoint.Spec.Subnets...)
 }
 
 func (t *testDriver) verifyNoHostNetworkingRoutes() {
 	time.Sleep(200 * time.Millisecond)
-	t.netLink.AwaitNoRoutes(t.hostInterfaceIndex, t.remoteEndpoint.Spec.Subnets...)
+	t.netLink.AwaitNoDstRoutes(t.hostInterfaceIndex, constants.RouteAgentHostNetworkTableID, t.remoteEndpoint.Spec.Subnets...)
 }
 
 func (t *testDriver) verifyRemoteSubnetIPTableRules() {

--- a/pkg/routeagent_driver/handlers/ovn/fake/ovsdb_client.go
+++ b/pkg/routeagent_driver/handlers/ovn/fake/ovsdb_client.go
@@ -1,0 +1,249 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	. "github.com/onsi/gomega"
+	"github.com/ovn-org/libovsdb/cache"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/libovsdb/ovsdb"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/admiral/pkg/slices"
+)
+
+type OVSDBClient struct {
+	mutex     sync.Mutex
+	connected atomic.Bool
+	models    map[reflect.Type][]any
+}
+
+func NewOVSDBClient() *OVSDBClient {
+	return &OVSDBClient{
+		models: map[reflect.Type][]any{},
+	}
+}
+
+func (c *OVSDBClient) Connect(_ context.Context) error {
+	c.connected.Store(true)
+	return nil
+}
+
+func (c *OVSDBClient) Disconnect() {
+	c.connected.Store(false)
+}
+
+func (c *OVSDBClient) Close() {
+}
+
+func (c *OVSDBClient) Schema() ovsdb.DatabaseSchema {
+	return ovsdb.DatabaseSchema{}
+}
+
+func (c *OVSDBClient) Cache() *cache.TableCache {
+	return nil
+}
+
+func (c *OVSDBClient) SetOption(_ libovsdbclient.Option) error {
+	return nil
+}
+
+func (c *OVSDBClient) Connected() bool {
+	return c.connected.Load()
+}
+
+func (c *OVSDBClient) DisconnectNotify() chan struct{} {
+	return make(chan struct{})
+}
+
+func (c *OVSDBClient) Echo(_ context.Context) error {
+	return nil
+}
+
+func (c *OVSDBClient) Transact(_ context.Context, _ ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	return []ovsdb.OperationResult{}, nil
+}
+
+func (c *OVSDBClient) Monitor(_ context.Context, _ *libovsdbclient.Monitor) (libovsdbclient.MonitorCookie, error) {
+	return libovsdbclient.MonitorCookie{}, nil
+}
+
+func (c *OVSDBClient) MonitorAll(_ context.Context) (libovsdbclient.MonitorCookie, error) {
+	return libovsdbclient.MonitorCookie{}, nil
+}
+
+func (c *OVSDBClient) MonitorCancel(_ context.Context, _ libovsdbclient.MonitorCookie) error {
+	return nil
+}
+
+func (c *OVSDBClient) NewMonitor(_ ...libovsdbclient.MonitorOption) *libovsdbclient.Monitor {
+	return &libovsdbclient.Monitor{
+		Method:            ovsdb.ConditionalMonitorSinceRPC,
+		Errors:            make([]error, 0),
+		LastTransactionID: "00000000-0000-0000-0000-000000000000",
+	}
+}
+
+func (c *OVSDBClient) CurrentEndpoint() string {
+	return ""
+}
+
+func (c *OVSDBClient) List(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (c *OVSDBClient) WhereCache(predicate interface{}) libovsdbclient.ConditionalAPI {
+	return &predicateConditionalAPI{client: c, predicate: predicate}
+}
+
+func (c *OVSDBClient) Where(m model.Model, _ ...model.Condition) libovsdbclient.ConditionalAPI {
+	return &modelConditionalAPI{client: c, model: m}
+}
+
+func (c *OVSDBClient) WhereAll(_ model.Model, _ ...model.Condition) libovsdbclient.ConditionalAPI {
+	return &noopConditionalAPI{}
+}
+
+func (c *OVSDBClient) Get(_ context.Context, _ model.Model) error {
+	return nil
+}
+
+func (c *OVSDBClient) Create(models ...model.Model) ([]ovsdb.Operation, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for _, m := range models {
+		c.models[reflect.TypeOf(m)] = append(c.models[reflect.TypeOf(m)], m)
+	}
+
+	return []ovsdb.Operation{}, nil
+}
+
+func (c *OVSDBClient) hasModel(m any) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for _, o := range c.models[reflect.TypeOf(m)] {
+		switch t := m.(type) {
+		case *nbdb.LogicalRouterPolicy:
+			if strings.Contains(o.(*nbdb.LogicalRouterPolicy).Match, t.Match) &&
+				reflect.DeepEqual(o.(*nbdb.LogicalRouterPolicy).Nexthop, t.Nexthop) {
+				return true
+			}
+		case *nbdb.LogicalRouterStaticRoute:
+			if o.(*nbdb.LogicalRouterStaticRoute).IPPrefix == t.IPPrefix {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (c *OVSDBClient) AwaitModel(m any) {
+	Eventually(func() bool {
+		return c.hasModel(m)
+	}).Should(BeTrue(), "OVSBD model not found: %s", resource.ToJSON(m))
+}
+
+func (c *OVSDBClient) AwaitNoModel(m any) {
+	Eventually(func() bool {
+		return c.hasModel(m)
+	}).Should(BeFalse(), "OVSBD model exists: %s", resource.ToJSON(m))
+}
+
+type noopConditionalAPI struct{}
+
+func (c noopConditionalAPI) List(_ context.Context, _ interface{}) error {
+	return nil
+}
+
+func (c noopConditionalAPI) Mutate(_ model.Model, _ ...model.Mutation) ([]ovsdb.Operation, error) {
+	return []ovsdb.Operation{}, nil
+}
+
+func (c noopConditionalAPI) Update(_ model.Model, _ ...interface{}) ([]ovsdb.Operation, error) {
+	return []ovsdb.Operation{}, nil
+}
+
+func (c noopConditionalAPI) Delete() ([]ovsdb.Operation, error) {
+	return []ovsdb.Operation{}, nil
+}
+
+func (c noopConditionalAPI) Wait(_ ovsdb.WaitCondition, _ *int, _ model.Model, _ ...interface{}) ([]ovsdb.Operation, error) {
+	return []ovsdb.Operation{}, nil
+}
+
+type predicateConditionalAPI struct {
+	noopConditionalAPI
+	client    *OVSDBClient
+	predicate any
+}
+
+func list[T any](client *OVSDBClient, t T, p any, result *[]T) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+
+	r := []T{}
+	fn := reflect.ValueOf(p)
+
+	for _, o := range client.models[reflect.TypeOf(t)] {
+		v := fn.Call([]reflect.Value{reflect.ValueOf(o)})
+		if v[0].Bool() {
+			r = append(r, o.(T))
+		}
+	}
+
+	*result = r
+}
+
+func (c *predicateConditionalAPI) List(_ context.Context, result interface{}) error {
+	switch r := result.(type) {
+	case *[]*nbdb.LogicalRouter:
+		list(c.client, &nbdb.LogicalRouter{}, c.predicate, r)
+	case *[]*nbdb.LogicalRouterPolicy:
+		list(c.client, &nbdb.LogicalRouterPolicy{}, c.predicate, r)
+	case *[]*nbdb.LogicalRouterStaticRoute:
+		list(c.client, &nbdb.LogicalRouterStaticRoute{}, c.predicate, r)
+	}
+
+	return nil
+}
+
+type modelConditionalAPI struct {
+	noopConditionalAPI
+	client *OVSDBClient
+	model  any
+}
+
+func (c *modelConditionalAPI) Delete() ([]ovsdb.Operation, error) {
+	c.client.mutex.Lock()
+	defer c.client.mutex.Unlock()
+
+	c.client.models[reflect.TypeOf(c.model)], _ = slices.Remove(c.client.models[reflect.TypeOf(c.model)], c.model, resource.ToJSON)
+
+	return []ovsdb.Operation{}, nil
+}

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -34,7 +34,7 @@ func (ovn *Handler) cleanupGatewayDataplane() error {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}
 
-	err = ovn.handleSubnets(currentRemoteSubnets.UnsortedList(), netlink.RuleDel, os.IsNotExist)
+	err = ovn.handleSubnets(currentRemoteSubnets.UnsortedList(), ovn.netLink.RuleDel, os.IsNotExist)
 	if err != nil {
 		return errors.Wrapf(err, "error removing routing rule")
 	}
@@ -44,7 +44,7 @@ func (ovn *Handler) cleanupGatewayDataplane() error {
 		return errors.Wrap(err, "error creating default route")
 	}
 
-	err = netlink.RouteDel(defaultRoute)
+	err = ovn.netLink.RouteDel(defaultRoute)
 	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "error deleting submariner default route")
 	}
@@ -62,14 +62,14 @@ func (ovn *Handler) updateGatewayDataplane() error {
 
 	toAdd := endpointSubnets.Difference(currentRuleRemotes).UnsortedList()
 
-	err = ovn.handleSubnets(toAdd, netlink.RuleAdd, os.IsExist)
+	err = ovn.handleSubnets(toAdd, ovn.netLink.RuleAdd, os.IsExist)
 	if err != nil {
 		return errors.Wrap(err, "error adding routing rule")
 	}
 
 	toRemove := currentRuleRemotes.Difference(endpointSubnets).UnsortedList()
 
-	err = ovn.handleSubnets(toRemove, netlink.RuleDel, os.IsNotExist)
+	err = ovn.handleSubnets(toRemove, ovn.netLink.RuleDel, os.IsNotExist)
 	if err != nil {
 		return errors.Wrapf(err, "error removing routing rule")
 	}
@@ -79,7 +79,7 @@ func (ovn *Handler) updateGatewayDataplane() error {
 		return errors.Wrap(err, "error creating default route")
 	}
 
-	err = netlink.RouteAdd(defaultRoute)
+	err = ovn.netLink.RouteAdd(defaultRoute)
 	if err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "error adding submariner default")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -53,6 +53,9 @@ func (ovn *Handler) cleanupGatewayDataplane() error {
 }
 
 func (ovn *Handler) updateGatewayDataplane() error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
 	currentRuleRemotes, err := ovn.getExistingIPv4RuleSubnets()
 	if err != nil {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -147,16 +147,16 @@ func (ovn *Handler) getMSSClampingRuleSpecs() ([][]string, error) {
 type forwardRuleSpecGenerator func() ([][]string, error)
 
 const (
-	forwardingSubmarinerMSSClampChain = "SUBMARINER-FWD-MSSCLAMP"
-	forwardingSubmarinerFWDChain      = "SUBMARINER-FORWARD"
+	ForwardingSubmarinerMSSClampChain = "SUBMARINER-FWD-MSSCLAMP"
+	ForwardingSubmarinerFWDChain      = "SUBMARINER-FORWARD"
 )
 
 func (ovn *Handler) setupForwardingIptables() error {
-	if err := ovn.updateIPtableChains(constants.FilterTable, forwardingSubmarinerMSSClampChain, ovn.getMSSClampingRuleSpecs); err != nil {
+	if err := ovn.updateIPtableChains(constants.FilterTable, ForwardingSubmarinerMSSClampChain, ovn.getMSSClampingRuleSpecs); err != nil {
 		return err
 	}
 
-	return ovn.updateIPtableChains(constants.FilterTable, forwardingSubmarinerFWDChain, ovn.getForwardingRuleSpecs)
+	return ovn.updateIPtableChains(constants.FilterTable, ForwardingSubmarinerFWDChain, ovn.getForwardingRuleSpecs)
 }
 
 func (ovn *Handler) addNoMasqueradeIPTables(subnet string) error {
@@ -186,12 +186,12 @@ func (ovn *Handler) removeNoMasqueradeIPTables(subnet string) error {
 }
 
 func (ovn *Handler) cleanupForwardingIptables() error {
-	if err := ovn.ipt.ClearChain(constants.FilterTable, forwardingSubmarinerMSSClampChain); err != nil {
-		return errors.Wrapf(err, "error clearing chain %q", forwardingSubmarinerMSSClampChain)
+	if err := ovn.ipt.ClearChain(constants.FilterTable, ForwardingSubmarinerMSSClampChain); err != nil {
+		return errors.Wrapf(err, "error clearing chain %q", ForwardingSubmarinerMSSClampChain)
 	}
 
-	return errors.Wrapf(ovn.ipt.ClearChain(constants.FilterTable, forwardingSubmarinerFWDChain),
-		"error clearing chain %q", forwardingSubmarinerFWDChain)
+	return errors.Wrapf(ovn.ipt.ClearChain(constants.FilterTable, ForwardingSubmarinerFWDChain),
+		"error clearing chain %q", ForwardingSubmarinerFWDChain)
 }
 
 func (ovn *Handler) getRouteToOVNDataPlane() (*netlink.Route, error) {
@@ -219,21 +219,21 @@ func (ovn *Handler) initIPtablesChains() error {
 }
 
 func (ovn *Handler) ensureForwardChains() error {
-	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, forwardingSubmarinerMSSClampChain); err != nil {
-		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerMSSClampChain)
+	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, ForwardingSubmarinerMSSClampChain); err != nil {
+		return errors.Wrapf(err, "error creating chain %q", ForwardingSubmarinerMSSClampChain)
 	}
 
 	if err := ovn.ipt.InsertUnique(constants.FilterTable, "FORWARD", 1,
-		[]string{"-j", forwardingSubmarinerMSSClampChain}); err != nil {
-		return errors.Wrapf(err, "error inserting rule for chain %q", forwardingSubmarinerMSSClampChain)
+		[]string{"-j", ForwardingSubmarinerMSSClampChain}); err != nil {
+		return errors.Wrapf(err, "error inserting rule for chain %q", ForwardingSubmarinerMSSClampChain)
 	}
 
-	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, forwardingSubmarinerFWDChain); err != nil {
-		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerFWDChain)
+	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, ForwardingSubmarinerFWDChain); err != nil {
+		return errors.Wrapf(err, "error creating chain %q", ForwardingSubmarinerFWDChain)
 	}
 
-	return errors.Wrapf(ovn.ipt.InsertUnique(constants.FilterTable, "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
-		"error inserting rule for chain %q", forwardingSubmarinerFWDChain)
+	return errors.Wrapf(ovn.ipt.InsertUnique(constants.FilterTable, "FORWARD", 2, []string{"-j", ForwardingSubmarinerFWDChain}),
+		"error inserting rule for chain %q", ForwardingSubmarinerFWDChain)
 }
 
 func (ovn *Handler) updateIPtableChains(table, chain string, ruleGen forwardRuleSpecGenerator) error {

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -152,45 +152,45 @@ const (
 )
 
 func (ovn *Handler) setupForwardingIptables() error {
-	if err := ovn.updateIPtableChains("filter", forwardingSubmarinerMSSClampChain, ovn.getMSSClampingRuleSpecs); err != nil {
+	if err := ovn.updateIPtableChains(constants.FilterTable, forwardingSubmarinerMSSClampChain, ovn.getMSSClampingRuleSpecs); err != nil {
 		return err
 	}
 
-	return ovn.updateIPtableChains("filter", forwardingSubmarinerFWDChain, ovn.getForwardingRuleSpecs)
+	return ovn.updateIPtableChains(constants.FilterTable, forwardingSubmarinerFWDChain, ovn.getForwardingRuleSpecs)
 }
 
 func (ovn *Handler) addNoMasqueradeIPTables(subnet string) error {
-	err := errors.Wrapf(ovn.ipt.AppendUnique("nat", constants.SmPostRoutingChain,
+	err := errors.Wrapf(ovn.ipt.AppendUnique(constants.NATTable, constants.SmPostRoutingChain,
 		[]string{"-d", subnet, "-j", "ACCEPT"}...), "error updating %q rules for subnet %q",
 		constants.SmPostRoutingChain, subnet)
 	if err != nil {
 		return err
 	}
 
-	return errors.Wrapf(ovn.ipt.AppendUnique("nat", constants.SmPostRoutingChain,
+	return errors.Wrapf(ovn.ipt.AppendUnique(constants.NATTable, constants.SmPostRoutingChain,
 		[]string{"-s", subnet, "-j", "ACCEPT"}...), "error updating %q rules for subnet %q",
 		constants.SmPostRoutingChain, subnet)
 }
 
 func (ovn *Handler) removeNoMasqueradeIPTables(subnet string) error {
-	err := errors.Wrapf(ovn.ipt.Delete("nat", constants.SmPostRoutingChain,
+	err := errors.Wrapf(ovn.ipt.Delete(constants.NATTable, constants.SmPostRoutingChain,
 		[]string{"-d", subnet, "-j", "ACCEPT"}...), "error updating %q rules for subnet %q",
 		constants.SmPostRoutingChain, subnet)
 	if err != nil {
 		return err
 	}
 
-	return errors.Wrapf(ovn.ipt.Delete("nat", constants.SmPostRoutingChain,
+	return errors.Wrapf(ovn.ipt.Delete(constants.NATTable, constants.SmPostRoutingChain,
 		[]string{"-s", subnet, "-j", "ACCEPT"}...), "error updating %q rules for subnet %q",
 		constants.SmPostRoutingChain, subnet)
 }
 
 func (ovn *Handler) cleanupForwardingIptables() error {
-	if err := ovn.ipt.ClearChain("filter", forwardingSubmarinerMSSClampChain); err != nil {
+	if err := ovn.ipt.ClearChain(constants.FilterTable, forwardingSubmarinerMSSClampChain); err != nil {
 		return errors.Wrapf(err, "error clearing chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
-	return errors.Wrapf(ovn.ipt.ClearChain("filter", forwardingSubmarinerFWDChain),
+	return errors.Wrapf(ovn.ipt.ClearChain(constants.FilterTable, forwardingSubmarinerFWDChain),
 		"error clearing chain %q", forwardingSubmarinerFWDChain)
 }
 
@@ -219,20 +219,20 @@ func (ovn *Handler) initIPtablesChains() error {
 }
 
 func (ovn *Handler) ensureForwardChains() error {
-	if err := ovn.ipt.CreateChainIfNotExists("filter", forwardingSubmarinerMSSClampChain); err != nil {
+	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, forwardingSubmarinerMSSClampChain); err != nil {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
-	if err := ovn.ipt.InsertUnique("filter", "FORWARD", 1,
+	if err := ovn.ipt.InsertUnique(constants.FilterTable, "FORWARD", 1,
 		[]string{"-j", forwardingSubmarinerMSSClampChain}); err != nil {
 		return errors.Wrapf(err, "error inserting rule for chain %q", forwardingSubmarinerMSSClampChain)
 	}
 
-	if err := ovn.ipt.CreateChainIfNotExists("filter", forwardingSubmarinerFWDChain); err != nil {
+	if err := ovn.ipt.CreateChainIfNotExists(constants.FilterTable, forwardingSubmarinerFWDChain); err != nil {
 		return errors.Wrapf(err, "error creating chain %q", forwardingSubmarinerFWDChain)
 	}
 
-	return errors.Wrapf(ovn.ipt.InsertUnique("filter", "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
+	return errors.Wrapf(ovn.ipt.InsertUnique(constants.FilterTable, "FORWARD", 2, []string{"-j", forwardingSubmarinerFWDChain}),
 		"error inserting rule for chain %q", forwardingSubmarinerFWDChain)
 }
 

--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
@@ -20,7 +20,6 @@ package ovn
 
 import (
 	"context"
-	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -37,7 +36,6 @@ import (
 
 type GatewayRouteHandler struct {
 	event.HandlerBase
-	mutex           sync.Mutex
 	smClient        submarinerClientset.Interface
 	config          *environment.Specification
 	remoteEndpoints map[string]*submarinerv1.Endpoint
@@ -76,9 +74,6 @@ func (h *GatewayRouteHandler) GetNetworkPlugins() []string {
 }
 
 func (h *GatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.Endpoint) error {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
 	h.remoteEndpoints[endpoint.Name] = endpoint
 
 	if h.isGateway {
@@ -93,9 +88,6 @@ func (h *GatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.Endpo
 }
 
 func (h *GatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
 	delete(h.remoteEndpoints, endpoint.Name)
 
 	if h.isGateway {
@@ -109,18 +101,12 @@ func (h *GatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpo
 }
 
 func (h *GatewayRouteHandler) TransitionToNonGateway() error {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
 	h.isGateway = false
 
 	return nil
 }
 
 func (h *GatewayRouteHandler) TransitionToGateway() error {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
 	h.isGateway = true
 
 	for _, endpoint := range h.remoteEndpoints {

--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
@@ -1,0 +1,115 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn_test
+
+import (
+	"errors"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/test"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event/testing"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	"github.com/vishvananda/netlink"
+)
+
+var _ = Describe("GatewayRouteHandler", func() {
+	t := newTestDriver()
+
+	var nextHopIP *net.IPNet
+
+	BeforeEach(func() {
+		nextHopIP = &net.IPNet{
+			IP: []byte{128, 1, 20, 2},
+		}
+	})
+
+	JustBeforeEach(func() {
+		link := &netlink.GenericLink{
+			LinkAttrs: netlink.LinkAttrs{
+				Index: 99,
+				Name:  ovn.OVNK8sMgmntIntfName,
+			},
+		}
+
+		t.netLink.SetLinkIndex(ovn.OVNK8sMgmntIntfName, link.Index)
+		Expect(t.netLink.LinkAdd(link)).To(Succeed())
+		Expect(t.netLink.AddrAdd(link, &netlink.Addr{
+			IPNet: nextHopIP,
+		})).To(Succeed())
+
+		t.Start(ovn.NewGatewayRouteHandler(t.submClient))
+	})
+
+	awaitGatewayRoute := func(ep *submarinerv1.Endpoint) {
+		gwRoute := test.AwaitResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), ep.Name)
+		Expect(gwRoute.RoutePolicySpec.RemoteCIDRs).To(Equal(ep.Spec.Subnets))
+		Expect(gwRoute.RoutePolicySpec.NextHops).To(Equal([]string{nextHopIP.IP.String()}))
+	}
+
+	When("a remote Endpoint is created and deleted on the gateway", func() {
+		JustBeforeEach(func() {
+			t.CreateLocalHostEndpoint()
+		})
+
+		It("should create/delete a GatewayRoute", func() {
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", "192.0.4.0/24"))
+			awaitGatewayRoute(endpoint)
+
+			t.DeleteEndpoint(endpoint.Name)
+			test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+		})
+
+		Context("and the GatewayRoute operations initially fail", func() {
+			JustBeforeEach(func() {
+				r := fake.NewFailingReactorForResource(&t.submClient.Fake, "gatewayroutes")
+				r.SetResetOnFailure(true)
+				r.SetFailOnCreate(errors.New("mock GatewayRoute create error"))
+				r.SetFailOnDelete(errors.New("mock GatewayRoute delete error"))
+			})
+
+			It("should eventually create/delete a GatewayRoute", func() {
+				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", "192.0.4.0/24"))
+				awaitGatewayRoute(endpoint)
+
+				t.DeleteEndpoint(endpoint.Name)
+				test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			})
+		})
+	})
+
+	Context("on transition to gateway", func() {
+		It("should create GatewayRoutes for all remote Endpoints", func() {
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", "192.0.4.0/24"))
+			test.EnsureNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+
+			localEndpoint := t.CreateLocalHostEndpoint()
+			awaitGatewayRoute(endpoint)
+
+			t.DeleteEndpoint(localEndpoint.Name)
+
+			t.submClient.Fake.ClearActions()
+			t.CreateLocalHostEndpoint()
+			test.EnsureNoActionsForResource(&t.submClient.Fake, "gatewayroutes", "create")
+		})
+	})
+})

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -50,7 +50,7 @@ type Handler struct {
 	cableRoutingInterface     *net.Interface
 	remoteEndpoints           map[string]*submV1.Endpoint
 	isGateway                 bool
-	netlink                   netlink.Interface
+	netLink                   netlink.Interface
 	ipt                       iptables.Interface
 	gatewayRouteController    *GatewayRouteController
 	nonGatewayRouteController *NonGatewayRouteController
@@ -75,7 +75,7 @@ func NewHandler(env *environment.Specification, smClientSet clientset.Interface,
 		dynamicClient:   dynamicClient,
 		watcherConfig:   watcherConfig,
 		remoteEndpoints: map[string]*submV1.Endpoint{},
-		netlink:         netlink.New(),
+		netLink:         netlink.New(),
 		ipt:             ipt,
 		stopCh:          make(chan struct{}),
 	}

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -1,0 +1,337 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn_test
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	libovsdbclient "github.com/ovn-org/libovsdb/client"
+	"github.com/ovn-org/libovsdb/model"
+	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/admiral/pkg/watcher"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event/testing"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	fakeovn "github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn/fake"
+	"github.com/vishvananda/netlink"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	clusterCIDR      = "171.0.1.0/24"
+	serviceCIDR      = "181.0.1.0/24"
+	OVNK8sMgmntIntGw = "100.1.1.1"
+)
+
+var _ = Describe("Handler", func() {
+	t := newTestDriver()
+
+	var ovsdbClient *fakeovn.OVSDBClient
+
+	BeforeEach(func() {
+		ovsdbClient = fakeovn.NewOVSDBClient()
+
+		_, _ = ovsdbClient.Create(&nbdb.LogicalRouter{
+			Name: ovn.OVNClusterRouter,
+		})
+	})
+
+	JustBeforeEach(func() {
+		_, err := t.k8sClient.CoreV1().Pods(testing.Namespace).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "ovn-pod",
+				Labels: map[string]string{"app": "ovnkube-node"},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).To(Succeed())
+
+		Expect(t.netLink.RouteAdd(&netlink.Route{
+			LinkIndex: OVNK8sMgmntIntIndex,
+			Family:    syscall.AF_INET,
+			Dst:       toIPNet(clusterCIDR),
+			Gw:        net.ParseIP(OVNK8sMgmntIntGw),
+		})).To(Succeed())
+
+		restMapper := test.GetRESTMapperFor(&submarinerv1.GatewayRoute{}, &submarinerv1.NonGatewayRoute{})
+
+		t.Start(ovn.NewHandler(&ovn.HandlerConfig{
+			Namespace:   testing.Namespace,
+			ClusterCIDR: []string{clusterCIDR},
+			ServiceCIDR: []string{serviceCIDR},
+			SubmClient:  t.submClient,
+			K8sClient:   t.k8sClient,
+			DynClient:   t.dynClient,
+			WatcherConfig: &watcher.Config{
+				RestMapper: restMapper,
+				Client:     t.dynClient,
+			},
+			NewOVSDBClient: func(_ model.ClientDBModel, opts ...libovsdbclient.Option) (libovsdbclient.Client, error) {
+				return ovsdbClient, nil
+			},
+		}))
+
+		Expect(ovsdbClient.Connected()).To(BeTrue())
+	})
+
+	When("a remote Endpoint is created, updated, and deleted", func() {
+		It("should correctly update the host network dataplane", func() {
+			By("Creating remote Endpoint")
+
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "192.0.1.0/24", "192.0.2.0/24"))
+
+			for _, s := range endpoint.Spec.Subnets {
+				t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID, "", s)
+				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+			}
+
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentHostNetworkTableID, OVNK8sMgmntIntGw)
+
+			By("Updating remote Endpoint")
+
+			oldSubnets := endpoint.Spec.Subnets
+			endpoint.Spec.Subnets = []string{"192.0.3.0/24"}
+			t.UpdateEndpoint(endpoint)
+
+			for _, s := range oldSubnets {
+				t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", s)
+			}
+
+			for _, s := range endpoint.Spec.Subnets {
+				t.netLink.AwaitRule(constants.RouteAgentHostNetworkTableID, "", s)
+			}
+
+			By("Deleting remote Endpoint")
+
+			t.DeleteEndpoint(endpoint.Name)
+
+			for _, s := range endpoint.Spec.Subnets {
+				t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", s)
+			}
+		})
+
+		Context("on the gateway", func() {
+			JustBeforeEach(func() {
+				t.CreateLocalHostEndpoint()
+			})
+
+			It("should correctly update the gateway dataplane", func() {
+				By("Creating remote Endpoint")
+
+				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "192.0.1.0/24", "192.0.2.0/24"))
+
+				for _, s := range endpoint.Spec.Subnets {
+					t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+					t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+				}
+
+				By("Updating remote Endpoint")
+
+				oldSubnets := endpoint.Spec.Subnets
+				endpoint.Spec.Subnets = []string{oldSubnets[0], "192.0.3.0/24"}
+				t.UpdateEndpoint(endpoint)
+
+				for i := 1; i < len(oldSubnets); i++ {
+					t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, oldSubnets[i], clusterCIDR)
+					t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, oldSubnets[i], serviceCIDR)
+				}
+
+				for _, s := range endpoint.Spec.Subnets {
+					t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+					t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+				}
+
+				By("Deleting remote Endpoint")
+
+				t.DeleteEndpoint(endpoint.Name)
+
+				for _, s := range endpoint.Spec.Subnets {
+					t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+					t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+				}
+			})
+		})
+	})
+
+	Context("on gateway transitions", func() {
+		It("should correctly update the gateway dataplane", func() {
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "192.0.1.0/24", "192.0.2.0/24"))
+
+			By("Creating local gateway Endpoint")
+
+			localEP := t.CreateLocalHostEndpoint()
+
+			for _, s := range endpoint.Spec.Subnets {
+				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+			}
+
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
+
+			By("Deleting local gateway Endpoint")
+
+			t.DeleteEndpoint(localEP.Name)
+
+			for _, s := range endpoint.Spec.Subnets {
+				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
+				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
+			}
+
+			t.netLink.AwaitNoGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
+		})
+	})
+
+	When("a GatewayRoute is created and deleted", func() {
+		It("should correctly reconcile OVN router policies", func() {
+			client := t.dynClient.Resource(submarinerv1.SchemeGroupVersion.WithResource("gatewayroutes")).Namespace(testing.Namespace)
+
+			gwRoute := &submarinerv1.GatewayRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway-route",
+				},
+				RoutePolicySpec: submarinerv1.RoutePolicySpec{
+					NextHops:    []string{OVNK8sMgmntIntCIDR.IP.String()},
+					RemoteCIDRs: []string{"192.0.1.0/24", "192.0.2.0/24"},
+				},
+			}
+
+			test.CreateResource(client, gwRoute)
+
+			for _, cidr := range gwRoute.RoutePolicySpec.RemoteCIDRs {
+				ovsdbClient.AwaitModel(&nbdb.LogicalRouterPolicy{
+					Match:   cidr,
+					Nexthop: ptr.To(gwRoute.RoutePolicySpec.NextHops[0]),
+				})
+
+				ovsdbClient.AwaitModel(&nbdb.LogicalRouterStaticRoute{
+					IPPrefix: cidr,
+				})
+			}
+
+			Expect(client.Delete(context.Background(), gwRoute.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			for _, cidr := range gwRoute.RoutePolicySpec.RemoteCIDRs {
+				ovsdbClient.AwaitNoModel(&nbdb.LogicalRouterPolicy{
+					Match:   cidr,
+					Nexthop: ptr.To(gwRoute.RoutePolicySpec.NextHops[0]),
+				})
+
+				ovsdbClient.AwaitNoModel(&nbdb.LogicalRouterStaticRoute{
+					IPPrefix: cidr,
+				})
+			}
+		})
+	})
+
+	When("a NonGatewayRoute is created and deleted", func() {
+		It("should correctly reconcile OVN router policies", func() {
+			client := t.dynClient.Resource(submarinerv1.SchemeGroupVersion.WithResource("nongatewayroutes")).Namespace(testing.Namespace)
+
+			nonGWRoute := &submarinerv1.NonGatewayRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-nongateway-route",
+				},
+				RoutePolicySpec: submarinerv1.RoutePolicySpec{
+					NextHops:    []string{"111.1.1.1"},
+					RemoteCIDRs: []string{"192.0.1.0/24", "192.0.2.0/24"},
+				},
+			}
+
+			test.CreateResource(client, nonGWRoute)
+
+			for _, cidr := range nonGWRoute.RoutePolicySpec.RemoteCIDRs {
+				ovsdbClient.AwaitModel(&nbdb.LogicalRouterPolicy{
+					Match:   cidr,
+					Nexthop: ptr.To(nonGWRoute.RoutePolicySpec.NextHops[0]),
+				})
+			}
+
+			Expect(client.Delete(context.Background(), nonGWRoute.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			for _, cidr := range nonGWRoute.RoutePolicySpec.RemoteCIDRs {
+				ovsdbClient.AwaitNoModel(&nbdb.LogicalRouterPolicy{
+					Match:   cidr,
+					Nexthop: ptr.To(nonGWRoute.RoutePolicySpec.NextHops[0]),
+				})
+			}
+		})
+	})
+
+	When("the OVN management interface address changes", func() {
+		JustBeforeEach(func() {
+			t.CreateLocalHostEndpoint()
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
+
+			t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "192.0.1.0/24"))
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentHostNetworkTableID, OVNK8sMgmntIntGw)
+		})
+
+		It("should update the gateway and host network dataplanes", func() {
+			Expect(t.netLink.FlushRouteTable(constants.RouteAgentInterClusterNetworkTableID)).To(Succeed())
+			Expect(t.netLink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)).To(Succeed())
+
+			link, err := t.netLink.LinkByName(ovn.OVNK8sMgmntIntfName)
+			Expect(err).To(Succeed())
+
+			Expect(t.netLink.AddrDel(link, &netlink.Addr{
+				IPNet: OVNK8sMgmntIntCIDR,
+			})).To(Succeed())
+
+			newMgmtIPNet := toIPNet("128.2.30.3/24")
+			Expect(t.netLink.AddrAdd(link, &netlink.Addr{
+				IPNet: newMgmtIPNet,
+			})).To(Succeed())
+
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
+			t.netLink.AwaitGwRoutes(0, constants.RouteAgentHostNetworkTableID, OVNK8sMgmntIntGw)
+		})
+	})
+
+	Context("on Uninstall", func() {
+		It("should delete the table rules", func() {
+			Expect(t.ipTables.ChainExists(constants.FilterTable, ovn.ForwardingSubmarinerFWDChain)).To(BeTrue())
+			Expect(t.ipTables.ChainExists(constants.FilterTable, ovn.ForwardingSubmarinerMSSClampChain)).To(BeTrue())
+
+			_ = t.netLink.RuleAdd(&netlink.Rule{
+				Table:  constants.RouteAgentHostNetworkTableID,
+				Family: netlink.FAMILY_V4,
+			})
+
+			_ = t.netLink.RuleAdd(&netlink.Rule{
+				Table:  constants.RouteAgentInterClusterNetworkTableID,
+				Family: netlink.FAMILY_V4,
+			})
+
+			Expect(t.handler.Uninstall()).To(Succeed())
+
+			t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", "")
+			t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, "", "")
+
+			Expect(t.ipTables.ChainExists(constants.FilterTable, ovn.ForwardingSubmarinerFWDChain)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -133,12 +133,12 @@ func (ovn *Handler) getNextHopOnK8sMgmtIntf() (*net.IP, error) {
 		// with nexthop matching the nexthop on the ovn-k8s-mp0 interface. Basically, we want the Submariner
 		// managed traffic to be forwarded to the ovn_cluster_router and pass through the CNI network so that
 		// it reaches the active gateway node in the cluster via the submariner pipeline.
-		for _, subnet := range ovn.config.ClusterCidr {
+		for _, subnet := range ovn.ClusterCIDR {
 			if currentRouteList[i].Dst.String() == subnet {
 				return &currentRouteList[i].Gw, nil
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("could not find the route to %v via %q", ovn.config.ClusterCidr, OVNK8sMgmntIntfName)
+	return nil, fmt.Errorf("could not find the route to %v via %q", ovn.ClusterCIDR, OVNK8sMgmntIntfName)
 }

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -36,6 +36,9 @@ const (
 )
 
 func (ovn *Handler) updateHostNetworkDataplane() error {
+	ovn.mutex.Lock()
+	defer ovn.mutex.Unlock()
+
 	currentRuleRemotes, err := ovn.getExistingIPv4HostNetworkRoutes()
 	if err != nil {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
@@ -1,0 +1,119 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/test"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/event/testing"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+)
+
+var _ = Describe("NonGatewayRouteHandler", func() {
+	t := newTestDriver()
+
+	JustBeforeEach(func() {
+		t.Start(ovn.NewNonGatewayRouteHandler(t.submClient, t.k8sClient))
+	})
+
+	awaitNonGatewayRoute := func(ep *submarinerv1.Endpoint) {
+		nonGWRoute := test.AwaitResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), ep.Name)
+		Expect(nonGWRoute.RoutePolicySpec.RemoteCIDRs).To(Equal(ep.Spec.Subnets))
+		Expect(nonGWRoute.RoutePolicySpec.NextHops).To(Equal([]string{t.transitSwitchIP}))
+	}
+
+	When("a remote Endpoint is created and deleted on the gateway", func() {
+		JustBeforeEach(func() {
+			t.CreateLocalHostEndpoint()
+		})
+
+		It("should create/delete a NonGatewayRoute", func() {
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
+			awaitNonGatewayRoute(endpoint)
+
+			t.DeleteEndpoint(endpoint.Name)
+			test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+		})
+
+		Context("and the NonGatewayRoute operations initially fail", func() {
+			JustBeforeEach(func() {
+				r := fake.NewFailingReactorForResource(&t.submClient.Fake, "nongatewayroutes")
+				r.SetResetOnFailure(true)
+				r.SetFailOnCreate(errors.New("mock NonGatewayRoute create error"))
+				r.SetFailOnDelete(errors.New("mock NonGatewayRoute delete error"))
+			})
+
+			It("should eventually create/delete a NonGatewayRoute", func() {
+				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
+				awaitNonGatewayRoute(endpoint)
+
+				t.DeleteEndpoint(endpoint.Name)
+				test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			})
+		})
+
+		Context("and no transit switch IP configured", func() {
+			BeforeEach(func() {
+				t.transitSwitchIP = ""
+			})
+
+			It("should not create a NonGatewayRoute", func() {
+				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
+				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+
+				t.submClient.Fake.ClearActions()
+				t.DeleteEndpoint(endpoint.Name)
+				test.EnsureNoActionsForResource(&t.submClient.Fake, "nongatewayroutes", "delete")
+			})
+		})
+	})
+
+	Context("on transition to gateway", func() {
+		It("should create NonGatewayRoutes for all remote Endpoints", func() {
+			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
+			test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+
+			localEndpoint := t.CreateLocalHostEndpoint()
+			awaitNonGatewayRoute(endpoint)
+
+			t.DeleteEndpoint(localEndpoint.Name)
+
+			t.submClient.Fake.ClearActions()
+			t.CreateLocalHostEndpoint()
+			test.EnsureNoActionsForResource(&t.submClient.Fake, "nongatewayroutes", "create")
+		})
+
+		Context("with no transit switch IP configured", func() {
+			BeforeEach(func() {
+				t.transitSwitchIP = ""
+			})
+
+			It("should not create any NonGatewayRoutes", func() {
+				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
+				t.CreateLocalHostEndpoint()
+				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			})
+		})
+	})
+})

--- a/pkg/routeagent_driver/handlers/ovn/ovn_logical_routes.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_logical_routes.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ovnClusterRouter     = "ovn_cluster_router"
+	OVNClusterRouter     = "ovn_cluster_router"
 	ovnRoutePoliciesPrio = 20000
 )
 
@@ -43,7 +43,7 @@ func (c *ConnectionHandler) reconcileOvnLogicalRouterStaticRoutes(remoteSubnets 
 			(item.Nexthop != nextHop && remoteSubnets.Has(item.IPPrefix))
 	}
 
-	err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(c.nbdb, ovnClusterRouter, staleLRSRPred)
+	err := libovsdbops.DeleteLogicalRouterStaticRoutesWithPredicate(c.nbdb, OVNClusterRouter, staleLRSRPred)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete existing ovn logical route static routes for nexthop: %s", nextHop)
 	}
@@ -55,7 +55,7 @@ func (c *ConnectionHandler) reconcileOvnLogicalRouterStaticRoutes(remoteSubnets 
 			return item.Nexthop == nextHop && item.IPPrefix == lrsr.IPPrefix
 		}
 
-		err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(c.nbdb, ovnClusterRouter, lrsr, LRSRPred)
+		err = libovsdbops.CreateOrUpdateLogicalRouterStaticRoutesWithPredicate(c.nbdb, OVNClusterRouter, lrsr, LRSRPred)
 		if err != nil {
 			return errors.Wrap(err, "failed to create ovn lrsr and add it to the ovn submariner router")
 		}
@@ -88,7 +88,7 @@ func (c *ConnectionHandler) reconcileSubOvnLogicalRouterPolicies(remoteSubnets s
 	}
 
 	// Cleanup any existing lrps not representing the correct set of remote subnets
-	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(c.nbdb, ovnClusterRouter, lrpStalePredicate)
+	err := libovsdbops.DeleteLogicalRouterPoliciesWithPredicate(c.nbdb, OVNClusterRouter, lrpStalePredicate)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete stale submariner logical route policies")
 	}
@@ -104,7 +104,7 @@ func (c *ConnectionHandler) reconcileSubOvnLogicalRouterPolicies(remoteSubnets s
 		}
 
 		if err := libovsdbops.CreateOrUpdateLogicalRouterPolicyWithPredicate(c.nbdb,
-			ovnClusterRouter, lrp, lrpSubPredicate); err != nil {
+			OVNClusterRouter, lrp, lrpSubPredicate); err != nil {
 			return errors.Wrapf(err, "failed to create submariner logical Router policy %v and add it to the ovn cluster router", lrp)
 		}
 	}

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -19,15 +19,23 @@ limitations under the License.
 package ovn_test
 
 import (
+	"context"
+	"encoding/json"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	fakesubm "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	"github.com/submariner-io/submariner/pkg/event"
 	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
 )
 
 func init() {
@@ -45,8 +53,10 @@ func TestOvn(t *testing.T) {
 
 type testDriver struct {
 	*eventtesting.ControllerSupport
-	submClient *fakesubm.Clientset
-	netLink    *fakenetlink.NetLink
+	submClient      *fakesubm.Clientset
+	k8sClient       *fakek8s.Clientset
+	netLink         *fakenetlink.NetLink
+	transitSwitchIP string
 }
 
 func newTestDriver() *testDriver {
@@ -55,7 +65,9 @@ func newTestDriver() *testDriver {
 	}
 
 	BeforeEach(func() {
+		t.transitSwitchIP = "192.0.2.0"
 		t.submClient = fakesubm.NewSimpleClientset()
+		t.k8sClient = fakek8s.NewSimpleClientset()
 
 		t.netLink = fakenetlink.New()
 		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
@@ -64,4 +76,30 @@ func newTestDriver() *testDriver {
 	})
 
 	return t
+}
+
+func (t *testDriver) Start(handler event.Handler) {
+	t.createNode()
+	t.ControllerSupport.Start(handler)
+}
+
+func (t *testDriver) createNode() {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	if t.transitSwitchIP != "" {
+		data := map[string]string{"ipv4": t.transitSwitchIP + "/24"}
+		bytes, err := json.Marshal(data)
+		Expect(err).To(Succeed())
+
+		node.Annotations = map[string]string{constants.OvnTransitSwitchIPAnnotation: string(bytes)}
+	}
+
+	_, err := t.k8sClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	Expect(err).To(Succeed())
+
+	os.Setenv("NODE_NAME", node.Name)
 }

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -1,0 +1,67 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	fakesubm "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestOvn(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ovn Suite")
+}
+
+type testDriver struct {
+	*eventtesting.ControllerSupport
+	submClient *fakesubm.Clientset
+	netLink    *fakenetlink.NetLink
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{
+		ControllerSupport: eventtesting.NewControllerSupport(),
+	}
+
+	BeforeEach(func() {
+		t.submClient = fakesubm.NewSimpleClientset()
+
+		t.netLink = fakenetlink.New()
+		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
+			return t.netLink
+		}
+	})
+
+	return t
+}

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -21,22 +21,37 @@ package ovn_test
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	fakesubm "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
 	"github.com/submariner-io/submariner/pkg/event"
 	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	"github.com/submariner-io/submariner/pkg/iptables"
+	fakeIPT "github.com/submariner-io/submariner/pkg/iptables/fake"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
+	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 )
+
+const (
+	OVNK8sMgmntIntIndex = 99
+)
+
+var OVNK8sMgmntIntCIDR = toIPNet("128.1.20.2/24")
 
 func init() {
 	kzerolog.AddFlags(nil)
@@ -44,6 +59,7 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
+	Expect(submV1.AddToScheme(scheme.Scheme)).To(Succeed())
 })
 
 func TestOvn(t *testing.T) {
@@ -55,8 +71,12 @@ type testDriver struct {
 	*eventtesting.ControllerSupport
 	submClient      *fakesubm.Clientset
 	k8sClient       *fakek8s.Clientset
+	dynClient       *fakedynamic.FakeDynamicClient
 	netLink         *fakenetlink.NetLink
+	ipTables        *fakeIPT.IPTables
+	handler         event.Handler
 	transitSwitchIP string
+	mgmntIntfIP     string
 }
 
 func newTestDriver() *testDriver {
@@ -65,14 +85,37 @@ func newTestDriver() *testDriver {
 	}
 
 	BeforeEach(func() {
-		t.transitSwitchIP = "192.0.2.0"
+		t.transitSwitchIP = "190.1.2.0"
 		t.submClient = fakesubm.NewSimpleClientset()
 		t.k8sClient = fakek8s.NewSimpleClientset()
+		t.dynClient = fakedynamic.NewSimpleDynamicClient(scheme.Scheme)
 
 		t.netLink = fakenetlink.New()
 		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
 			return t.netLink
 		}
+
+		t.ipTables = fakeIPT.New()
+		iptables.NewFunc = func() (iptables.Interface, error) {
+			return t.ipTables, nil
+		}
+
+		link := &netlink.GenericLink{
+			LinkAttrs: netlink.LinkAttrs{
+				Index: OVNK8sMgmntIntIndex,
+				Name:  ovn.OVNK8sMgmntIntfName,
+			},
+		}
+
+		t.netLink.SetLinkIndex(ovn.OVNK8sMgmntIntfName, link.Index)
+		Expect(t.netLink.LinkAdd(link)).To(Succeed())
+
+		addr := &netlink.Addr{
+			IPNet: OVNK8sMgmntIntCIDR,
+		}
+		Expect(t.netLink.AddrAdd(link, addr)).To(Succeed())
+
+		t.mgmntIntfIP = addr.IPNet.IP.String()
 	})
 
 	return t
@@ -80,6 +123,7 @@ func newTestDriver() *testDriver {
 
 func (t *testDriver) Start(handler event.Handler) {
 	t.createNode()
+	t.handler = handler
 	t.ControllerSupport.Start(handler)
 }
 
@@ -102,4 +146,11 @@ func (t *testDriver) createNode() {
 	Expect(err).To(Succeed())
 
 	os.Setenv("NODE_NAME", node.Name)
+}
+
+func toIPNet(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	utilruntime.Must(err)
+
+	return n
 }

--- a/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
+++ b/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
@@ -42,7 +42,7 @@ func (ovn *Handler) startRouteConfigSyncer(stop chan struct{}) {
 }
 
 func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
-	iface, err := netlink.LinkByName(OVNK8sMgmntIntfName)
+	iface, err := ovn.netLink.LinkByName(OVNK8sMgmntIntfName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find interface: %q", OVNK8sMgmntIntfName)
 	}
@@ -50,7 +50,7 @@ func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
 	addrCh := make(chan netlink.AddrUpdate)
 	doneCh := make(chan struct{})
 
-	err = netlink.AddrSubscribe(addrCh, doneCh)
+	err = ovn.netLink.AddrSubscribe(addrCh, doneCh)
 	if err != nil {
 		return errors.Wrapf(err, "failed to subscribe to address updates")
 	}
@@ -60,7 +60,7 @@ func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
 	var prevIP net.IP
 
 	assignPrevIP := func() {
-		addrs, err := netlink.AddrList(iface, netlink.FAMILY_V4)
+		addrs, err := ovn.netLink.AddrList(iface, netlink.FAMILY_V4)
 		if err != nil {
 			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
 		} else if len(addrs) > 0 {
@@ -79,7 +79,7 @@ func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
 			return
 		}
 
-		addrs, err := netlink.AddrList(iface, netlink.FAMILY_V4)
+		addrs, err := ovn.netLink.AddrList(iface, netlink.FAMILY_V4)
 		if err != nil {
 			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
 			return

--- a/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
+++ b/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
@@ -131,9 +131,7 @@ func (ovn *Handler) handleInterfaceAddressChange() error {
 		logger.Infof("Waiting for interface %q to be ready: %v", OVNK8sMgmntIntfName, err)
 		return true
 	}, func() error {
-		ovn.mutex.Lock()
-		defer ovn.mutex.Unlock()
-		if ovn.isGateway {
+		if ovn.State().IsOnGateway() {
 			err = ovn.updateGatewayDataplane()
 			if err != nil {
 				return errors.Wrap(err, "error syncing gateway routes")

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -34,8 +34,8 @@ import (
 func (ovn *Handler) handleSubnets(remoteSubnets []string, ruleFunc func(rule *netlink.Rule) error,
 	ignoredErrorFunc func(error) bool,
 ) error {
-	localCIDRs := set.New(ovn.config.ClusterCidr...)
-	localCIDRs.Insert(ovn.config.ServiceCidr...)
+	localCIDRs := set.New(ovn.ClusterCIDR...)
+	localCIDRs.Insert(ovn.ServiceCIDR...)
 
 	for _, subnetToHandle := range remoteSubnets {
 		for _, localSubnet := range localCIDRs.UnsortedList() {

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -86,7 +86,7 @@ func (ovn *Handler) getRuleSpec(dest, src string, tableID int) (*netlink.Rule, e
 func (ovn *Handler) getExistingIPv4RuleSubnets() (set.Set[string], error) {
 	currentRuleRemotes := set.New[string]()
 
-	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	rules, err := ovn.netLink.RuleList(netlink.FAMILY_V4)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error listing rules")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/subnets.go
+++ b/pkg/routeagent_driver/handlers/ovn/subnets.go
@@ -23,8 +23,9 @@ import "k8s.io/utils/set"
 func (ovn *Handler) getRemoteSubnets() set.Set[string] {
 	endpointSubnets := set.New[string]()
 
-	for _, endpoint := range ovn.remoteEndpoints {
-		for _, subnet := range endpoint.Spec.Subnets {
+	endpoints := ovn.State().GetRemoteEndpoints()
+	for i := range endpoints {
+		for _, subnet := range endpoints[i].Spec.Subnets {
 			endpointSubnets.Insert(subnet)
 		}
 	}

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -53,7 +53,7 @@ func (ovn *Handler) Uninstall() error {
 			constants.RouteAgentHostNetworkTableID)
 	}
 
-	ovn.flushAndDeleteIPTableChains(constants.FilterTable, constants.ForwardChain, forwardingSubmarinerFWDChain)
+	ovn.flushAndDeleteIPTableChains(constants.FilterTable, constants.ForwardChain, ForwardingSubmarinerFWDChain)
 	ovn.flushAndDeleteIPTableChains(constants.NATTable, constants.PostRoutingChain, constants.SmPostRoutingChain)
 
 	return nil

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -41,13 +41,13 @@ func (ovn *Handler) Uninstall() error {
 		logger.Errorf(err, "Error cleaning the routes")
 	}
 
-	err = ovn.netlink.FlushRouteTable(constants.RouteAgentInterClusterNetworkTableID)
+	err = ovn.netLink.FlushRouteTable(constants.RouteAgentInterClusterNetworkTableID)
 	if err != nil {
 		logger.Errorf(err, "Flushing routing table %d returned error",
 			constants.RouteAgentInterClusterNetworkTableID)
 	}
 
-	err = ovn.netlink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
+	err = ovn.netLink.FlushRouteTable(constants.RouteAgentHostNetworkTableID)
 	if err != nil {
 		logger.Errorf(err, "Flushing routing table %d returned error",
 			constants.RouteAgentHostNetworkTableID)
@@ -60,14 +60,14 @@ func (ovn *Handler) Uninstall() error {
 }
 
 func (ovn *Handler) cleanupRoutes() error {
-	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	rules, err := ovn.netLink.RuleList(netlink.FAMILY_V4)
 	if err != nil {
 		return errors.Wrapf(err, "error listing rules")
 	}
 
 	for i := range rules {
 		if rules[i].Table == constants.RouteAgentInterClusterNetworkTableID || rules[i].Table == constants.RouteAgentHostNetworkTableID {
-			err = netlink.RuleDel(&rules[i])
+			err = ovn.netLink.RuleDel(&rules[i])
 			if err != nil {
 				return errors.Wrapf(err, "error deleting the rule %v", rules[i])
 			}

--- a/pkg/routeagent_driver/handlers/ovn/utils.go
+++ b/pkg/routeagent_driver/handlers/ovn/utils.go
@@ -36,7 +36,7 @@ func getNextHopOnK8sMgmtIntf() (string, error) {
 		return "", errors.Wrapf(err, "failed to retrieve link by name")
 	}
 
-	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	addrs, err := netLink.AddrList(link, netlink.FAMILY_V4)
 	if err != nil || len(addrs) == 0 {
 		return "", errors.Wrapf(err, "failed to retrieve addresses for link")
 	}

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -136,7 +136,7 @@ func main() {
 		eventlogger.NewHandler(),
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
 		ovn.NewHandler(&env, smClientset, k8sClientSet, dynamicClientSet, config),
-		ovn.NewGatewayRouteHandler(&env, smClientset),
+		ovn.NewGatewayRouteHandler(smClientset),
 		ovn.NewNonGatewayRouteHandler(smClientset, k8sClientSet),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -135,7 +135,15 @@ func main() {
 	if err := registry.AddHandlers(
 		eventlogger.NewHandler(),
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
-		ovn.NewHandler(&env, smClientset, k8sClientSet, dynamicClientSet, config),
+		ovn.NewHandler(&ovn.HandlerConfig{
+			Namespace:     env.Namespace,
+			ClusterCIDR:   env.ClusterCidr,
+			ServiceCIDR:   env.ServiceCidr,
+			SubmClient:    smClientset,
+			K8sClient:     k8sClientSet,
+			DynClient:     dynamicClientSet,
+			WatcherConfig: config,
+		}),
 		ovn.NewGatewayRouteHandler(smClientset),
 		ovn.NewNonGatewayRouteHandler(smClientset, k8sClientSet),
 		cabledriver.NewXRFMCleanupHandler(),


### PR DESCRIPTION
See the individual for details. To summarize:

- Added `HandlerState` that contains global state common to all event handlers, specifically IsOnGateway and `GetRemoteEndpoints` which is provided to the handlers via a `SetState` method.
- Modified all handlers to use the `HandlerState` rather than maintaining such state themselves.
- The event controller now provides synchronization across all event callbacks so handlers don't have to.
- Added unit tests for handlers that didn't have any prior.

Fixes https://github.com/submariner-io/submariner/issues/2623