### PR TITLE
Remove external-net from CI E2E matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,8 +53,6 @@ jobs:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
           - extra-toggles: globalnet, ovn
-          - extra-toggles: external-net
-          - extra-toggles: external-net, globalnet
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
These tests sporadically fail and the original dev is no longer involved with the project so there's no one to maintain them.