### PR TITLE
Don't use extra-toggles for Globalnet GHA config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         exclude:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,14 +45,14 @@ jobs:
       fail-fast: false
       matrix:
         cable-driver: ['libreswan', 'wireguard', 'vxlan']
-        extra-toggles: ['', 'globalnet', 'ovn']
+        extra-toggles: ['', 'ovn']
+        globalnet: ['', 'globalnet']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
-          - extra-toggles: globalnet, ovn
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         exclude:

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -17,12 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         cable-driver: ['libreswan', 'wireguard', 'vxlan']
-        extra-toggles: ['', 'globalnet', 'ovn']
+        extra-toggles: ['', 'ovn']
+        globalnet: ['', 'globalnet']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
-          - extra-toggles: globalnet, ovn
           - extra-toggles: external-net
     steps:
       - name: Check out the repository


### PR DESCRIPTION
In Shipyard, Globalnet GHA config has a dedicated field. There is no need to pass it with extra-toggles. Doing so makes the config in this repo unnecessary different from other repos and harder to maintain.

This should not change the matrix of tested combinations.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
