### PR TITLE
Eliminate duplicate all-defaults E2E run, add K8s E2E, standardize GHA config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         exclude:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,14 +45,14 @@ jobs:
       fail-fast: false
       matrix:
         cable-driver: ['libreswan', 'wireguard', 'vxlan']
-        extra-toggles: ['', 'globalnet', 'ovn']
+        extra-toggles: ['', 'ovn']
+        globalnet: ['', 'globalnet']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
-          - extra-toggles: globalnet, ovn
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,12 +47,21 @@ jobs:
         cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.28']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
+          # Oldest Kubernetes version thought to work with SubM.
+          # This should match minK8sMajor.minK8sMinor in subctl/pkg/version/version.go.
+          # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
+          # https://submariner.io/development/building-testing/ci-maintenance/
+          - k8s_version: '1.19'
+          # Test top and bottom of supported K8s version range
+          - k8s_version: '1.26'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -17,12 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         cable-driver: ['libreswan', 'wireguard', 'vxlan']
-        extra-toggles: ['', 'globalnet', 'ovn']
+        extra-toggles: ['', 'ovn']
+        globalnet: ['', 'globalnet']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
-        include:
-          - extra-toggles: globalnet, ovn
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -19,9 +19,14 @@ jobs:
         cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.28']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
+        include:
+          # Test top and bottom of supported K8s version range
+          - k8s_version: '1.26'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cable-driver: ['libreswan', 'wireguard', 'vxlan']
+        cable-driver: ['', 'wireguard', 'vxlan']
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         exclude:


### PR DESCRIPTION
Set of changes that results in:

* Eliminate duplication between `E2E (libreswan)` and `End to End / E2E` runs.
* Add E2E for top and bottom of supported K8s versions range, as well as the oldest-working K8s version. The oldest-working coverage currently in the Operator repo will be removed.
* Standardize and simplify GHA config, to make it more like the other repos and therefore easier to maintain and reason about.

See commit messages for details.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
