### PR TITLE
Add monitor for rp_filter changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/coreos/go-iptables v0.7.0
 	github.com/emirpasic/gods v1.18.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.13.1
 	github.com/onsi/gomega v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -662,6 +663,7 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -31,6 +31,10 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 
 	// We are on nonGateway node
 	if !kp.State().IsOnGateway() {
+		if kp.interfaceWatcher != nil {
+			close(kp.interfaceWatcher.Done)
+		}
+
 		// If the node already has a vxLAN interface that points to an oldEndpoint
 		// (i.e., during gateway migration), delete it.
 		if kp.vxlanDevice != nil && kp.vxlanDevice.activeEndpointHostname != endpoint.Spec.Hostname {
@@ -71,6 +75,10 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 	// If the vxLAN device exists and it points to the same endpoint, delete it.
 	if kp.vxlanDevice != nil && kp.vxlanDevice.activeEndpointHostname == endpoint.Spec.Hostname {
+		if kp.interfaceWatcher != nil {
+			close(kp.interfaceWatcher.Done)
+		}
+
 		err := kp.vxlanDevice.deleteVxLanIface()
 		kp.vxlanDevice = nil
 		kp.vxlanGwIP = nil

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_iptables.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/iptables"
 	"github.com/submariner-io/submariner/pkg/netlink"
 	cniapi "github.com/submariner-io/submariner/pkg/routeagent_driver/cni"
+	"github.com/submariner-io/submariner/pkg/util"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/set"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -53,6 +54,7 @@ type SyncHandler struct {
 	hostname         string
 	cniIface         *cniapi.Interface
 	defaultHostIface *net.Interface
+	interfaceWatcher *util.InterfaceWatcher
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("KubeProxy")}

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/port"
+	"github.com/submariner-io/submariner/pkg/util"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -275,6 +276,15 @@ func (kp *SyncHandler) createVxLANInterface(activeEndPoint string, ifaceType int
 		if err != nil {
 			return errors.Wrap(err, "error while validating loose mode")
 		}
+
+		logger.Infof("Starting monitor for  %q", VxLANIface)
+
+		kp.interfaceWatcher, err = util.NewInterfaceWatcher(VxLANIface)
+		if err != nil {
+			return errors.Wrap(err, "error creating interface watcher to monitor rp_filter setting")
+		}
+
+		kp.interfaceWatcher.Monitor()
 
 		logger.Infof("Successfully configured reverse path filter to loose mode on %q", VxLANIface)
 	} else if ifaceType == VxInterfaceWorker {

--- a/pkg/util/InterfaceWatcher.go
+++ b/pkg/util/InterfaceWatcher.go
@@ -1,0 +1,136 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var logger = log.Logger{Logger: logf.Log.WithName("InterfaceWatcher")}
+
+type InterfaceWatcher struct {
+	InterfaceName string
+	Done          chan struct{}
+}
+
+// NewInterfaceWatcher creates a new InterfaceWatcher for the given interface.
+func NewInterfaceWatcher(interfaceName string) (*InterfaceWatcher, error) {
+	return &InterfaceWatcher{
+		InterfaceName: interfaceName,
+		Done:          make(chan struct{}),
+	}, nil
+}
+
+// Monitor periodically checks the rp_filter setting for the interface.
+func (iw *InterfaceWatcher) Monitor() {
+	go func() {
+		for {
+			select {
+			case <-iw.Done:
+				// Done signal received
+				return
+			default:
+				// Check and update the rp_filter setting
+				if err := iw.checkAndUpdateRpFilter(); err != nil {
+					logger.Errorf(err, "error checking/updating rp_filter setting for %q\n", iw.InterfaceName)
+				}
+
+				// Sleep for a specific interval before the next check
+				time.Sleep(5 * time.Second)
+			}
+		}
+	}()
+}
+
+func (iw *InterfaceWatcher) checkAndUpdateRpFilter() error {
+	// Get the current rp_filter setting for the interface
+	currentRpFilter, err := iw.getCurrentRpFilterSetting()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Current rp_filter setting for %s: %d\n", iw.InterfaceName, currentRpFilter)
+
+	// If the current setting is not 2, update it to 2
+	if currentRpFilter != 2 {
+		if err := iw.setRpFilterSetting(2); err != nil {
+			return err
+		}
+
+		logger.Infof("The rp_filter setting for %s updated to 2\n", iw.InterfaceName)
+	}
+
+	return nil
+}
+
+func (iw *InterfaceWatcher) getCurrentRpFilterSetting() (int, error) {
+	// Read the content of the rp_filter file directly
+	netPath := fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", iw.InterfaceName)
+
+	content, err := ReadFile(netPath)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to read rp_filter setting for %q", iw.InterfaceName)
+	}
+
+	// Parse the rp_filter value
+	var rpFilterValue int
+
+	_, err = fmt.Sscanf(string(content), "%d", &rpFilterValue)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to parse rp_filter setting for %q", iw.InterfaceName)
+	}
+
+	return rpFilterValue, nil
+}
+
+func (iw *InterfaceWatcher) setRpFilterSetting(value int) error {
+	// Write the value to the rp_filter file directly
+	netPath := fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", iw.InterfaceName)
+
+	err := WriteFile(netPath, fmt.Sprintf("%d", value))
+	if err != nil {
+		return errors.Wrapf(err, "failed to set rp_filter setting for %s", iw.InterfaceName)
+	}
+
+	return nil
+}
+
+func ReadFile(filename string) ([]byte, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read file %s", filename)
+	}
+
+	return content, nil
+}
+
+func WriteFile(filename, content string) error {
+	err := os.WriteFile(filename, []byte(content), 0o600)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write to file %s", filename)
+	}
+
+	return nil
+}


### PR DESCRIPTION
In some of the baremetal setup, the rp_filter was getting reset to strick to loose for vx_submariner interface. This PR monitors the value periodically and resets the value.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
