### PR TITLE
Fix ovn-failover

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
@@ -22,7 +22,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -68,11 +67,15 @@ func (h *GatewayRouteHandler) GetNetworkPlugins() []string {
 
 func (h *GatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.Endpoint) error {
 	if h.State().IsOnGateway() {
-		_, err := h.smClient.SubmarinerV1().GatewayRoutes(endpoint.Namespace).Create(context.TODO(),
-			h.newGatewayRoute(endpoint), metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		gwr := h.newGatewayRoute(endpoint)
+
+		result, err := util.CreateOrUpdate(context.TODO(), GatewayResourceInterface(h.smClient, endpoint.Namespace),
+			gwr, util.Replace(gwr))
+		if err != nil {
 			return errors.Wrapf(err, "error processing the remote endpoint creation for %q", endpoint.Name)
 		}
+
+		logger.Infof("GatewayRoute %s from remote endpoint %s: %s", result, endpoint.Name, resource.ToJSON(gwr))
 	}
 
 	return nil
@@ -81,9 +84,11 @@ func (h *GatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.Endpo
 func (h *GatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
 	if h.State().IsOnGateway() {
 		if err := h.smClient.SubmarinerV1().GatewayRoutes(endpoint.Namespace).Delete(context.TODO(),
-			endpoint.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			endpoint.Spec.ClusterID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error deleting gatewayRoute %q", endpoint.Name)
 		}
+
+		logger.Infof("GatewayRoute %s deleted for remote endpoint %s", endpoint.Spec.ClusterID, endpoint.Name)
 	}
 
 	return nil
@@ -92,6 +97,14 @@ func (h *GatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpo
 func (h *GatewayRouteHandler) TransitionToGateway() error {
 	endpoints := h.State().GetRemoteEndpoints()
 	for i := range endpoints {
+		// This piece of code is designed to manage upgrades from a version lower than 0.16.3 to a higher version,
+		// where we utilize the endpoint name as the identifier for gwr. It can be removed once we stop supporting
+		// the 0.16 version.
+		if err := h.smClient.SubmarinerV1().GatewayRoutes(endpoints[i].Namespace).Delete(context.TODO(),
+			endpoints[i].Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error deleting gatewayRoute %q", endpoints[i].Name)
+		}
+
 		gwr := h.newGatewayRoute(&endpoints[i])
 
 		result, err := util.CreateOrUpdate(context.TODO(), GatewayResourceInterface(h.smClient, endpoints[i].Namespace),
@@ -100,7 +113,7 @@ func (h *GatewayRouteHandler) TransitionToGateway() error {
 			return errors.Wrapf(err, "error creating/updating GatewayRoute")
 		}
 
-		logger.V(log.TRACE).Infof("GatewayRoute %s: %#v", result, gwr)
+		logger.Infof("GatewayRoute %s from remote endpoint %s: %s", result, endpoints[i].Name, resource.ToJSON(gwr))
 	}
 
 	return nil
@@ -109,7 +122,7 @@ func (h *GatewayRouteHandler) TransitionToGateway() error {
 func (h *GatewayRouteHandler) newGatewayRoute(endpoint *submarinerv1.Endpoint) *submarinerv1.GatewayRoute {
 	return &submarinerv1.GatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: endpoint.Name,
+			Name: endpoint.Spec.ClusterID,
 		},
 		RoutePolicySpec: submarinerv1.RoutePolicySpec{
 			RemoteCIDRs: endpoint.Spec.Subnets,

--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("GatewayRouteHandler", func() {
 	})
 
 	awaitGatewayRoute := func(ep *submarinerv1.Endpoint) {
-		gwRoute := test.AwaitResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), ep.Name)
+		gwRoute := test.AwaitResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), ep.Spec.ClusterID)
 		Expect(gwRoute.RoutePolicySpec.RemoteCIDRs).To(Equal(ep.Spec.Subnets))
 		Expect(gwRoute.RoutePolicySpec.NextHops).To(Equal([]string{t.mgmntIntfIP}))
 	}
@@ -53,7 +53,7 @@ var _ = Describe("GatewayRouteHandler", func() {
 			awaitGatewayRoute(endpoint)
 
 			t.DeleteEndpoint(endpoint.Name)
-			test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 		})
 
 		Context("and the GatewayRoute operations initially fail", func() {
@@ -69,7 +69,7 @@ var _ = Describe("GatewayRouteHandler", func() {
 				awaitGatewayRoute(endpoint)
 
 				t.DeleteEndpoint(endpoint.Name)
-				test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+				test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 			})
 		})
 	})
@@ -77,7 +77,7 @@ var _ = Describe("GatewayRouteHandler", func() {
 	Context("on transition to gateway", func() {
 		It("should create GatewayRoutes for all remote Endpoints", func() {
 			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", "192.0.4.0/24"))
-			test.EnsureNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			test.EnsureNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 
 			localEndpoint := t.CreateLocalHostEndpoint()
 			awaitGatewayRoute(endpoint)

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
@@ -22,7 +22,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -85,12 +84,15 @@ func (h *NonGatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.En
 		return nil
 	}
 
-	_, err := h.smClient.SubmarinerV1().
-		NonGatewayRoutes(endpoint.Namespace).Create(context.TODO(),
-		h.newNonGatewayRoute(endpoint), metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	ngwr := h.newNonGatewayRoute(endpoint)
+
+	result, err := util.CreateOrUpdate(context.TODO(), NonGatewayResourceInterface(h.smClient, endpoint.Namespace),
+		ngwr, util.Replace(ngwr))
+	if err != nil {
 		return errors.Wrapf(err, "error processing the remote endpoint create event for %q", endpoint.Name)
 	}
+
+	logger.Infof("NonGatewayRoute %s from remote endpoint %s: %s", result, endpoint.Name, resource.ToJSON(ngwr))
 
 	return nil
 }
@@ -101,9 +103,11 @@ func (h *NonGatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.En
 	}
 
 	if err := h.smClient.SubmarinerV1().NonGatewayRoutes(endpoint.Namespace).Delete(context.TODO(),
-		endpoint.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		endpoint.Spec.ClusterID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "error deleting nonGatewayRoute %q", endpoint.Name)
 	}
+
+	logger.Infof("NonGatewayRoute %s deleted for remote endpoint %s", endpoint.Spec.ClusterID, endpoint.Name)
 
 	return nil
 }
@@ -115,6 +119,14 @@ func (h *NonGatewayRouteHandler) TransitionToGateway() error {
 
 	endpoints := h.State().GetRemoteEndpoints()
 	for i := range endpoints {
+		// This piece of code is designed to manage upgrades from a version lower than 0.16.3 to a higher version,
+		// where we utilize the endpoint name as the identifier for ngwr. It can be removed once we stop supporting
+		// the 0.16 version.
+		if err := h.smClient.SubmarinerV1().NonGatewayRoutes(endpoints[i].Namespace).Delete(context.TODO(),
+			endpoints[i].Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error deleting nonGatewayRoute %q", endpoints[i].Name)
+		}
+
 		ngwr := h.newNonGatewayRoute(&endpoints[i])
 
 		result, err := util.CreateOrUpdate(context.TODO(), NonGatewayResourceInterface(h.smClient, endpoints[i].Namespace),
@@ -123,7 +135,7 @@ func (h *NonGatewayRouteHandler) TransitionToGateway() error {
 			return errors.Wrapf(err, "error creating/updating NonGatewayRoute")
 		}
 
-		logger.V(log.TRACE).Infof("NonGatewayRoute %s: %#v", result, ngwr)
+		logger.Infof("NonGatewayRoute %s from remote endpoint %s: %s", result, endpoints[i].Name, resource.ToJSON(ngwr))
 	}
 
 	return nil
@@ -132,7 +144,7 @@ func (h *NonGatewayRouteHandler) TransitionToGateway() error {
 func (h *NonGatewayRouteHandler) newNonGatewayRoute(endpoint *submarinerv1.Endpoint) *submarinerv1.NonGatewayRoute {
 	return &submarinerv1.NonGatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      endpoint.Name,
+			Name:      endpoint.Spec.ClusterID,
 			Namespace: endpoint.Namespace,
 		},
 		RoutePolicySpec: submarinerv1.RoutePolicySpec{

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 	})
 
 	awaitNonGatewayRoute := func(ep *submarinerv1.Endpoint) {
-		nonGWRoute := test.AwaitResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), ep.Name)
+		nonGWRoute := test.AwaitResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), ep.Spec.ClusterID)
 		Expect(nonGWRoute.RoutePolicySpec.RemoteCIDRs).To(Equal(ep.Spec.Subnets))
 		Expect(nonGWRoute.RoutePolicySpec.NextHops).To(Equal([]string{t.transitSwitchIP}))
 	}
@@ -53,7 +53,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 			awaitNonGatewayRoute(endpoint)
 
 			t.DeleteEndpoint(endpoint.Name)
-			test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 		})
 
 		Context("and the NonGatewayRoute operations initially fail", func() {
@@ -69,7 +69,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 				awaitNonGatewayRoute(endpoint)
 
 				t.DeleteEndpoint(endpoint.Name)
-				test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+				test.AwaitNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 			})
 		})
 
@@ -80,7 +80,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 
 			It("should not create a NonGatewayRoute", func() {
 				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
-				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 
 				t.submClient.Fake.ClearActions()
 				t.DeleteEndpoint(endpoint.Name)
@@ -92,7 +92,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 	Context("on transition to gateway", func() {
 		It("should create NonGatewayRoutes for all remote Endpoints", func() {
 			endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
-			test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+			test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 
 			localEndpoint := t.CreateLocalHostEndpoint()
 			awaitNonGatewayRoute(endpoint)
@@ -112,7 +112,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 			It("should not create any NonGatewayRoutes", func() {
 				endpoint := t.CreateEndpoint(testing.NewEndpoint("remote-cluster", "host", "193.0.4.0/24"))
 				t.CreateLocalHostEndpoint()
-				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Name)
+				test.EnsureNoResource(ovn.NonGatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
 			})
 		})
 	})


### PR DESCRIPTION
In OVN-Kubernetes out of order event leads to stale gatewayroutes and
nongatewayroutes. This leads to incorrect flow in datatpath. Now gatewayroutes
and nongatewayroutes use cluster ID instead of endpoint name. This ensures that
there is only one resource and it gets updated when remote endpoint is created
and updated and preventing stale endpoints. The gatewayroutes only care about
remoteCIDRs do not matter if the remote gateway switches.
