### PR TITLE
Update Gateway on local Endpoint public IP update

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // +genclient
@@ -391,4 +392,16 @@ type RoutePolicySpec struct {
 
 	// Specifies the remote CIDRs available via the next hop
 	RemoteCIDRs []string `json:"remoteCIDRs"`
+}
+
+var EndpointGVR = schema.GroupVersionResource{
+	Group:    SchemeGroupVersion.Group,
+	Version:  SchemeGroupVersion.Version,
+	Resource: "endpoints",
+}
+
+var ClusterGVR = schema.GroupVersionResource{
+	Group:    SchemeGroupVersion.Group,
+	Version:  SchemeGroupVersion.Version,
+	Resource: "clusters",
 }

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -32,9 +32,12 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cable/fake"
 	"github.com/submariner-io/submariner/pkg/cableengine"
+	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
@@ -97,7 +100,7 @@ var _ = Describe("Cable Engine", func() {
 			Spec: subv1.ClusterSpec{
 				ClusterID: localClusterID,
 			},
-		}, &types.SubmarinerEndpoint{Spec: localEndpoint.Spec})
+		}, submendpoint.NewLocal(&localEndpoint.Spec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), ""))
 
 		natDiscovery = &fakeNATDiscovery{removeEndpoint: make(chan string, 20), readyChannel: make(chan *natdiscovery.NATEndpointInfo, 100)}
 		engine.SetupNATDiscovery(natDiscovery)

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -49,8 +49,8 @@ func testEndpointSyncing() {
 
 	Context("on startup", func() {
 		It("should create a new Endpoint locally and sync to the broker", func() {
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
-			awaitEndpoint(t.brokerEndpoints, &t.localEndpoint.Spec)
+			awaitEndpoint(t.localEndpoints, t.localEndpoint)
+			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
 		})
 
 		When("creation of the local Endpoint fails", func() {
@@ -84,7 +84,7 @@ func testEndpointSyncing() {
 
 	When("a remote Endpoint is created, updated and deleted on the broker", func() {
 		It("should correctly sync the local datastore", func() {
-			awaitEndpoint(t.brokerEndpoints, &t.localEndpoint.Spec)
+			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
 
 			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
 				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
@@ -109,7 +109,7 @@ func testEndpointSyncing() {
 
 	When("a remote Endpoint is synced locally", func() {
 		It("should not try to re-sync to the broker", func() {
-			awaitEndpoint(t.brokerEndpoints, &t.localEndpoint.Spec)
+			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
 
 			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
 				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
@@ -137,27 +137,27 @@ func testEndpointSyncing() {
 		})
 
 		JustBeforeEach(func() {
-			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+			t.localEndpoint.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
+			awaitEndpoint(t.localEndpoints, t.localEndpoint)
 		})
 
 		It("should update the local Endpoint's HealthCheckIP", func() {
 			node.Annotations[constants.SmGlobalIP] = "200.0.0.100"
-			t.localEndpoint.Spec.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
+			t.localEndpoint.HealthCheckIP = node.Annotations[constants.SmGlobalIP]
 
 			test.UpdateResource(t.localNodes, node)
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+			awaitEndpoint(t.localEndpoints, t.localEndpoint)
 		})
 
 		Context("but the local Endpoint no longer exists", func() {
 			It("should not recreate the local Endpoint", func() {
-				Expect(t.localEndpoints.Delete(context.Background(), getEndpointName(&t.localEndpoint.Spec), metav1.DeleteOptions{})).
+				Expect(t.localEndpoints.Delete(context.Background(), getEndpointName(t.localEndpoint), metav1.DeleteOptions{})).
 					To(Succeed())
 
 				node.Annotations[constants.SmGlobalIP] = "200.0.0.100"
 				test.UpdateResource(t.localNodes, node)
 
-				testutil.EnsureNoResource(resource.ForDynamic(t.localEndpoints), getEndpointName(&t.localEndpoint.Spec))
+				testutil.EnsureNoResource(resource.ForDynamic(t.localEndpoints), getEndpointName(t.localEndpoint))
 			})
 		})
 	})
@@ -180,7 +180,6 @@ func testEndpointExclusivity() {
 		})
 
 		It("should delete the Endpoint from the local datastore and the broker", func() {
-			time.Sleep(500 * time.Millisecond)
 			test.AwaitNoResource(t.localEndpoints, existingEndpoint.GetName())
 			test.AwaitNoResource(t.brokerEndpoints, existingEndpoint.GetName())
 		})
@@ -202,35 +201,42 @@ func testEndpointExclusivity() {
 			})
 
 			It("should ignore it", func() {
-				awaitEndpoint(t.brokerEndpoints, &t.localEndpoint.Spec)
+				awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
 			})
 		})
 	})
 
 	When("an Endpoint initially exists that matches the local Endpoint", func() {
 		BeforeEach(func() {
-			test.CreateResource(t.localEndpoints, newEndpoint(&t.localEndpoint.Spec))
+			test.CreateResource(t.localEndpoints, newEndpoint(t.localEndpoint))
 		})
 
 		It("should not delete it", func() {
 			time.Sleep(500 * time.Millisecond)
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+			awaitEndpoint(t.localEndpoints, t.localEndpoint)
+			testutil.EnsureNoActionsForResource(&t.localClient.Fake, submarinerv1.EndpointGVR.Resource, "delete")
 		})
 	})
 
 	When("an Endpoint from another cluster initially exists", func() {
+		var remoteEndpointName string
+
 		BeforeEach(func() {
 			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
 				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
 				ClusterID: otherClusterID,
 			})
 
-			test.CreateResource(t.localEndpoints, test.SetClusterIDLabel(endpoint, endpoint.Spec.ClusterID))
+			remoteEndpointName = endpoint.Name
+
+			endpoint = test.SetClusterIDLabel(endpoint, endpoint.Spec.ClusterID)
+			test.CreateResource(t.localEndpoints, endpoint)
+			test.CreateResource(t.brokerEndpoints, endpoint)
 		})
 
 		It("should not delete it", func() {
 			time.Sleep(500 * time.Millisecond)
-			awaitEndpoint(t.localEndpoints, &t.localEndpoint.Spec)
+			test.AwaitResource(t.localEndpoints, remoteEndpointName)
 		})
 	})
 }

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -28,10 +28,10 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	resourceSyncer "github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
-	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/types"
 	k8sv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,24 +45,23 @@ import (
 )
 
 type DatastoreSyncer struct {
-	localCluster    types.SubmarinerCluster
-	localEndpoint   types.SubmarinerEndpoint
-	localNodeName   string
-	syncerConfig    broker.SyncerConfig
-	updateFederator federate.Federator
+	localCluster  types.SubmarinerCluster
+	localEndpoint *endpoint.Local
+	localNodeName string
+	syncerConfig  broker.SyncerConfig
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("DSSyncer")}
 
 func New(syncerConfig *broker.SyncerConfig, localCluster *types.SubmarinerCluster,
-	localEndpoint *types.SubmarinerEndpoint,
+	localEndpoint *endpoint.Local,
 ) *DatastoreSyncer {
 	// We'll panic if syncerConfig, localCluster or localEndpoint are nil, this is intentional
 	syncerConfig.LocalClusterID = localCluster.Spec.ClusterID
 
 	return &DatastoreSyncer{
 		localCluster:  *localCluster,
-		localEndpoint: *localEndpoint,
+		localEndpoint: localEndpoint,
 		syncerConfig:  *syncerConfig,
 	}
 }
@@ -71,9 +70,6 @@ func (d *DatastoreSyncer) Start(ctx context.Context) error {
 	defer utilruntime.HandleCrash()
 
 	logger.Info("Starting the datastore syncer")
-
-	d.updateFederator = federate.NewUpdateFederator(d.syncerConfig.LocalClient, d.syncerConfig.RestMapper, d.syncerConfig.LocalNamespace,
-		util.CopyImmutableMetadata)
 
 	syncer, err := d.createSyncer()
 	if err != nil {
@@ -192,17 +188,17 @@ func (d *DatastoreSyncer) createSyncer() (*broker.Syncer, error) {
 func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, _ int,
 	_ resourceSyncer.Operation,
 ) (runtime.Object, bool) {
-	endpoint := obj.(*submarinerv1.Endpoint)
+	remoteEndpoint := obj.(*submarinerv1.Endpoint)
 
-	for _, localSubnet := range d.localEndpoint.Spec.Subnets {
-		overlap, err := cidr.IsOverlapping(endpoint.Spec.Subnets, localSubnet)
+	for _, localSubnet := range d.localEndpoint.Spec().Subnets {
+		overlap, err := cidr.IsOverlapping(remoteEndpoint.Spec.Subnets, localSubnet)
 		if err != nil {
 			logger.Errorf(err, "Unable to validate if remote CIDR overlaps with local CIDR")
 			return nil, false
 		}
 
 		if overlap {
-			logger.Errorf(nil, "Skip processing the remote endpoint %#v as subnets are overlapping", endpoint)
+			logger.Errorf(nil, "Skip processing the remote endpoint %#v as subnets are overlapping", remoteEndpoint)
 			return nil, false
 		}
 	}
@@ -215,27 +211,21 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint(ctx context.Context, syncer *b
 
 	endpoints := syncer.ListLocalResources(&submarinerv1.Endpoint{})
 	for i := range endpoints {
-		endpoint := endpoints[i].(*submarinerv1.Endpoint)
-		if endpoint.Spec.ClusterID != d.localCluster.Spec.ClusterID {
+		existing := endpoints[i].(*submarinerv1.Endpoint)
+		if existing.Spec.ClusterID != d.localCluster.Spec.ClusterID {
 			continue
 		}
 
-		if endpoint.Spec.Equals(&d.localEndpoint.Spec) {
+		if existing.Spec.Equals(d.localEndpoint.Spec()) {
 			continue
 		}
 
-		endpointName, err := endpoint.Spec.GenerateName()
-		if err != nil {
-			logger.Errorf(err, "Error extracting the submariner Endpoint name from %#v", endpoint)
-			continue
-		}
-
-		err = syncer.GetLocalFederator().Delete(ctx, endpoint)
+		err := syncer.GetLocalFederator().Delete(ctx, existing)
 		if err != nil && !apierrors.IsNotFound(err) {
-			return errors.Wrapf(err, "error deleting submariner Endpoint %q from the local datastore", endpointName)
+			return errors.Wrapf(err, "error deleting submariner Endpoint %q from the local datastore", existing.Name)
 		}
 
-		logger.Infof("Successfully deleted existing submariner Endpoint %q", endpointName)
+		logger.Infof("Successfully deleted existing submariner Endpoint %q", existing.Name)
 	}
 
 	return nil
@@ -286,7 +276,7 @@ func (d *DatastoreSyncer) createNodeWatcher(stopCh <-chan struct{}) error {
 }
 
 func (d *DatastoreSyncer) createLocalCluster(ctx context.Context, federator federate.Federator) error {
-	logger.Infof("Creating local submariner Cluster: %#v ", d.localCluster)
+	logger.Infof("Creating local submariner Cluster: %s", resource.ToJSON(d.localCluster))
 
 	cluster := &submarinerv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -299,19 +289,9 @@ func (d *DatastoreSyncer) createLocalCluster(ctx context.Context, federator fede
 }
 
 func (d *DatastoreSyncer) createOrUpdateLocalEndpoint(ctx context.Context, federator federate.Federator) error {
-	logger.Infof("Creating local submariner Endpoint: %#v ", d.localEndpoint)
+	localEndpoint := d.localEndpoint.Resource()
 
-	endpointName, err := d.localEndpoint.Spec.GenerateName()
-	if err != nil {
-		return errors.Wrapf(err, "error extracting the submariner Endpoint name from %#v", d.localEndpoint)
-	}
+	logger.Infof("Creating local submariner Endpoint: %s", resource.ToJSON(localEndpoint))
 
-	endpoint := &submarinerv1.Endpoint{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: endpointName,
-		},
-		Spec: d.localEndpoint.Spec,
-	}
-
-	return federator.Distribute(ctx, endpoint) //nolint:wrapcheck  // Let the caller wrap it
+	return federator.Distribute(ctx, localEndpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -38,7 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -123,20 +122,12 @@ func (d *DatastoreSyncer) Cleanup(ctx context.Context) error {
 		}
 	}
 
-	err = d.cleanupResources(ctx, localClient.Resource(schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "endpoints",
-	}), syncer)
+	err = d.cleanupResources(ctx, localClient.Resource(submarinerv1.EndpointGVR), syncer)
 	if err != nil {
 		return err
 	}
 
-	err = d.cleanupResources(ctx, localClient.Resource(schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "clusters",
-	}), syncer)
+	err = d.cleanupResources(ctx, localClient.Resource(submarinerv1.ClusterGVR), syncer)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -76,7 +77,7 @@ var _ = BeforeSuite(func() {
 type testDriver struct {
 	syncer           *datastoresyncer.DatastoreSyncer
 	localCluster     *types.SubmarinerCluster
-	localEndpoint    *types.SubmarinerEndpoint
+	localEndpoint    *submarinerv1.EndpointSpec
 	localClient      *dynamicfake.FakeDynamicClient
 	brokerClient     *dynamicfake.FakeDynamicClient
 	localClusters    dynamic.ResourceInterface
@@ -103,15 +104,13 @@ func newTestDriver() *testDriver {
 				GlobalCIDR:  []string{"200.0.0.0/16"},
 			},
 		},
-		localEndpoint: &types.SubmarinerEndpoint{
-			Spec: submarinerv1.EndpointSpec{
-				CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
-				ClusterID: clusterID,
-				Hostname:  "redsox",
-				PrivateIP: "192.68.1.2",
-				Subnets:   []string{"100.0.0.0/16", "10.0.0.0/14"},
-				Backend:   "ipsec",
-			},
+		localEndpoint: &submarinerv1.EndpointSpec{
+			CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
+			ClusterID: clusterID,
+			Hostname:  "redsox",
+			PrivateIP: "192.68.1.2",
+			Subnets:   []string{"100.0.0.0/16", "10.0.0.0/14"},
+			Backend:   "ipsec",
 		},
 	}
 
@@ -164,7 +163,7 @@ func (t *testDriver) run() {
 		BrokerNamespace: brokerNamespace,
 		RestMapper:      t.restMapper,
 		Scheme:          t.syncerScheme,
-	}, t.localCluster, t.localEndpoint)
+	}, t.localCluster, endpoint.NewLocal(t.localEndpoint, t.localClient, localNamespace))
 
 	if t.doStart {
 		var ctx context.Context

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable/fake"
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
+	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,13 +105,13 @@ var _ = Describe("Managing tunnels", func() {
 	})
 
 	JustBeforeEach(func() {
-		engine := cableengine.NewEngine(&types.SubmarinerCluster{}, &types.SubmarinerEndpoint{
-			Spec: v1.EndpointSpec{
-				Backend: fake.DriverName,
-			},
-		})
+		localEp := submendpoint.NewLocal(&v1.EndpointSpec{
+			Backend: fake.DriverName,
+		}, fakeClient.NewSimpleDynamicClient(kubeScheme.Scheme), "")
 
-		nat, err := natdiscovery.New(&types.SubmarinerEndpoint{})
+		engine := cableengine.NewEngine(&types.SubmarinerCluster{}, localEp)
+
+		nat, err := natdiscovery.New(localEp)
 		Expect(err).To(Succeed())
 
 		engine.SetupNATDiscovery(nat)

--- a/pkg/endpoint/local_endpoint_suite_test.go
+++ b/pkg/endpoint/local_endpoint_suite_test.go
@@ -24,10 +24,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
 	kzerolog.AddFlags(nil)
+	utilruntime.Must(submarinerv1.AddToScheme(scheme.Scheme))
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -33,7 +33,7 @@ import (
 
 const testNodeName = "this-node"
 
-var _ = Describe("GetLocal", func() {
+var _ = Describe("GetLocalSpec", func() {
 	var submSpec *types.SubmarinerSpecification
 	var client kubernetes.Interface
 	testPrivateIP := endpoint.GetLocalIP()
@@ -74,18 +74,18 @@ var _ = Describe("GetLocal", func() {
 		os.Setenv("NODE_NAME", testNodeName)
 	})
 
-	It("should return a valid SubmarinerEndpoint object", func() {
-		endpoint, err := endpoint.GetLocal(submSpec, client, false)
+	It("should return a valid EndpointSpec object", func() {
+		spec, err := endpoint.GetLocalSpec(submSpec, client, false)
 
 		Expect(err).ToNot(HaveOccurred())
-		Expect(endpoint.Spec.ClusterID).To(Equal("east"))
-		Expect(endpoint.Spec.CableName).To(HavePrefix("submariner-cable-east-"))
-		Expect(endpoint.Spec.Hostname).NotTo(BeEmpty())
-		Expect(endpoint.Spec.PrivateIP).To(Equal(testPrivateIP))
-		Expect(endpoint.Spec.Backend).To(Equal("backend"))
-		Expect(endpoint.Spec.Subnets).To(Equal(subnets))
-		Expect(endpoint.Spec.NATEnabled).To(BeFalse())
-		Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
+		Expect(spec.ClusterID).To(Equal("east"))
+		Expect(spec.CableName).To(HavePrefix("submariner-cable-east-"))
+		Expect(spec.Hostname).NotTo(BeEmpty())
+		Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+		Expect(spec.Backend).To(Equal("backend"))
+		Expect(spec.Subnets).To(Equal(subnets))
+		Expect(spec.NATEnabled).To(BeFalse())
+		Expect(spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
 	})
 
 	When("gateway node is not annotated with udp port", func() {
@@ -94,37 +94,37 @@ var _ = Describe("GetLocal", func() {
 			client = fake.NewSimpleClientset(node)
 			os.Setenv("CE_IPSEC_NATTPORT", testClusterUDPPort)
 
-			endpoint, err := endpoint.GetLocal(submSpec, client, false)
+			spec, err := endpoint.GetLocalSpec(submSpec, client, false)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testClusterUDPPort))
+			Expect(spec.BackendConfig[testUDPPortLabel]).To(Equal(testClusterUDPPort))
 		})
 	})
 
 	When("gateway node is annotated with udp port", func() {
 		It("should return the udp-port backend from the annotation", func() {
 			os.Setenv("CE_IPSEC_NATTPORT", testClusterUDPPort)
-			endpoint, err := endpoint.GetLocal(submSpec, client, false)
+			spec, err := endpoint.GetLocalSpec(submSpec, client, false)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
+			Expect(spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
 		})
 	})
 
 	When("no NAT discovery port label is set on the node", func() {
-		It("should return a valid SubmarinerEndpoint object", func() {
+		It("should return a valid EndpointSpec object", func() {
 			delete(node.Labels, testNATTPortLabel)
-			_, err := endpoint.GetLocal(submSpec, client, false)
+			_, err := endpoint.GetLocalSpec(submSpec, client, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
 	When("gateway node is not annotated with public-ip", func() {
 		It("should use empty public-ip in the endpoint object for air-gapped deployments", func() {
-			endpoint, err := endpoint.GetLocal(submSpec, client, true)
+			spec, err := endpoint.GetLocalSpec(submSpec, client, true)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Spec.ClusterID).To(Equal("east"))
-			Expect(endpoint.Spec.PrivateIP).To(Equal(testPrivateIP))
-			Expect(endpoint.Spec.PublicIP).To(Equal(""))
+			Expect(spec.ClusterID).To(Equal("east"))
+			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+			Expect(spec.PublicIP).To(Equal(""))
 		})
 	})
 
@@ -132,11 +132,11 @@ var _ = Describe("GetLocal", func() {
 		It("should use the annotated public-ip for air-gapped deployments", func() {
 			node.Labels[backendConfigPrefix+testPublicIPLabel] = testIPv4Label + testPublicIP
 			client = fake.NewSimpleClientset(node)
-			endpoint, err := endpoint.GetLocal(submSpec, client, true)
+			spec, err := endpoint.GetLocalSpec(submSpec, client, true)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Spec.PrivateIP).To(Equal(testPrivateIP))
-			Expect(endpoint.Spec.PublicIP).To(Equal(testPublicIP))
+			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+			Expect(spec.PublicIP).To(Equal(testPublicIP))
 		})
 	})
 })

--- a/pkg/endpoint/public_ip_internal_test.go
+++ b/pkg/endpoint/public_ip_internal_test.go
@@ -103,6 +103,8 @@ var _ = Describe("public ip resolvers", func() {
 	When("a LoadBalancer with no ingress is specified", func() {
 		It("should return error", func() {
 			loadBalancerRetryConfig.Cap = 1 * time.Second
+			loadBalancerRetryConfig.Duration = 50 * time.Millisecond
+			loadBalancerRetryConfig.Steps = 1
 			backendConfig[publicIPConfig] = lbPublicIP
 			client := fake.NewSimpleClientset(serviceWithIngress())
 			_, err := getPublicIP(submSpec, client, backendConfig, false)

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -143,7 +143,7 @@ func New(config *Config) (Interface, error) {
 	g.airGapped = os.Getenv("AIR_GAPPED_DEPLOYMENT") == "true"
 	logger.Infof("AIR_GAPPED_DEPLOYMENT is set to %t", g.airGapped)
 
-	g.localEndpoint, err = endpoint.GetLocal(&g.Spec, g.KubeClient, g.airGapped)
+	localEndpointSpec, err := endpoint.GetLocalSpec(&g.Spec, g.KubeClient, g.airGapped)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating local endpoint object")
 	}

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -80,8 +80,8 @@ type Config struct {
 	SubmarinerClient     submclientset.Interface
 	KubeClient           kubernetes.Interface
 	LeaderElectionClient kubernetes.Interface
-	NewCableEngine       func(localCluster *types.SubmarinerCluster, localEndpoint *types.SubmarinerEndpoint) cableengine.Engine
-	NewNATDiscovery      func(localEndpoint *types.SubmarinerEndpoint) (natdiscovery.Interface, error)
+	NewCableEngine       func(localCluster *types.SubmarinerCluster, localEndpoint *endpoint.Local) cableengine.Engine
+	NewNATDiscovery      func(localEndpoint *endpoint.Local) (natdiscovery.Interface, error)
 }
 
 type gatewayType struct {
@@ -95,7 +95,7 @@ type gatewayType struct {
 	natDiscovery            natdiscovery.Interface
 	gatewayPod              *pod.GatewayPod
 	hostName                string
-	localEndpoint           *types.SubmarinerEndpoint
+	localEndpoint           *endpoint.Local
 	fatalError              chan error
 	leaderComponentsStarted *sync.WaitGroup
 	recorder                record.EventRecorder
@@ -147,6 +147,8 @@ func New(config *Config) (Interface, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating local endpoint object")
 	}
+
+	g.localEndpoint = endpoint.NewLocal(localEndpointSpec, g.SyncerConfig.LocalClient, g.Spec.Namespace)
 
 	g.cableEngine = g.NewCableEngine(localCluster, g.localEndpoint)
 
@@ -351,8 +353,7 @@ func (g *gatewayType) initPublicIPWatcher() {
 	publicIPConfig := &endpoint.PublicIPWatcherConfig{
 		SubmSpec:      &g.Spec,
 		K8sClient:     g.KubeClient,
-		Endpoints:     g.SubmarinerClient.SubmarinerV1().Endpoints(g.Spec.Namespace),
-		LocalEndpoint: *g.localEndpoint,
+		LocalEndpoint: g.localEndpoint,
 	}
 
 	g.publicIPWatcher = endpoint.NewPublicIPWatcher(publicIPConfig)

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	enginefake "github.com/submariner-io/submariner/pkg/cableengine/fake"
 	submfake "github.com/submariner-io/submariner/pkg/client/clientset/versioned/fake"
+	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/gateway"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
@@ -263,11 +264,11 @@ func newTestDriver() *testDriver {
 			SubmarinerClient:     submfake.NewSimpleClientset(),
 			KubeClient:           t.kubeClient,
 			LeaderElectionClient: t.kubeClient,
-			NewCableEngine: func(_ *types.SubmarinerCluster, ep *types.SubmarinerEndpoint) cableengine.Engine {
-				t.cableEngine.LocalEndPoint = ep
+			NewCableEngine: func(_ *types.SubmarinerCluster, lep *submendpoint.Local) cableengine.Engine {
+				t.cableEngine.LocalEndPoint = &types.SubmarinerEndpoint{Spec: *lep.Spec()}
 				return t.cableEngine
 			},
-			NewNATDiscovery: func(_ *types.SubmarinerEndpoint) (natdiscovery.Interface, error) {
+			NewNATDiscovery: func(_ *submendpoint.Local) (natdiscovery.Interface, error) {
 				return &fakeNATDiscovery{}, nil
 			},
 		}

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -30,7 +30,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/endpoint"
-	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -49,7 +48,7 @@ type (
 
 type natDiscovery struct {
 	sync.Mutex
-	localEndpoint   *types.SubmarinerEndpoint
+	localEndpoint   *endpoint.Local
 	remoteEndpoints map[string]*remoteEndpointNAT
 	requestCounter  uint64
 	serverUDPWrite  udpWriteFunction
@@ -60,17 +59,17 @@ type natDiscovery struct {
 
 var logger = log.Logger{Logger: logf.Log.WithName("NAT")}
 
-func New(localEndpoint *types.SubmarinerEndpoint) (Interface, error) {
+func New(localEndpoint *endpoint.Local) (Interface, error) {
 	return newNATDiscovery(localEndpoint)
 }
 
-func newNATDiscovery(localEndpoint *types.SubmarinerEndpoint) (*natDiscovery, error) {
+func newNATDiscovery(localEndpoint *endpoint.Local) (*natDiscovery, error) {
 	requestCounter, err := randomRequestCounter()
 	if err != nil {
 		return nil, err
 	}
 
-	ndPort, err := localEndpoint.Spec.GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
+	ndPort, err := localEndpoint.Spec().GetBackendPort(v1.NATTDiscoveryPortConfig, 0)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing nat discovery port")
 	}

--- a/pkg/natdiscovery/natdiscovery_internal_test.go
+++ b/pkg/natdiscovery/natdiscovery_internal_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package natdiscovery
 
 import (
+	"context"
 	"net"
 	"sync/atomic"
 	"time"
@@ -182,7 +183,9 @@ var _ = When("a remote Endpoint is added", func() {
 		Context("with the Endpoint's private IP changed", func() {
 			BeforeEach(func() {
 				newRemoteEndpoint.Spec.PrivateIP = testRemotePrivateIP2
-				t.remoteND.localEndpoint.Spec.PrivateIP = testRemotePrivateIP2
+				Expect(t.remoteND.localEndpoint.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
+					existing.PrivateIP = testRemotePrivateIP2
+				})).To(Succeed())
 			})
 
 			It("should notify with new NATEndpointInfo settings", func() {
@@ -217,7 +220,9 @@ var _ = When("a remote Endpoint is added", func() {
 		Context("with the Endpoint's private IP changed", func() {
 			BeforeEach(func() {
 				newRemoteEndpoint.Spec.PrivateIP = testRemotePrivateIP2
-				t.remoteND.localEndpoint.Spec.PrivateIP = testRemotePrivateIP2
+				Expect(t.remoteND.localEndpoint.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
+					existing.PrivateIP = testRemotePrivateIP2
+				})).To(Succeed())
 			})
 
 			JustBeforeEach(func() {

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -24,10 +24,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submarineriov1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
 	kzerolog.AddFlags(nil)
+	utilruntime.Must(submarineriov1.AddToScheme(scheme.Scheme))
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -73,11 +73,13 @@ func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT,
 
 	nd.requestCounter++
 
+	localEndpointSpec := nd.localEndpoint.Spec()
+
 	request := &natproto.SubmarinerNATDiscoveryRequest{
 		RequestNumber: nd.requestCounter,
 		Sender: &natproto.EndpointDetails{
-			EndpointId: nd.localEndpoint.Spec.CableName,
-			ClusterId:  nd.localEndpoint.Spec.ClusterID,
+			EndpointId: localEndpointSpec.CableName,
+			ClusterId:  localEndpointSpec.ClusterID,
 		},
 		Receiver: &natproto.EndpointDetails{
 			EndpointId: remoteNAT.endpoint.Spec.CableName,


### PR DESCRIPTION
When it's detected that the public IP has changed, the local `Endpoint` resource is properly updated however the `Gateway` resource is not and retains the old IP. This is because the `Gateway` syncer is initialized with the local `SubmarinerEndpoint` instance on startup and assumes it never changes.

Introduce an `endpoint.Local` struct that encapsulates the local `EndpointSpec` and allows updating. Share this instance with the various components rather than passing the static `SubmarinerEndpoint`.

See the individual commits for details.

Fixes #1871