### PR TITLE
Automated backport of #2865: Fix race condition in ovn-kubernetes CNI

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -83,11 +82,15 @@ func (h *GatewayRouteHandler) RemoteEndpointCreated(endpoint *submarinerv1.Endpo
 	h.remoteEndpoints[endpoint.Name] = endpoint
 
 	if h.isGateway {
-		_, err := h.smClient.SubmarinerV1().GatewayRoutes(endpoint.Namespace).Create(context.TODO(),
-			h.newGatewayRoute(endpoint), metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		gwr := h.newGatewayRoute(endpoint)
+
+		result, err := util.CreateOrUpdate(context.TODO(), h.gatewayResourceInterface(endpoint.Namespace),
+			gwr, util.Replace(gwr))
+		if err != nil {
 			return errors.Wrapf(err, "error processing the remote endpoint creation for %q", endpoint.Name)
 		}
+
+		logger.Infof("GatewayRoute %s from remote endpoint %s: %s", result, endpoint.Name, resource.ToJSON(gwr))
 	}
 
 	return nil
@@ -101,9 +104,11 @@ func (h *GatewayRouteHandler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpo
 
 	if h.isGateway {
 		if err := h.smClient.SubmarinerV1().GatewayRoutes(endpoint.Namespace).Delete(context.TODO(),
-			endpoint.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			endpoint.Spec.ClusterID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return errors.Wrapf(err, "error deleting gatewayRoute %q", endpoint.Name)
 		}
+
+		logger.Infof("GatewayRoute %s deleted for remote endpoint %s", endpoint.Spec.ClusterID, endpoint.Name)
 	}
 
 	return nil
@@ -125,6 +130,14 @@ func (h *GatewayRouteHandler) TransitionToGateway() error {
 	h.isGateway = true
 
 	for _, endpoint := range h.remoteEndpoints {
+		// This piece of code is designed to manage upgrades from a version lower than 0.16.3 to a higher version,
+		// where we utilize the endpoint name as the identifier for gwr. It can be removed once we stop supporting
+		// the 0.16 version.
+		if err := h.smClient.SubmarinerV1().GatewayRoutes(endpoint.Namespace).Delete(context.TODO(),
+			endpoint.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "error deleting gatewayRoute %q", endpoint.Name)
+		}
+
 		gwr := h.newGatewayRoute(endpoint)
 
 		result, err := util.CreateOrUpdate(context.TODO(), h.gatewayResourceInterface(endpoint.Namespace),
@@ -133,7 +146,7 @@ func (h *GatewayRouteHandler) TransitionToGateway() error {
 			return errors.Wrapf(err, "error creating/updating GatewayRoute")
 		}
 
-		logger.V(log.TRACE).Infof("GatewayRoute %s: %#v", result, gwr)
+		logger.Infof("GatewayRoute %s from remote endpoint %s: %s", result, endpoint.Name, resource.ToJSON(gwr))
 	}
 
 	return nil
@@ -142,7 +155,7 @@ func (h *GatewayRouteHandler) TransitionToGateway() error {
 func (h *GatewayRouteHandler) newGatewayRoute(endpoint *submarinerv1.Endpoint) *submarinerv1.GatewayRoute {
 	return &submarinerv1.GatewayRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: endpoint.Name,
+			Name: endpoint.Spec.ClusterID,
 		},
 		RoutePolicySpec: submarinerv1.RoutePolicySpec{
 			RemoteCIDRs: endpoint.Spec.Subnets,


### PR DESCRIPTION
Backport of #2865 on release-0.16.

#2865: Fix race condition in ovn-kubernetes CNI

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.