### PR TITLE
Automated backport of #2348: Bump the base image to Fedora 37

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=36
+ARG FEDORA_VERSION=37
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=36
+ARG FEDORA_VERSION=37
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-networkplugin-syncer
+++ b/package/Dockerfile.submariner-networkplugin-syncer
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=36
+ARG FEDORA_VERSION=37
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH
-ARG FEDORA_VERSION=36
+ARG FEDORA_VERSION=37
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder


### PR DESCRIPTION
Backport of #2348 on release-0.14.

#2348: Bump the base image to Fedora 37

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.