### PR TITLE
Workaround for ROKS datapath configuration

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
+++ b/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
@@ -25,8 +25,34 @@ import (
 	. "github.com/onsi/gomega"
 	calicoapi "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"github.com/submariner-io/submariner/pkg/event"
+	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
+
+type testDriver struct {
+	*eventtesting.ControllerSupport
+	handler   event.Handler
+	k8sClient *fakek8s.Clientset
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{
+		ControllerSupport: eventtesting.NewControllerSupport(),
+	}
+
+	BeforeEach(func() {
+		t.k8sClient = fakek8s.NewSimpleClientset()
+	})
+
+	return t
+}
+
+func (t *testDriver) Start(handler event.Handler) {
+	t.handler = handler
+	t.ControllerSupport.Start(handler)
+}
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -145,7 +145,7 @@ func main() {
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
 		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(k8sClientSet)),
-		calico.NewCalicoIPPoolHandler(cfg))
+		calico.NewCalicoIPPoolHandler(cfg, env.Namespace, k8sClientSet))
 
 	logger.FatalOnError(err, "Error registering the handlers")
 


### PR DESCRIPTION
Submariner datapath is broken with the default Calico configuration on ROKS.

This PR updates Calico configuration for ROKS platform to address this issue. When Submariner is uninstalled, the original Calico configuration is restored.

Depends on https://github.com/submariner-io/submariner-operator/pull/2958
Depends on https://github.com/submariner-io/subctl/pull/1062

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
