### PR TITLE
Automated backport of #2897: Workaround for ROKS datapath configuration

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
+++ b/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
@@ -25,8 +25,34 @@ import (
 	. "github.com/onsi/gomega"
 	calicoapi "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"github.com/submariner-io/submariner/pkg/event"
+	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 )
+
+type testDriver struct {
+	*eventtesting.ControllerSupport
+	handler   event.Handler
+	k8sClient *fakek8s.Clientset
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{
+		ControllerSupport: eventtesting.NewControllerSupport(),
+	}
+
+	BeforeEach(func() {
+		t.k8sClient = fakek8s.NewSimpleClientset()
+	})
+
+	return t
+}
+
+func (t *testDriver) Start(handler event.Handler) {
+	t.handler = handler
+	t.ControllerSupport.Start(handler)
+}
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -138,7 +138,7 @@ func main() {
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
 		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(k8sClientSet)),
-		calico.NewCalicoIPPoolHandler(cfg))
+		calico.NewCalicoIPPoolHandler(cfg, env.Namespace, k8sClientSet))
 
 	logger.FatalOnError(err, "Error registering the handlers")
 


### PR DESCRIPTION
Backport of #2897 on release-0.17.

#2897: Workaround for ROKS datapath configuration

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.