### PR TITLE
Adjust chain rule implementation in fake packetfilter

### DIFF
--- a/pkg/globalnet/controllers/cluster_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller_test.go
@@ -361,6 +361,7 @@ func newClusterGlobalEgressIPControllerTestDriver() *clusterGlobalEgressIPContro
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 
 		var err error
 

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -142,6 +142,24 @@ func (t *testDriverBase) afterEach() {
 	t.controller.Stop()
 }
 
+func (t *testDriverBase) initChains() {
+	for _, chain := range []string{
+		constants.SmGlobalnetIngressChain,
+		constants.SmGlobalnetEgressChain,
+		constants.SmGlobalnetEgressChainForPods,
+		constants.SmGlobalnetEgressChainForHeadlessSvcPods,
+		constants.SmGlobalnetEgressChainForHeadlessSvcEPs,
+		constants.SmGlobalnetEgressChainForNamespace,
+		constants.SmGlobalnetEgressChainForCluster,
+		routeAgent.SmPostRoutingChain,
+		constants.SmGlobalnetMarkChain,
+	} {
+		Expect(t.pFilter.CreateChainIfNotExists(packetfilter.TableTypeNAT, &packetfilter.Chain{
+			Name: chain,
+		})).To(Succeed())
+	}
+}
+
 func (t *testDriverBase) verifyIPsReservedInPool(ips ...string) {
 	if t.pool == nil {
 		return

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Endpoint monitoring", func() {
 
 			It("should stop and restart the controllers", func() {
 				t.leaderElection.AwaitLeaseReleased()
-				t.awaitNoGlobalnetChains()
+				t.awaitGlobalnetChainsCleared()
 				t.ensureControllersStopped()
 
 				By("Recreating the Endpoint")
@@ -167,7 +167,7 @@ var _ = Describe("Endpoint monitoring", func() {
 
 					Expect(t.endpoints.Delete(context.TODO(), endpoint.Name, metav1.DeleteOptions{})).To(Succeed())
 
-					t.awaitNoGlobalnetChains()
+					t.awaitGlobalnetChainsCleared()
 				})
 			})
 		})
@@ -304,14 +304,19 @@ func (t *gatewayMonitorTestDriver) ensureControllersStopped() {
 func (t *gatewayMonitorTestDriver) awaitGlobalnetChains() {
 	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetIngressChain)
 	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChain)
+	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChainForPods)
+	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChainForHeadlessSvcPods)
+	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChainForHeadlessSvcEPs)
+	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChainForNamespace)
+	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChainForCluster)
 	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, routeAgent.SmPostRoutingChain)
 	t.pFilter.AwaitChain(packetfilter.TableTypeNAT, constants.SmGlobalnetMarkChain)
 }
 
-func (t *gatewayMonitorTestDriver) awaitNoGlobalnetChains() {
-	t.pFilter.AwaitNoChain(packetfilter.TableTypeNAT, constants.SmGlobalnetIngressChain)
-	t.pFilter.AwaitNoChain(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChain)
-	t.pFilter.AwaitNoChain(packetfilter.TableTypeNAT, constants.SmGlobalnetMarkChain)
+func (t *gatewayMonitorTestDriver) awaitGlobalnetChainsCleared() {
+	t.pFilter.AwaitNoRules(packetfilter.TableTypeNAT, constants.SmGlobalnetIngressChain)
+	t.pFilter.AwaitNoRules(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChain)
+	t.pFilter.AwaitNoRules(packetfilter.TableTypeNAT, constants.SmGlobalnetMarkChain)
 }
 
 func newEndpointSpec(clusterID, hostname, subnet string) *submarinerv1.EndpointSpec {

--- a/pkg/globalnet/controllers/global_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_egressip_controller_test.go
@@ -593,6 +593,7 @@ func newGlobalEgressIPControllerTestDriver() *globalEgressIPControllerTestDriver
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 
 		var err error
 

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -505,6 +505,7 @@ func newGlobalIngressIPControllerDriver() *globalIngressIPControllerTestDriver {
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 
 		var err error
 

--- a/pkg/globalnet/controllers/node_controller_test.go
+++ b/pkg/globalnet/controllers/node_controller_test.go
@@ -174,6 +174,7 @@ func newNodeControllerTestDriver() *nodeControllerTestDriver {
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 
 		var err error
 

--- a/pkg/globalnet/controllers/service_controller_test.go
+++ b/pkg/globalnet/controllers/service_controller_test.go
@@ -176,6 +176,7 @@ func newServiceControllerTestDriver() *serviceControllerTestDriver {
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -448,6 +448,7 @@ func newServiceExportControllerTestDriver() *serviceExportControllerTestDriver {
 
 	BeforeEach(func() {
 		t.testDriverBase = newTestDriverBase()
+		t.testDriverBase.initChains()
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
The purpose of `ClearChain` is to clear/flush all rules for a table chain. The fake implementation was modified to do this, previously it deleted the entire chain, ie it was equivalent to `DeleteChain`. To facilitate this, the `tableChains` map, which just tracked the existence of chains, was removed. The `chainRules` map can also be used for this purpose.

In addition, inserting/appending a rule now fails if the chain doesn't exist to align with the behavior of the real iptables implementation. This required adjustments to the globalnet unit tests.

