### PR TITLE
Automated backport of #2892: Use the Admiral metrics/profile helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/projectcalico/api v0.0.0-20230602153125-fb7148692637
 	github.com/prometheus-community/pro-bing v0.3.0
 	github.com/prometheus/client_golang v1.18.0
-	github.com/submariner-io/admiral v0.17.0
+	github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674
 	github.com/submariner-io/shipyard v0.17.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/sys v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.17.0 h1:Hz722z70W8hPAlKv/Y70MhNGwmmjl4eMZ+bDw9S+BAQ=
-github.com/submariner-io/admiral v0.17.0/go.mod h1:OYkNN5EYaMZ1w1qxzVzD5q8hVNtojQkVoNPcO8/LL+Y=
+github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674 h1:gAVNTHz4scVMNGnBvjdB4Dk3BGhpit+Qs8cN18yxpJ0=
+github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674/go.mod h1:OYkNN5EYaMZ1w1qxzVzD5q8hVNtojQkVoNPcO8/LL+Y=
 github.com/submariner-io/shipyard v0.17.0 h1:MMs7LkptS4QabYzRrvxxauJov0uQ0gAcdSjBkebpyNU=
 github.com/submariner-io/shipyard v0.17.0/go.mod h1:1TX7V+rxEEEZKm5t7kruTyBm52eOk7PSBJLAqMrqNNc=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -88,7 +88,7 @@ type Specification struct {
 	ClusterID   string
 	Namespace   string
 	GlobalCIDR  []string
-	MetricsPort string `default:"32781"`
+	MetricsPort int `default:"32781"`
 	Uninstall   bool
 }
 

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -24,6 +24,7 @@ type Specification struct {
 	ClusterCidr []string
 	ServiceCidr []string
 	GlobalCidr  []string
+	ProfilePort int `default:"32782"`
 	Uninstall   bool
 	WaitForNode bool
 }

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/http"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/admiral/pkg/names"
@@ -147,6 +148,8 @@ func main() {
 
 		return
 	}
+
+	defer http.StartServer(http.Profile, env.ProfilePort)()
 
 	if err = annotateNode(env.ClusterCidr, k8sClientSet); err != nil {
 		logger.Errorf(err, "Error while annotating the node")

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,5 +48,5 @@ type SubmarinerSpecification struct {
 	HaltOnCertError               bool `split_words:"true"`
 	HealthCheckInterval           uint
 	HealthCheckMaxPacketLossCount uint
-	MetricsPort                   string `default:"32780"`
+	MetricsPort                   int `default:"32780"`
 }


### PR DESCRIPTION
Backport of #2892 on release-0.17.

#2892: Use the Admiral metrics/profile helper

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.