### PR TITLE
Refactor event controller to use a shared informer

### DIFF
--- a/pkg/event/controller/controller_suite_test.go
+++ b/pkg/event/controller/controller_suite_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
@@ -32,6 +34,7 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
+	Expect(submv1.AddToScheme(scheme.Scheme)).To(Succeed())
 })
 
 func TestWatcher(t *testing.T) {

--- a/pkg/event/controller/node_handlers.go
+++ b/pkg/event/controller/node_handlers.go
@@ -20,17 +20,13 @@ package controller
 
 import (
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *Controller) handleRemovedNode(obj runtime.Object, _ int) bool {
-	node := obj.(*k8sv1.Node)
-
+func (c *handlerController) handleRemovedNode(node *k8sv1.Node, _ int) bool {
 	c.syncMutex.Lock()
 	defer c.syncMutex.Unlock()
 
-	if err := c.handlers.NodeRemoved(node); err != nil {
+	if err := c.nodeHandler.NodeRemoved(node); err != nil {
 		logger.Error(err, "Error handling removed Node")
 		return true
 	}
@@ -38,13 +34,11 @@ func (c *Controller) handleRemovedNode(obj runtime.Object, _ int) bool {
 	return false
 }
 
-func (c *Controller) handleCreatedNode(obj runtime.Object, _ int) bool {
-	node := obj.(*k8sv1.Node)
-
+func (c *handlerController) handleCreatedNode(node *k8sv1.Node, _ int) bool {
 	c.syncMutex.Lock()
 	defer c.syncMutex.Unlock()
 
-	if err := c.handlers.NodeCreated(node); err != nil {
+	if err := c.nodeHandler.NodeCreated(node); err != nil {
 		logger.Error(err, "Error handling created Node")
 		return true
 	}
@@ -52,21 +46,14 @@ func (c *Controller) handleCreatedNode(obj runtime.Object, _ int) bool {
 	return false
 }
 
-func (c *Controller) handleUpdatedNode(obj runtime.Object, _ int) bool {
-	node := obj.(*k8sv1.Node)
-
+func (c *handlerController) handleUpdatedNode(node *k8sv1.Node, _ int) bool {
 	c.syncMutex.Lock()
 	defer c.syncMutex.Unlock()
 
-	if err := c.handlers.NodeUpdated(node); err != nil {
+	if err := c.nodeHandler.NodeUpdated(node); err != nil {
 		logger.Error(err, "Error handling updated Node")
 		return true
 	}
 
-	return false
-}
-
-func (c *Controller) isNodeEquivalent(_, _ *unstructured.Unstructured) bool {
-	// TODO: filter on changes for labels, annotations, podcidr, podcidrs, addresses
 	return false
 }

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -40,25 +40,7 @@ func (c *DefaultHandlerState) GetRemoteEndpoints() []submV1.Endpoint {
 	return nil
 }
 
-type Handler interface {
-	// Init is called once on startup to let the handler initialize any state it needs.
-	Init() error
-
-	// SetHandlerState is called once on startup after Init with the HandlerState that can be used to access global data from event callbacks.
-	SetState(handlerCtx HandlerState)
-
-	// GetName returns the name of the event handler
-	GetName() string
-
-	// GetNetworkPlugin returns the kubernetes network plugin that this handler supports.
-	GetNetworkPlugins() []string
-
-	// Stop is called once during shutdown to let the handler perform any cleanup.
-	Stop() error
-
-	// Uninstall is called once after shutdown to let the handler process a Submariner uninstallation.
-	Uninstall() error
-
+type EndpointHandler interface {
 	// TransitionToNonGateway is called once for each transition of the local node from Gateway to a non-Gateway.
 	TransitionToNonGateway() error
 
@@ -82,7 +64,9 @@ type Handler interface {
 
 	// RemoteEndpointRemoved is called when an endpoint associated with a remote cluster is removed
 	RemoteEndpointRemoved(endpoint *submV1.Endpoint) error
+}
 
+type NodeHandler interface {
 	// NodeCreated indicates when a node has been added to the cluster
 	NodeCreated(node *k8sV1.Node) error
 
@@ -91,6 +75,28 @@ type Handler interface {
 
 	// NodeRemoved indicates when a node has been removed from the cluster
 	NodeRemoved(node *k8sV1.Node) error
+}
+
+type Handler interface {
+	// Init is called once on startup to let the handler initialize any state it needs.
+	Init() error
+
+	// SetHandlerState is called once on startup after Init with the HandlerState that can be used to access global data from event callbacks.
+	SetState(handlerCtx HandlerState)
+
+	// GetName returns the name of the event handler
+	GetName() string
+
+	// GetNetworkPlugin returns the kubernetes network plugin that this handler supports.
+	GetNetworkPlugins() []string
+
+	// Stop is called once during shutdown to let the handler perform any cleanup.
+	Stop() error
+
+	// Uninstall is called once after shutdown to let the handler process a Submariner uninstallation.
+	Uninstall() error
+
+	EndpointHandler
 }
 
 // Base structure for event handlers that stubs out methods considered to be optional.
@@ -154,14 +160,16 @@ func (ev *HandlerBase) RemoteEndpointRemoved(_ *submV1.Endpoint) error {
 	return nil
 }
 
-func (ev *HandlerBase) NodeCreated(_ *k8sV1.Node) error {
+type NodeHandlerBase struct{}
+
+func (h *NodeHandlerBase) NodeCreated(_ *k8sV1.Node) error {
 	return nil
 }
 
-func (ev *HandlerBase) NodeUpdated(_ *k8sV1.Node) error {
+func (h *NodeHandlerBase) NodeUpdated(_ *k8sV1.Node) error {
 	return nil
 }
 
-func (ev *HandlerBase) NodeRemoved(_ *k8sV1.Node) error {
+func (h *NodeHandlerBase) NodeRemoved(_ *k8sV1.Node) error {
 	return nil
 }

--- a/pkg/event/registry.go
+++ b/pkg/event/registry.go
@@ -95,6 +95,10 @@ func (er *Registry) SetHandlerState(handlerState HandlerState) {
 	})
 }
 
+func (er *Registry) GetHandlers() []Handler {
+	return er.eventHandlers
+}
+
 func (er *Registry) StopHandlers() error {
 	return er.invokeHandlers("Stop", func(h Handler) error {
 		return h.Stop()
@@ -181,19 +185,19 @@ func (er *Registry) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 
 func (er *Registry) NodeCreated(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeCreated", func(h Handler) error {
-		return h.NodeCreated(node)
+		return h.(NodeHandler).NodeCreated(node)
 	})
 }
 
 func (er *Registry) NodeUpdated(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeUpdated", func(h Handler) error {
-		return h.NodeUpdated(node)
+		return h.(NodeHandler).NodeUpdated(node)
 	})
 }
 
 func (er *Registry) NodeRemoved(node *k8sV1.Node) error {
 	return er.invokeHandlers("NodeRemoved", func(h Handler) error {
-		return h.NodeRemoved(node)
+		return h.(NodeHandler).NodeRemoved(node)
 	})
 }
 

--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -59,10 +59,15 @@ func NewControllerSupport() *ControllerSupport {
 	return c
 }
 
-func (c *ControllerSupport) Start(handler event.Handler) {
+func (c *ControllerSupport) Start(handlers ...event.Handler) {
 	stopCh := make(chan struct{})
 
-	registry, err := event.NewRegistry("test-registry", handler.GetNetworkPlugins()[0], handler)
+	networkPlugin := handlers[0].GetNetworkPlugins()[0]
+	if len(handlers) > 1 {
+		networkPlugin = event.AnyNetworkPlugin
+	}
+
+	registry, err := event.NewRegistry("test-registry", networkPlugin, handlers...)
 	Expect(err).To(Succeed())
 
 	config := controller.Config{

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -38,6 +38,7 @@ import (
 
 type SyncHandler struct {
 	event.HandlerBase
+	event.NodeHandlerBase
 	localCableDriver string
 	localClusterCidr []string
 	localServiceCidr []string

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -40,7 +40,6 @@ import (
 	cni "github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
-	eventlogger "github.com/submariner-io/submariner/pkg/event/logger"
 	"github.com/submariner-io/submariner/pkg/node"
 	packetfilter "github.com/submariner-io/submariner/pkg/packetfilter"
 	iptables "github.com/submariner-io/submariner/pkg/packetfilter/iptables"
@@ -133,7 +132,6 @@ func main() {
 	config := &watcher.Config{RestConfig: cfg}
 
 	registry, err := event.NewRegistry("routeagent_driver", np,
-		eventlogger.NewHandler(),
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
 		ovn.NewHandler(&ovn.HandlerConfig{
 			Namespace:     env.Namespace,

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/admiral/pkg/names"
+	"github.com/submariner-io/admiral/pkg/util"
 	admversion "github.com/submariner-io/admiral/pkg/version"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -110,6 +111,9 @@ func main() {
 	smClientset, err := submarinerClientset.NewForConfig(cfg)
 	logger.FatalOnError(err, "Error building submariner clientset")
 
+	restMapper, err := util.BuildRestMapper(cfg)
+	logger.FatalOnError(err, "Error building the REST mapper")
+
 	if env.WaitForNode {
 		waitForNodeReady(k8sClientSet)
 
@@ -163,7 +167,8 @@ func main() {
 
 	ctl, err := controller.New(&controller.Config{
 		Registry:   registry,
-		RestConfig: cfg,
+		Client:     dynamicClientSet,
+		RestMapper: restMapper,
 	})
 	logger.FatalOnError(err, "Error creating controller for event handling")
 


### PR DESCRIPTION
...and create a resource syncer per event handler. This decouples the handlers from one another and allows them to run in parallel and independently from one another, such that if an error or delay occurs in one handler, it doesn't affect the others.

Depends on https://github.com/submariner-io/admiral/pull/895