### PR TITLE
Switch to math/rand/v2

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"regexp"
@@ -51,9 +51,6 @@ var publicIPMethods = map[string]publicIPResolverFunction{
 
 var IPv4RE = regexp.MustCompile(`(?:\d{1,3}\.){3}\d{1,3}`)
 
-//nolint:gosec // This is only used to shuffle the list of resolvers
-var randgen = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 func getPublicIPResolvers() string {
 	serverList := []string{
 		"api:ip4.seeip.org", "api:ipecho.net/plain", "api:ifconfig.me",
@@ -61,7 +58,7 @@ func getPublicIPResolvers() string {
 		"api:myexternalip.com/raw", "api:4.tnedi.me", "api:api.ipify.org",
 	}
 
-	randgen.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
+	rand.Shuffle(len(serverList), func(i, j int) { serverList[i], serverList[j] = serverList[j], serverList[i] })
 
 	return strings.Join(serverList, ",")
 }


### PR DESCRIPTION
This provides more robust functions and defaults than math/rand, and provides sensible global convenience functions so a package-specific source is no longer necessary. See https://go.dev/blog/randv2 for context.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
