### PR TITLE
Fix error prepending rule in createGlobalnetChains

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -468,15 +468,6 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 		}
 	}
 
-	ruleSpec := packetfilter.Rule{
-		TargetChain: constants.SmGlobalnetEgressChain,
-		Action:      packetfilter.RuleActionJump,
-	}
-
-	if err := g.pFilter.PrependUnique(packetfilter.TableTypeNAT, routeAgent.SmPostRoutingChain, &ruleSpec); err != nil {
-		return errors.Wrapf(err, "Error prepending rule %+v", ruleSpec)
-	}
-
 	for _, chain := range []string{
 		constants.SmGlobalnetEgressChain,
 		constants.SmGlobalnetMarkChain,
@@ -489,6 +480,15 @@ func (g *gatewayMonitor) createGlobalnetChains() error {
 		if err := g.createNATChain(chain); err != nil {
 			return err
 		}
+	}
+
+	ruleSpec := packetfilter.Rule{
+		TargetChain: constants.SmGlobalnetEgressChain,
+		Action:      packetfilter.RuleActionJump,
+	}
+
+	if err := g.pFilter.PrependUnique(packetfilter.TableTypeNAT, routeAgent.SmPostRoutingChain, &ruleSpec); err != nil {
+		return errors.Wrapf(err, "Error prepending rule %+v", ruleSpec)
 	}
 
 	if err := g.pFilter.PrependUnique(packetfilter.TableTypeNAT, constants.SmGlobalnetEgressChain,

--- a/pkg/packetfilter/adapter_test.go
+++ b/pkg/packetfilter/adapter_test.go
@@ -25,7 +25,11 @@ import (
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
 )
 
-const chain = "test-chain"
+const (
+	chain        = "test-chain"
+	targetChain1 = "target-chain1"
+	targetChain2 = "target-chain2"
+)
 
 var _ = Describe("Adapter", func() {
 	rule1 := &packetfilter.Rule{
@@ -56,7 +60,7 @@ var _ = Describe("Adapter", func() {
 	rule4 := &packetfilter.Rule{
 		Action:      packetfilter.RuleActionJump,
 		Proto:       packetfilter.RuleProtoICMP,
-		TargetChain: "target-chain",
+		TargetChain: targetChain1,
 	}
 
 	rule5 := &packetfilter.Rule{
@@ -98,12 +102,24 @@ var _ = Describe("Adapter", func() {
 		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeRoute, &packetfilter.Chain{
 			Name: chain,
 		})).To(Succeed())
+
+		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeNAT, &packetfilter.Chain{
+			Name: targetChain1,
+		})).To(Succeed())
+
+		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeRoute, &packetfilter.Chain{
+			Name: targetChain1,
+		})).To(Succeed())
+
+		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeNAT, &packetfilter.Chain{
+			Name: targetChain2,
+		})).To(Succeed())
 	})
 
 	Context("PrependUnique", func() {
 		otherRule := &packetfilter.Rule{
 			Action:      packetfilter.RuleActionJump,
-			TargetChain: "other-chain",
+			TargetChain: targetChain2,
 		}
 
 		When("the rules don't exist", func() {


### PR DESCRIPTION
It prepends a jump rule with SUBMARINER-GN-EGRESS chain as the target to the SUBMARINER-POSTROUTING chain but the SUBMARINER-GN-EGRESS wasn't created yet. This was introduced by
https://github.com/submariner-io/submariner/pull/3000 (not sure why the GN E2E succeeded).
