### PR TITLE
Globalnet not running in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
-          using: ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
+          using: ${{ matrix.globalnet }} ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
 
       - name: Post mortem
         if: failure()


### PR DESCRIPTION
The E2E jobs intended to install/run Globalnet are not doing so. This is b/c the E2E GHA needs to specify the `matrix.globalnet` var in the `using` statement. This was broken by https://github.com/submariner-io/submariner/pull/2832/commits/6cd0a39b9114f68da5a8304fbd2e71ce840d5b5a when the `globalnet` option was removed from `extra-toggles`.
