### PR TITLE
Automated backport of #3009: Globalnet not running in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@release-0.17
         with:
-          using: ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
+          using: ${{ matrix.globalnet }} ${{ matrix.cable-driver }} ${{ matrix.extra-toggles }}
 
       - name: Post mortem
         if: failure()


### PR DESCRIPTION
Backport of #3009 on release-0.17.

#3009: Globalnet not running in E2E

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.