### PR TITLE
De-duplicate CNI discovery code

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -178,7 +178,7 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 
 	var ipAddress net.IP
 
-	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR[0])
+	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR)
 	if err == nil {
 		ipAddress = net.ParseIP(cniIface.IPAddress)
 	} else {

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -172,7 +172,7 @@ func newTestDriver() *testDriver {
 			return t.netLink
 		}
 
-		cni.DiscoverFunc = func(_ string) (*cni.Interface, error) {
+		cni.DiscoverFunc = func(_ []string) (*cni.Interface, error) {
 			return &cni.Interface{
 				Name:      "veth0",
 				IPAddress: cniIPAddress,

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -80,9 +81,9 @@ func init() {
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
 
-	cni.DiscoverFunc = func(cidr string) (*cni.Interface, error) {
-		if cidr != localCIDR {
-			return nil, fmt.Errorf("invalid CIDR %q", cidr)
+	cni.DiscoverFunc = func(cidrs []string) (*cni.Interface, error) {
+		if !reflect.DeepEqual(cidrs, []string{localCIDR}) {
+			return nil, fmt.Errorf("invalid CIDRs %v", cidrs)
 		}
 
 		return &cni.Interface{

--- a/pkg/globalnet/controllers/node_controller.go
+++ b/pkg/globalnet/controllers/node_controller.go
@@ -52,12 +52,7 @@ func NewNodeController(config *syncer.ResourceSyncerConfig, pool *ipam.IPPool, n
 		nodeName:                   nodeName,
 	}
 
-	clusterCIDR := ""
-	if len(clusterCIDRs) > 0 {
-		clusterCIDR = clusterCIDRs[0]
-	}
-
-	cniIface, err := cni.Discover(clusterCIDR)
+	cniIface, err := cni.Discover(clusterCIDRs)
 	if err == nil {
 		controller.cniIP = cniIface.IPAddress
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -105,7 +105,7 @@ func (kp *SyncHandler) Init() error {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s", kp.hostname)
 	}
 
-	cniIface, err := cni.Discover(kp.localClusterCidr[0])
+	cniIface, err := cni.Discover(kp.localClusterCidr)
 	if err == nil {
 		// Configure CNI Specific changes
 		kp.cniIface = cniIface

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -381,7 +381,7 @@ func newTestDriver() *testDriver {
 		}
 		t.pFilter = fakePF.New()
 
-		cni.DiscoverFunc = func(_ string) (*cni.Interface, error) {
+		cni.DiscoverFunc = func(_ []string) (*cni.Interface, error) {
 			return &cni.Interface{
 				Name:      "veth0",
 				IPAddress: cniIPAddress,


### PR DESCRIPTION
The `getCNIInterfaceIPAddress` in endpoint.go is mainly a duplicate of `cni.discover` so eliminate the former. The main difference is that `getCNIInterfaceIPAddress` took an array of CIDR strings so update `cni.discover` accordingly.
