### PR TITLE
Fix issues with Pinger on relection as leader

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -167,10 +167,25 @@ var _ = Describe("Controller", func() {
 			Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint2.Spec) }).
 				Should(Equal(latencyInfo2))
 
+			By("Stopping health checker")
+
+			close(stopCh)
 			healthChecker.Stop()
 
 			Expect(healthChecker.GetLatencyInfo(&endpoint1.Spec)).To(BeNil())
 			Expect(healthChecker.GetLatencyInfo(&endpoint2.Spec)).To(BeNil())
+
+			By("Restarting health checker")
+
+			pingerMap = map[string]*fake.Pinger{
+				healthCheckIP1: fake.NewPinger(healthCheckIP1),
+				healthCheckIP2: fake.NewPinger(healthCheckIP2),
+			}
+
+			stopCh = make(chan struct{})
+			Expect(healthChecker.Start(stopCh)).To(Succeed())
+
+			pingerMap[healthCheckIP1].AwaitStart()
 		})
 	})
 
@@ -234,58 +249,6 @@ var _ = Describe("Controller", func() {
 		It("should not start a Pinger", func() {
 			createEndpoint(remoteClusterID1, "")
 			pingerMap[healthCheckIP1].AwaitNoStart()
-		})
-	})
-
-	When("Start is called", func() {
-		JustBeforeEach(func() {
-			stopCh = make(chan struct{})
-			scheme := runtime.NewScheme()
-			Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())
-			Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())
-
-			dynamicClient := fakeClient.NewSimpleDynamicClient(scheme)
-			restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{})
-			endpoints = dynamicClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{})).Namespace(namespace)
-
-			var err error
-
-			config := &healthchecker.Config{
-				WatcherConfig: &watcher.Config{
-					RestMapper: restMapper,
-					Client:     dynamicClient,
-					Scheme:     scheme,
-				},
-				EndpointNamespace:  namespace,
-				ClusterID:          localClusterID,
-				PingInterval:       3,
-				MaxPacketLossCount: 4,
-			}
-
-			config.NewPinger = func(pingerCfg healthchecker.PingerConfig) healthchecker.PingerInterface {
-				defer GinkgoRecover()
-				Expect(pingerCfg.Interval).To(Equal(time.Second * time.Duration(config.PingInterval)))
-				Expect(pingerCfg.MaxPacketLossCount).To(Equal(config.MaxPacketLossCount))
-
-				p, ok := pingerMap[pingerCfg.IP]
-				Expect(ok).To(BeTrue())
-				return p
-			}
-
-			healthChecker, err = healthchecker.New(config)
-
-			Expect(err).To(Succeed())
-		})
-		It("should start the endpoint watcher and start pingers for existing endpoints", func() {
-			createEndpoint(remoteClusterID1, healthCheckIP1)
-			createEndpoint(remoteClusterID2, healthCheckIP2)
-
-			// Start the healthchecker
-			Expect(healthChecker.Start(stopCh)).To(Succeed())
-
-			// Ensure that the Pingers has started for already existing endpoints
-			pingerMap[healthCheckIP1].AwaitStart()
-			pingerMap[healthCheckIP2].AwaitStart()
 		})
 	})
 })


### PR DESCRIPTION
The pinger  for remote endpoints are started
when a node is relected as a leader, once it
looses it leadership.

Fixes: https://github.com/submariner-io/submariner/issues/3008

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
