### PR TITLE
Automated backport of #3017: Fix issues with Pinger on relection as leader

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -167,10 +167,25 @@ var _ = Describe("Controller", func() {
 			Eventually(func() *healthchecker.LatencyInfo { return healthChecker.GetLatencyInfo(&endpoint2.Spec) }).
 				Should(Equal(latencyInfo2))
 
+			By("Stopping health checker")
+
+			close(stopCh)
 			healthChecker.Stop()
 
 			Expect(healthChecker.GetLatencyInfo(&endpoint1.Spec)).To(BeNil())
 			Expect(healthChecker.GetLatencyInfo(&endpoint2.Spec)).To(BeNil())
+
+			By("Restarting health checker")
+
+			pingerMap = map[string]*fake.Pinger{
+				healthCheckIP1: fake.NewPinger(healthCheckIP1),
+				healthCheckIP2: fake.NewPinger(healthCheckIP2),
+			}
+
+			stopCh = make(chan struct{})
+			Expect(healthChecker.Start(stopCh)).To(Succeed())
+
+			pingerMap[healthCheckIP1].AwaitStart()
 		})
 	})
 
@@ -234,58 +249,6 @@ var _ = Describe("Controller", func() {
 		It("should not start a Pinger", func() {
 			createEndpoint(remoteClusterID1, "")
 			pingerMap[healthCheckIP1].AwaitNoStart()
-		})
-	})
-
-	When("Start is called", func() {
-		JustBeforeEach(func() {
-			stopCh = make(chan struct{})
-			scheme := runtime.NewScheme()
-			Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())
-			Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())
-
-			dynamicClient := fakeClient.NewSimpleDynamicClient(scheme)
-			restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{})
-			endpoints = dynamicClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{})).Namespace(namespace)
-
-			var err error
-
-			config := &healthchecker.Config{
-				WatcherConfig: &watcher.Config{
-					RestMapper: restMapper,
-					Client:     dynamicClient,
-					Scheme:     scheme,
-				},
-				EndpointNamespace:  namespace,
-				ClusterID:          localClusterID,
-				PingInterval:       3,
-				MaxPacketLossCount: 4,
-			}
-
-			config.NewPinger = func(pingerCfg healthchecker.PingerConfig) healthchecker.PingerInterface {
-				defer GinkgoRecover()
-				Expect(pingerCfg.Interval).To(Equal(time.Second * time.Duration(config.PingInterval)))
-				Expect(pingerCfg.MaxPacketLossCount).To(Equal(config.MaxPacketLossCount))
-
-				p, ok := pingerMap[pingerCfg.IP]
-				Expect(ok).To(BeTrue())
-				return p
-			}
-
-			healthChecker, err = healthchecker.New(config)
-
-			Expect(err).To(Succeed())
-		})
-		It("should start the endpoint watcher and start pingers for existing endpoints", func() {
-			createEndpoint(remoteClusterID1, healthCheckIP1)
-			createEndpoint(remoteClusterID2, healthCheckIP2)
-
-			// Start the healthchecker
-			Expect(healthChecker.Start(stopCh)).To(Succeed())
-
-			// Ensure that the Pingers has started for already existing endpoints
-			pingerMap[healthCheckIP1].AwaitStart()
-			pingerMap[healthCheckIP2].AwaitStart()
 		})
 	})
 })


### PR DESCRIPTION
Backport of #3017 on release-0.16.

#3017: Fix issues with Pinger on relection as leader

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.