### PR TITLE
Iptables List avoid unnecessary row processing

### DIFF
--- a/pkg/packetfilter/iptables/iptables.go
+++ b/pkg/packetfilter/iptables/iptables.go
@@ -188,6 +188,14 @@ func (p *packetFilter) List(table packetfilter.TableType, chain string) ([]*pack
 
 	for _, existingRule := range existingRules {
 		ruleSpec := strings.Split(existingRule, " ")
+
+		// ipt.List ( == iptables -t <table_name> -S <chain_name>) also returns
+		// extra line '-N chain_name', we have to skip this line.
+
+		if ruleSpec[0] == "-N" {
+			continue
+		}
+
 		if ruleSpec[0] == "-A" {
 			ruleSpec = ruleSpec[2:] // remove "-A", "$chain"
 		}


### PR DESCRIPTION
I noticed [1] warning in route-agent pod logs,
the cause of this warning seems to be the processing of an unnecessary line ('-N <chain_name>') returned by iptables.List.

This PR updates iptables List to ignore '-N <chain_name' line.

[1]
2024-05-29T14:54:28.041Z WRN ..etfilter/adapter.go:120 Packetfilter Unable to delete rule "packetfilter.Rule{Action: Jump}" from table "Route", chain "SUBMARINER-POSTROUTING": error deleting rule "-j " from table "mangle", chain "SUBMARINER-POSTROUTING": running [/usr/sbin/iptables -t mangle -D SUBMARINER-POSTROUTING -j  --wait 5]: exit status 2: iptables v1.8.9 (nf_tables): Invalid target name (too short) Try `iptables -h' or 'iptables --help' for more information.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
