### PR TITLE
Ensure HealthCheckIP is set for remote connections in Gateway

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker.go
+++ b/pkg/cableengine/healthchecker/healthchecker.go
@@ -33,6 +33,7 @@ import (
 type LatencyInfo struct {
 	ConnectionError  string
 	ConnectionStatus ConnectionStatus
+	IP               string
 	Spec             *submarinerv1.LatencyRTTSpec
 }
 

--- a/pkg/cableengine/healthchecker/pinger.go
+++ b/pkg/cableengine/healthchecker/pinger.go
@@ -205,6 +205,7 @@ func (p *pingerInfo) GetLatencyInfo() *LatencyInfo {
 	defer p.Unlock()
 
 	return &LatencyInfo{
+		IP:               p.ip,
 		ConnectionStatus: p.connectionStatus,
 		ConnectionError:  p.failureMsg,
 		Spec: &submarinerv1.LatencyRTTSpec{

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -237,6 +237,8 @@ func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 			latencyInfo := gs.healthCheck.GetLatencyInfo(&connection.Endpoint)
 			if latencyInfo != nil {
 				connection.LatencyRTT = latencyInfo.Spec
+				connection.Endpoint.HealthCheckIP = latencyInfo.IP
+
 				if connection.Status == v1.Connected {
 					lastRTT, _ := time.ParseDuration(latencyInfo.Spec.Last)
 					cable.RecordConnectionLatency(localEndpoint.Spec.Backend, &localEndpoint.Spec, &connection.Endpoint, lastRTT.Seconds())

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -405,6 +405,7 @@ func testGatewayLatencyInfo() {
 			}
 
 			t.engine.Connections = []submarinerv1.Connection{t.expectedGateway.Status.Connections[0]}
+			t.engine.Connections[0].Endpoint.HealthCheckIP = ""
 
 			t.expectedGateway.Status.Connections[0].LatencyRTT = &submarinerv1.LatencyRTTSpec{
 				Last:    "93ms",
@@ -415,6 +416,7 @@ func testGatewayLatencyInfo() {
 			}
 
 			t.pinger.SetLatencyInfo(&healthchecker.LatencyInfo{
+				IP:               t.pinger.GetIP(),
 				ConnectionStatus: healthchecker.Connected,
 				Spec:             t.expectedGateway.Status.Connections[0].LatencyRTT,
 			})
@@ -427,6 +429,7 @@ func testGatewayLatencyInfo() {
 			t.expectedGateway.Status.Connections[0].StatusMessage = "Ping failed"
 
 			t.pinger.SetLatencyInfo(&healthchecker.LatencyInfo{
+				IP:               t.pinger.GetIP(),
 				ConnectionStatus: healthchecker.ConnectionError,
 				ConnectionError:  t.expectedGateway.Status.Connections[0].StatusMessage,
 				Spec:             t.expectedGateway.Status.Connections[0].LatencyRTT,
@@ -438,6 +441,7 @@ func testGatewayLatencyInfo() {
 			t.expectedGateway.Status.Connections[0].StatusMessage = ""
 
 			t.pinger.SetLatencyInfo(&healthchecker.LatencyInfo{
+				IP:               t.pinger.GetIP(),
 				ConnectionStatus: healthchecker.Connected,
 				Spec:             t.expectedGateway.Status.Connections[0].LatencyRTT,
 			})


### PR DESCRIPTION
We've seen sporadic failures for the "Gateway status reporting" E2E test where the endpoint `HealthCheckIP` isn't set, specifically when globalnet is enabled. This is b/c globalnet sets the `HealthCheckIP` sometime later but the cable driver(s) don't process updates to the remote endpoint's `HealthCheckIP` (the gateway syncer gets the endpoint info from the cable engine). The health checker does process `HealthCheckIP` updates so adjust the gateway syncer to set the `HealthCheckIP` from the `LatencyInfo`.
