### PR TITLE
Skip gateway failover E2E test for wireguard

### DIFF
--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -53,7 +53,7 @@ const (
 	// handshakeTimeout is maximal time from handshake a connections is still considered connected.
 	handshakeTimeout = 2*time.Minute + 10*time.Second
 
-	cableDriverName = "wireguard"
+	CableDriverName = "wireguard"
 	receiveBytes    = "ReceiveBytes"  // for peer connection status
 	transmitBytes   = "TransmitBytes" // for peer connection status
 	lastChecked     = "LastChecked"   // for connection peer status
@@ -65,7 +65,7 @@ const (
 var logger = log.Logger{Logger: logf.Log.WithName("wireguard")}
 
 func init() {
-	cable.AddDriver(cableDriverName, NewDriver)
+	cable.AddDriver(CableDriverName, NewDriver)
 }
 
 type specification struct {
@@ -203,7 +203,7 @@ func (w *wireguard) Init() error {
 }
 
 func (w *wireguard) GetName() string {
-	return cableDriverName
+	return CableDriverName
 }
 
 func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
@@ -301,7 +301,7 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 
 	logger.V(log.DEBUG).Infof("Done connecting endpoint peer %s@%s", *remoteKey, remoteIP)
 
-	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
+	cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
 
 	return ip, nil
 }
@@ -350,7 +350,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpo
 	delete(w.connections, remoteEndpoint.Spec.ClusterID)
 
 	logger.V(log.DEBUG).Infof("Done removing endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
-	cable.RecordDisconnected(cableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
+	cable.RecordDisconnected(CableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
 
 	return nil
 }

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -95,7 +95,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if lc > handshakeTimeout.Milliseconds() {
 			// No initial handshake for too long.
 			connection.SetStatus(v1.ConnectionError, "no initial handshake for %.1f seconds", lcSec)
-			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -103,7 +103,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if tx > 0 || rx > 0 {
 			// No handshake, but at least some communication in progress.
 			connection.SetStatus(v1.Connecting, "no initial handshake yet")
-			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -112,7 +112,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	if tx > 0 || rx > 0 {
 		// All is good.
 		connection.SetStatus(v1.Connected, "Rx=%d Bytes, Tx=%d Bytes", p.ReceiveBytes, p.TransmitBytes)
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 		saveAndRecordPeerTraffic(&w.localEndpoint.Spec, &connection.Endpoint, now, p.TransmitBytes, p.ReceiveBytes)
 
 		return
@@ -124,7 +124,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		// Hard error, really long time since handshake.
 		connection.SetStatus(v1.ConnectionError, "no handshake for %.1f seconds",
 			handshakeDelta.Seconds())
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 		return
 	}
@@ -138,14 +138,14 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	// Soft error, no traffic, stale handshake.
 	connection.SetStatus(v1.ConnectionError, "no bytes sent or received for %.1f seconds",
 		lcSec)
-	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+	cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 }
 
 func (w *wireguard) updatePeerStatus(c *v1.Connection, key *wgtypes.Key) {
 	p, err := w.peerByKey(key)
 	if err != nil {
 		c.SetStatus(v1.ConnectionError, "cannot fetch status for peer %s: %v", key, err)
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &c.Endpoint, string(c.Status), false)
+		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &c.Endpoint, string(c.Status), false)
 
 		return
 	}
@@ -174,6 +174,6 @@ func saveAndRecordPeerTraffic(localEndpoint, remoteEndpoint *v1.EndpointSpec, lc
 	remoteEndpoint.BackendConfig[transmitBytes] = strconv.FormatInt(tx, 10)
 	remoteEndpoint.BackendConfig[receiveBytes] = strconv.FormatInt(rx, 10)
 
-	cable.RecordTxBytes(cableDriverName, localEndpoint, remoteEndpoint, int(tx))
-	cable.RecordRxBytes(cableDriverName, localEndpoint, remoteEndpoint, int(rx))
+	cable.RecordTxBytes(CableDriverName, localEndpoint, remoteEndpoint, int(tx))
+	cable.RecordRxBytes(CableDriverName, localEndpoint, remoteEndpoint, int(rx))
 }


### PR DESCRIPTION
The `testGatewayPodRestartScenario` is consistently failing with `wireguard`. We've narrowed it down to an unknown issue with Kind 0.21 so skip the test for now.
