### PR TITLE
Drop the dependency on wireguard in e2e

### DIFF
--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -53,7 +53,7 @@ const (
 	// handshakeTimeout is maximal time from handshake a connections is still considered connected.
 	handshakeTimeout = 2*time.Minute + 10*time.Second
 
-	CableDriverName = "wireguard"
+	cableDriverName = "wireguard"
 	receiveBytes    = "ReceiveBytes"  // for peer connection status
 	transmitBytes   = "TransmitBytes" // for peer connection status
 	lastChecked     = "LastChecked"   // for connection peer status
@@ -65,7 +65,7 @@ const (
 var logger = log.Logger{Logger: logf.Log.WithName("wireguard")}
 
 func init() {
-	cable.AddDriver(CableDriverName, NewDriver)
+	cable.AddDriver(cableDriverName, NewDriver)
 }
 
 type specification struct {
@@ -203,7 +203,7 @@ func (w *wireguard) Init() error {
 }
 
 func (w *wireguard) GetName() string {
-	return CableDriverName
+	return cableDriverName
 }
 
 func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
@@ -301,7 +301,7 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 
 	logger.V(log.DEBUG).Infof("Done connecting endpoint peer %s@%s", *remoteKey, remoteIP)
 
-	cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
+	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
 
 	return ip, nil
 }
@@ -350,7 +350,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpo
 	delete(w.connections, remoteEndpoint.Spec.ClusterID)
 
 	logger.V(log.DEBUG).Infof("Done removing endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
-	cable.RecordDisconnected(CableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
+	cable.RecordDisconnected(cableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
 
 	return nil
 }

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -95,7 +95,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if lc > handshakeTimeout.Milliseconds() {
 			// No initial handshake for too long.
 			connection.SetStatus(v1.ConnectionError, "no initial handshake for %.1f seconds", lcSec)
-			cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -103,7 +103,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if tx > 0 || rx > 0 {
 			// No handshake, but at least some communication in progress.
 			connection.SetStatus(v1.Connecting, "no initial handshake yet")
-			cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -112,7 +112,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	if tx > 0 || rx > 0 {
 		// All is good.
 		connection.SetStatus(v1.Connected, "Rx=%d Bytes, Tx=%d Bytes", p.ReceiveBytes, p.TransmitBytes)
-		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 		saveAndRecordPeerTraffic(&w.localEndpoint.Spec, &connection.Endpoint, now, p.TransmitBytes, p.ReceiveBytes)
 
 		return
@@ -124,7 +124,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		// Hard error, really long time since handshake.
 		connection.SetStatus(v1.ConnectionError, "no handshake for %.1f seconds",
 			handshakeDelta.Seconds())
-		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 
 		return
 	}
@@ -138,14 +138,14 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	// Soft error, no traffic, stale handshake.
 	connection.SetStatus(v1.ConnectionError, "no bytes sent or received for %.1f seconds",
 		lcSec)
-	cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
 }
 
 func (w *wireguard) updatePeerStatus(c *v1.Connection, key *wgtypes.Key) {
 	p, err := w.peerByKey(key)
 	if err != nil {
 		c.SetStatus(v1.ConnectionError, "cannot fetch status for peer %s: %v", key, err)
-		cable.RecordConnection(CableDriverName, &w.localEndpoint.Spec, &c.Endpoint, string(c.Status), false)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &c.Endpoint, string(c.Status), false)
 
 		return
 	}
@@ -174,6 +174,6 @@ func saveAndRecordPeerTraffic(localEndpoint, remoteEndpoint *v1.EndpointSpec, lc
 	remoteEndpoint.BackendConfig[transmitBytes] = strconv.FormatInt(tx, 10)
 	remoteEndpoint.BackendConfig[receiveBytes] = strconv.FormatInt(rx, 10)
 
-	cable.RecordTxBytes(CableDriverName, localEndpoint, remoteEndpoint, int(tx))
-	cable.RecordRxBytes(CableDriverName, localEndpoint, remoteEndpoint, int(rx))
+	cable.RecordTxBytes(cableDriverName, localEndpoint, remoteEndpoint, int(tx))
+	cable.RecordRxBytes(cableDriverName, localEndpoint, remoteEndpoint, int(rx))
 }

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -28,7 +28,6 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/cable/wireguard"
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -82,7 +81,8 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	submEndpoint := f.AwaitSubmarinerEndpoint(primaryCluster, subFramework.NoopCheckEndpoint)
 
-	if submEndpoint.Spec.Backend == wireguard.CableDriverName &&
+	// The cable driver name can't be imported from pkg/cable/wireguard to avoid breaking the subctl build on Windows
+	if submEndpoint.Spec.Backend == "wireguard" &&
 		framework.DetectProvider(context.TODO(), primaryCluster, gatewayNodes[0].Name) == "kind" {
 		framework.Skipf("The test is known to fail on Kind 0.21+ with the wireguard cable driver - skipping the test...")
 		return


### PR DESCRIPTION
The wireguard package has dependencies which can't be built on Windows. If the e2e tests end up with a dependency on the wireguard cable driver, that leaks into subctl and prevents it from being built on Windows.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
