### PR TITLE
Ensure exported test code doesn't depend on wireguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,15 @@
 ---
 linters-settings:
+  depguard:
+    rules:
+      # Importing WireGuard breaks downstream projects, we mustn't use it in exported packages
+      wireguard:
+        list-mode: lax
+        files:
+          - "**/test/**/*.go"
+        deny:
+          - pkg: github.com/submariner-io/submariner/pkg/cable/wireguard
+            desc: Breaks Windows builds
   gocritic:
     enabled-tags:
       - diagnostic
@@ -47,7 +57,7 @@ linters:
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
     - decorder
-    # - depguard # depguard now denies by default, it should only be enabled if we actually use it
+    - depguard
     - dogsled
     - dupl
     - dupword


### PR DESCRIPTION
The WireGuard packages depend on packages which aren't available on Windows; since the exported test code is used in subctl, if the test packages end up with a dependency on the WireGuard packages, subctl can no longer be built.

This adds depguard configuration to enforce the exclusion.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
