### PR TITLE
Automated backport of #3073: Fix testGatewayPodRestartScenario for ROKS platform

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -96,7 +96,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	framework.By(fmt.Sprintf("Ensuring that the gateway reports as active on %q", primaryClusterName))
 
-	activeGateway := f.AwaitGatewayFullyConnected(primaryCluster, resource.EnsureValidName(gatewayNodes[0].Name))
+	activeGateway := f.AwaitGatewayFullyConnected(primaryCluster, resource.EnsureValidName(submEndpoint.Spec.Hostname))
 
 	framework.By(fmt.Sprintf("Deleting submariner gateway pod %q", gatewayPod.Name))
 	f.DeletePod(primaryCluster, gatewayPod.Name, framework.TestContext.SubmarinerNamespace)


### PR DESCRIPTION
Backport of #3073 on release-0.18.

#3073: Fix testGatewayPodRestartScenario for ROKS platform

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.