### PR TITLE
Remove TODO in libreswan.Init

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -157,7 +157,6 @@ func (i *libreswan) GetName() string {
 func (i *libreswan) Init() error {
 	// Write the secrets file:
 	// %any %any : PSK "secret"
-	// TODO Check whether the file already exists
 	file, err := os.Create("/etc/ipsec.d/submariner.secrets")
 	if err != nil {
 		return errors.Wrap(err, "error creating the secrets file")


### PR DESCRIPTION
...for "_Check whether the file already exists_". This isn't necessary as os.Create truncates/overwrites an existing file.
