### PR TITLE
Datastoresyncer - recreate local endpoint for WG even if specs are equal

### DIFF
--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -214,7 +214,7 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint(ctx context.Context, syncer *b
 			continue
 		}
 
-		if existing.Spec.Equals(d.localEndpoint.Spec()) {
+		if existing.Spec.Equals(d.localEndpoint.Spec()) && existing.Spec.Backend != "wireguard" {
 			continue
 		}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -66,15 +66,6 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 		if err != nil {
 			return errors.Wrap(err, "error while reconciling routes")
 		}
-	} else if kp.localCableDriver == "wireguard" {
-		// We are on Gateway node and cable is wireguard.
-		//	After GW pod failure, the wireguard network interface (named 'submariner')
-		//	is created with a new ifindex, meaning all host routes created with LinkIndex
-		//	pointing to previous wireguard ifindex are deleted.
-		//	so, we need to make sure that host routes on GW node will be
-		//  reconfigured (pointing to updated wireguard ifindex)
-		kp.routeCacheGWNode.Clear()
-		kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.UnsortedList(), Add)
 	}
 
 	return nil


### PR DESCRIPTION
Starting from [1] commit we avoid recreating (delete and create) local endpoint if existing and local endpoint specs are equal.

Wireguard cable is an exception, as it is required to reconfigure host routing rules after GW pod failover even when local and existing endpoints specs are equal.

[1]
https://github.com/submariner-io/submariner/commit/c0fa24503ae5d66c9135b52a731e9a86b25143b5#diff-55092d2c14edea833b4702577bd0c0800b520811d7b73bc069ff2578ce3a686e

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
