### PR TITLE
Address underlying gateway failover issue with wireguard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/projectcalico/api v0.0.0-20230602153125-fb7148692637
 	github.com/prometheus-community/pro-bing v0.4.0
 	github.com/prometheus/client_golang v1.19.1
-	github.com/submariner-io/admiral v0.19.0-m0
+	github.com/submariner-io/admiral v0.19.0-m0.0.20240718120154-11bb4f8f51a2
 	github.com/submariner-io/shipyard v0.19.0-m0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/net v0.27.0
@@ -27,7 +27,7 @@ require (
 	k8s.io/client-go v0.30.2
 	k8s.io/component-helpers v0.30.2
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
-	sigs.k8s.io/controller-runtime v0.18.3
+	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/knftables v0.0.16
 	sigs.k8s.io/mcs-api v0.1.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.19.0-m0 h1:itGgB3Sew2Wa2E1oC3TJL51XYeguPTOgEt89CxJVNIg=
-github.com/submariner-io/admiral v0.19.0-m0/go.mod h1:l9Pr2DzG3fFJHr/58F5nfso0kaXWVnVWgpJnvLgL3Io=
+github.com/submariner-io/admiral v0.19.0-m0.0.20240718120154-11bb4f8f51a2 h1:YEi2E9glruzdGOVsJvA1egQHqYg3UjCgmqlDFBcdpvI=
+github.com/submariner-io/admiral v0.19.0-m0.0.20240718120154-11bb4f8f51a2/go.mod h1:aEGLDWiU6dR8AaN+FaDt4eL49zy4teXXSn1PuoZXzDk=
 github.com/submariner-io/shipyard v0.19.0-m0 h1:JZI3TU/jYz82PNcrWBS4S6DGt8mixkxq+GIUuk5dUzs=
 github.com/submariner-io/shipyard v0.19.0-m0/go.mod h1:ytax3kLIv6gg7FgHq4jFNy6g8LJG+fUe5iJC8reTdJQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -709,8 +709,8 @@ k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSn
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gEORz0efEja7A=
-sigs.k8s.io/controller-runtime v0.18.3 h1:B5Wmmo8WMWK7izei+2LlXLVDGzMwAHBNLX68lwtlSR4=
-sigs.k8s.io/controller-runtime v0.18.3/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
+sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHvm5BZw=
+sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -66,15 +66,6 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 		if err != nil {
 			return errors.Wrap(err, "error while reconciling routes")
 		}
-	} else if kp.localCableDriver == "wireguard" {
-		// We are on Gateway node and cable is wireguard.
-		//	After GW pod failure, the wireguard network interface (named 'submariner')
-		//	is created with a new ifindex, meaning all host routes created with LinkIndex
-		//	pointing to previous wireguard ifindex are deleted.
-		//	so, we need to make sure that host routes on GW node will be
-		//  reconfigured (pointing to updated wireguard ifindex)
-		kp.routeCacheGWNode.Clear()
-		kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.UnsortedList(), Add)
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/submariner-io/submariner/pull/3069 addressed this issue with a workaround in the route-agent's `kubeproxy` handler but the underlying root cause is due to a missed delete event in admiral's resource syncer.  The `wireguard` driver sets a “_public-key_” entry in the local `Endpoint`'s  `BackendConfig` map which is used by the remote clusters to establish a connection. This is a random-generated key so is different on each startup. So with `wireguard`, a new local `Endpoint` is always created on startup and the prior one deleted. However, client listeners, specifically the `kubeproxy` handler, may not observe the delete event due to timing which results in a failure of the gateway failover E2E test. This is addressed by https://github.com/submariner-io/admiral/pull/953. So this PR bumps the admiral dependency to pick up the change and removes the workaround by https://github.com/submariner-io/submariner/pull/3069.

Depends on https://github.com/submariner-io/admiral/pull/953