### PR TITLE
Automated backport of #3069: Fix GW failover bug with wireguard cable

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -66,6 +66,15 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 		if err != nil {
 			return errors.Wrap(err, "error while reconciling routes")
 		}
+	} else if kp.localCableDriver == "wireguard" {
+		// We are on Gateway node and cable is wireguard.
+		//	After GW pod failure, the wireguard network interface (named 'submariner')
+		//	is created with a new ifindex, meaning all host routes created with LinkIndex
+		//	pointing to previous wireguard ifindex are deleted.
+		//	so, we need to make sure that host routes on GW node will be
+		//  reconfigured (pointing to updated wireguard ifindex)
+		kp.routeCacheGWNode.Clear()
+		kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.UnsortedList(), Add)
 	}
 
 	return nil

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -79,15 +79,6 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 	Expect(gatewayNodes).To(HaveLen(1), fmt.Sprintf("Expected only one gateway node on %q", primaryClusterName))
 	framework.By(fmt.Sprintf("Found gateway on node %q on %q", gatewayNodes[0].Name, primaryClusterName))
 
-	submEndpoint := f.AwaitSubmarinerEndpoint(primaryCluster, subFramework.NoopCheckEndpoint)
-
-	// The cable driver name can't be imported from pkg/cable/wireguard to avoid breaking the subctl build on Windows
-	if submEndpoint.Spec.Backend == "wireguard" &&
-		framework.DetectProvider(context.TODO(), primaryCluster, gatewayNodes[0].Name) == "kind" {
-		framework.Skipf("The test is known to fail on Kind 0.21+ with the wireguard cable driver - skipping the test...")
-		return
-	}
-
 	gatewayPod := f.AwaitSubmarinerGatewayPod(primaryCluster)
 	framework.By(fmt.Sprintf("Found submariner gateway pod %q on %q, checking node and HA status labels", gatewayPod.Name, primaryClusterName))
 
@@ -96,6 +87,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	framework.By(fmt.Sprintf("Ensuring that the gateway reports as active on %q", primaryClusterName))
 
+	submEndpoint := f.AwaitSubmarinerEndpoint(primaryCluster, subFramework.NoopCheckEndpoint)
 	activeGateway := f.AwaitGatewayFullyConnected(primaryCluster, resource.EnsureValidName(submEndpoint.Spec.Hostname))
 
 	framework.By(fmt.Sprintf("Deleting submariner gateway pod %q", gatewayPod.Name))


### PR DESCRIPTION
Backport of #3069 on release-0.18.

#3069: Fix GW failover bug with wireguard cable

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.