### PR TITLE
Allow cable drivers to expose settings via the local Endpoint's BackendConfig

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -55,7 +56,7 @@ type Driver interface {
 }
 
 // Function prototype to create a new driver.
-type DriverCreateFunc func(localEndpoint *types.SubmarinerEndpoint, localCluster *types.SubmarinerCluster) (Driver, error)
+type DriverCreateFunc func(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster) (Driver, error)
 
 // Static map of supported drivers.
 var drivers = map[string]DriverCreateFunc{}
@@ -75,9 +76,11 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 }
 
 // Returns a new driver according the required Backend.
-func NewDriver(localEndpoint *types.SubmarinerEndpoint, localCluster *types.SubmarinerCluster) (Driver, error) {
+func NewDriver(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster) (Driver, error) {
 	// We'll panic if localEndpoint or localCluster are nil, this is intentional
-	driverCreate, ok := drivers[localEndpoint.Spec.Backend]
+	spec := localEndpoint.Spec()
+
+	driverCreate, ok := drivers[spec.Backend]
 	if !ok {
 		var driverList strings.Builder
 
@@ -89,7 +92,7 @@ func NewDriver(localEndpoint *types.SubmarinerEndpoint, localCluster *types.Subm
 			driverList.WriteString(driver)
 		}
 
-		return nil, fmt.Errorf("unsupported cable type %s; supported types: %s", localEndpoint.Spec.Backend, driverList.String())
+		return nil, fmt.Errorf("unsupported cable type %s; supported types: %s", spec.Backend, driverList.String())
 	}
 
 	return driverCreate(localEndpoint, localCluster)

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -115,6 +115,11 @@ func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster)
 		return nil, errors.Wrapf(err, "error parsing %q from local endpoint", subv1.UDPPortConfig)
 	}
 
+	err = processPreferredServerConfig(localEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
 	encodedPsk := ipSecSpec.PSK
 
 	if ipSecSpec.PSKSecret != "" {

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -32,7 +32,7 @@ const (
 )
 
 func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) operationMode {
-	leftPreferred, err := i.localEndpoint.Spec.GetBackendBool(v1.PreferredServerConfig, ptr.To(false))
+	leftPreferred, err := i.localEndpoint.GetBackendBool(v1.PreferredServerConfig, ptr.To(false))
 	if err != nil {
 		logger.Errorf(err, "Error parsing local endpoint config")
 	}
@@ -55,7 +55,7 @@ func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) oper
 	}
 
 	// At this point both would like to be server, so we decide based on the cable name
-	if i.localEndpoint.Spec.CableName > remoteEndpoint.CableName {
+	if i.localEndpoint.CableName > remoteEndpoint.CableName {
 		return operationModeServer
 	}
 

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -19,7 +19,14 @@ limitations under the License.
 package libreswan
 
 import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"k8s.io/utils/ptr"
 )
 
@@ -73,4 +80,39 @@ func (m operationMode) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+func processPreferredServerConfig(localEndpoint *submendpoint.Local) error {
+	preferredServerStr := localEndpoint.Spec().BackendConfig[v1.PreferredServerConfig]
+
+	if preferredServerStr == "" {
+		preferredServerStr = os.Getenv("CE_IPSEC_PREFERREDSERVER")
+	}
+
+	if preferredServerStr == "" {
+		preferredServerStr = strconv.FormatBool(false)
+	}
+
+	preferredServer, err := strconv.ParseBool(preferredServerStr)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing CE_IPSEC_PREFERREDSERVER or node gateway.submariner."+
+			"io/preferred-server annotation bool: %s", preferredServerStr)
+	}
+
+	err = localEndpoint.Update(context.TODO(), func(existing *v1.EndpointSpec) {
+		if existing.BackendConfig == nil {
+			existing.BackendConfig = map[string]string{}
+		}
+
+		existing.BackendConfig[v1.PreferredServerConfig] = preferredServerStr
+
+		// When this Endpoint is in "preferred-server" mode, a bogus timestamp is inserted in the BackendConfig,
+		// forcing the resynchronization of the object to the broker, which will indicate to all clients that the
+		// server has been restarted, and that they must re-connect to the endpoint.
+		if preferredServer {
+			existing.BackendConfig[v1.PreferredServerConfig+"-timestamp"] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
+		}
+	})
+
+	return errors.Wrap(err, "error updating local endpoint")
 }

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -19,6 +19,7 @@ limitations under the License.
 package wireguard
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"net"
@@ -31,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/vishvananda/netlink"
@@ -74,7 +76,7 @@ type specification struct {
 }
 
 type wireguard struct {
-	localEndpoint types.SubmarinerEndpoint
+	localEndpoint v1.EndpointSpec
 	connections   map[string]*v1.Connection // clusterID -> remote ep connection
 	mutex         sync.Mutex
 	client        *wgctrl.Client
@@ -84,14 +86,13 @@ type wireguard struct {
 }
 
 // NewDriver creates a new WireGuard driver.
-func NewDriver(localEndpoint *types.SubmarinerEndpoint, _ *types.SubmarinerCluster) (cable.Driver, error) {
+func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
 	// We'll panic if localEndpoint is nil, this is intentional
 	var err error
 
 	w := wireguard{
-		connections:   make(map[string]*v1.Connection),
-		localEndpoint: *localEndpoint,
-		spec:          new(specification),
+		connections: make(map[string]*v1.Connection),
+		spec:        new(specification),
 	}
 
 	if err := envconfig.Process(specEnvPrefix, w.spec); err != nil {
@@ -136,9 +137,16 @@ func NewDriver(localEndpoint *types.SubmarinerEndpoint, _ *types.SubmarinerClust
 
 	pub = priv.PublicKey()
 
-	w.localEndpoint.Spec.BackendConfig[PublicKey] = pub.String()
+	err = localEndpoint.Update(context.TODO(), func(existing *v1.EndpointSpec) {
+		existing.BackendConfig[PublicKey] = pub.String()
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error updating local endpoint")
+	}
 
-	port, err := localEndpoint.Spec.GetBackendPort(v1.UDPPortConfig, int32(w.spec.NATTPort))
+	w.localEndpoint = *localEndpoint.Spec()
+
+	port, err := w.localEndpoint.GetBackendPort(v1.UDPPortConfig, int32(w.spec.NATTPort))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing %q from local endpoint", v1.UDPPortConfig)
 	}
@@ -166,7 +174,7 @@ func (w *wireguard) Init() error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	logger.V(log.DEBUG).Infof("Initializing WireGuard device for cluster %s", w.localEndpoint.Spec.ClusterID)
+	logger.V(log.DEBUG).Infof("Initializing WireGuard device for cluster %s", w.localEndpoint.ClusterID)
 
 	if len(w.connections) != 0 {
 		return fmt.Errorf("cannot initialize with existing connections: %+v", w.connections)
@@ -182,7 +190,7 @@ func (w *wireguard) Init() error {
 		return errors.Wrap(err, "wgctrl cannot find WireGuard device")
 	}
 
-	k, err := keyFromSpec(&w.localEndpoint.Spec)
+	k, err := keyFromSpec(&w.localEndpoint)
 	if err != nil {
 		return errors.Wrapf(err, "endpoint is missing public key %s", d.PublicKey)
 	}
@@ -211,7 +219,7 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 	remoteEndpoint := &endpointInfo.Endpoint
 	ip := endpointInfo.UseIP
 
-	if w.localEndpoint.Spec.ClusterID == remoteEndpoint.Spec.ClusterID {
+	if w.localEndpoint.ClusterID == remoteEndpoint.Spec.ClusterID {
 		logger.V(log.DEBUG).Infof("Will not connect to self")
 		return "", nil
 	}
@@ -301,7 +309,7 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 
 	logger.V(log.DEBUG).Infof("Done connecting endpoint peer %s@%s", *remoteKey, remoteIP)
 
-	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(v1.Connected), true)
+	cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(v1.Connected), true)
 
 	return ip, nil
 }
@@ -324,7 +332,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpo
 	// We'll panic if remoteEndpoint is nil, this is intentional
 	logger.V(log.DEBUG).Infof("Removing endpoint %v+", remoteEndpoint)
 
-	if w.localEndpoint.Spec.ClusterID == remoteEndpoint.Spec.ClusterID {
+	if w.localEndpoint.ClusterID == remoteEndpoint.Spec.ClusterID {
 		logger.V(log.DEBUG).Infof("Will not disconnect self")
 		return nil
 	}
@@ -350,7 +358,7 @@ func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpo
 	delete(w.connections, remoteEndpoint.Spec.ClusterID)
 
 	logger.V(log.DEBUG).Infof("Done removing endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
-	cable.RecordDisconnected(cableDriverName, &w.localEndpoint.Spec, &remoteEndpoint.Spec)
+	cable.RecordDisconnected(cableDriverName, &w.localEndpoint, &remoteEndpoint.Spec)
 
 	return nil
 }

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -95,7 +95,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if lc > handshakeTimeout.Milliseconds() {
 			// No initial handshake for too long.
 			connection.SetStatus(v1.ConnectionError, "no initial handshake for %.1f seconds", lcSec)
-			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -103,7 +103,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		if tx > 0 || rx > 0 {
 			// No handshake, but at least some communication in progress.
 			connection.SetStatus(v1.Connecting, "no initial handshake yet")
-			cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+			cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(connection.Status), false)
 
 			return
 		}
@@ -112,8 +112,8 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	if tx > 0 || rx > 0 {
 		// All is good.
 		connection.SetStatus(v1.Connected, "Rx=%d Bytes, Tx=%d Bytes", p.ReceiveBytes, p.TransmitBytes)
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
-		saveAndRecordPeerTraffic(&w.localEndpoint.Spec, &connection.Endpoint, now, p.TransmitBytes, p.ReceiveBytes)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(connection.Status), false)
+		saveAndRecordPeerTraffic(&w.localEndpoint, &connection.Endpoint, now, p.TransmitBytes, p.ReceiveBytes)
 
 		return
 	}
@@ -124,7 +124,7 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 		// Hard error, really long time since handshake.
 		connection.SetStatus(v1.ConnectionError, "no handshake for %.1f seconds",
 			handshakeDelta.Seconds())
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(connection.Status), false)
 
 		return
 	}
@@ -138,14 +138,14 @@ func (w *wireguard) updateConnectionForPeer(p *wgtypes.Peer, connection *v1.Conn
 	// Soft error, no traffic, stale handshake.
 	connection.SetStatus(v1.ConnectionError, "no bytes sent or received for %.1f seconds",
 		lcSec)
-	cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &connection.Endpoint, string(connection.Status), false)
+	cable.RecordConnection(cableDriverName, &w.localEndpoint, &connection.Endpoint, string(connection.Status), false)
 }
 
 func (w *wireguard) updatePeerStatus(c *v1.Connection, key *wgtypes.Key) {
 	p, err := w.peerByKey(key)
 	if err != nil {
 		c.SetStatus(v1.ConnectionError, "cannot fetch status for peer %s: %v", key, err)
-		cable.RecordConnection(cableDriverName, &w.localEndpoint.Spec, &c.Endpoint, string(c.Status), false)
+		cable.RecordConnection(cableDriverName, &w.localEndpoint, &c.Endpoint, string(c.Status), false)
 
 		return
 	}

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -129,7 +129,7 @@ func (i *engine) startDriver() error {
 
 	var err error
 
-	if i.driver, err = cable.NewDriver(i.GetLocalEndpoint(), &i.localCluster); err != nil {
+	if i.driver, err = cable.NewDriver(i.localEndpoint, &i.localCluster); err != nil {
 		return errors.Wrap(err, "error creating the cable driver")
 	}
 

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -48,7 +48,7 @@ var fakeDriver *fake.Driver
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
-	cable.AddDriver(fake.DriverName, func(_ *types.SubmarinerEndpoint, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 })

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -87,7 +87,7 @@ func (d *DatastoreSyncer) Start(ctx context.Context) error {
 		return errors.WithMessage(err, "error creating the local submariner Cluster")
 	}
 
-	if err := d.createOrUpdateLocalEndpoint(ctx, syncer.GetLocalFederator()); err != nil {
+	if err := d.createOrUpdateLocalEndpoint(ctx); err != nil {
 		return errors.WithMessage(err, "error creating the local submariner Endpoint")
 	}
 
@@ -275,10 +275,8 @@ func (d *DatastoreSyncer) createLocalCluster(ctx context.Context, federator fede
 	return federator.Distribute(ctx, cluster) //nolint:wrapcheck  // Let the caller wrap it
 }
 
-func (d *DatastoreSyncer) createOrUpdateLocalEndpoint(ctx context.Context, federator federate.Federator) error {
-	localEndpoint := d.localEndpoint.Resource()
+func (d *DatastoreSyncer) createOrUpdateLocalEndpoint(ctx context.Context) error {
+	logger.Infof("Creating local submariner Endpoint: %s", resource.ToJSON(d.localEndpoint.Resource()))
 
-	logger.Infof("Creating local submariner Endpoint: %s", resource.ToJSON(localEndpoint))
-
-	return federator.Distribute(ctx, localEndpoint) //nolint:wrapcheck  // Let the caller wrap it
+	return d.localEndpoint.Create(ctx) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -56,7 +56,7 @@ var fakeDriver *fake.Driver
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
-	cable.AddDriver(fake.DriverName, func(_ *types.SubmarinerEndpoint, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 })

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -225,33 +224,6 @@ func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {
 	// Enable and publish the natt-discovery-port by default.
 	if _, ok := backendConfig[submv1.NATTDiscoveryPortConfig]; !ok {
 		backendConfig[submv1.NATTDiscoveryPortConfig] = strconv.Itoa(port.NATTDiscovery)
-	}
-
-	// TODO: we should allow the cable drivers to capture and expose BackendConfig settings, instead of doing
-	//      it here.
-	preferredServerStr := backendConfig[submv1.PreferredServerConfig]
-
-	if preferredServerStr == "" {
-		preferredServerStr = os.Getenv("CE_IPSEC_PREFERREDSERVER")
-	}
-
-	if preferredServerStr == "" {
-		preferredServerStr = "false"
-	}
-
-	preferredServer, err := strconv.ParseBool(preferredServerStr)
-	if err != nil {
-		return backendConfig, errors.Wrapf(err, "error parsing CE_IPSEC_PREFERREDSERVER or node gateway.submariner."+
-			"io/preferred-server annotation bool: %s", preferredServerStr)
-	}
-
-	backendConfig[submv1.PreferredServerConfig] = preferredServerStr
-
-	// When this Endpoint is in "preferred-server" mode a bogus timestamp is inserted in the BackendConfig,
-	// forcing the resynchronization of the object to the broker, which will indicate all clients that the
-	// server has been restarted, and that they must re-connect to the endpoint.
-	if preferredServer {
-		backendConfig[submv1.PreferredServerConfig+"-timestamp"] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
 	}
 
 	return backendConfig, nil

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -91,7 +91,7 @@ func newPublicIPWatcherTestDriver() *publicIPWatcherTestDriver {
 	})
 
 	JustBeforeEach(func() {
-		test.CreateResource(t.endpointClient, t.localEndpoint.Resource())
+		Expect(t.localEndpoint.Create(context.TODO())).To(Succeed())
 
 		ipWatcher := endpoint.NewPublicIPWatcher(&endpoint.PublicIPWatcherConfig{
 			SubmSpec: &types.SubmarinerSpecification{
@@ -101,7 +101,7 @@ func newPublicIPWatcherTestDriver() *publicIPWatcherTestDriver {
 			},
 			Interval:      interval,
 			K8sClient:     t.k8sClient,
-			LocalEndpoint: endpoint.NewLocal(&t.localEPSpec, t.dynClient, testNamespace),
+			LocalEndpoint: t.localEndpoint,
 		})
 
 		ipWatcher.Run(t.stopCh)

--- a/pkg/gateway/gateway_suite_test.go
+++ b/pkg/gateway/gateway_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cable/fake"
 	"github.com/submariner-io/submariner/pkg/cableengine/syncer"
+	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -43,7 +44,7 @@ var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
 	Expect(submarinerv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	cable.AddDriver(fake.DriverName, func(_ *types.SubmarinerEndpoint, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *endpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 


### PR DESCRIPTION
The wireguard cable driver actually exposes the "_publicKey_" setting now by modifying the `BackendConfig` map in the supplied `SubmarinerEndpoint` instance which gets leaked as a side-effect because it contains a shallow copy of the `EndpointSpec`.  However this was not intended nor ideal.

This PR modifies the cable drivers to take the shared `endpoint.Local` instance and use the `Update` method to modify the `BackendConfig` map. Since cable drivers are initialized prior to creation of the local `Endpoint` resource in K8s (which is done by the data store syncer), we don't want `Update` trying to prematurely update the K8s resource. So a `Create` method was added to `endpoint.Local` which also sets an internal flag that is checked by `Update`, ie if not yet created then only update the cached `EndpointSpec`.

Since the `PreferredServerConfig` `BackendConfig` setting is specific to libreswan, processing was moved to the libreswan driver.

See individual commits for details.