### PR TITLE
Automated backport of #3084: Address underlying gateway failover issue with wireguard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/projectcalico/api v0.0.0-20230602153125-fb7148692637
 	github.com/prometheus-community/pro-bing v0.4.0
 	github.com/prometheus/client_golang v1.19.1
-	github.com/submariner-io/admiral v0.18.0
+	github.com/submariner-io/admiral v0.18.1-0.20240719125139-e24eff08e932
 	github.com/submariner-io/shipyard v0.18.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/net v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.18.0 h1:f8+owedukeKjwNazwmQScJjP3wXkEB+FqEJQJHOjDwU=
-github.com/submariner-io/admiral v0.18.0/go.mod h1:Xy24HCHRsq+LUSyuQh0pLgKFpAFyPhuzcPRUyUlL30s=
+github.com/submariner-io/admiral v0.18.1-0.20240719125139-e24eff08e932 h1:LfZFIHay9MejD3yhFLc/NtSjX5ftIRflxPZilhwz7Cg=
+github.com/submariner-io/admiral v0.18.1-0.20240719125139-e24eff08e932/go.mod h1:Xy24HCHRsq+LUSyuQh0pLgKFpAFyPhuzcPRUyUlL30s=
 github.com/submariner-io/shipyard v0.18.0 h1:bBvqho5UtEplMhyxX2YhEC4DzjrfWTqF8KOGblaDJJw=
 github.com/submariner-io/shipyard v0.18.0/go.mod h1:wJD8mgVkdTCRiOH4UKu6DNDyu8hw8RPTtynalkgKZOM=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -66,15 +66,6 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 		if err != nil {
 			return errors.Wrap(err, "error while reconciling routes")
 		}
-	} else if kp.localCableDriver == "wireguard" {
-		// We are on Gateway node and cable is wireguard.
-		//	After GW pod failure, the wireguard network interface (named 'submariner')
-		//	is created with a new ifindex, meaning all host routes created with LinkIndex
-		//	pointing to previous wireguard ifindex are deleted.
-		//	so, we need to make sure that host routes on GW node will be
-		//  reconfigured (pointing to updated wireguard ifindex)
-		kp.routeCacheGWNode.Clear()
-		kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.UnsortedList(), Add)
 	}
 
 	return nil


### PR DESCRIPTION
Backport of #3084 on release-0.18.

#3084: Address underlying gateway failover issue with wireguard

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.