### PR TITLE
Expose wireguard's interface name via local EndPoint BackendConfig

### DIFF
--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -58,6 +58,8 @@ type Driver interface {
 // Function prototype to create a new driver.
 type DriverCreateFunc func(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster) (Driver, error)
 
+const InterfaceNameConfig = "interface-name"
+
 // Static map of supported drivers.
 var drivers = map[string]DriverCreateFunc{}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -23,12 +23,13 @@ import (
 
 	"github.com/pkg/errors"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/vxlan"
 )
 
 func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
-	kp.localCableDriver = endpoint.Spec.Backend
+	kp.localEndpointIfaceName = endpoint.Spec.BackendConfig[cable.InterfaceNameConfig]
 
 	// We are on nonGateway node
 	if !kp.State().IsOnGateway() {

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -38,9 +38,9 @@ import (
 type SyncHandler struct {
 	event.HandlerBase
 	event.NodeHandlerBase
-	localCableDriver string
-	localClusterCidr []string
-	localServiceCidr []string
+	localEndpointIfaceName string
+	localClusterCidr       []string
+	localServiceCidr       []string
 
 	remoteSubnets          set.Set[string]
 	remoteSubnetGw         map[string]net.IP
@@ -65,7 +65,6 @@ func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
 	return &SyncHandler{
 		localClusterCidr: cidr.ExtractIPv4Subnets(localClusterCidr),
 		localServiceCidr: cidr.ExtractIPv4Subnets(localServiceCidr),
-		localCableDriver: "",
 		remoteSubnets:    set.New[string](),
 		remoteSubnetGw:   map[string]net.IP{},
 		remoteVTEPs:      set.New[string](),

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/submariner/pkg/cable/wireguard"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -114,12 +113,12 @@ func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation, 
 	}
 
 	ifaceIndex := kp.defaultHostIface.Index
-	// TODO: Add support for this in the CableDrivers themselves.
-	if kp.localCableDriver == "wireguard" {
-		if wg, err := net.InterfaceByName(wireguard.DefaultDeviceName); err == nil {
-			ifaceIndex = wg.Index
+
+	if kp.localEndpointIfaceName != "" {
+		if iface, err := net.InterfaceByName(kp.localEndpointIfaceName); err == nil {
+			ifaceIndex = iface.Index
 		} else {
-			logger.Errorf(nil, "Wireguard interface %s not found on the node.", wireguard.DefaultDeviceName)
+			logger.Errorf(err, "Error getting local endpoint interface %q", kp.localEndpointIfaceName)
 		}
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -28,7 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	clientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/cni"
@@ -139,11 +139,11 @@ func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 	var routingInterface *net.Interface
 	var err error
 
-	// TODO: this logic belongs to the cabledrivers instead
-	if endpoint.Spec.Backend == "wireguard" {
+	interfaceName := endpoint.Spec.BackendConfig[cable.InterfaceNameConfig]
+	if interfaceName != "" {
 		// NOTE: This assumes that LocalEndpointCreated happens before than TransitionToGatewayNode
-		if routingInterface, err = net.InterfaceByName(wireguard.DefaultDeviceName); err != nil {
-			return errors.Wrapf(err, "Wireguard interface %s not found on the node", wireguard.DefaultDeviceName)
+		if routingInterface, err = net.InterfaceByName(interfaceName); err != nil {
+			return errors.Wrapf(err, "error getting local endpoint interface %q", interfaceName)
 		}
 	} else {
 		if routingInterface, err = netlink.GetDefaultGatewayInterface(); err != nil {


### PR DESCRIPTION
This avoids hard-coding references to wireguard in the kubeproxy and OVN route-agent handlers. Also removes a couple TODOs.

See commits for details.