### PR TITLE
Remove TODO in .../ovn/uninstall.go

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -103,7 +103,6 @@ func (ovn *Handler) cleanupRoutes() error {
 	return nil
 }
 
-// TODO need to be removed when the clusters are fully upgraded to new implementation.
 func (ovn *Handler) LegacyCleanup() {
 	err := vsctl.DelInternalPort(ovnK8sSubmarinerBridge, ovnK8sSubmarinerInterface)
 	if err != nil {


### PR DESCRIPTION
"_need to be removed when the clusters are fully upgraded to new implementation._"

...since there's an issue created for it: https://github.com/submariner-io/submariner/issues/2806
