### PR TITLE
Update multiple GWs failover test to support ROKS as well

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -183,11 +183,13 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	Expect(initialGWPod).ToNot(BeNil(), "Did not find an active gateway pod")
 
 	framework.By(fmt.Sprintf("Ensure active gateway node %q has established connections", initialGWPod.Name))
-	gwConnection := f.AwaitGatewayWithStatus(framework.ClusterIndex(primaryCluster), initialGWPod.Spec.NodeName, subv1.HAStatusActive)
-	Expect(gwConnection.Status.Connections).NotTo(BeEmpty(), "The active gateway must have established connections")
 
 	submEndpoint := f.AwaitSubmarinerEndpoint(framework.ClusterIndex(primaryCluster), subFramework.NoopCheckEndpoint)
 	framework.By(fmt.Sprintf("Found submariner endpoint for %q: %#v", clusterAName, submEndpoint))
+
+	gwConnection := f.AwaitGatewayWithStatus(framework.ClusterIndex(primaryCluster),
+		resource.EnsureValidName(submEndpoint.Spec.Hostname), subv1.HAStatusActive)
+	Expect(gwConnection.Status.Connections).NotTo(BeEmpty(), "The active gateway must have established connections")
 
 	framework.By("Performing fail-over to passive gateway")
 	f.DoFailover(context.TODO(), framework.ClusterIndex(primaryCluster), initialGWPod.Spec.NodeName, initialGWPod.Name)
@@ -199,13 +201,14 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	Expect(newGWPod).ToNot(BeNil(), "Did not find a new active gateway pod running on a different node")
 	framework.By(fmt.Sprintf("Found new submariner gateway pod %q", newGWPod.Name))
 
-	framework.By(fmt.Sprintf("Waiting for the new pod %q to report as fully connected", newGWPod.Name))
-	f.AwaitGatewayFullyConnected(framework.ClusterIndex(primaryCluster), resource.EnsureValidName(newGWPod.Spec.NodeName))
-
 	// Verify a new Endpoint instance is created by the new gateway instance. This is a bit whitebox but it's a sanity check
 	// and also gives it a bit more of a cushion to avoid premature timeout in the connectivity test.
 	newSubmEndpoint := f.AwaitNewSubmarinerEndpoint(framework.ClusterIndex(primaryCluster), submEndpoint.ObjectMeta.UID)
 	framework.By(fmt.Sprintf("Found new submariner endpoint for %q: %#v", clusterAName, newSubmEndpoint))
+
+	framework.By(fmt.Sprintf("Waiting for the new pod %q to report as fully connected", newGWPod.Name))
+	f.AwaitGatewayFullyConnected(framework.ClusterIndex(primaryCluster),
+		resource.EnsureValidName(resource.EnsureValidName(newSubmEndpoint.Spec.Hostname)))
 
 	framework.By(fmt.Sprintf("Waiting for the previous submariner endpoint %q to be removed on %q", newGWPod.Name, clusterBName))
 	f.AwaitSubmarinerEndpointRemoved(framework.ClusterIndex(secondaryCluster), submEndpoint.Name)


### PR DESCRIPTION
Submariner endpoint and gateway names are based on node's os.Hostname().
For ROKS the node names are not equal to os.Hostname().

Now that we are going to support multiple gateways for ROKS as well, the name parameter used for searching gateway CR needs to be updated to endpoint.spec.hostname instead of gwpod.spec.nodeName.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
