### PR TITLE
Automated backport of #3122: Update multiple GWs failover test to support ROKS as well

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -183,11 +183,13 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	Expect(initialGWPod).ToNot(BeNil(), "Did not find an active gateway pod")
 
 	framework.By(fmt.Sprintf("Ensure active gateway node %q has established connections", initialGWPod.Name))
-	gwConnection := f.AwaitGatewayWithStatus(framework.ClusterIndex(primaryCluster), initialGWPod.Spec.NodeName, subv1.HAStatusActive)
-	Expect(gwConnection.Status.Connections).NotTo(BeEmpty(), "The active gateway must have established connections")
 
 	submEndpoint := f.AwaitSubmarinerEndpoint(framework.ClusterIndex(primaryCluster), subFramework.NoopCheckEndpoint)
 	framework.By(fmt.Sprintf("Found submariner endpoint for %q: %#v", clusterAName, submEndpoint))
+
+	gwConnection := f.AwaitGatewayWithStatus(framework.ClusterIndex(primaryCluster),
+		resource.EnsureValidName(submEndpoint.Spec.Hostname), subv1.HAStatusActive)
+	Expect(gwConnection.Status.Connections).NotTo(BeEmpty(), "The active gateway must have established connections")
 
 	framework.By("Performing fail-over to passive gateway")
 	f.DoFailover(context.TODO(), framework.ClusterIndex(primaryCluster), initialGWPod.Spec.NodeName, initialGWPod.Name)
@@ -199,13 +201,14 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	Expect(newGWPod).ToNot(BeNil(), "Did not find a new active gateway pod running on a different node")
 	framework.By(fmt.Sprintf("Found new submariner gateway pod %q", newGWPod.Name))
 
-	framework.By(fmt.Sprintf("Waiting for the new pod %q to report as fully connected", newGWPod.Name))
-	f.AwaitGatewayFullyConnected(framework.ClusterIndex(primaryCluster), resource.EnsureValidName(newGWPod.Spec.NodeName))
-
 	// Verify a new Endpoint instance is created by the new gateway instance. This is a bit whitebox but it's a sanity check
 	// and also gives it a bit more of a cushion to avoid premature timeout in the connectivity test.
 	newSubmEndpoint := f.AwaitNewSubmarinerEndpoint(framework.ClusterIndex(primaryCluster), submEndpoint.ObjectMeta.UID)
 	framework.By(fmt.Sprintf("Found new submariner endpoint for %q: %#v", clusterAName, newSubmEndpoint))
+
+	framework.By(fmt.Sprintf("Waiting for the new pod %q to report as fully connected", newGWPod.Name))
+	f.AwaitGatewayFullyConnected(framework.ClusterIndex(primaryCluster),
+		resource.EnsureValidName(resource.EnsureValidName(newSubmEndpoint.Spec.Hostname)))
 
 	framework.By(fmt.Sprintf("Waiting for the previous submariner endpoint %q to be removed on %q", newGWPod.Name, clusterBName))
 	f.AwaitSubmarinerEndpointRemoved(framework.ClusterIndex(secondaryCluster), submEndpoint.Name)


### PR DESCRIPTION
Backport of #3122 on release-0.18.

#3122: Update multiple GWs failover test to support ROKS as well

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.