### PR TITLE
Automated backport of #3156: Explicitly disable BGP export for Calico IPPools

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/ippool_handler.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler.go
@@ -161,9 +161,10 @@ func (h *calicoIPPoolHandler) createIPPool(endpoint *submV1.Endpoint) error {
 				Labels: map[string]string{SubmarinerIPPool: "true"},
 			},
 			Spec: calicoapi.IPPoolSpec{
-				CIDR:        subnet,
-				NATOutgoing: false,
-				Disabled:    true,
+				CIDR:             subnet,
+				NATOutgoing:      false,
+				Disabled:         true,
+				DisableBGPExport: true,
 			},
 		}
 		_, err := h.client.ProjectcalicoV3().IPPools().Create(context.TODO(), iPPoolObj, metav1.CreateOptions{})


### PR DESCRIPTION
Backport of #3156 on release-0.18.

#3156: Explicitly disable BGP export for Calico IPPools

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.