### PR TITLE
Fix bug in RouteAgent resource creation on OpenShift

### DIFF
--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -300,6 +300,9 @@ func (h *controller) syncRouteAgentStatus() {
 
 func (h *controller) generateRouteAgentObject() *submarinerv1.RouteAgent {
 	return &submarinerv1.RouteAgent{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "RouteAgent",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: h.localNodeName,
 		},


### PR DESCRIPTION
RouteAgent resources creation failed on OpenShift with [1] error.

[1]
the object provided is unrecognized (must be of type RouteAgent):
 Object 'Kind' is missing in
'{"metadata":{"name":"submqe-azure-ks4th-master-1",

