### PR TITLE
Automated backport of #3192: Adjust OVN TransitSwitchIP initialization

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -51,7 +51,7 @@ type HandlerConfig struct {
 	DynClient       dynamic.Interface
 	WatcherConfig   *watcher.Config
 	NewOVSDBClient  NewOVSDBClientFn
-	TransitSwitchIP TransitSwitchIPGetter
+	TransitSwitchIP TransitSwitchIP
 }
 
 type Handler struct {
@@ -112,6 +112,11 @@ func (ovn *Handler) Init() error {
 	err = connectionHandler.initClients(ovn.NewOVSDBClient)
 	if err != nil {
 		return errors.Wrapf(err, "error getting connection handler to connect to OvnDB")
+	}
+
+	err = ovn.TransitSwitchIP.Init(ovn.K8sClient)
+	if err != nil {
+		return errors.Wrap(err, "error initializing TransitSwitchIP")
 	}
 
 	gatewayRouteController, err := NewGatewayRouteController(*ovn.WatcherConfig, connectionHandler, ovn.Namespace)

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -102,7 +102,6 @@ var _ = Describe("Handler", func() {
 		}))
 
 		Expect(ovsdbClient.Connected()).To(BeTrue())
-		Expect(transitSwitchIP.Init(t.k8sClient)).To(Succeed())
 	})
 
 	When("a remote Endpoint is created, updated, and deleted", func() {

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
@@ -31,29 +31,26 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 type NonGatewayRouteHandler struct {
 	event.HandlerBase
 	event.NodeHandlerBase
 	smClient        submarinerClientset.Interface
-	k8sClient       kubernetes.Interface
 	transitSwitchIP TransitSwitchIP
 }
 
-func NewNonGatewayRouteHandler(smClient submarinerClientset.Interface, k8sClient kubernetes.Interface, transitSwitchIP TransitSwitchIP,
+func NewNonGatewayRouteHandler(smClient submarinerClientset.Interface, transitSwitchIP TransitSwitchIP,
 ) *NonGatewayRouteHandler {
 	return &NonGatewayRouteHandler{
 		smClient:        smClient,
-		k8sClient:       k8sClient,
 		transitSwitchIP: transitSwitchIP,
 	}
 }
 
 func (h *NonGatewayRouteHandler) Init() error {
 	logger.Info("Starting NonGatewayRouteHandler")
-	return errors.Wrap(h.transitSwitchIP.Init(h.k8sClient), "error initializing TransitSwitchIP")
+	return nil
 }
 
 func (h *NonGatewayRouteHandler) GetName() string {

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
@@ -38,7 +38,9 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 	t := newTestDriver()
 
 	JustBeforeEach(func() {
-		t.Start(ovn.NewNonGatewayRouteHandler(t.submClient, t.k8sClient, ovn.NewTransitSwitchIP()))
+		tsIP := ovn.NewTransitSwitchIP()
+		t.Start(ovn.NewNonGatewayRouteHandler(t.submClient, tsIP))
+		Expect(tsIP.Init(t.k8sClient)).To(Succeed())
 	})
 
 	awaitNonGatewayRoute := func(ep *submarinerv1.Endpoint) {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -156,7 +156,7 @@ func main() {
 			TransitSwitchIP: transitSwitchIP,
 		}),
 		ovn.NewGatewayRouteHandler(smClientset),
-		ovn.NewNonGatewayRouteHandler(smClientset, k8sClientSet, transitSwitchIP),
+		ovn.NewNonGatewayRouteHandler(smClientset, transitSwitchIP),
 		cabledriver.NewXRFMCleanupHandler(),
 		cabledriver.NewVXLANCleanup(),
 		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(localNode)),


### PR DESCRIPTION
Backport of #3192 on release-0.19.

#3192: Adjust OVN TransitSwitchIP initialization

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.