### PR TITLE
Use exec form instead of shell form in docker files

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -35,4 +35,4 @@ COPY --from=base /output/gateway /
 
 COPY --from=builder ${SOURCE}/package/submariner.sh ${SOURCE}/package/pluto ${SOURCE}/bin/${TARGETPLATFORM}/submariner-gateway /usr/local/bin/
 
-ENTRYPOINT submariner.sh
+ENTRYPOINT ["submariner.sh"]

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -38,4 +38,4 @@ COPY --from=builder ${SOURCE}/package/iptables-wrapper-installer.sh /usr/sbin/
 # The sanity checks can fail when building foreign arch images; we know we meet the requirements
 RUN /usr/sbin/iptables-wrapper-installer.sh --no-sanity-check
 
-ENTRYPOINT submariner-globalnet.sh
+ENTRYPOINT ["submariner-globalnet.sh"]

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -38,4 +38,4 @@ COPY --from=builder ${SOURCE}/package/iptables-wrapper-installer.sh /usr/sbin/
 # The sanity checks can fail when building foreign arch images; we know we meet the requirements
 RUN /usr/sbin/iptables-wrapper-installer.sh --no-sanity-check
 
-ENTRYPOINT submariner-route-agent.sh
+ENTRYPOINT ["submariner-route-agent.sh"]


### PR DESCRIPTION
This is reported by Sonar:

"_Using the shell form instead of the exec form for CMD and ENTRYPOINT instructions in Dockerfiles can lead to several issues. When you use the shell form, the executable runs as a child process to a shell, which does not pass OS signals. This can cause problems when trying to gracefully stop containers because the main process will not receive the signal intended to terminate it. Moreover, the exec form provides more control and predictability over the execution of the command. It does not invoke a command shell, which means it does not have the potential side effects of shell processing._"
