### PR TITLE
Automated backport of #3219: Propagate PublishNotReadyAddresses flag to GN internal

### DIFF
--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -288,10 +288,11 @@ func (c *globalIngressIPController) createOrUpdateInternalService(from *corev1.S
 			Finalizers: []string{InternalServiceFinalizer},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:          from.Spec.Ports,
-			Selector:       from.Spec.Selector,
-			ExternalIPs:    []string{extIP},
-			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicySingleStack),
+			Ports:                    from.Spec.Ports,
+			Selector:                 from.Spec.Selector,
+			ExternalIPs:              []string{extIP},
+			IPFamilyPolicy:           ptr.To(corev1.IPFamilyPolicySingleStack),
+			PublishNotReadyAddresses: from.Spec.PublishNotReadyAddresses,
 		},
 	}
 


### PR DESCRIPTION
Backport of #3219 on release-0.19.

#3219: Propagate PublishNotReadyAddresses flag to GN internal

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.