### PR TITLE
Automated backport of #3219: Propagate PublishNotReadyAddresses flag to GN internal

### DIFF
--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -288,10 +288,11 @@ func (c *globalIngressIPController) createOrUpdateInternalService(from *corev1.S
 			Finalizers: []string{InternalServiceFinalizer},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:          from.Spec.Ports,
-			Selector:       from.Spec.Selector,
-			ExternalIPs:    []string{extIP},
-			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicySingleStack),
+			Ports:                    from.Spec.Ports,
+			Selector:                 from.Spec.Selector,
+			ExternalIPs:              []string{extIP},
+			IPFamilyPolicy:           ptr.To(corev1.IPFamilyPolicySingleStack),
+			PublishNotReadyAddresses: from.Spec.PublishNotReadyAddresses,
 		},
 	}
 

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -131,8 +131,11 @@ var _ = Describe("GlobalIngressIP controller", func() {
 func testGlobalIngressIPCreatedClusterIPSvc(t *globalIngressIPControllerTestDriver, ingressIP *submarinerv1.GlobalIngressIP) {
 	var service *corev1.Service
 
-	JustBeforeEach(func() {
+	BeforeEach(func() {
 		service = newClusterIPService()
+	})
+
+	JustBeforeEach(func() {
 		t.createService(service)
 		t.createGlobalIngressIP(ingressIP)
 	})
@@ -149,9 +152,21 @@ func testGlobalIngressIPCreatedClusterIPSvc(t *globalIngressIPControllerTestDriv
 		Expect(intSvc.Spec.Ports).To(Equal(service.Spec.Ports))
 		Expect(intSvc.Spec.IPFamilyPolicy).ToNot(BeNil())
 		Expect(*intSvc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicySingleStack))
+		Expect(intSvc.Spec.PublishNotReadyAddresses).To(BeFalse())
 
 		finalizer := intSvc.GetFinalizers()[0]
 		Expect(finalizer).To(Equal(controllers.InternalServiceFinalizer))
+	})
+
+	Context("and the service has PublishNotReadyAddresses set to true", func() {
+		BeforeEach(func() {
+			service.Spec.PublishNotReadyAddresses = true
+		})
+
+		It("should set PublishNotReadyAddresses to true on the internal submariner service", func() {
+			intSvc := t.awaitService(controllers.GetInternalSvcName(serviceName))
+			Expect(intSvc.Spec.PublishNotReadyAddresses).To(BeTrue())
+		})
 	})
 
 	Context("with the IP pool exhausted", func() {


### PR DESCRIPTION
Backport of #3219 on release-0.18.

#3219: Propagate PublishNotReadyAddresses flag to GN internal

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.