### PR TITLE
Allow the gateway to wait for node readiness

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -35,7 +35,7 @@ import (
 
 var logger = log.Logger{Logger: logf.Log.WithName("Node")}
 
-var nodeRetry = wait.Backoff{
+var Retry = wait.Backoff{
 	Steps:    5,
 	Duration: 5 * time.Second,
 	Factor:   1.2,
@@ -50,7 +50,7 @@ func GetLocalNode(clientset kubernetes.Interface) (*v1.Node, error) {
 
 	var node *v1.Node
 
-	err := retry.OnError(nodeRetry, func(err error) bool {
+	err := retry.OnError(Retry, func(err error) bool {
 		logger.Warningf("Error reading the local node - retrying: %v", err)
 		return true
 	}, func() error {

--- a/pkg/node/node_suite_test.go
+++ b/pkg/node/node_suite_test.go
@@ -1,0 +1,40 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Suite")
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,111 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/submariner/pkg/node"
+	corev1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fakeK8s "k8s.io/client-go/kubernetes/fake"
+)
+
+const localNodeName = "local-node"
+
+var _ = Describe("GetLocalNode", func() {
+	t := newTestDriver()
+
+	When("the local Node resource exists", func() {
+		It("should return the resource", func() {
+			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+		})
+	})
+
+	When("the local Node resource does not exist", func() {
+		BeforeEach(func() {
+			t.initialObjs = []runtime.Object{}
+		})
+
+		It("should return an error", func() {
+			_, err := node.GetLocalNode(t.client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the local Node retrieval initially fails", func() {
+		JustBeforeEach(func() {
+			fake.FailOnAction(&t.client.Fake, "nodes", "get", nil, true)
+		})
+
+		It("should eventually return the resource", func() {
+			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+		})
+	})
+
+	When("the NODE_NAME env var isn't set", func() {
+		BeforeEach(func() {
+			os.Unsetenv("NODE_NAME")
+		})
+
+		It("should return an error", func() {
+			_, err := node.GetLocalNode(t.client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+type testDriver struct {
+	client      *fakeK8s.Clientset
+	node        *corev1.Node
+	initialObjs []runtime.Object
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		node.Retry = wait.Backoff{
+			Steps:    2,
+			Duration: 10 * time.Millisecond,
+		}
+
+		t.node = &corev1.Node{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: localNodeName,
+			},
+		}
+
+		t.initialObjs = []runtime.Object{t.node}
+
+		os.Setenv("NODE_NAME", localNodeName)
+	})
+
+	JustBeforeEach(func() {
+		t.client = fakeK8s.NewClientset(t.initialObjs...)
+	})
+
+	return t
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -46,6 +46,7 @@ type SubmarinerSpecification struct {
 	HealthCheckEnabled            bool `default:"true"`
 	Uninstall                     bool
 	HaltOnCertError               bool `split_words:"true"`
+	WaitForNode                   bool
 	HealthCheckInterval           int
 	HealthCheckMaxPacketLossCount int
 	MetricsPort                   int `default:"32780"`


### PR DESCRIPTION
We've observed instances where the gateway pod may fail to connect to the K8s API server on startup after failover on node restart. While it eventually succeeds on pod restart, the initial pod failure can cause E2E to fail.  We suspect this is b/c the node, specifically it's networking, isn't fully ready when the pod starts up. To alleviate this, add functionality to the gateway pod to wait for the node to be ready using a variant of the gateway invoked using the `SUBMARINER_WAITFORNODE` environment variable as is done with the route agent.

The code to perform the wait was refactored from route agent main to the node module for re-use. See individual commits for details.