### PR TITLE
Add ctx param to GetLocalNode

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func main() {
 		return
 	}
 
-	gw, err := gateway.New(&gateway.Config{
+	gw, err := gateway.New(ctx, &gateway.Config{
 		LeaderElectionConfig: gateway.LeaderElectionConfig{
 			LeaseDuration: time.Duration(gwLeadershipConfig.LeaseDuration) * time.Second,
 			RenewDeadline: time.Duration(gwLeadershipConfig.RenewDeadline) * time.Second,

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -133,13 +133,13 @@ func (l *Local) Create(ctx context.Context) error {
 	return err
 }
 
-func GetLocalSpec(submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
+func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
 	airGappedDeployment bool,
 ) (*submv1.EndpointSpec, error) {
 	// We'll panic if submSpec is nil, this is intentional
 	privateIP := GetLocalIP()
 
-	gwNode, err := node.GetLocalNode(k8sClient)
+	gwNode, err := node.GetLocalNode(ctx, k8sClient)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting information on the local node")
 	}

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -96,7 +96,7 @@ var _ = Describe("GetLocalSpec", func() {
 	})
 
 	It("should return a valid EndpointSpec object", func() {
-		spec, err := endpoint.GetLocalSpec(submSpec, client, false)
+		spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, false)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(spec.ClusterID).To(Equal("east"))
@@ -116,7 +116,7 @@ var _ = Describe("GetLocalSpec", func() {
 		})
 
 		It("should return the udp-port backend config of the cluster", func() {
-			spec, err := endpoint.GetLocalSpec(submSpec, client, false)
+			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.BackendConfig[testUDPPortLabel]).To(Equal(testClusterUDPPort))
 		})
@@ -128,14 +128,14 @@ var _ = Describe("GetLocalSpec", func() {
 		})
 
 		It("should return a valid EndpointSpec object", func() {
-			_, err := endpoint.GetLocalSpec(submSpec, client, false)
+			_, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
 	When("the gateway node is not annotated with public-ip", func() {
 		It("should use empty public-ip in the endpoint object for air-gapped deployments", func() {
-			spec, err := endpoint.GetLocalSpec(submSpec, client, true)
+			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.ClusterID).To(Equal("east"))
@@ -150,7 +150,7 @@ var _ = Describe("GetLocalSpec", func() {
 		})
 
 		It("should use the annotated public-ip for air-gapped deployments", func() {
-			spec, err := endpoint.GetLocalSpec(submSpec, client, true)
+			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
@@ -164,7 +164,7 @@ var _ = Describe("GetLocalSpec", func() {
 		})
 
 		It("should set the HealthCheckIP", func() {
-			spec, err := endpoint.GetLocalSpec(submSpec, client, true)
+			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.HealthCheckIP).To(Equal(cniInterfaceIP))
 		})
@@ -175,7 +175,7 @@ var _ = Describe("GetLocalSpec", func() {
 			})
 
 			It("should not set the HealthCheckIP", func() {
-				spec, err := endpoint.GetLocalSpec(submSpec, client, true)
+				spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(spec.HealthCheckIP).To(BeEmpty())
 			})

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package event
 
 import (
+	"context"
 	"sync/atomic"
 
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -81,7 +82,7 @@ type NodeHandler interface {
 
 type Handler interface {
 	// Init is called once on startup to let the handler initialize any state it needs.
-	Init() error
+	Init(ctx context.Context) error
 
 	// SetHandlerState is called once on startup after Init with the HandlerState that can be used to access global data from event callbacks.
 	SetState(handlerCtx HandlerState)
@@ -106,7 +107,7 @@ type HandlerBase struct {
 	handlerState atomic.Value
 }
 
-func (ev *HandlerBase) Init() error {
+func (ev *HandlerBase) Init(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package event_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -55,8 +57,8 @@ var _ = Describe("Event Registry", func() {
 
 			var err error
 
-			registry, err = event.NewRegistry("test-registry", npGenericKubeproxyIptables, logger.NewHandler(), matchingHandlers[0],
-				nonMatchingHandlers[0], matchingHandlers[1], matchingHandlers[2])
+			registry, err = event.NewRegistry(context.TODO(), "test-registry", npGenericKubeproxyIptables, logger.NewHandler(),
+				matchingHandlers[0], nonMatchingHandlers[0], matchingHandlers[1], matchingHandlers[2])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(registry.GetName()).To(Equal("test-registry"))
 		})
@@ -115,7 +117,7 @@ var _ = Describe("Event Registry", func() {
 			h := testing.NewTestHandler("test-handler", event.AnyNetworkPlugin, make(chan testing.TestEvent, 10))
 			h.FailOnEvent(testing.EvInit)
 
-			_, err := event.NewRegistry("test-registry", event.AnyNetworkPlugin, h)
+			_, err := event.NewRegistry(context.TODO(), "test-registry", event.AnyNetworkPlugin, h)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -67,7 +67,7 @@ func (c *ControllerSupport) Start(handlers ...event.Handler) {
 		networkPlugin = event.AnyNetworkPlugin
 	}
 
-	registry, err := event.NewRegistry("test-registry", networkPlugin, handlers...)
+	registry, err := event.NewRegistry(context.TODO(), "test-registry", networkPlugin, handlers...)
 	Expect(err).To(Succeed())
 
 	config := controller.Config{

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -19,6 +19,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -110,7 +111,7 @@ func (t *TestHandlerBase) addEvent(eventName string, param interface{}) error {
 	return nil
 }
 
-func (t *TestHandlerBase) Init() error {
+func (t *TestHandlerBase) Init(_ context.Context) error {
 	t.Initialized = true
 	return t.checkFailOnEvent(EvInit)
 }

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -104,7 +104,7 @@ type gatewayType struct {
 
 var logger = log.Logger{Logger: logf.Log.WithName("Gateway")}
 
-func New(config *Config) (Interface, error) {
+func New(ctx context.Context, config *Config) (Interface, error) {
 	logger.Info("Initializing the gateway engine")
 
 	g := &gatewayType{
@@ -144,7 +144,7 @@ func New(config *Config) (Interface, error) {
 	g.airGapped = os.Getenv("AIR_GAPPED_DEPLOYMENT") == "true"
 	logger.Infof("AIR_GAPPED_DEPLOYMENT is set to %t", g.airGapped)
 
-	localEndpointSpec, err := endpoint.GetLocalSpec(&g.Spec, g.KubeClient, g.airGapped)
+	localEndpointSpec, err := endpoint.GetLocalSpec(ctx, &g.Spec, g.KubeClient, g.airGapped)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating local endpoint object")
 	}

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -321,7 +321,7 @@ func newTestDriver() *testDriver {
 	})
 
 	JustBeforeEach(func() {
-		gw, err := gateway.New(&t.config)
+		gw, err := gateway.New(context.TODO(), &t.config)
 		Expect(err).To(Succeed())
 
 		ctx, stop := context.WithCancel(context.Background())

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -416,7 +416,7 @@ func (t *gatewayMonitorTestDriver) start() {
 
 	localSubnets := []string{localCIDR}
 
-	t.controller, err = controllers.NewGatewayMonitor(&controllers.GatewayMonitorConfig{
+	t.controller, err = controllers.NewGatewayMonitor(context.TODO(), &controllers.GatewayMonitorConfig{
 		RestMapper: t.restMapper,
 		Client:     t.dynClient,
 		Scheme:     t.scheme,

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -120,7 +120,8 @@ type LeaderElectionInfo struct {
 }
 
 type gatewayMonitorInterface struct {
-	monitor *gatewayMonitor
+	monitor  *gatewayMonitor
+	registry *event.Registry
 }
 
 type gatewayMonitor struct {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	fakeK8s "k8s.io/client-go/kubernetes/fake"
 	nodeutil "k8s.io/component-helpers/node/util"
 )
@@ -42,7 +41,7 @@ var _ = Describe("GetLocalNode", func() {
 
 	When("the local Node resource exists", func() {
 		It("should return the resource", func() {
-			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+			Expect(node.GetLocalNode(context.TODO(), t.client)).To(Equal(t.node))
 		})
 	})
 
@@ -52,7 +51,7 @@ var _ = Describe("GetLocalNode", func() {
 		})
 
 		It("should return an error", func() {
-			_, err := node.GetLocalNode(t.client)
+			_, err := node.GetLocalNode(context.TODO(), t.client)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -63,7 +62,7 @@ var _ = Describe("GetLocalNode", func() {
 		})
 
 		It("should eventually return the resource", func() {
-			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+			Expect(node.GetLocalNode(context.TODO(), t.client)).To(Equal(t.node))
 		})
 	})
 
@@ -73,7 +72,7 @@ var _ = Describe("GetLocalNode", func() {
 		})
 
 		It("should return an error", func() {
-			_, err := node.GetLocalNode(t.client)
+			_, err := node.GetLocalNode(context.TODO(), t.client)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -133,10 +132,8 @@ func newTestDriver() *testDriver {
 	t := &testDriver{}
 
 	BeforeEach(func() {
-		node.Retry = wait.Backoff{
-			Steps:    2,
-			Duration: 10 * time.Millisecond,
-		}
+		node.PollTimeout = 30 * time.Millisecond
+		node.PollInterval = 10 * time.Millisecond
 
 		t.node = &corev1.Node{
 			ObjectMeta: v1meta.ObjectMeta{

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -170,7 +170,8 @@ func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) erro
 	return nil
 }
 
-func (h *controller) Init() error {
+func (h *controller) Init(_ context.Context) error {
+	//nolint:contextcheck // Ignore "should pass the context parameter"
 	go func() {
 		wait.Until(func() {
 			h.Lock()

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -19,6 +19,7 @@ limitations under the License.
 package kubeproxy
 
 import (
+	"context"
 	"net"
 	"os"
 	"time"
@@ -101,7 +102,7 @@ var discoverCNIRetryConfig = wait.Backoff{
 	Steps:    12,
 }
 
-func (kp *SyncHandler) Init() error {
+func (kp *SyncHandler) Init(_ context.Context) error {
 	var err error
 	var cniIface *cni.Interface
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package mtu
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -81,7 +82,7 @@ func (h *mtuHandler) GetName() string {
 	return "MTU handler"
 }
 
-func (h *mtuHandler) Init() error {
+func (h *mtuHandler) Init(_ context.Context) error {
 	var err error
 
 	h.pFilter, err = packetfilter.New()

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package mtu_test
 
 import (
+	"context"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -140,7 +141,7 @@ func newTestDriver() *testDriver {
 
 	JustBeforeEach(func() {
 		t.handler = mtu.NewMTUHandler([]string{localCIDR}, t.isGlobalnet, t.tcpMssValue)
-		Expect(t.handler.Init()).To(Succeed())
+		Expect(t.handler.Init(context.TODO())).To(Succeed())
 	})
 
 	return t

--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler.go
@@ -44,7 +44,7 @@ func NewGatewayRouteHandler(smClientSet submarinerClientset.Interface) *GatewayR
 	}
 }
 
-func (h *GatewayRouteHandler) Init() error {
+func (h *GatewayRouteHandler) Init(_ context.Context) error {
 	logger.Info("Starting GatewayRouteHandler")
 
 	nextHopIP, err := getNextHopOnK8sMgmtIntf()

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -98,7 +98,7 @@ func (ovn *Handler) GetNetworkPlugins() []string {
 	return []string{cni.OVNKubernetes}
 }
 
-func (ovn *Handler) Init(_ context.Context) error {
+func (ovn *Handler) Init(ctx context.Context) error {
 	ovn.LegacyCleanup()
 
 	err := ovn.initIPtablesChains()
@@ -110,12 +110,12 @@ func (ovn *Handler) Init(_ context.Context) error {
 
 	connectionHandler := NewConnectionHandler(ovn.K8sClient, ovn.DynClient)
 
-	err = connectionHandler.initClients(ovn.NewOVSDBClient)
+	err = connectionHandler.initClients(ctx, ovn.NewOVSDBClient)
 	if err != nil {
 		return errors.Wrapf(err, "error getting connection handler to connect to OvnDB")
 	}
 
-	err = ovn.TransitSwitchIP.Init(ovn.K8sClient)
+	err = ovn.TransitSwitchIP.Init(ctx, ovn.K8sClient)
 	if err != nil {
 		return errors.Wrap(err, "error initializing TransitSwitchIP")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package ovn
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -97,7 +98,7 @@ func (ovn *Handler) GetNetworkPlugins() []string {
 	return []string{cni.OVNKubernetes}
 }
 
-func (ovn *Handler) Init() error {
+func (ovn *Handler) Init(_ context.Context) error {
 	ovn.LegacyCleanup()
 
 	err := ovn.initIPtablesChains()

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler.go
@@ -48,7 +48,7 @@ func NewNonGatewayRouteHandler(smClient submarinerClientset.Interface, transitSw
 	}
 }
 
-func (h *NonGatewayRouteHandler) Init() error {
+func (h *NonGatewayRouteHandler) Init(_ context.Context) error {
 	logger.Info("Starting NonGatewayRouteHandler")
 	return nil
 }

--- a/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/non_gateway_route_handler_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package ovn_test
 
 import (
+	"context"
 	"errors"
 	"os"
 
@@ -40,7 +41,7 @@ var _ = Describe("NonGatewayRouteHandler", func() {
 	JustBeforeEach(func() {
 		tsIP := ovn.NewTransitSwitchIP()
 		t.Start(ovn.NewNonGatewayRouteHandler(t.submClient, tsIP))
-		Expect(tsIP.Init(t.k8sClient)).To(Succeed())
+		Expect(tsIP.Init(context.TODO(), t.k8sClient)).To(Succeed())
 	})
 
 	awaitNonGatewayRoute := func(ep *submarinerv1.Endpoint) {

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip.go
@@ -19,6 +19,7 @@ limitations under the License.
 package ovn
 
 import (
+	"context"
 	"os"
 	"sync/atomic"
 
@@ -35,7 +36,7 @@ type TransitSwitchIPGetter interface {
 
 type TransitSwitchIP interface {
 	TransitSwitchIPGetter
-	Init(k8sClient kubernetes.Interface) error
+	Init(ctx context.Context, k8sClient kubernetes.Interface) error
 	UpdateFrom(node *corev1.Node) (bool, error)
 }
 
@@ -54,8 +55,8 @@ func (t *transitSwitchIPImpl) Get() string {
 	return t.value.Load().(string)
 }
 
-func (t *transitSwitchIPImpl) Init(k8sClient kubernetes.Interface) error {
-	node, err := nodeutil.GetLocalNode(k8sClient)
+func (t *transitSwitchIPImpl) Init(ctx context.Context, k8sClient kubernetes.Interface) error {
+	node, err := nodeutil.GetLocalNode(ctx, k8sClient)
 	if err != nil {
 		return errors.Wrap(err, "error getting the local node")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
@@ -57,14 +57,14 @@ var _ = Describe("TransitSwitchIP", func() {
 			})
 
 			It("should set the TransitSwitchIP value", func() {
-				Expect(transitSwitchIP.Init(k8sClient)).To(Succeed())
+				Expect(transitSwitchIP.Init(context.TODO(), k8sClient)).To(Succeed())
 				Expect(transitSwitchIP.Get()).To(Equal(nodeIP))
 			})
 		})
 
 		When("the node annotation does not exist", func() {
 			It("should succeed and set an empty TransitSwitchIP value", func() {
-				Expect(transitSwitchIP.Init(k8sClient)).To(Succeed())
+				Expect(transitSwitchIP.Init(context.TODO(), k8sClient)).To(Succeed())
 				Expect(transitSwitchIP.Get()).To(Equal(""))
 			})
 		})
@@ -75,7 +75,7 @@ var _ = Describe("TransitSwitchIP", func() {
 			})
 
 			It("should fail", func() {
-				Expect(transitSwitchIP.Init(k8sClient)).ToNot(Succeed())
+				Expect(transitSwitchIP.Init(context.TODO(), k8sClient)).ToNot(Succeed())
 			})
 		})
 
@@ -87,7 +87,7 @@ var _ = Describe("TransitSwitchIP", func() {
 			})
 
 			It("should fail", func() {
-				Expect(transitSwitchIP.Init(k8sClient)).ToNot(Succeed())
+				Expect(transitSwitchIP.Init(context.TODO(), k8sClient)).ToNot(Succeed())
 			})
 		})
 	})

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -132,7 +132,7 @@ func main() {
 
 	config := &watcher.Config{RestConfig: cfg}
 
-	localNode, err := node.GetLocalNode(k8sClientSet)
+	localNode, err := node.GetLocalNode(ctx, k8sClientSet)
 	logger.FatalOnError(err, "Error getting information on the local node")
 
 	healthcheckerConfig := &healthchecker.Config{

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -142,7 +142,7 @@ func main() {
 		RouteAgentUpdateInterval: 60 * time.Second,
 	}
 
-	registry, err := event.NewRegistry("routeagent_driver", np,
+	registry, err := event.NewRegistry(ctx, "routeagent_driver", np,
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
 		ovn.NewHandler(&ovn.HandlerConfig{
 			Namespace:       env.Namespace,

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -38,7 +38,7 @@ var logger = log.Logger{Logger: logf.Log.WithName("ClusterFiles")}
 // using an url schema that supports configmap://<namespace>/<configmap-name>/<data-file>
 // secret://<namespace>/<secret-name>/<data-file> and file:///<path> returning
 // a local path to the file.
-func Get(k8sClient kubernetes.Interface, urlAddress string) (string, error) {
+func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string) (string, error) {
 	logger.V(log.DEBUG).Infof("Reading cluster_file: %s", urlAddress)
 
 	parsedURL, err := url.Parse(urlAddress)
@@ -61,7 +61,7 @@ func Get(k8sClient kubernetes.Interface, urlAddress string) (string, error) {
 		return parsedURL.Path, nil
 
 	case "secret":
-		secret, err := k8sClient.CoreV1().Secrets(namespace).Get(context.TODO(), pathContainerObject, metav1.GetOptions{})
+		secret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
 			return "", errors.Wrapf(err, "error reading secret %q from namespace %q", pathContainerObject, namespace)
 		}
@@ -74,7 +74,7 @@ func Get(k8sClient kubernetes.Interface, urlAddress string) (string, error) {
 		}
 
 	case "configmap":
-		configMap, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(context.TODO(), pathContainerObject, metav1.GetOptions{})
+		configMap, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
 			return "", errors.Wrapf(err, "error reading configmap %q from namespace %q", pathContainerObject, namespace)
 		}

--- a/pkg/util/clusterfiles/cluster_files_test.go
+++ b/pkg/util/clusterfiles/cluster_files_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package clusterfiles_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -45,6 +46,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("Cluster Files Get", func() {
+	ctx := context.TODO()
+
 	var client kubernetes.Interface
 	BeforeEach(func() {
 		client = fake.NewClientset(
@@ -70,39 +73,39 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("The scheme is unknown", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(client, "randomschema://ns1/my-secret-noo/data1")
+			_, err := clusterfiles.Get(ctx, client, "randomschema://ns1/my-secret-noo/data1")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("a file source does not exist", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(client, "secret://ns1/my-secret-noo/data1")
+			_, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret-noo/data1")
 			Expect(err).To(HaveOccurred())
-			_, err = clusterfiles.Get(client, "configmap://ns1/my-configmap-noo/data1")
+			_, err = clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-noo/data1")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the content inside the file does not exist", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(client, "secret://ns1/my-secret/data1-does-not-exist")
+			_, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1-does-not-exist")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the URL is malformed", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(client, "secret://ns1/")
+			_, err := clusterfiles.Get(ctx, client, "secret://ns1/")
 			Expect(err).To(HaveOccurred())
-			_, err = clusterfiles.Get(client, "secret://ns1/secret-with-no-content-detail")
+			_, err = clusterfiles.Get(ctx, client, "secret://ns1/secret-with-no-content-detail")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the source secret exist", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(client, "secret://ns1/my-secret/data1")
+			file, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1")
 			Expect(err).NotTo(HaveOccurred())
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
@@ -112,7 +115,7 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source configmap exist", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(client, "configmap://ns1/my-configmap/data1")
+			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap/data1")
 			Expect(err).NotTo(HaveOccurred())
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
@@ -122,7 +125,7 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source configmap exist and has binary data", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(client, "configmap://ns1/my-configmap-binary/data1")
+			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-binary/data1")
 			Expect(err).NotTo(HaveOccurred())
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
@@ -132,7 +135,7 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source is a file", func() {
 		It("should return the original path for the file:/// scheme", func() {
-			file, err := clusterfiles.Get(nil, "file:///dir/file")
+			file, err := clusterfiles.Get(ctx, nil, "file:///dir/file")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(file).To(Equal("/dir/file"))
 		})


### PR DESCRIPTION
This allows it to be cancelled by the user should retries take too long.

Since `GetLocalNode` is called from the `Init` method even handlers, the ctx param was also added to that method to allow propagation from main. Consequently the `contextcheck` linter also revealed other code paths where ctx should be propagated.