### PR TITLE
Automated backport of #3222: Allow the gateway to wait for node readiness

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -35,7 +35,7 @@ import (
 
 var logger = log.Logger{Logger: logf.Log.WithName("Node")}
 
-var nodeRetry = wait.Backoff{
+var Retry = wait.Backoff{
 	Steps:    5,
 	Duration: 5 * time.Second,
 	Factor:   1.2,
@@ -50,7 +50,7 @@ func GetLocalNode(clientset kubernetes.Interface) (*v1.Node, error) {
 
 	var node *v1.Node
 
-	err := retry.OnError(nodeRetry, func(err error) bool {
+	err := retry.OnError(Retry, func(err error) bool {
 		logger.Warningf("Error reading the local node - retrying: %v", err)
 		return true
 	}, func() error {

--- a/pkg/node/node_suite_test.go
+++ b/pkg/node/node_suite_test.go
@@ -1,0 +1,40 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Suite")
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,111 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/submariner/pkg/node"
+	corev1 "k8s.io/api/core/v1"
+	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fakeK8s "k8s.io/client-go/kubernetes/fake"
+)
+
+const localNodeName = "local-node"
+
+var _ = Describe("GetLocalNode", func() {
+	t := newTestDriver()
+
+	When("the local Node resource exists", func() {
+		It("should return the resource", func() {
+			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+		})
+	})
+
+	When("the local Node resource does not exist", func() {
+		BeforeEach(func() {
+			t.initialObjs = []runtime.Object{}
+		})
+
+		It("should return an error", func() {
+			_, err := node.GetLocalNode(t.client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the local Node retrieval initially fails", func() {
+		JustBeforeEach(func() {
+			fake.FailOnAction(&t.client.Fake, "nodes", "get", nil, true)
+		})
+
+		It("should eventually return the resource", func() {
+			Expect(node.GetLocalNode(t.client)).To(Equal(t.node))
+		})
+	})
+
+	When("the NODE_NAME env var isn't set", func() {
+		BeforeEach(func() {
+			os.Unsetenv("NODE_NAME")
+		})
+
+		It("should return an error", func() {
+			_, err := node.GetLocalNode(t.client)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+type testDriver struct {
+	client      *fakeK8s.Clientset
+	node        *corev1.Node
+	initialObjs []runtime.Object
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		node.Retry = wait.Backoff{
+			Steps:    2,
+			Duration: 10 * time.Millisecond,
+		}
+
+		t.node = &corev1.Node{
+			ObjectMeta: v1meta.ObjectMeta{
+				Name: localNodeName,
+			},
+		}
+
+		t.initialObjs = []runtime.Object{t.node}
+
+		os.Setenv("NODE_NAME", localNodeName)
+	})
+
+	JustBeforeEach(func() {
+		t.client = fakeK8s.NewClientset(t.initialObjs...)
+	})
+
+	return t
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -150,7 +150,7 @@ func newTestDriver() *testDriver {
 	})
 
 	JustBeforeEach(func() {
-		t.client = fakeK8s.NewClientset(t.initialObjs...)
+		t.client = fakeK8s.NewSimpleClientset(t.initialObjs...)
 	})
 
 	return t

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -54,7 +54,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
-	nodeutil "k8s.io/component-helpers/node/util"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
@@ -82,7 +81,7 @@ func main() {
 
 	logger.Info("Starting submariner-route-agent using the event framework")
 	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler().Done()
+	ctx := signals.SetupSignalHandler()
 
 	// Clean up "sockets" created as directories by previous versions
 	removeInvalidSockets()
@@ -111,7 +110,7 @@ func main() {
 	logger.FatalOnError(err, "Error building the REST mapper")
 
 	if env.WaitForNode {
-		waitForNodeReady(k8sClientSet)
+		node.WaitForLocalNodeReady(ctx, k8sClientSet)
 
 		return
 	}
@@ -163,6 +162,8 @@ func main() {
 	})
 	logger.FatalOnError(err, "Error creating controller for event handling")
 
+	stopCh := ctx.Done()
+
 	err = ctl.Start(stopCh)
 	logger.FatalOnError(err, "Error starting controller")
 
@@ -208,27 +209,6 @@ func uninstall(registry *event.Registry) {
 
 	if err := registry.Uninstall(); err != nil {
 		logger.Warningf("Error uninstalling handlers: %v", err)
-	}
-}
-
-func waitForNodeReady(k8sClientSet *kubernetes.Clientset) {
-	// In most cases the node will already be ready; otherwise, wait for ever
-	for {
-		localNode, err := node.GetLocalNode(k8sClientSet)
-
-		if err != nil {
-			logger.Error(err, "Error retrieving local node")
-		} else if localNode != nil {
-			_, condition := nodeutil.GetNodeCondition(&localNode.Status, corev1.NodeReady)
-			if condition != nil && condition.Status == corev1.ConditionTrue {
-				logger.Info("Node ready")
-				return
-			}
-
-			logger.Infof("Node not ready, waiting: %v", localNode.Status)
-		}
-
-		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -23,7 +23,6 @@ import (
 	"io/fs"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
@@ -49,7 +48,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
 	"github.com/submariner-io/submariner/pkg/versions"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -46,6 +46,7 @@ type SubmarinerSpecification struct {
 	HealthCheckEnabled            bool `default:"true"`
 	Uninstall                     bool
 	HaltOnCertError               bool `split_words:"true"`
+	WaitForNode                   bool
 	HealthCheckInterval           uint
 	HealthCheckMaxPacketLossCount uint
 	MetricsPort                   int `default:"32780"`


### PR DESCRIPTION
Backport of #3222 on release-0.18.

#3222: Add unit tests for the node module

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.