### PR TITLE
Use Endpoint plural IP fields instead of singular fields

### DIFF
--- a/pkg/apis/submariner.io/v1/types.go
+++ b/pkg/apis/submariner.io/v1/types.go
@@ -78,6 +78,7 @@ type EndpointSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ClusterID string `json:"cluster_id"`
 	CableName string `json:"cable_name"`
+	// Deprecated: Get/SetHealthCheckIP() or, if necessary, HealthCheckIPs
 	// +optional
 	HealthCheckIP string `json:"healthCheckIP,omitempty"`
 	// +kubebuilder:validation:MaxItems:=2
@@ -85,11 +86,13 @@ type EndpointSpec struct {
 	HealthCheckIPs []string `json:"healthCheckIPs,omitempty"`
 	Hostname       string   `json:"hostname"`
 	Subnets        []string `json:"subnets"`
+	// Deprecated: Use Get/SetPrivateIP() or, if necessary, PrivateIPs
 	// +optional
 	PrivateIP string `json:"private_ip,omitempty"`
 	// +kubebuilder:validation:MaxItems:=2
 	// +optional
 	PrivateIPs []string `json:"privateIPs,omitempty"`
+	// Deprecated: Set/SetPublicIP() or, if necessary, PublicIPs
 	// +optional
 	PublicIP string `json:"public_ip,omitempty"`
 	// +kubebuilder:validation:MaxItems:=2

--- a/pkg/cable/libreswan/libreswan_internal_test.go
+++ b/pkg/cable/libreswan/libreswan_internal_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 var _ = Describe("Libreswan", func() {
@@ -99,10 +100,10 @@ func testConnectToEndpoint() {
 		natInfo = &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "east",
-					CableName: "submariner-cable-east-192-68-2-1",
-					PrivateIP: "192.68.2.1",
-					Subnets:   []string{"20.0.0.0/16"},
+					ClusterID:  "east",
+					CableName:  "submariner-cable-east-192-68-2-1",
+					PrivateIPs: []string{"192.68.2.1"},
+					Subnets:    []string{"20.0.0.0/16"},
 				},
 			},
 			UseIP:  "172.93.2.1",
@@ -117,7 +118,7 @@ func testConnectToEndpoint() {
 		Expect(ip).To(Equal(natInfo.UseIP))
 
 		t.assertActiveConnection(natInfo)
-		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.PrivateIP, natInfo.UseIP,
+		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(k8snet.IPv4), natInfo.UseIP,
 			t.endpointSpec.Subnets[0], natInfo.Endpoint.Spec.Subnets[0])
 		t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
 	}
@@ -129,7 +130,7 @@ func testConnectToEndpoint() {
 		Expect(ip).To(Equal(natInfo.UseIP))
 
 		t.assertActiveConnection(natInfo)
-		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.PrivateIP, t.endpointSpec.Subnets[0],
+		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(k8snet.IPv4), t.endpointSpec.Subnets[0],
 			natInfo.Endpoint.Spec.Subnets[0])
 		t.cmdExecutor.EnsureNoCommand("whack", "--initiate")
 	}
@@ -158,7 +159,7 @@ func testConnectToEndpoint() {
 			Expect(ip).To(Equal(natInfo.UseIP))
 
 			t.assertActiveConnection(natInfo)
-			t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.PrivateIP, natInfo.UseIP,
+			t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(k8snet.IPv4), natInfo.UseIP,
 				t.endpointSpec.Subnets[0], natInfo.Endpoint.Spec.Subnets[0])
 			t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
 		})
@@ -200,10 +201,10 @@ func testDisconnectFromEndpoint() {
 		natInfo1 := &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "remote1",
-					CableName: "submariner-cable-remote1-192-68-2-1",
-					PrivateIP: "192.68.2.1",
-					Subnets:   []string{"20.0.0.0/16"},
+					ClusterID:  "remote1",
+					CableName:  "submariner-cable-remote1-192-68-2-1",
+					PrivateIPs: []string{"192.68.2.1"},
+					Subnets:    []string{"20.0.0.0/16"},
 				},
 			},
 			UseIP: "172.93.2.1",
@@ -215,10 +216,10 @@ func testDisconnectFromEndpoint() {
 		natInfo2 := &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "remote2",
-					CableName: "submariner-cable-remote2-192-68-3-1",
-					PrivateIP: "192.68.3.1",
-					Subnets:   []string{"30.0.0.0/16"},
+					ClusterID:  "remote2",
+					CableName:  "submariner-cable-remote2-192-68-3-1",
+					PrivateIPs: []string{"192.68.3.1"},
+					Subnets:    []string{"30.0.0.0/16"},
 				},
 			},
 			UseIP: "173.93.2.1",
@@ -246,10 +247,10 @@ func testGetConnections() {
 		natInfo1 := &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "remote1",
-					CableName: "submariner-cable-remote1-192-68-2-1",
-					PrivateIP: "192.68.2.1",
-					Subnets:   []string{"20.0.0.0/16", "30.0.0.0/16"},
+					ClusterID:  "remote1",
+					CableName:  "submariner-cable-remote1-192-68-2-1",
+					PrivateIPs: []string{"192.68.2.1"},
+					Subnets:    []string{"20.0.0.0/16", "30.0.0.0/16"},
 				},
 			},
 			UseIP: "172.93.2.1",
@@ -261,10 +262,10 @@ func testGetConnections() {
 		natInfo2 := &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "remote2",
-					CableName: "submariner-cable-remote2-192-68-3-1",
-					PrivateIP: "192.68.3.1",
-					Subnets:   []string{"11.0.0.0/16"},
+					ClusterID:  "remote2",
+					CableName:  "submariner-cable-remote2-192-68-3-1",
+					PrivateIPs: []string{"192.68.3.1"},
+					Subnets:    []string{"11.0.0.0/16"},
 				},
 			},
 			UseIP: "173.93.3.1",
@@ -350,10 +351,10 @@ func newTestDriver() *testDriver {
 	BeforeEach(func() {
 		t.cmdExecutor = fakecommand.New()
 		t.endpointSpec = subv1.EndpointSpec{
-			ClusterID: "local",
-			CableName: "submariner-cable-local-192-68-1-1",
-			PrivateIP: "192.68.1.1",
-			Subnets:   []string{"10.0.0.0/16"},
+			ClusterID:  "local",
+			CableName:  "submariner-cable-local-192-68-1-1",
+			PrivateIPs: []string{"192.68.1.1"},
+			Subnets:    []string{"10.0.0.0/16"},
 		}
 	})
 

--- a/pkg/cable/metrics.go
+++ b/pkg/cable/metrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package cable
 
 import (
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -136,10 +137,10 @@ func getLabels(cableDriverName string, localEndpoint, remoteEndpoint *submv1.End
 		cableDriverLabel:      cableDriverName,
 		localClusterLabel:     localEndpoint.ClusterID,
 		localHostnameLabel:    localEndpoint.Hostname,
-		localEndpointIPLabel:  localEndpoint.PublicIP,
+		localEndpointIPLabel:  strings.Join(localEndpoint.PublicIPs, ","),
 		remoteClusterLabel:    remoteEndpoint.ClusterID,
 		remoteHostnameLabel:   remoteEndpoint.Hostname,
-		remoteEndpointIPLabel: remoteEndpoint.PublicIP,
+		remoteEndpointIPLabel: strings.Join(remoteEndpoint.PublicIPs, ","),
 	}
 }
 

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -35,6 +35,7 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/vxlan"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -89,7 +90,7 @@ func NewDriver(localEndpoint *submendpoint.Local, localCluster *types.Submariner
 }
 
 func (v *vxLan) createVxlanInterface(port int) error {
-	ipAddr := v.localEndpoint.PrivateIP
+	ipAddr := v.localEndpoint.GetPrivateIP(k8snet.IPv4)
 
 	var err error
 
@@ -165,7 +166,7 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 
 	cable.RecordConnection(CableDriverName, &v.localEndpoint, &remoteEndpoint.Spec, string(v1.Connected), true)
 
-	privateIP := endpointInfo.Endpoint.Spec.PrivateIP
+	privateIP := endpointInfo.Endpoint.Spec.GetPrivateIP(k8snet.IPv4)
 
 	remoteVtepIP, err := vxlan.GetVtepIPAddressFrom(privateIP, VxlanVTepNetworkPrefix)
 	if err != nil {

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -68,10 +68,10 @@ var _ = Describe("Vxlan", func() {
 		natInfo = &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
-					ClusterID: "east",
-					CableName: "submariner-cable-east-192-68-2-1",
-					PrivateIP: "192.68.2.1",
-					Subnets:   []string{"20.0.0.0/16", "21.0.0.0/16"},
+					ClusterID:  "east",
+					CableName:  "submariner-cable-east-192-68-2-1",
+					PrivateIPs: []string{"192.68.2.1"},
+					Subnets:    []string{"20.0.0.0/16", "21.0.0.0/16"},
 				},
 			},
 			UseIP:  "172.93.2.1",
@@ -164,10 +164,10 @@ func newTestDriver() *testDriver {
 		}
 
 		t.localEndpoint = subv1.EndpointSpec{
-			ClusterID: t.localCluster.Spec.ClusterID,
-			CableName: "submariner-cable-local-192-68-1-1",
-			PrivateIP: "192.68.1.1",
-			Subnets:   append(t.localCluster.Spec.ServiceCIDR, t.localCluster.Spec.ClusterCIDR...),
+			ClusterID:  t.localCluster.Spec.ClusterID,
+			CableName:  "submariner-cable-local-192-68-1-1",
+			PrivateIPs: []string{"192.68.1.1"},
+			Subnets:    append(t.localCluster.Spec.ServiceCIDR, t.localCluster.Spec.ClusterCIDR...),
 		}
 
 		t.netLink = fakeNetlink.New()

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 func init() {
@@ -76,7 +77,7 @@ var _ = Describe("Cable Engine", func() {
 				ClusterID: localClusterID,
 				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", localClusterID),
 				PrivateIP: "1.1.1.1",
-				PublicIP:  "2.2.2.2",
+				PublicIPs: []string{"2.2.2.2"},
 				Backend:   fake.DriverName,
 			},
 		}
@@ -89,7 +90,7 @@ var _ = Describe("Cable Engine", func() {
 				ClusterID:     remoteClusterID,
 				CableName:     fmt.Sprintf("submariner-cable-%s-1.1.1.1", remoteClusterID),
 				PrivateIP:     "1.1.1.1",
-				PublicIP:      "2.2.2.2",
+				PublicIPs:     []string{"2.2.2.2"},
 				BackendConfig: map[string]string{"port": "1234"},
 			},
 		}
@@ -189,7 +190,7 @@ var _ = Describe("Cable Engine", func() {
 
 				Context("but different endpoint IP", func() {
 					BeforeEach(func() {
-						newEndpoint.Spec.PublicIP = "3.3.3.3"
+						newEndpoint.Spec.PublicIPs = []string{"3.3.3.3"}
 					})
 
 					It("should disconnect from the previous endpoint and connect to the new one", func() {
@@ -411,7 +412,7 @@ func (n *fakeNATDiscovery) notifyReady(endpoint *subv1.Endpoint) {
 
 func natEndpointInfoFor(endpoint *subv1.Endpoint) *natdiscovery.NATEndpointInfo {
 	return &natdiscovery.NATEndpointInfo{
-		UseIP:    endpoint.Spec.PublicIP,
+		UseIP:    endpoint.Spec.GetPublicIP(k8snet.IPv4),
 		UseNAT:   true,
 		Endpoint: *endpoint,
 	}

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -74,11 +74,11 @@ var _ = Describe("Cable Engine", func() {
 				CreationTimestamp: metav1.Now(),
 			},
 			Spec: subv1.EndpointSpec{
-				ClusterID: localClusterID,
-				CableName: fmt.Sprintf("submariner-cable-%s-1.1.1.1", localClusterID),
-				PrivateIP: "1.1.1.1",
-				PublicIPs: []string{"2.2.2.2"},
-				Backend:   fake.DriverName,
+				ClusterID:  localClusterID,
+				CableName:  fmt.Sprintf("submariner-cable-%s-1.1.1.1", localClusterID),
+				PrivateIPs: []string{"1.1.1.1"},
+				PublicIPs:  []string{"2.2.2.2"},
+				Backend:    fake.DriverName,
 			},
 		}
 
@@ -89,7 +89,7 @@ var _ = Describe("Cable Engine", func() {
 			Spec: subv1.EndpointSpec{
 				ClusterID:     remoteClusterID,
 				CableName:     fmt.Sprintf("submariner-cable-%s-1.1.1.1", remoteClusterID),
-				PrivateIP:     "1.1.1.1",
+				PrivateIPs:    []string{"1.1.1.1"},
 				PublicIPs:     []string{"2.2.2.2"},
 				BackendConfig: map[string]string{"port": "1234"},
 			},

--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -107,9 +107,9 @@ var _ = Describe("Controller", func() {
 
 	createEndpoint := func(clusterID, healthCheckIP string) *submarinerv1.Endpoint {
 		endpointSpec := &submarinerv1.EndpointSpec{
-			ClusterID:     clusterID,
-			CableName:     fmt.Sprintf("submariner-cable-%s-192-68-1-20", clusterID),
-			HealthCheckIP: healthCheckIP,
+			ClusterID:      clusterID,
+			CableName:      fmt.Sprintf("submariner-cable-%s-192-68-1-20", clusterID),
+			HealthCheckIPs: []string{healthCheckIP},
 		}
 
 		endpointName, err := endpointSpec.GenerateName()
@@ -223,7 +223,7 @@ var _ = Describe("Controller", func() {
 			})
 
 			It("should stop the Pinger and start a new one", func() {
-				endpoint.Spec.HealthCheckIP = healthCheckIP3
+				endpoint.Spec.HealthCheckIPs = []string{healthCheckIP3}
 
 				test.UpdateResource(endpoints, endpoint)
 				pingerMap[healthCheckIP1].AwaitStop()

--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -243,7 +243,7 @@ func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 			latencyInfo := gs.healthCheck.GetLatencyInfo(&connection.Endpoint)
 			if latencyInfo != nil {
 				connection.LatencyRTT = latencyInfo.Spec
-				connection.Endpoint.HealthCheckIP = latencyInfo.IP
+				connection.Endpoint.SetHealthCheckIP(latencyInfo.IP)
 
 				if connection.Status == v1.Connected {
 					lastRTT, _ := time.ParseDuration(latencyInfo.Spec.Last)

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -394,11 +394,12 @@ func testGatewayLatencyInfo() {
 			t.awaitGatewayUpdated(t.expectedGateway)
 
 			endpointSpec := &submarinerv1.EndpointSpec{
-				ClusterID:     "north",
-				CableName:     "submariner-cable-north-192-68-1-20",
-				PrivateIPs:    []string{"192-68-1-20"},
-				HealthCheckIP: t.pinger.GetIP(),
+				ClusterID:  "north",
+				CableName:  "submariner-cable-north-192-68-1-20",
+				PrivateIPs: []string{"192-68-1-20"},
 			}
+
+			endpointSpec.SetHealthCheckIP(t.pinger.GetIP())
 
 			endpointName, err := endpointSpec.GenerateName()
 			Expect(err).To(Succeed())
@@ -423,7 +424,7 @@ func testGatewayLatencyInfo() {
 			}
 
 			t.engine.Connections = []submarinerv1.Connection{t.expectedGateway.Status.Connections[0]}
-			t.engine.Connections[0].Endpoint.HealthCheckIP = ""
+			t.engine.Connections[0].Endpoint.HealthCheckIPs = []string{}
 
 			t.expectedGateway.Status.Connections[0].LatencyRTT = &submarinerv1.LatencyRTTSpec{
 				Last:    "93ms",

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -158,20 +158,20 @@ func testGatewaySyncing() {
 					Status:        submarinerv1.Connecting,
 					StatusMessage: "Connecting to 1.2.3.4:400",
 					Endpoint: submarinerv1.EndpointSpec{
-						ClusterID: "west",
-						CableName: "submariner-cable-west-192-68-1-10",
-						PrivateIP: "192.6.1.11",
-						Backend:   "libreswan",
+						ClusterID:  "west",
+						CableName:  "submariner-cable-west-192-68-1-10",
+						PrivateIPs: []string{"192.6.1.11"},
+						Backend:    "libreswan",
 					},
 				},
 				{
 					Status:        submarinerv1.Connected,
 					StatusMessage: "Connected to 1.2.3.5:500",
 					Endpoint: submarinerv1.EndpointSpec{
-						ClusterID: "north",
-						CableName: "submariner-cable-north-192-68-1-20",
-						PrivateIP: "192.6.1.21",
-						Backend:   "wireguard",
+						ClusterID:  "north",
+						CableName:  "submariner-cable-north-192-68-1-20",
+						PrivateIPs: []string{"192.6.1.21"},
+						Backend:    "wireguard",
 					},
 				},
 			}
@@ -396,7 +396,7 @@ func testGatewayLatencyInfo() {
 			endpointSpec := &submarinerv1.EndpointSpec{
 				ClusterID:     "north",
 				CableName:     "submariner-cable-north-192-68-1-20",
-				PrivateIP:     "192-68-1-20",
+				PrivateIPs:    []string{"192-68-1-20"},
 				HealthCheckIP: t.pinger.GetIP(),
 			}
 
@@ -505,11 +505,11 @@ func newTestDriver() *testDriver {
 	}
 
 	t.engine.LocalEndPoint = &types.SubmarinerEndpoint{Spec: submarinerv1.EndpointSpec{
-		ClusterID: "east",
-		CableName: "submariner-cable-east-192-68-1-2",
-		Hostname:  "redsox",
-		PrivateIP: "192.6.1.3",
-		Backend:   "libreswan",
+		ClusterID:  "east",
+		CableName:  "submariner-cable-east-192-68-1-2",
+		Hostname:   "redsox",
+		PrivateIPs: []string{"192.6.1.3"},
+		Backend:    "libreswan",
 	}}
 
 	t.expectedGateway = &submarinerv1.Gateway{

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -86,11 +86,11 @@ func testEndpointSyncing() {
 			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
 
 			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
-				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
-				ClusterID: otherClusterID,
-				Hostname:  "bruins",
-				PrivateIP: "10-253-1-2",
-				Subnets:   []string{"200.0.0.0/16", "20.0.0.0/14"},
+				CableName:  fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
+				ClusterID:  otherClusterID,
+				Hostname:   "bruins",
+				PrivateIPs: []string{"10-253-1-2"},
+				Subnets:    []string{"200.0.0.0/16", "20.0.0.0/14"},
 			})
 
 			test.CreateResource(t.brokerEndpoints, test.SetClusterIDLabel(endpoint, endpoint.Spec.ClusterID))

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -137,13 +137,13 @@ func testEndpointSyncing() {
 		})
 
 		JustBeforeEach(func() {
-			t.localEndpoint.HealthCheckIP = gateway.Annotations[constants.SmGlobalIP]
+			t.localEndpoint.SetHealthCheckIP(gateway.Annotations[constants.SmGlobalIP])
 			awaitEndpoint(t.localEndpoints, t.localEndpoint)
 		})
 
 		It("should update the local Endpoint's HealthCheckIP", func() {
 			gateway.Annotations[constants.SmGlobalIP] = "200.0.0.100"
-			t.localEndpoint.HealthCheckIP = gateway.Annotations[constants.SmGlobalIP]
+			t.localEndpoint.SetHealthCheckIP(gateway.Annotations[constants.SmGlobalIP])
 
 			test.UpdateResource(t.localGateways, gateway)
 			awaitEndpoint(t.localEndpoints, t.localEndpoint)

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -103,12 +103,12 @@ func newTestDriver() *testDriver {
 			},
 		},
 		localEndpoint: &submarinerv1.EndpointSpec{
-			CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
-			ClusterID: clusterID,
-			Hostname:  "redsox",
-			PrivateIP: "192.68.1.2",
-			Subnets:   []string{"100.0.0.0/16", "10.0.0.0/14"},
-			Backend:   "ipsec",
+			CableName:  fmt.Sprintf("submariner-cable-%s-192-68-1-2", clusterID),
+			ClusterID:  clusterID,
+			Hostname:   "redsox",
+			PrivateIPs: []string{"192.68.1.2"},
+			Subnets:    []string{"100.0.0.0/16", "10.0.0.0/14"},
+			Backend:    "ipsec",
 		},
 	}
 

--- a/pkg/controllers/datastoresyncer/gateway_handler.go
+++ b/pkg/controllers/datastoresyncer/gateway_handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8snet "k8s.io/utils/net"
 )
 
 func (d *DatastoreSyncer) handleCreateOrUpdateGateway(obj runtime.Object, _ int) bool {
@@ -62,11 +63,11 @@ func (d *DatastoreSyncer) areGatewaysEquivalent(obj1, obj2 *unstructured.Unstruc
 
 func (d *DatastoreSyncer) updateLocalEndpointIfNecessary(globalIP string) bool {
 	spec := d.localEndpoint.Spec()
-	if spec.HealthCheckIP != globalIP {
+	if spec.GetHealthCheckIP(k8snet.IPv4) != globalIP {
 		logger.Infof("Updating the endpoint HealthCheckIP to globalIP %q", globalIP)
 
 		err := d.localEndpoint.Update(context.TODO(), func(existing *submarinerv1.EndpointSpec) {
-			existing.HealthCheckIP = globalIP
+			existing.SetHealthCheckIP(globalIP)
 		})
 		if err != nil {
 			logger.Warningf("Error updating the local submariner Endpoint with HealthcheckIP %s: %v", globalIP, err)

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	fakeClient "k8s.io/client-go/dynamic/fake"
 	kubeScheme "k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -78,10 +79,10 @@ var _ = Describe("Managing tunnels", func() {
 				Namespace: namespace,
 			},
 			Spec: v1.EndpointSpec{
-				CableName: "submariner-cable-east-192-68-1-1",
-				ClusterID: "east",
-				Hostname:  "redsox",
-				PrivateIP: "192.68.1.2",
+				CableName:  "submariner-cable-east-192-68-1-1",
+				ClusterID:  "east",
+				Hostname:   "redsox",
+				PrivateIPs: []string{"192.68.1.2"},
 			},
 		}
 
@@ -129,7 +130,7 @@ var _ = Describe("Managing tunnels", func() {
 
 	verifyConnectToEndpoint := func() {
 		fakeDriver.AwaitConnectToEndpoint(&natdiscovery.NATEndpointInfo{
-			UseIP:    endpoint.Spec.PrivateIP,
+			UseIP:    endpoint.Spec.GetPrivateIP(k8snet.IPv4),
 			UseNAT:   false,
 			Endpoint: *endpoint,
 		})
@@ -151,7 +152,7 @@ var _ = Describe("Managing tunnels", func() {
 			test.CreateResource(endpoints, endpoint)
 			verifyConnectToEndpoint()
 
-			endpoint.Spec.PrivateIP = "192.68.1.3"
+			endpoint.Spec.PrivateIPs = []string{"192.68.1.3"}
 			test.UpdateResource(endpoints, endpoint)
 
 			verifyConnectToEndpoint()

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -141,7 +141,7 @@ var _ = Describe("GetLocalSpec", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.ClusterID).To(Equal("east"))
 			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
-			Expect(spec.PublicIP).To(Equal(""))
+			Expect(spec.PublicIPs).To(BeEmpty())
 		})
 	})
 
@@ -155,7 +155,7 @@ var _ = Describe("GetLocalSpec", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
-			Expect(spec.PublicIP).To(Equal(testPublicIP))
+			Expect(spec.PublicIPs).To(Equal([]string{testPublicIP}))
 		})
 	})
 
@@ -197,7 +197,7 @@ var _ = Describe("Local", func() {
 			ClusterID:     "east",
 			Hostname:      "redsox",
 			PrivateIP:     "192.68.1.2",
-			PublicIP:      "1.2.3.4",
+			PublicIPs:     []string{"1.2.3.4"},
 			Subnets:       []string{"100.0.0.0/16", "10.0.0.0/14"},
 			Backend:       "ipsec",
 			BackendConfig: map[string]string{"foo": "bar"},
@@ -227,10 +227,10 @@ var _ = Describe("Local", func() {
 
 		verifyResource()
 
-		spec.PublicIP = "11.22.33.44"
+		spec.PublicIPs = []string{"11.22.33.44"}
 
 		Expect(local.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
-			existing.PublicIP = spec.PublicIP
+			existing.PublicIPs = spec.PublicIPs
 		})).To(Succeed())
 
 		Expect(*local.Spec()).To(Equal(*spec))
@@ -239,7 +239,7 @@ var _ = Describe("Local", func() {
 
 	Specify("Create with an existing resource in the datastore should update it", func() {
 		r := local.Resource()
-		r.Spec.PublicIP = "8.8.8.8"
+		r.Spec.PublicIPs = []string{"8.8.8.8"}
 		test.CreateResource(dynClient.Resource(submarinerv1.EndpointGVR).Namespace(testNamespace), r)
 
 		Expect(local.Create(context.TODO())).To(Succeed())
@@ -248,10 +248,10 @@ var _ = Describe("Local", func() {
 	})
 
 	Specify("Update before creation should only update the cached Spec", func() {
-		spec.PublicIP = "11.22.33.44"
+		spec.PublicIPs = []string{"11.22.33.44"}
 
 		Expect(local.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
-			existing.PublicIP = spec.PublicIP
+			existing.PublicIPs = spec.PublicIPs
 		})).To(Succeed())
 
 		Expect(*local.Spec()).To(Equal(*spec))

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -108,7 +108,7 @@ var _ = Describe("GetLocalSpec", func() {
 		Expect(spec.Subnets).To(Equal(subnets))
 		Expect(spec.NATEnabled).To(BeFalse())
 		Expect(spec.BackendConfig[testUDPPortLabel]).To(Equal(testUDPPort))
-		Expect(spec.HealthCheckIP).To(BeEmpty())
+		Expect(spec.HealthCheckIPs).To(BeEmpty())
 	})
 
 	When("the gateway node is not annotated with udp port", func() {
@@ -167,7 +167,7 @@ var _ = Describe("GetLocalSpec", func() {
 		It("should set the HealthCheckIP", func() {
 			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(spec.HealthCheckIP).To(Equal(cniInterfaceIP))
+			Expect(spec.HealthCheckIPs).To(Equal([]string{cniInterfaceIP}))
 		})
 
 		Context("and globalnet is enabled", func() {
@@ -178,7 +178,7 @@ var _ = Describe("GetLocalSpec", func() {
 			It("should not set the HealthCheckIP", func() {
 				spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec.HealthCheckIP).To(BeEmpty())
+				Expect(spec.HealthCheckIPs).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -103,7 +103,7 @@ var _ = Describe("GetLocalSpec", func() {
 		Expect(spec.ClusterID).To(Equal("east"))
 		Expect(spec.CableName).To(HavePrefix("submariner-cable-east-"))
 		Expect(spec.Hostname).NotTo(BeEmpty())
-		Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+		Expect(spec.GetPrivateIP(k8snet.IPv4)).To(Equal(testPrivateIP))
 		Expect(spec.Backend).To(Equal("backend"))
 		Expect(spec.Subnets).To(Equal(subnets))
 		Expect(spec.NATEnabled).To(BeFalse())
@@ -140,7 +140,7 @@ var _ = Describe("GetLocalSpec", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.ClusterID).To(Equal("east"))
-			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+			Expect(spec.PrivateIPs).To(Equal([]string{testPrivateIP}))
 			Expect(spec.PublicIPs).To(BeEmpty())
 		})
 	})
@@ -154,7 +154,7 @@ var _ = Describe("GetLocalSpec", func() {
 			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(spec.PrivateIP).To(Equal(testPrivateIP))
+			Expect(spec.PrivateIPs).To(Equal([]string{testPrivateIP}))
 			Expect(spec.PublicIPs).To(Equal([]string{testPublicIP}))
 		})
 	})
@@ -196,7 +196,7 @@ var _ = Describe("Local", func() {
 			CableName:     "submariner-cable-192-68-1-2",
 			ClusterID:     "east",
 			Hostname:      "redsox",
-			PrivateIP:     "192.68.1.2",
+			PrivateIPs:    []string{"192.68.1.2"},
 			PublicIPs:     []string{"1.2.3.4"},
 			Subnets:       []string{"100.0.0.0/16", "10.0.0.0/14"},
 			Backend:       "ipsec",

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -52,16 +52,16 @@ var _ = Describe("PublicIPWatcher", func() {
 
 	When("using the LoadBalancer mode and the Ingress IP is modified", func() {
 		It("should update the public IP of local endpoint accordingly", func() {
-			Eventually(func() string {
-				return t.getLocalEndpoint().Spec.PublicIP
-			}, 5).Should(Equal(initialIP))
+			Eventually(func() []string {
+				return t.getLocalEndpoint().Spec.PublicIPs
+			}, 5).Should(Equal([]string{initialIP}))
 
 			// Update the load-balancer ingress ip
 			t.updateLoadbalancerService(testServiceName, testNamespace, updatedIP)
 
-			Eventually(func() string {
-				return t.getLocalEndpoint().Spec.PublicIP
-			}, 5).Should(Equal(updatedIP))
+			Eventually(func() []string {
+				return t.getLocalEndpoint().Spec.PublicIPs
+			}, 5).Should(Equal([]string{updatedIP}))
 		})
 	})
 })

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -120,11 +120,11 @@ func (t *publicIPWatcherTestDriver) getLocalEndpoint() *submarinerv1.Endpoint {
 
 func newEndpointSpec(clusterID, cableName string) submarinerv1.EndpointSpec {
 	return submarinerv1.EndpointSpec{
-		CableName: cableName,
-		ClusterID: clusterID,
-		PrivateIP: "192-68-10-2",
-		Hostname:  "myhost",
-		Subnets:   []string{"10.1.0.0/24", "100.1.0.0/24"},
+		CableName:  cableName,
+		ClusterID:  clusterID,
+		PrivateIPs: []string{"192-68-10-2"},
+		Hostname:   "myhost",
+		Subnets:    []string{"10.1.0.0/24", "100.1.0.0/24"},
 		BackendConfig: map[string]string{
 			UsingLoadBalancer: "true",
 		},

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -19,6 +19,8 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
+
 	smv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 )
 
@@ -55,7 +57,8 @@ func (c *handlerController) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) 
 	err := c.handler.LocalEndpointCreated(endpoint)
 
 	if err == nil && !c.handlerState.wasOnGateway && c.handlerState.IsOnGateway() {
-		logger.Infof("Transitioned to gateway node %q with endpoint private IP %s", c.hostname, endpoint.Spec.PrivateIP)
+		logger.Infof("Transitioned to gateway node %q with endpoint private IPs %s", c.hostname,
+			strings.Join(endpoint.Spec.PrivateIPs, ","))
 
 		err = c.handler.TransitionToGateway()
 	}

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -407,13 +407,13 @@ func (t *testDriver) newRemoteEndpoint() *submarinerv1.Endpoint {
 			Labels: map[string]string{federate.ClusterIDLabelKey: "west"},
 		},
 		Spec: submarinerv1.EndpointSpec{
-			ClusterID: "west",
-			CableName: fmt.Sprintf("submariner-cable-west-192-168-40-%d", t.remoteIPCounter),
-			Hostname:  "redsox",
-			Subnets:   []string{"169.254.3.0/24"},
-			PrivateIP: "11.1.2.3",
-			PublicIPs: []string{"ipv4:12.1.2.3"},
-			Backend:   "libreswan",
+			ClusterID:  "west",
+			CableName:  fmt.Sprintf("submariner-cable-west-192-168-40-%d", t.remoteIPCounter),
+			Hostname:   "redsox",
+			Subnets:    []string{"169.254.3.0/24"},
+			PrivateIPs: []string{"11.1.2.3"},
+			PublicIPs:  []string{"ipv4:12.1.2.3"},
+			Backend:    "libreswan",
 		},
 	}
 

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -379,7 +379,7 @@ func (t *testDriver) awaitLocalEndpoint() {
 			endpoint := toEndpoint(&l.Items[i])
 
 			if endpoint.Spec.ClusterID == t.config.Spec.ClusterID {
-				Expect(endpoint.Spec.PublicIP).To(Equal(publicIP))
+				Expect(endpoint.Spec.PublicIPs).To(Equal([]string{publicIP}))
 				Expect(endpoint.Spec.Backend).To(Equal(fakecable.DriverName))
 				Expect(endpoint.Spec.Subnets).To(Equal(t.config.Spec.GlobalCidr))
 
@@ -412,7 +412,7 @@ func (t *testDriver) newRemoteEndpoint() *submarinerv1.Endpoint {
 			Hostname:  "redsox",
 			Subnets:   []string{"169.254.3.0/24"},
 			PrivateIP: "11.1.2.3",
-			PublicIP:  "ipv4:12.1.2.3",
+			PublicIPs: []string{"ipv4:12.1.2.3"},
 			Backend:   "libreswan",
 		},
 	}

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -484,10 +484,10 @@ func (t *gatewayMonitorTestDriver) awaitGlobalnetChainsCleared() {
 
 func newEndpointSpec(clusterID, hostname, subnet string) *submarinerv1.EndpointSpec {
 	return &submarinerv1.EndpointSpec{
-		CableName: fmt.Sprintf("submariner-cable-%s-%s", clusterID, hostname),
-		ClusterID: clusterID,
-		PrivateIP: "192.68.1.2",
-		Hostname:  hostname,
-		Subnets:   []string{subnet},
+		CableName:  fmt.Sprintf("submariner-cable-%s-%s", clusterID, hostname),
+		ClusterID:  clusterID,
+		PrivateIPs: []string{"192.68.1.2"},
+		Hostname:   hostname,
+		Subnets:    []string{subnet},
 	}
 }

--- a/pkg/natdiscovery/natdiscovery_internal_test.go
+++ b/pkg/natdiscovery/natdiscovery_internal_test.go
@@ -61,7 +61,7 @@ var _ = When("a remote Endpoint is added", func() {
 	Context("with only the public IP set", func() {
 		BeforeEach(func() {
 			t.remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
-			t.remoteEndpoint.Spec.PrivateIP = ""
+			t.remoteEndpoint.Spec.PrivateIPs = []string{}
 		})
 
 		t.testRemoteEndpointAdded(testRemotePublicIP, natExpected)
@@ -99,7 +99,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
 					UseNAT:   false,
-					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+					UseIP:    t.remoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 				})))
 			})
 		})
@@ -132,7 +132,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
 					UseNAT:   false,
-					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+					UseIP:    t.remoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 				})))
 
 				Expect(t.remoteND.parseAndHandleMessageFromAddress(publicIPReq, t.localUDPAddr)).
@@ -148,7 +148,7 @@ var _ = When("a remote Endpoint is added", func() {
 			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 				Endpoint: t.remoteEndpoint,
 				UseNAT:   false,
-				UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+				UseIP:    t.remoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 			})))
 		})
 	})
@@ -164,7 +164,7 @@ var _ = When("a remote Endpoint is added", func() {
 		JustBeforeEach(func() {
 			Eventually(t.readyChannel, 5).Should(Receive())
 
-			t.remoteUDPAddr.IP = net.ParseIP(newRemoteEndpoint.Spec.PrivateIP)
+			t.remoteUDPAddr.IP = net.ParseIP(newRemoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4))
 			forwardFromUDPChan(t.localUDPSent, t.localUDPAddr, t.remoteND, 1)
 
 			t.localND.AddEndpoint(&newRemoteEndpoint)
@@ -176,16 +176,16 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
 					UseNAT:   false,
-					UseIP:    t.remoteEndpoint.Spec.PrivateIP,
+					UseIP:    t.remoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 				})))
 			})
 		})
 
 		Context("with the Endpoint's private IP changed", func() {
 			BeforeEach(func() {
-				newRemoteEndpoint.Spec.PrivateIP = testRemotePrivateIP2
+				newRemoteEndpoint.Spec.PrivateIPs = []string{testRemotePrivateIP2}
 				Expect(t.remoteND.localEndpoint.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
-					existing.PrivateIP = testRemotePrivateIP2
+					existing.PrivateIPs = []string{testRemotePrivateIP2}
 				})).To(Succeed())
 			})
 
@@ -193,7 +193,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: newRemoteEndpoint,
 					UseNAT:   false,
-					UseIP:    newRemoteEndpoint.Spec.PrivateIP,
+					UseIP:    newRemoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 				})))
 			})
 		})
@@ -220,14 +220,14 @@ var _ = When("a remote Endpoint is added", func() {
 
 		Context("with the Endpoint's private IP changed", func() {
 			BeforeEach(func() {
-				newRemoteEndpoint.Spec.PrivateIP = testRemotePrivateIP2
+				newRemoteEndpoint.Spec.PrivateIPs = []string{testRemotePrivateIP2}
 				Expect(t.remoteND.localEndpoint.Update(context.Background(), func(existing *submarinerv1.EndpointSpec) {
-					existing.PrivateIP = testRemotePrivateIP2
+					existing.PrivateIPs = []string{testRemotePrivateIP2}
 				})).To(Succeed())
 			})
 
 			JustBeforeEach(func() {
-				t.remoteUDPAddr.IP = net.ParseIP(newRemoteEndpoint.Spec.PrivateIP)
+				t.remoteUDPAddr.IP = net.ParseIP(newRemoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4))
 				forwardFromUDPChan(t.localUDPSent, t.localUDPAddr, t.remoteND, -1)
 				t.localND.checkEndpointList()
 			})
@@ -236,7 +236,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: newRemoteEndpoint,
 					UseNAT:   false,
-					UseIP:    newRemoteEndpoint.Spec.PrivateIP,
+					UseIP:    newRemoteEndpoint.Spec.GetPrivateIP(k8snet.IPv4),
 				})))
 			})
 		})
@@ -261,7 +261,7 @@ var _ = When("a remote Endpoint is added", func() {
 	Context("with no NAT discovery port set", func() {
 		BeforeEach(func() {
 			t.remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
-			t.remoteEndpoint.Spec.PrivateIP = ""
+			t.remoteEndpoint.Spec.PrivateIPs = []string{}
 			delete(t.remoteEndpoint.Spec.BackendConfig, submarinerv1.NATTDiscoveryPortConfig)
 		})
 

--- a/pkg/natdiscovery/natdiscovery_internal_test.go
+++ b/pkg/natdiscovery/natdiscovery_internal_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -44,7 +45,7 @@ var _ = When("a remote Endpoint is added", func() {
 		atomic.StoreInt64(&totalTimeout, time.Hour.Nanoseconds())
 		atomic.StoreInt64(&publicToPrivateFailoverTimeout, time.Hour.Nanoseconds())
 		forwardHowManyFromLocal = 1
-		t.remoteEndpoint.Spec.PublicIP = ""
+		t.remoteEndpoint.Spec.PublicIPs = []string{}
 	})
 
 	JustBeforeEach(func() {
@@ -59,7 +60,7 @@ var _ = When("a remote Endpoint is added", func() {
 
 	Context("with only the public IP set", func() {
 		BeforeEach(func() {
-			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
 			t.remoteEndpoint.Spec.PrivateIP = ""
 		})
 
@@ -72,7 +73,7 @@ var _ = When("a remote Endpoint is added", func() {
 
 		BeforeEach(func() {
 			forwardHowManyFromLocal = 0
-			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
 			t.remoteND.AddEndpoint(&t.localEndpoint)
 		})
 
@@ -89,7 +90,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
 					UseNAT:   true,
-					UseIP:    t.remoteEndpoint.Spec.PublicIP,
+					UseIP:    t.remoteEndpoint.Spec.GetPublicIP(k8snet.IPv4),
 				})))
 
 				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr)).
@@ -113,7 +114,7 @@ var _ = When("a remote Endpoint is added", func() {
 				Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 					Endpoint: t.remoteEndpoint,
 					UseNAT:   true,
-					UseIP:    t.remoteEndpoint.Spec.PublicIP,
+					UseIP:    t.remoteEndpoint.Spec.GetPublicIP(k8snet.IPv4),
 				})))
 
 				Expect(t.remoteND.parseAndHandleMessageFromAddress(privateIPReq, t.localUDPAddr)).
@@ -259,7 +260,7 @@ var _ = When("a remote Endpoint is added", func() {
 
 	Context("with no NAT discovery port set", func() {
 		BeforeEach(func() {
-			t.remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			t.remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
 			t.remoteEndpoint.Spec.PrivateIP = ""
 			delete(t.remoteEndpoint.Spec.BackendConfig, submarinerv1.NATTDiscoveryPortConfig)
 		})
@@ -268,7 +269,7 @@ var _ = When("a remote Endpoint is added", func() {
 			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 				Endpoint: t.remoteEndpoint,
 				UseNAT:   true,
-				UseIP:    t.remoteEndpoint.Spec.PublicIP,
+				UseIP:    t.remoteEndpoint.Spec.GetPublicIP(k8snet.IPv4),
 			})))
 		})
 	})
@@ -292,7 +293,7 @@ var _ = When("a remote Endpoint is added", func() {
 			Eventually(t.readyChannel, 5).Should(Receive(Equal(&NATEndpointInfo{
 				Endpoint: t.remoteEndpoint,
 				UseNAT:   true,
-				UseIP:    t.remoteEndpoint.Spec.PublicIP,
+				UseIP:    t.remoteEndpoint.Spec.GetPublicIP(k8snet.IPv4),
 			})))
 		})
 	})

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	k8snet "k8s.io/utils/net"
 )
 
 type endpointState int
@@ -109,14 +110,14 @@ func (rn *remoteEndpointNAT) useLegacyNATSettings() {
 	switch {
 	case rn.usingLoadBalancer:
 		rn.useNAT = true
-		rn.useIP = rn.endpoint.Spec.PublicIP
+		rn.useIP = rn.endpoint.Spec.GetPublicIP(k8snet.IPv4)
 		rn.transitionToState(selectedPublicIP)
 		logger.V(log.DEBUG).Infof("using NAT for the load balancer backed endpoint %q, using public IP %q", rn.endpoint.Spec.CableName,
 			rn.useIP)
 
 	case rn.endpoint.Spec.NATEnabled:
 		rn.useNAT = true
-		rn.useIP = rn.endpoint.Spec.PublicIP
+		rn.useIP = rn.endpoint.Spec.GetPublicIP(k8snet.IPv4)
 		rn.transitionToState(selectedPublicIP)
 		logger.V(log.DEBUG).Infof("using NAT legacy settings for endpoint %q, using public IP %q", rn.endpoint.Spec.CableName,
 			rn.useIP)
@@ -158,7 +159,7 @@ func (rn *remoteEndpointNAT) checkSent() {
 func (rn *remoteEndpointNAT) transitionToPublicIP(remoteEndpointID string, useNAT bool) bool {
 	switch rn.state {
 	case waitingForResponse:
-		rn.useIP = rn.endpoint.Spec.PublicIP
+		rn.useIP = rn.endpoint.Spec.GetPublicIP(k8snet.IPv4)
 		rn.useNAT = useNAT
 		rn.transitionToState(selectedPublicIP)
 		logger.V(log.DEBUG).Infof("selected public IP %q for endpoint %q", rn.useIP, rn.endpoint.Spec.CableName)

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -124,7 +124,7 @@ func (rn *remoteEndpointNAT) useLegacyNATSettings() {
 
 	default:
 		rn.useNAT = false
-		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.useIP = rn.endpoint.Spec.GetPrivateIP(k8snet.IPv4)
 		rn.transitionToState(selectedPrivateIP)
 		logger.V(log.DEBUG).Infof("using NAT legacy settings for endpoint %q, using private IP %q", rn.endpoint.Spec.CableName,
 			rn.useIP)
@@ -179,7 +179,7 @@ func (rn *remoteEndpointNAT) transitionToPublicIP(remoteEndpointID string, useNA
 func (rn *remoteEndpointNAT) transitionToPrivateIP(remoteEndpointID string, useNAT bool) bool {
 	switch rn.state {
 	case waitingForResponse:
-		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.useIP = rn.endpoint.Spec.GetPrivateIP(k8snet.IPv4)
 		rn.useNAT = useNAT
 		rn.transitionToState(selectedPrivateIP)
 		logger.V(log.DEBUG).Infof("selected private IP %q for endpoint %q", rn.useIP, rn.endpoint.Spec.CableName)
@@ -194,7 +194,7 @@ func (rn *remoteEndpointNAT) transitionToPrivateIP(remoteEndpointID string, useN
 			return false
 		}
 
-		rn.useIP = rn.endpoint.Spec.PrivateIP
+		rn.useIP = rn.endpoint.Spec.GetPrivateIP(k8snet.IPv4)
 		rn.useNAT = useNAT
 		rn.transitionToState(selectedPrivateIP)
 		logger.V(log.DEBUG).Infof("updated to private IP %q for endpoint %q", rn.useIP, rn.endpoint.Spec.CableName)

--- a/pkg/natdiscovery/remote_endpoint_internal_test.go
+++ b/pkg/natdiscovery/remote_endpoint_internal_test.go
@@ -24,9 +24,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	k8snet "k8s.io/utils/net"
 )
 
-//nolint:dupl // Some line blocks are very similar but not exactly duplicated, either way not worth refactoring.
 var _ = Describe("remoteEndpointNAT", func() {
 	var rnat *remoteEndpointNAT
 	var remoteEndpoint submarinerv1.Endpoint
@@ -83,7 +83,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				rnat.endpoint.Spec.NATEnabled = true
 				rnat.useLegacyNATSettings()
 				Expect(rnat.state).To(Equal(selectedPublicIP))
-				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPublicIP(k8snet.IPv4)))
 			})
 		})
 		Context("and targeting a load balancer", func() {
@@ -93,7 +93,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				rnat.endpoint.Spec.NATEnabled = false
 				rnat.useLegacyNATSettings()
 				Expect(rnat.state).To(Equal(selectedPublicIP))
-				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPublicIP(k8snet.IPv4)))
 				Expect(rnat.useNAT).To(BeTrue())
 			})
 		})
@@ -161,7 +161,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 		})
 
 		It("should use the public IP", func() {
-			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPublicIP(k8snet.IPv4)))
 		})
 
 		Context("with NAT discovered", func() {
@@ -204,7 +204,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				rnat.lastTransition = rnat.lastTransition.Add(-time.Duration(publicToPrivateFailoverTimeout))
 				Expect(rnat.transitionToPrivateIP(testRemoteEndpointName, false)).To(BeFalse())
 				Expect(rnat.state).To(Equal(selectedPublicIP))
-				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PublicIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPublicIP(k8snet.IPv4)))
 				Expect(rnat.useNAT).To(BeTrue())
 			})
 		})

--- a/pkg/natdiscovery/remote_endpoint_internal_test.go
+++ b/pkg/natdiscovery/remote_endpoint_internal_test.go
@@ -75,7 +75,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				rnat.endpoint.Spec.NATEnabled = false
 				rnat.useLegacyNATSettings()
 				Expect(rnat.state).To(Equal(selectedPrivateIP))
-				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPrivateIP(k8snet.IPv4)))
 			})
 		})
 		Context("and NAT is enabled", func() {
@@ -117,6 +117,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 		})
 	})
 
+	//nolint:dupl // Ignore
 	When("the private IP is selected", func() {
 		var useNAT bool
 
@@ -127,7 +128,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 		})
 
 		It("should use the private IP", func() {
-			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+			Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPrivateIP(k8snet.IPv4)))
 		})
 
 		Context("with NAT discovered", func() {
@@ -151,6 +152,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 		})
 	})
 
+	//nolint:dupl // Ignore
 	When("the public IP is selected", func() {
 		var useNAT bool
 
@@ -192,7 +194,7 @@ var _ = Describe("remoteEndpointNAT", func() {
 				Expect(rnat.transitionToPublicIP(testRemoteEndpointName, true)).To(BeTrue())
 				Expect(rnat.transitionToPrivateIP(testRemoteEndpointName, false)).To(BeTrue())
 				Expect(rnat.state).To(Equal(selectedPrivateIP))
-				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.PrivateIP))
+				Expect(rnat.useIP).To(Equal(rnat.endpoint.Spec.GetPrivateIP(k8snet.IPv4)))
 				Expect(rnat.useNAT).To(BeFalse())
 			})
 		})

--- a/pkg/natdiscovery/request_handle.go
+++ b/pkg/natdiscovery/request_handle.go
@@ -25,6 +25,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/natdiscovery/proto"
 	proto2 "google.golang.org/protobuf/proto"
+	k8snet "k8s.io/utils/net"
 )
 
 func (nd *natDiscovery) handleRequestFromAddress(req *proto.SubmarinerNATDiscoveryRequest, addr *net.UDPAddr) error {
@@ -94,7 +95,7 @@ func (nd *natDiscovery) handleRequestFromAddress(req *proto.SubmarinerNATDiscove
 	// Detect DST NAT with a naive implementation that assumes that we always receive on the PrivateIP,
 	// if we will listen at some point on multiple addresses we will need to implement the
 	// unix.IP_RECVORIGDSTADDR on the UDP socket, and the go recvmsg implementation instead of readfrom
-	if req.GetUsingDst().GetIP() != localEndpointSpec.PrivateIP {
+	if req.GetUsingDst().GetIP() != localEndpointSpec.GetPrivateIP(k8snet.IPv4) {
 		response.DstIpNatDetected = true
 	}
 

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -32,8 +32,8 @@ func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 	var errPrivate, errPublic error
 	var reqID uint64
 
-	if remoteNAT.endpoint.Spec.PrivateIP != "" {
-		reqID, errPrivate = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.PrivateIP)
+	if remoteNAT.endpoint.Spec.GetPrivateIP(k8snet.IPv4) != "" {
+		reqID, errPrivate = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.GetPrivateIP(k8snet.IPv4))
 		if errPrivate == nil {
 			remoteNAT.lastPrivateIPRequestID = reqID
 		}

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -25,6 +25,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	natproto "github.com/submariner-io/submariner/pkg/natdiscovery/proto"
 	"google.golang.org/protobuf/proto"
+	k8snet "k8s.io/utils/net"
 )
 
 func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
@@ -38,8 +39,8 @@ func (nd *natDiscovery) sendCheckRequest(remoteNAT *remoteEndpointNAT) error {
 		}
 	}
 
-	if remoteNAT.endpoint.Spec.PublicIP != "" {
-		reqID, errPublic = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.PublicIP)
+	if remoteNAT.endpoint.Spec.GetPublicIP(k8snet.IPv4) != "" {
+		reqID, errPublic = nd.sendCheckRequestToTargetIP(remoteNAT, remoteNAT.endpoint.Spec.GetPublicIP(k8snet.IPv4))
 		if errPublic == nil {
 			remoteNAT.lastPublicIPRequestID = reqID
 		}

--- a/pkg/natdiscovery/request_send_internal_test.go
+++ b/pkg/natdiscovery/request_send_internal_test.go
@@ -37,7 +37,7 @@ var _ = When("a request is sent", func() {
 
 	BeforeEach(func() {
 		remoteEndpoint = createTestRemoteEndpoint()
-		remoteEndpoint.Spec.PublicIP = ""
+		remoteEndpoint.Spec.PublicIPs = []string{}
 		remoteEndpoint.Spec.PrivateIP = ""
 	})
 
@@ -90,7 +90,7 @@ var _ = When("a request is sent", func() {
 
 		Context("and the public IP set", func() {
 			BeforeEach(func() {
-				remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+				remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
 			})
 
 			JustBeforeEach(func() {
@@ -103,7 +103,7 @@ var _ = When("a request is sent", func() {
 
 	Context("with the public IP set", func() {
 		BeforeEach(func() {
-			remoteEndpoint.Spec.PublicIP = testRemotePublicIP
+			remoteEndpoint.Spec.PublicIPs = []string{testRemotePublicIP}
 		})
 
 		testRequest(testRemotePublicIP)

--- a/pkg/natdiscovery/request_send_internal_test.go
+++ b/pkg/natdiscovery/request_send_internal_test.go
@@ -38,7 +38,7 @@ var _ = When("a request is sent", func() {
 	BeforeEach(func() {
 		remoteEndpoint = createTestRemoteEndpoint()
 		remoteEndpoint.Spec.PublicIPs = []string{}
-		remoteEndpoint.Spec.PrivateIP = ""
+		remoteEndpoint.Spec.PrivateIPs = []string{}
 	})
 
 	JustBeforeEach(func() {
@@ -83,7 +83,7 @@ var _ = When("a request is sent", func() {
 
 	Context("with the private IP set", func() {
 		BeforeEach(func() {
-			remoteEndpoint.Spec.PrivateIP = testRemotePrivateIP
+			remoteEndpoint.Spec.PrivateIPs = []string{testRemotePrivateIP}
 		})
 
 		testRequest(testRemotePrivateIP)

--- a/pkg/natdiscovery/test_utils.go
+++ b/pkg/natdiscovery/test_utils.go
@@ -124,7 +124,7 @@ func createTestLocalEndpoint() submarinerv1.Endpoint {
 			CableName:  testLocalEndpointName,
 			ClusterID:  testLocalClusterID,
 			PublicIPs:  []string{testLocalPublicIP},
-			PrivateIP:  testLocalPrivateIP,
+			PrivateIPs: []string{testLocalPrivateIP},
 			NATEnabled: true,
 			BackendConfig: map[string]string{
 				submarinerv1.NATTDiscoveryPortConfig: strconv.Itoa(int(testLocalNATPort)),
@@ -139,7 +139,7 @@ func createTestRemoteEndpoint() submarinerv1.Endpoint {
 			CableName:  testRemoteEndpointName,
 			ClusterID:  testRemoteClusterID,
 			PublicIPs:  []string{testRemotePublicIP},
-			PrivateIP:  testRemotePrivateIP,
+			PrivateIPs: []string{testRemotePrivateIP},
 			NATEnabled: true,
 			BackendConfig: map[string]string{
 				submarinerv1.NATTDiscoveryPortConfig: strconv.Itoa(int(testRemoteNATPort)),

--- a/pkg/natdiscovery/test_utils.go
+++ b/pkg/natdiscovery/test_utils.go
@@ -123,7 +123,7 @@ func createTestLocalEndpoint() submarinerv1.Endpoint {
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testLocalEndpointName,
 			ClusterID:  testLocalClusterID,
-			PublicIP:   testLocalPublicIP,
+			PublicIPs:  []string{testLocalPublicIP},
 			PrivateIP:  testLocalPrivateIP,
 			NATEnabled: true,
 			BackendConfig: map[string]string{
@@ -138,7 +138,7 @@ func createTestRemoteEndpoint() submarinerv1.Endpoint {
 		Spec: submarinerv1.EndpointSpec{
 			CableName:  testRemoteEndpointName,
 			ClusterID:  testRemoteClusterID,
-			PublicIP:   testRemotePublicIP,
+			PublicIPs:  []string{testRemotePublicIP},
 			PrivateIP:  testRemotePrivateIP,
 			NATEnabled: true,
 			BackendConfig: map[string]string{

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubeScheme "k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -160,7 +161,7 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				t.pingerMap[healthCheckIP1].AwaitStart()
 				t.pingerMap[healthCheckIP2] = fake.NewPinger(healthCheckIP2)
 
-				endpoint1.Spec.HealthCheckIP = healthCheckIP2
+				endpoint1.Spec.HealthCheckIPs = []string{healthCheckIP2}
 
 				t.UpdateEndpoint(endpoint1)
 				t.pingerMap[healthCheckIP1].AwaitStop()
@@ -176,7 +177,7 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				endpoint1.Spec.Hostname = "newHostName"
 				t.UpdateEndpoint(endpoint1)
 
-				pingerObject, found := t.pingerMap[endpoint1.Spec.HealthCheckIP]
+				pingerObject, found := t.pingerMap[endpoint1.Spec.GetHealthCheckIP(k8snet.IPv4)]
 				Expect(found).To(BeTrue())
 				Expect(pingerObject.GetIP()).To(Equal(healthCheckIP1))
 
@@ -306,7 +307,7 @@ func (t *testDriver) newSubmEndpoint(healthCheckIP string) *submarinerv1.Endpoin
 		ClusterID: remoteClusterID,
 		CableName: fmt.Sprintf("submariner-cable-%s-192-68-1-20", remoteClusterID),
 	}
-	endpointSpec.HealthCheckIP = healthCheckIP
+	endpointSpec.HealthCheckIPs = []string{healthCheckIP}
 
 	endpointName, err := endpointSpec.GenerateName()
 	Expect(err).To(Succeed())

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/vxlan"
+	k8snet "k8s.io/utils/net"
 )
 
 func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
@@ -46,7 +47,7 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 			kp.activeEndpointHostname = ""
 		}
 
-		localClusterGwNodeIP := net.ParseIP(endpoint.Spec.PrivateIP)
+		localClusterGwNodeIP := net.ParseIP(endpoint.Spec.GetPrivateIP(k8snet.IPv4))
 
 		remoteVtepIP, err := vxlan.GetVtepIPAddressFrom(localClusterGwNodeIP.String(), VxLANVTepNetworkPrefix)
 		if err != nil {

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -38,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -69,7 +70,8 @@ func testEndpoints() {
 		})
 
 		It("should add the VxLAN interface", func() {
-			Expect(toVxlan(t.netLink.AwaitLink(kubeproxy.VxLANIface)).Group.String()).To(Equal(t.localEndpoint.Spec.PrivateIP))
+			Expect(toVxlan(t.netLink.AwaitLink(kubeproxy.VxLANIface)).Group.String()).To(Equal(
+				t.localEndpoint.Spec.GetPrivateIP(k8snet.IPv4)))
 		})
 
 		Context("and old VxLAN routes are present", func() {
@@ -448,11 +450,11 @@ func newLocalEndpoint(hostname string) *submarinerv1.Endpoint {
 			Name: string(uuid.NewUUID()),
 		},
 		Spec: submarinerv1.EndpointSpec{
-			CableName: "submariner-cable-local-192-68-1-2",
-			ClusterID: testing.LocalClusterID,
-			PrivateIP: "192.68.1.2",
-			Hostname:  hostname,
-			Backend:   "libreswan",
+			CableName:  "submariner-cable-local-192-68-1-2",
+			ClusterID:  testing.LocalClusterID,
+			PrivateIPs: []string{"192.68.1.2"},
+			Hostname:   hostname,
+			Backend:    "libreswan",
 		},
 	}
 }
@@ -463,12 +465,12 @@ func newRemoteEndpoint() *submarinerv1.Endpoint {
 			Name: string(uuid.NewUUID()),
 		},
 		Spec: submarinerv1.EndpointSpec{
-			CableName: "submariner-cable-remote-192-68-1-2",
-			ClusterID: "remote",
-			PrivateIP: "192.68.1.2",
-			Hostname:  remoteNodeName,
-			Subnets:   []string{remoteSubnet1, remoteSubnet2},
-			Backend:   "libreswan",
+			CableName:  "submariner-cable-remote-192-68-1-2",
+			ClusterID:  "remote",
+			PrivateIPs: []string{"192.68.1.2"},
+			Hostname:   remoteNodeName,
+			Subnets:    []string{remoteSubnet1, remoteSubnet2},
+			Backend:    "libreswan",
 		},
 	}
 }

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -110,7 +110,7 @@ func verifyGateway(gw *submarinerv1.Gateway, otherCluster string, healthCheckedE
 		}
 
 		if healthCheckedEnabled {
-			if gw.Status.Connections[i].Endpoint.HealthCheckIP == "" {
+			if len(gw.Status.Connections[i].Endpoint.HealthCheckIPs) == 0 {
 				return false, fmt.Sprintf("Connection for cluster %q has no health check IP. This could be because the Gateway or"+
 					" Globalnet pod could not determine the cluster's CNI IP address. If so, this would be reported in the pod log.",
 					otherCluster), nil


### PR DESCRIPTION
Also mark the singular fields as deprecated so the `staticcheck` linter flags any usages outside the package.