### PR TITLE
Enable pinger unit tests

### DIFF
--- a/pkg/pinger/pinger_suite_test.go
+++ b/pkg/pinger/pinger_suite_test.go
@@ -1,0 +1,31 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pinger_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPinger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pinger Suite")
+}

--- a/pkg/pinger/pinger_test.go
+++ b/pkg/pinger/pinger_test.go
@@ -92,10 +92,8 @@ var _ = Describe("Pinger", func() {
 			Timeout:  pingTimeout,
 		})
 		pingerInterface.Start()
-	})
 
-	AfterEach(func() {
-		pingerInterface.Stop()
+		DeferCleanup(pingerInterface.Stop)
 	})
 
 	verifyPingStats := func(count int) {


### PR DESCRIPTION
Add the ginkgo bootstrap file/function so the unit tests run. This was missed a while back when the pinger code was refactored to its own package.
