### PR TITLE
Add unit tests for the wireguard cable driver

### DIFF
--- a/pkg/apis/submariner.io/v1/endpoint.go
+++ b/pkg/apis/submariner.io/v1/endpoint.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	"k8s.io/apimachinery/pkg/api/equality"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -180,4 +182,19 @@ func (ep *EndpointSpec) GetIPFamilies() []k8snet.IPFamily {
 
 func (ep *EndpointSpec) GetFamilyCableName(family k8snet.IPFamily) string {
 	return ep.CableName + "-v" + string(family)
+}
+
+func (ep *EndpointSpec) ParseSubnets(family k8snet.IPFamily) []net.IPNet {
+	var subnets []net.IPNet
+
+	for i := range ep.Subnets {
+		_, cidr, err := net.ParseCIDR(ep.Subnets[i])
+		utilruntime.Must(err)
+
+		if k8snet.IPFamilyOfCIDR(cidr) == family {
+			subnets = append(subnets, *cidr)
+		}
+	}
+
+	return subnets
 }

--- a/pkg/cable/wireguard/client.go
+++ b/pkg/cable/wireguard/client.go
@@ -1,0 +1,34 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wireguard
+
+import (
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+type Client interface {
+	ConfigureDevice(name string, cfg wgtypes.Config) error
+	Device(name string) (*wgtypes.Device, error)
+	Close() error
+}
+
+var NewClient = func() (Client, error) {
+	return wgctrl.New()
+}

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -221,11 +221,6 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 	remoteEndpoint := &endpointInfo.Endpoint
 	ip := endpointInfo.UseIP
 
-	if w.localEndpoint.ClusterID == remoteEndpoint.Spec.ClusterID {
-		logger.V(log.DEBUG).Infof("Will not connect to self")
-		return "", nil
-	}
-
 	// Parse remote addresses and allowed IPs.
 	remoteIP := net.ParseIP(ip)
 	if remoteIP == nil {
@@ -329,11 +324,6 @@ func keyFromSpec(ep *v1.EndpointSpec) (*wgtypes.Key, error) {
 func (w *wireguard) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpoint, family k8snet.IPFamily) error {
 	// We'll panic if remoteEndpoint is nil, this is intentional
 	logger.V(log.DEBUG).Infof("Removing IPv%v endpoint %v+", family, remoteEndpoint)
-
-	if w.localEndpoint.ClusterID == remoteEndpoint.Spec.ClusterID {
-		logger.V(log.DEBUG).Infof("Will not disconnect self")
-		return nil
-	}
 
 	// parse remote public key
 	remoteKey, err := keyFromSpec(&remoteEndpoint.Spec)

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -232,7 +232,7 @@ func (w *wireguard) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 		return "", fmt.Errorf("failed to parse remote IP %s", ip)
 	}
 
-	allowedIPs := parseSubnets(remoteEndpoint.Spec.Subnets)
+	allowedIPs := remoteEndpoint.Spec.ParseSubnets(endpointInfo.UseFamily)
 
 	// Parse remote public key.
 	remoteKey, err := keyFromSpec(&remoteEndpoint.Spec)
@@ -388,24 +388,6 @@ func (w *wireguard) setWGLink() error {
 	err := w.netLink.LinkAdd(w.link)
 
 	return errors.Wrap(err, "failed to add WireGuard device")
-}
-
-// Parse CIDR string and skip errors.
-func parseSubnets(subnets []string) []net.IPNet {
-	nets := make([]net.IPNet, 0, len(subnets))
-
-	for _, sn := range subnets {
-		_, cidr, err := net.ParseCIDR(sn)
-		if err != nil {
-			// This should not happen. Log and continue.
-			logger.Errorf(err, "failed to parse subnet %s", sn)
-			continue
-		}
-
-		nets = append(nets, *cidr)
-	}
-
-	return nets
 }
 
 func (w *wireguard) removePeer(key *wgtypes.Key) error {

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -38,7 +38,6 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/vishvananda/netlink"
-	"golang.zx2c4.com/wireguard/wgctrl"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -79,7 +78,7 @@ type wireguard struct {
 	localEndpoint v1.EndpointSpec
 	connections   map[string]*v1.Connection // clusterID -> remote ep connection
 	mutex         sync.Mutex
-	client        *wgctrl.Client
+	client        Client
 	netLink       netlinkAPI.Interface
 	link          netlink.Link
 	spec          *specification
@@ -106,7 +105,7 @@ func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable
 	}
 
 	// Create the controller.
-	if w.client, err = wgctrl.New(); err != nil {
+	if w.client, err = NewClient(); err != nil {
 		if os.IsNotExist(err) {
 			return nil, errors.New("wgctrl is not available on this system")
 		}

--- a/pkg/cable/wireguard/getconnections.go
+++ b/pkg/cable/wireguard/getconnections.go
@@ -38,9 +38,6 @@ func (w *wireguard) GetConnections() ([]v1.Connection, error) {
 
 	connections := make([]v1.Connection, 0)
 
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
 	for i := range d.Peers {
 		key := d.Peers[i].PublicKey
 

--- a/pkg/cable/wireguard/wireguard_suite_test.go
+++ b/pkg/cable/wireguard/wireguard_suite_test.go
@@ -1,0 +1,285 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wireguard_test
+
+import (
+	"flag"
+	"net"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"github.com/submariner-io/admiral/pkg/resource"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+	"github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/submariner-io/submariner/pkg/types"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=4"})
+
+	kzerolog.InitK8sLogging()
+})
+
+func TestWireguard(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Wireguard Suite")
+}
+
+type testDriver struct {
+	endpointSpec      submarinerv1.EndpointSpec
+	localEndpoint     *endpoint.Local
+	driver            cable.Driver
+	netLink           *fakeNetlink.NetLink
+	client            *fakeClient
+	checkNewDriverErr func(error)
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{}
+
+	BeforeEach(func() {
+		t.endpointSpec = submarinerv1.EndpointSpec{
+			ClusterID:  "local",
+			CableName:  "submariner-cable-local-192-68-1-1",
+			PrivateIPs: []string{"192.68.1.1"},
+			Subnets:    []string{"10.0.0.0/16"},
+			BackendConfig: map[string]string{
+				submarinerv1.UDPPortConfig: strconv.Itoa(listenPort),
+			},
+		}
+
+		t.netLink = fakeNetlink.New()
+		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
+			return t.netLink
+		}
+
+		t.client = &fakeClient{}
+		t.client.devices = map[string]*wgtypes.Device{}
+
+		wireguard.NewClient = func() (wireguard.Client, error) {
+			return t.client, nil
+		}
+
+		t.checkNewDriverErr = func(err error) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	JustBeforeEach(func() {
+		var err error
+
+		t.localEndpoint = endpoint.NewLocal(&t.endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
+
+		t.driver, err = wireguard.NewDriver(t.localEndpoint, &types.SubmarinerCluster{})
+		t.checkNewDriverErr(err)
+	})
+
+	return t
+}
+
+func (t *testDriver) assertConnections(natInfos ...*natdiscovery.NATEndpointInfo) {
+	actual, err := t.driver.GetConnections()
+	Expect(err).ToNot(HaveOccurred())
+
+	for i := range actual {
+		actual[i].StatusMessage = ""
+	}
+
+	slices.SortFunc(actual, func(a, b submarinerv1.Connection) int {
+		return strings.Compare(a.Endpoint.BackendConfig[wireguard.PublicKey], b.Endpoint.BackendConfig[wireguard.PublicKey])
+	})
+
+	expected := make([]submarinerv1.Connection, len(natInfos))
+	for i := range natInfos {
+		expected[i] = submarinerv1.Connection{
+			Status:   submarinerv1.Connecting,
+			Endpoint: natInfos[i].Endpoint.Spec,
+			UsingIP:  natInfos[i].UseIP,
+			UsingNAT: natInfos[i].UseNAT,
+		}
+	}
+
+	slices.SortFunc(expected, func(a, b submarinerv1.Connection) int {
+		return strings.Compare(a.Endpoint.BackendConfig[wireguard.PublicKey], b.Endpoint.BackendConfig[wireguard.PublicKey])
+	})
+
+	Expect(actual).To(HaveExactElements(expected))
+}
+
+func newNATInfo(clusterID string, subnets ...string) *natdiscovery.NATEndpointInfo {
+	priv, err := wgtypes.GeneratePrivateKey()
+	Expect(err).ToNot(HaveOccurred())
+
+	return &natdiscovery.NATEndpointInfo{
+		Endpoint: submarinerv1.Endpoint{
+			Spec: submarinerv1.EndpointSpec{
+				ClusterID: clusterID,
+				CableName: "submariner-cable-" + clusterID,
+				Subnets:   subnets,
+				BackendConfig: map[string]string{
+					wireguard.PublicKey:        priv.PublicKey().String(),
+					submarinerv1.UDPPortConfig: strconv.Itoa(listenPort2),
+				},
+			},
+		},
+		UseIP:     "172.93.2.1",
+		UseNAT:    true,
+		UseFamily: k8snet.IPv4,
+	}
+}
+
+type fakeClient struct {
+	devices            map[string]*wgtypes.Device
+	configureDeviceErr error
+}
+
+func (c *fakeClient) ConfigureDevice(name string, cfg wgtypes.Config) error {
+	if c.configureDeviceErr != nil {
+		return c.configureDeviceErr
+	}
+
+	d := c.devices[name]
+	if d == nil {
+		c.devices[name] = &wgtypes.Device{}
+		d = c.devices[name]
+	}
+
+	if cfg.PrivateKey != nil {
+		d.PrivateKey = *cfg.PrivateKey
+		d.PublicKey = d.PrivateKey.PublicKey()
+	}
+
+	if cfg.ListenPort != nil {
+		d.ListenPort = *cfg.ListenPort
+	}
+
+	if cfg.ReplacePeers {
+		d.Peers = nil
+	}
+
+	for i := range cfg.Peers {
+		pc := &cfg.Peers[i]
+		if pc.Remove {
+			d.Peers = slices.DeleteFunc(d.Peers, func(p wgtypes.Peer) bool {
+				return p.PublicKey.String() == pc.PublicKey.String()
+			})
+
+			continue
+		}
+
+		index := slices.IndexFunc(d.Peers, func(p wgtypes.Peer) bool {
+			return p.PublicKey.String() == pc.PublicKey.String()
+		})
+
+		if index == -1 {
+			if pc.UpdateOnly {
+				continue
+			}
+
+			d.Peers = append(d.Peers, wgtypes.Peer{
+				PublicKey:    pc.PublicKey,
+				PresharedKey: ptr.Deref(pc.PresharedKey, wgtypes.Key{}),
+				Endpoint:     pc.Endpoint,
+			})
+
+			index = len(d.Peers) - 1
+		}
+
+		peer := &d.Peers[index]
+
+		if pc.ReplaceAllowedIPs {
+			peer.AllowedIPs = pc.AllowedIPs
+		} else {
+			peer.AllowedIPs = append(peer.AllowedIPs, pc.AllowedIPs...)
+		}
+	}
+
+	return nil
+}
+
+func (c *fakeClient) Device(name string) (*wgtypes.Device, error) {
+	if c.devices[name] != nil {
+		d := *c.devices[name]
+		d.Peers = make([]wgtypes.Peer, len(c.devices[name].Peers))
+		copy(d.Peers, c.devices[name].Peers)
+
+		return &d, nil
+	}
+
+	return nil, os.ErrNotExist
+}
+
+func (c *fakeClient) Close() error {
+	return nil
+}
+
+func (c *fakeClient) assertDevicePeers(natInfos ...*natdiscovery.NATEndpointInfo) {
+	device, err := c.Device(wireguard.DefaultDeviceName)
+	Expect(err).ToNot(HaveOccurred())
+
+	for i := range natInfos {
+		index := slices.IndexFunc(device.Peers, func(p wgtypes.Peer) bool {
+			return p.PublicKey.String() == natInfos[i].Endpoint.Spec.BackendConfig[wireguard.PublicKey]
+		})
+		Expect(index).To(BeNumerically(">=", 0), "Missing expected device peer for %s", resource.ToJSON(natInfos[i]))
+
+		peer := &device.Peers[index]
+		Expect(peer.PublicKey.String()).To(Equal(natInfos[i].Endpoint.Spec.BackendConfig[wireguard.PublicKey]))
+		Expect(peer.PresharedKey).ToNot(Equal(wgtypes.Key{}))
+		Expect(peer.Endpoint).To(Equal(&net.UDPAddr{
+			IP:   net.ParseIP(natInfos[i].UseIP),
+			Port: listenPort2,
+		}))
+
+		actualIPs := make([]string, len(peer.AllowedIPs))
+		for j := range peer.AllowedIPs {
+			actualIPs[j] = peer.AllowedIPs[j].String()
+		}
+
+		slices.Sort(actualIPs)
+		slices.Sort(natInfos[i].Endpoint.Spec.Subnets)
+		Expect(actualIPs).To(HaveExactElements(natInfos[i].Endpoint.Spec.Subnets))
+
+		device.Peers = slices.Delete(device.Peers, index, index+1)
+	}
+
+	Expect(device.Peers).To(BeEmpty(), "Received unexpected device peers")
+}

--- a/pkg/cable/wireguard/wireguard_test.go
+++ b/pkg/cable/wireguard/wireguard_test.go
@@ -1,0 +1,415 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wireguard_test
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cable/wireguard"
+	"github.com/submariner-io/submariner/pkg/types"
+	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	k8snet "k8s.io/utils/net"
+)
+
+const (
+	listenPort  = 123
+	listenPort2 = 456
+)
+
+var _ = Describe("Driver", func() {
+	Context("NewDriver", testNewDriver)
+	Context("Init", testInit)
+	Context("ConnectToEndpoint", testConnectToEndpoint)
+	Context("DisconnectFromEndpoint", testDisconnectFromEndpoint)
+	Context("GetConnections", testGetConnections)
+	Context("Cleanup", testCleanup)
+
+	Context("", func() {
+		t := newTestDriver()
+
+		Specify("GetName should return wireguard", func() {
+			Expect(t.driver.GetName()).To(Equal("wireguard"))
+		})
+	})
+})
+
+func testNewDriver() {
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		t.client.devices[wireguard.DefaultDeviceName] = &wgtypes.Device{
+			Peers: []wgtypes.Peer{{PublicKey: wgtypes.Key{}}},
+		}
+
+		// This should get replaced.
+		_ = t.netLink.LinkAdd(&netlink.GenericLink{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: wireguard.DefaultDeviceName,
+			},
+		})
+	})
+
+	It("should correctly configure the wireguard link and device", func() {
+		link := t.netLink.AwaitLink(wireguard.DefaultDeviceName)
+		Expect(link.Type()).To(Equal("wireguard"))
+
+		device := t.client.devices[wireguard.DefaultDeviceName]
+		Expect(device).ToNot(BeNil())
+		Expect(device.PrivateKey).ToNot(Equal(wgtypes.Key{}))
+		Expect(device.ListenPort).To(Equal(listenPort))
+		Expect(device.Peers).To(BeEmpty())
+
+		Expect(t.localEndpoint.Spec().BackendConfig).To(HaveKey(wireguard.PublicKey))
+		Expect(t.localEndpoint.Spec().BackendConfig).To(HaveKeyWithValue(cable.InterfaceNameConfig, wireguard.DefaultDeviceName))
+	})
+
+	When("configuring the wireguard device fails", func() {
+		BeforeEach(func() {
+			t.client.configureDeviceErr = errors.New("mock error")
+			t.checkNewDriverErr = func(err error) {
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("creating the wireguard client fails", func() {
+		BeforeEach(func() {
+			wireguard.NewClient = func() (wireguard.Client, error) {
+				return nil, errors.New("mock")
+			}
+
+			t.checkNewDriverErr = func(err error) {
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("should return an error", func() {
+		})
+	})
+
+	When("the backend port is invalid", func() {
+		BeforeEach(func() {
+			t.endpointSpec.BackendConfig[submarinerv1.UDPPortConfig] = "bogus"
+			t.checkNewDriverErr = func(err error) {
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("should return an error", func() {
+		})
+	})
+}
+
+func testInit() {
+	t := newTestDriver()
+
+	It("should succeed", func() {
+		Expect(t.driver.Init()).To(Succeed())
+		t.netLink.AwaitLinkSetup(wireguard.DefaultDeviceName)
+	})
+
+	When("link setup fails", func() {
+		It("should return an error", func() {
+			link := t.netLink.AwaitLink(wireguard.DefaultDeviceName)
+			_ = t.netLink.LinkDel(link)
+
+			Expect(t.driver.Init()).NotTo(Succeed())
+		})
+	})
+}
+
+func testConnectToEndpoint() {
+	t := newTestDriver()
+
+	It("should create a Connection and configure a peer on the wireguard device", func() {
+		natInfo := newNATInfo("east", "20.0.0.0/16", "30.0.0.0/16")
+
+		ip, err := t.driver.ConnectToEndpoint(natInfo)
+		Expect(err).To(Succeed())
+		Expect(ip).To(Equal(natInfo.UseIP))
+
+		t.client.assertDevicePeers(natInfo)
+		t.assertConnections(natInfo)
+
+		// Calling ConnectToEndpoint again with the same endpoint should essentially be a no-op.
+
+		ip, err = t.driver.ConnectToEndpoint(natInfo)
+		Expect(err).To(Succeed())
+		Expect(ip).To(Equal(natInfo.UseIP))
+
+		t.client.assertDevicePeers(natInfo)
+		t.assertConnections(natInfo)
+
+		// Calling ConnectToEndpoint again with a differing endpoint from the same cluster should replace the previous.
+
+		priv, err := wgtypes.GeneratePrivateKey()
+		Expect(err).To(Succeed())
+
+		natInfo.Endpoint = *natInfo.Endpoint.DeepCopy()
+		natInfo.Endpoint.Spec.BackendConfig[wireguard.PublicKey] = priv.PublicKey().String()
+		natInfo.Endpoint.Spec.Subnets = []string{"40.0.0.0/16"}
+
+		ip, err = t.driver.ConnectToEndpoint(natInfo)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ip).To(Equal(natInfo.UseIP))
+
+		t.client.assertDevicePeers(natInfo)
+		t.assertConnections(natInfo)
+
+		// Connect to an endpoint from a different cluster
+
+		natInfo2 := newNATInfo("west", "50.0.0.0/16")
+
+		ip, err = t.driver.ConnectToEndpoint(natInfo2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ip).To(Equal(natInfo2.UseIP))
+
+		t.client.assertDevicePeers(natInfo, natInfo2)
+		t.assertConnections(natInfo, natInfo2)
+
+		Expect(t.driver.GetActiveConnections()).To(BeEmpty())
+	})
+
+	When("configuring the wireguard device fails", func() {
+		It("should return an error", func() {
+			t.client.configureDeviceErr = errors.New("mock error")
+
+			_, err := t.driver.ConnectToEndpoint(newNATInfo("east"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the public key is missing from the remote endpoint", func() {
+		It("should return an error", func() {
+			natInfo := newNATInfo("east")
+			natInfo.Endpoint.Spec.BackendConfig = map[string]string{}
+
+			_, err := t.driver.ConnectToEndpoint(natInfo)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testDisconnectFromEndpoint() {
+	t := newTestDriver()
+
+	It("should remove the Connection and the wireguard device peer", func() {
+		natInfo := newNATInfo("east", "20.0.0.0/16")
+
+		_, err := t.driver.ConnectToEndpoint(natInfo)
+		Expect(err).ToNot(HaveOccurred())
+
+		natInfo2 := newNATInfo("west", "21.0.0.0/16")
+
+		_, err = t.driver.ConnectToEndpoint(natInfo2)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, k8snet.IPv4)
+		Expect(err).ToNot(HaveOccurred())
+
+		t.client.assertDevicePeers(natInfo2)
+		t.assertConnections(natInfo2)
+
+		err = t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo2.Endpoint.Spec}, k8snet.IPv4)
+		Expect(err).ToNot(HaveOccurred())
+
+		t.client.assertDevicePeers()
+		t.assertConnections()
+	})
+
+	When("the public key is missing from the remote endpoint", func() {
+		It("should return an error", func() {
+			natInfo := newNATInfo("east")
+			natInfo.Endpoint.Spec.BackendConfig = map[string]string{}
+
+			err := t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, k8snet.IPv4)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the remote endpoint public key does not match that of the prior connection from the same cluster", func() {
+		It("should return not remove the Connection", func() {
+			err := t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: newNATInfo("east").Endpoint.Spec}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+
+			natInfo := newNATInfo("east", "20.0.0.0/16")
+
+			_, err = t.driver.ConnectToEndpoint(natInfo)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: newNATInfo("east").Endpoint.Spec}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+
+			t.assertConnections(natInfo)
+		})
+	})
+}
+
+func testGetConnections() {
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		oldKeepAliveInterval := wireguard.KeepAliveInterval
+		wireguard.KeepAliveInterval = time.Millisecond * 50
+
+		oldHandshakeTimeout := wireguard.HandshakeTimeout
+		wireguard.HandshakeTimeout = time.Millisecond * 100
+
+		DeferCleanup(func() {
+			wireguard.KeepAliveInterval = oldKeepAliveInterval
+			wireguard.HandshakeTimeout = oldHandshakeTimeout
+		})
+	})
+
+	getConnection := func() *submarinerv1.Connection {
+		conns, err := t.driver.GetConnections()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(conns).To(HaveLen(1))
+
+		return &conns[0]
+	}
+
+	It("should correctly update the peer connection status", func() {
+		_, err := t.driver.ConnectToEndpoint(newNATInfo("east", "20.0.0.0/16"))
+		Expect(err).To(Succeed())
+
+		Expect(t.client.devices[wireguard.DefaultDeviceName].Peers).To(HaveLen(1))
+		peer := &t.client.devices[wireguard.DefaultDeviceName].Peers[0]
+
+		_ = getConnection()
+
+		By("No change - should remain Connecting")
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn := getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.Connecting), "Unexpected status %q", conn.StatusMessage)
+
+		By("Initial handshake timeout - should report ConnectionError")
+
+		time.Sleep(wireguard.HandshakeTimeout + time.Millisecond*10)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.ConnectionError), "Unexpected status %q", conn.StatusMessage)
+
+		By("Clear handshake timeout and add Tx bytes - should go back to Connecting since no handshake yet")
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		wireguard.HandshakeTimeout += time.Minute
+		peer.TransmitBytes = 1000
+		conn = getConnection()
+
+		Expect(conn.Status).To(Equal(submarinerv1.Connecting), "Unexpected status %q", conn.StatusMessage)
+
+		By("Set that handshake occurred and add Rx bytes - should report Connected")
+
+		peer.LastHandshakeTime = time.Now()
+		peer.ReceiveBytes += 1000
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.Connected), "Unexpected status %q", conn.StatusMessage)
+
+		By("No change - should remain Connected")
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.Connected), "Unexpected status %q", conn.StatusMessage)
+
+		By("No traffic - handshake stale - should report ConnectionError")
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.ConnectionError), "Unexpected status %q", conn.StatusMessage)
+
+		By("Add Tx/Rx bytes - should report Connected")
+
+		peer.ReceiveBytes += 1000
+		peer.TransmitBytes += 1000
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.Connected), "Unexpected status %q", conn.StatusMessage)
+
+		By("No traffic and handshake timeout - should report ConnectionError")
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		peer.LastHandshakeTime = time.Now().Add(-wireguard.HandshakeTimeout)
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.ConnectionError), "Unexpected status %q", conn.StatusMessage)
+
+		By("Clear handshake timeout and add Tx/Rx bytes - should report Connected")
+
+		peer.LastHandshakeTime = time.Now()
+		peer.ReceiveBytes += 1000
+		peer.TransmitBytes += 1000
+
+		time.Sleep(wireguard.KeepAliveInterval + time.Millisecond*5)
+
+		conn = getConnection()
+		Expect(conn.Status).To(Equal(submarinerv1.Connected), "Unexpected status %q", conn.StatusMessage)
+	})
+
+	Context("with a stale peer present", func() {
+		It("should remove the stale peer", func() {
+			key, err := wgtypes.GenerateKey()
+			Expect(err).ToNot(HaveOccurred())
+
+			t.client.devices[wireguard.DefaultDeviceName].Peers = append(t.client.devices[wireguard.DefaultDeviceName].Peers,
+				wgtypes.Peer{PublicKey: key})
+
+			_, err = t.driver.GetConnections()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(t.client.devices[wireguard.DefaultDeviceName].Peers).To(BeEmpty())
+		})
+	})
+
+	When("device retrieval fails", func() {
+		It("should return an error", func() {
+			t.client.devices = map[string]*wgtypes.Device{}
+			_, err := t.driver.GetConnections()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testCleanup() {
+	t := newTestDriver()
+
+	It("should remove the wireguard link", func() {
+		Expect(t.driver.Cleanup()).To(Succeed())
+		t.netLink.AwaitNoLink(wireguard.DefaultDeviceName)
+	})
+}

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -450,6 +450,10 @@ func (n *basicType) ConfigureTCPMTUProbe(_, _ string) error {
 	return nil
 }
 
+func (n *basicType) InterfaceByName(name string) (*net.Interface, error) {
+	return &net.Interface{Name: name}, nil
+}
+
 func (n *NetLink) AwaitLink(name string) netlink.Link {
 	var link netlink.Link
 

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -63,6 +63,7 @@ type Basic interface {
 	EnableForwarding(interfaceName string) error
 	GetReversePathFilter(interfaceName string) ([]byte, error)
 	ConfigureTCPMTUProbe(mtuProbe, baseMss string) error
+	InterfaceByName(name string) (*net.Interface, error)
 }
 
 type Interface interface {
@@ -241,6 +242,10 @@ func (n *netlinkType) ConfigureTCPMTUProbe(mtuProbe, baseMss string) error {
 	err = setSysctl("/proc/sys/net/ipv4/tcp_base_mss", []byte(baseMss))
 
 	return errors.Wrapf(err, "unable to update value of tcp_base_mss to %ss", baseMss)
+}
+
+func (n *netlinkType) InterfaceByName(name string) (*net.Interface, error) {
+	return net.InterfaceByName(name)
 }
 
 func setSysctl(path string, contents []byte) error {


### PR DESCRIPTION
The driver code was modified to use the netlink wrapper `Interface` and to abstract the wireguard client API behind an interface to facilitate testing.

Also simplified, restructured and removed unnecessary code in the driver to increase coverage and eliminate paths that need to be tested.

See individual commits for details.