### PR TITLE
OVN: mark packets with DontSNAT value

### DIFF
--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -21,6 +21,7 @@ package constants
 const (
 	// IPTable chains used by RouteAgent.
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
+	SmPreRoutingChain  = "SUBMARINER-PREROUTING"
 	SmInputChain       = "SUBMARINER-INPUT"
 	SmForwardChain     = "SUBMARINER-FORWARD"
 	PostRoutingChain   = "POSTROUTING"
@@ -42,4 +43,8 @@ const (
 
 	OvnTransitSwitchIPAnnotation = "k8s.ovn.org/node-transit-switch-port-ifaddr"
 	OvnZoneAnnotation            = "k8s.ovn.org/zone-name"
+
+	// To preserve the source IP for multi-cluster traffic, we need to mark packets with DontSNAT
+	// mark value defined by OVN (0x4f0).
+	OvnDontSNATMarkValue = "0x4f0"
 )

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -166,6 +166,7 @@ func (ovn *Handler) setupForwardingIptables() error {
 }
 
 func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
+	var err error
 	rules := []packetfilter.Rule{
 		{
 			DestCIDR: subnet,
@@ -178,8 +179,6 @@ func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
 	}
 
 	for i := range rules {
-		var err error
-
 		if add {
 			err = ovn.pFilter.AppendUnique(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, &rules[i])
 		} else {
@@ -189,6 +188,23 @@ func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
 		if err != nil {
 			return errors.Wrapf(err, "error updating %q rule for subnet %q", constants.SmPostRoutingChain, subnet)
 		}
+	}
+
+	// After OVN transition from iptables to nftables packets should be marked to avoid SNAT
+	markDontSNATRule := &packetfilter.Rule{
+		SrcCIDR:   subnet,
+		MarkValue: constants.OvnDontSNATMarkValue,
+		Action:    packetfilter.RuleActionMark,
+	}
+
+	if add {
+		err = ovn.pFilter.AppendUnique(packetfilter.TableTypeNAT, constants.SmPreRoutingChain, markDontSNATRule)
+	} else {
+		err = ovn.pFilter.Delete(packetfilter.TableTypeNAT, constants.SmPreRoutingChain, markDontSNATRule)
+	}
+
+	if err != nil {
+		return errors.Wrapf(err, "error creating mark rule for chain %q", constants.SmPreRoutingChain)
 	}
 
 	return nil
@@ -246,6 +262,15 @@ func (ovn *Handler) initIPtablesChains() error {
 
 	if err := ovn.ensureForwardChains(); err != nil {
 		return errors.Wrap(err, "error ensuring FORWARD sub-chain entries")
+	}
+
+	if err := ovn.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
+		Name:     constants.SmPreRoutingChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPrerouting,
+		Priority: packetfilter.ChainPriorityFirst,
+	}); err != nil {
+		return errors.Wrapf(err, "error creating IPHook chain %q", constants.SmPreRoutingChain)
 	}
 
 	return nil

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -82,6 +82,20 @@ func (ovn *Handler) Uninstall() error {
 			constants.SmPostRoutingChain)
 	}
 
+	if err := ovn.pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmPreRoutingChain); err != nil {
+		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmPreRoutingChain, "NAT")
+	}
+
+	if err := ovn.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
+		Name:     constants.SmPreRoutingChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPrerouting,
+		Priority: packetfilter.ChainPriorityFirst,
+	}); err != nil {
+		logger.Errorf(err, "DeleteIPHookChain %s returned error",
+			constants.SmPreRoutingChain)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
After OVN transition from iptables to nftables the source IP of inter-cluster traffic is SNATed.

This PR marks inter-cluster traffic with OVN DONT_SNAT value.

Depends on: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5113
Fixes: https://github.com/submariner-io/submariner/issues/3307

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
