### PR TITLE
Packetfilter API: add support for IPv6

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -92,7 +92,7 @@ func NewGatewayMonitor(ctx context.Context, config *GatewayMonitorConfig) (Inter
 
 	var err error
 
-	gatewayMonitor.pFilter, err = packetfilter.New()
+	gatewayMonitor.pFilter, err = packetfilter.New(k8snet.IPv4)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating packetfilter")
 	}

--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -43,6 +43,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -270,11 +271,11 @@ var _ = Describe("Uninstall", func() {
 
 		Expect(t.pFilter.NewNamedSet(&packetfilter.SetInfo{
 			Name: ipSetName,
-		}).Create(true)).To(Succeed())
+		}, k8snet.IPv4).Create(true)).To(Succeed())
 
 		Expect(t.pFilter.NewNamedSet(&packetfilter.SetInfo{
 			Name: "other",
-		}).Create(true)).To(Succeed())
+		}, k8snet.IPv4).Create(true)).To(Succeed())
 	})
 
 	Specify("UninstallDataPath should remove the IP table chains and sets", func() {

--- a/pkg/globalnet/controllers/packetfilter/iface.go
+++ b/pkg/globalnet/controllers/packetfilter/iface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -63,7 +64,7 @@ const (
 var logger = log.Logger{Logger: logf.Log.WithName("PacketFilter")}
 
 func New() (Interface, error) {
-	pFilterHandler, err := packetfilter.New()
+	pFilterHandler, err := packetfilter.New(k8snet.IPv4)
 	if err != nil {
 		return nil, err //nolint:wrapcheck  // Let the caller wrap it
 	}

--- a/pkg/globalnet/controllers/packetfilter/iface.go
+++ b/pkg/globalnet/controllers/packetfilter/iface.go
@@ -78,8 +78,7 @@ func New() (Interface, error) {
 
 func (i *pfilter) NewNamedSet(key string) NamedSet {
 	return i.pFilter.NewNamedSet(&packetfilter.SetInfo{
-		Name:   key,
-		Family: packetfilter.SetFamilyV4,
+		Name: key,
 	})
 }
 

--- a/pkg/globalnet/controllers/uninstall.go
+++ b/pkg/globalnet/controllers/uninstall.go
@@ -39,13 +39,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 func UninstallDataPath() {
 	gnpFilter, err := pfiface.New()
 	logger.FatalOnError(err, "Error initializing GN PacketFilter")
 
-	pFilter, err := packetfilter.New()
+	pFilter, err := packetfilter.New(k8snet.IPv4)
 	logger.FatalOnError(err, "Error initializing PacketFilter")
 
 	natTableChains := []string{

--- a/pkg/packetfilter/adapter_test.go
+++ b/pkg/packetfilter/adapter_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -92,7 +93,7 @@ var _ = Describe("Adapter", func() {
 
 		var err error
 
-		adapter, err = packetfilter.New()
+		adapter, err = packetfilter.New(k8snet.IPv4)
 		Expect(err).To(Succeed())
 
 		Expect(pFilter.CreateChainIfNotExists(packetfilter.TableTypeNAT, &packetfilter.Chain{
@@ -179,7 +180,7 @@ var _ = Describe("Adapter", func() {
 	})
 })
 
-func assertRules(pFilter packetfilter.Driver, table packetfilter.TableType, expected ...*packetfilter.Rule) {
+func assertRules(pFilter *fakePF.PacketFilter, table packetfilter.TableType, expected ...*packetfilter.Rule) {
 	actual, err := pFilter.List(table, chain)
 	Expect(err).To(Succeed())
 	Expect(actual).To(Equal(expected))

--- a/pkg/packetfilter/fake/driver.go
+++ b/pkg/packetfilter/fake/driver.go
@@ -1,0 +1,139 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	k8snet "k8s.io/utils/net"
+)
+
+type driverImpl struct {
+	pfilter *PacketFilter
+	family  k8snet.IPFamily
+}
+
+func (d *driverImpl) ChainExists(table packetfilter.TableType, chain string) (bool, error) {
+	return d.pfilter.ChainExists(table, chain)
+}
+
+func (d *driverImpl) CreateIPHookChainIfNotExists(chain *packetfilter.ChainIPHook) error {
+	return d.pfilter.CreateIPHookChainIfNotExists(chain)
+}
+
+func (d *driverImpl) CreateChainIfNotExists(table packetfilter.TableType, chain *packetfilter.Chain) error {
+	return d.pfilter.CreateChainIfNotExists(table, chain)
+}
+
+func (d *driverImpl) DeleteIPHookChain(chain *packetfilter.ChainIPHook) error {
+	return d.pfilter.DeleteIPHookChain(chain)
+}
+
+func (d *driverImpl) DeleteChain(table packetfilter.TableType, chain string) error {
+	return d.pfilter.DeleteChain(table, chain)
+}
+
+func (d *driverImpl) ClearChain(table packetfilter.TableType, chain string) error {
+	return d.pfilter.ClearChain(table, chain)
+}
+
+func (d *driverImpl) List(table packetfilter.TableType, chain string) ([]*packetfilter.Rule, error) {
+	return d.pfilter.List(table, chain)
+}
+
+func (d *driverImpl) Delete(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if err := d.verifyRule(rule); err != nil {
+		return err
+	}
+
+	return d.pfilter.Delete(table, chain, rule)
+}
+
+func (d *driverImpl) AppendUnique(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if err := d.verifyRule(rule); err != nil {
+		return err
+	}
+
+	return d.pfilter.AppendUnique(table, chain, rule)
+}
+
+func (d *driverImpl) Append(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if err := d.verifyRule(rule); err != nil {
+		return err
+	}
+
+	return d.pfilter.Append(table, chain, rule)
+}
+
+func (d *driverImpl) Insert(table packetfilter.TableType, chain string, pos int, rule *packetfilter.Rule) error {
+	if err := d.verifyRule(rule); err != nil {
+		return err
+	}
+
+	return d.pfilter.Insert(table, chain, pos, rule)
+}
+
+func (d *driverImpl) NewNamedSet(set *packetfilter.SetInfo) packetfilter.NamedSet {
+	return d.pfilter.NewNamedSet(set, d.family)
+}
+
+func (d *driverImpl) DestroySets(nameFilter func(string) bool) error {
+	return d.pfilter.DestroySets(nameFilter)
+}
+
+func (d *driverImpl) verifyRule(rule *packetfilter.Rule) error {
+	var errs []error
+
+	return utilerrors.NewAggregate(append(errs, verifyFamilyOf(rule.SrcCIDR, "SrcCIDR", d.family),
+		verifyFamilyOf(rule.DestCIDR, "DestCIDR", d.family),
+		verifyFamilyOf(rule.SnatCIDR, "SnatCIDR", d.family),
+		verifyFamilyOf(rule.DnatCIDR, "DnatCIDR", d.family)))
+}
+
+func verifyFamilyOf(s, name string, expectedFamily k8snet.IPFamily) error {
+	if s == "" {
+		return nil
+	}
+
+	ipRange := strings.Split(s, "-")
+	if len(ipRange) == 2 {
+		return utilerrors.NewAggregate([]error{
+			verifyFamilyOf(ipRange[0], name, expectedFamily),
+			verifyFamilyOf(ipRange[1], name, expectedFamily),
+		})
+	}
+
+	var family k8snet.IPFamily
+
+	if ip := net.ParseIP(s); ip != nil {
+		family = k8snet.IPFamilyOf(ip)
+	} else {
+		family = k8snet.IPFamilyOfCIDRString(s)
+	}
+
+	if family == expectedFamily {
+		return nil
+	}
+
+	return errors.Errorf("the family of %q (IPv%v) for %q is not allowed", s, family, name)
+}

--- a/pkg/packetfilter/iptables/iptables.go
+++ b/pkg/packetfilter/iptables/iptables.go
@@ -78,6 +78,7 @@ func (r RuleSpec) String() string {
 type packetFilter struct {
 	ipt        *iptables.IPTables
 	ipSetIface ipset.Interface
+	family     k8snet.IPFamily
 }
 
 func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
@@ -93,6 +94,7 @@ func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
 	return &packetFilter{
 		ipt:        ipt,
 		ipSetIface: ipSetIface,
+		family:     family,
 	}, nil
 }
 

--- a/pkg/packetfilter/iptables/iptables.go
+++ b/pkg/packetfilter/iptables/iptables.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/ipset"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -60,6 +61,11 @@ var (
 		packetfilter.RuleActionDNAT:   "DNAT",
 	}
 
+	protocolByFamily = map[k8snet.IPFamily]iptables.Protocol{
+		k8snet.IPv4: iptables.ProtocolIPv4,
+		k8snet.IPv6: iptables.ProtocolIPv6,
+	}
+
 	logger = log.Logger{Logger: logf.Log.WithName("IPTables")}
 )
 
@@ -74,15 +80,9 @@ type packetFilter struct {
 	ipSetIface ipset.Interface
 }
 
-func New() (packetfilter.Driver, error) {
-	return newiptables(iptables.ProtocolIPv4)
-}
+func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
+	proto := protocolByFamily[family]
 
-func NewV6() (packetfilter.Driver, error) {
-	return newiptables(iptables.ProtocolIPv6)
-}
-
-func newiptables(proto iptables.Protocol) (packetfilter.Driver, error) {
 	ipt, err := iptables.New(iptables.IPFamily(proto), iptables.Timeout(5))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating IP tables for protocol %d", proto)

--- a/pkg/packetfilter/iptables/namedset.go
+++ b/pkg/packetfilter/iptables/namedset.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/ipset"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
+	k8snet "k8s.io/utils/net"
 )
 
 type namedSet struct {
@@ -31,7 +32,7 @@ type namedSet struct {
 
 func (p *packetFilter) NewNamedSet(set *packetfilter.SetInfo) packetfilter.NamedSet {
 	hashFamily := ipset.ProtocolFamilyIPV4
-	if set.Family == packetfilter.SetFamilyV6 {
+	if p.family == k8snet.IPv6 {
 		hashFamily = ipset.ProtocolFamilyIPV6
 	}
 

--- a/pkg/packetfilter/nftables/namedset.go
+++ b/pkg/packetfilter/nftables/namedset.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
 )
@@ -35,6 +36,9 @@ type namedSet struct {
 
 func (p *packetFilter) NewNamedSet(set *packetfilter.SetInfo) packetfilter.NamedSet {
 	setType := "ipv4_addr"
+	if p.family == k8snet.IPv6 {
+		setType = "ipv6_addr"
+	}
 
 	return &namedSet{
 		set: knftables.Set{

--- a/pkg/packetfilter/nftables/nftables.go
+++ b/pkg/packetfilter/nftables/nftables.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/knftables"
@@ -66,6 +67,11 @@ var (
 		packetfilter.RuleActionJump:   {"jump"},
 	}
 
+	nftFamilies = map[k8snet.IPFamily]knftables.Family{
+		k8snet.IPv4: knftables.IPv4Family,
+		k8snet.IPv6: knftables.IPv6Family,
+	}
+
 	logger = log.Logger{Logger: logf.Log.WithName("NFTables")}
 )
 
@@ -79,10 +85,10 @@ type packetFilter struct {
 	nftables knftables.Interface
 }
 
-func New() (packetfilter.Driver, error) {
-	nft, err := knftables.New(knftables.IPv4Family, submarinerTable)
+func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
+	nft, err := knftables.New(nftFamilies[family], submarinerTable)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating knftables")
+		return nil, errors.Wrapf(err, "error creating knftables for family IPv%s", family)
 	}
 
 	return NewWithNft(nft), nil

--- a/pkg/packetfilter/nftables/nftables.go
+++ b/pkg/packetfilter/nftables/nftables.go
@@ -83,6 +83,7 @@ func (r RuleSpec) String() string {
 
 type packetFilter struct {
 	nftables knftables.Interface
+	family   k8snet.IPFamily
 }
 
 func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
@@ -91,12 +92,13 @@ func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
 		return nil, errors.Wrapf(err, "error creating knftables for family IPv%s", family)
 	}
 
-	return NewWithNft(nft), nil
+	return NewWithNft(nft, family), nil
 }
 
-func NewWithNft(nft knftables.Interface) packetfilter.Driver {
+func NewWithNft(nft knftables.Interface, family k8snet.IPFamily) packetfilter.Driver {
 	return &packetFilter{
 		nftables: nft,
+		family:   family,
 	}
 }
 

--- a/pkg/packetfilter/nftables/nftables_test.go
+++ b/pkg/packetfilter/nftables/nftables_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/packetfilter/nftables"
+	k8snet "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
 )
 
@@ -111,15 +112,14 @@ var _ = Describe("Interface", func() {
 		pf            packetfilter.Driver
 
 		setInfo = &packetfilter.SetInfo{
-			Name:   setName,
-			Table:  packetfilter.TableTypeNAT,
-			Family: packetfilter.SetFamilyV4,
+			Name:  setName,
+			Table: packetfilter.TableTypeNAT,
 		}
 	)
 
 	BeforeEach(func() {
 		fakeKnftables = &fakeKnftablesWrapper{knftables.NewFake(knftables.IPv4Family, "submariner")}
-		pf = nftables.NewWithNft(fakeKnftables)
+		pf = nftables.NewWithNft(fakeKnftables, k8snet.IPv4)
 	})
 
 	assertRules := func(r ...*packetfilter.Rule) {

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -308,12 +309,9 @@ type Interface interface {
 	UpdateChainRules(table TableType, chain string, rules []*Rule) error
 }
 
-type DriverFn func() (Driver, error)
+type DriverFn func(family k8snet.IPFamily) (Driver, error)
 
-var (
-	newDriverFn   DriverFn
-	newDriverFnV6 DriverFn
-)
+var newDriverFn DriverFn
 
 func SetNewDriverFn(f DriverFn) {
 	newDriverFn = f
@@ -323,28 +321,16 @@ func GetNewDriverFn() DriverFn {
 	return newDriverFn
 }
 
-func SetNewDriverFnV6(f DriverFn) {
-	newDriverFnV6 = f
-}
-
 type Adapter struct {
 	Driver
 }
 
-func New() (Interface, error) {
-	return newImpl(newDriverFn)
-}
-
-func NewV6() (Interface, error) {
-	return newImpl(newDriverFnV6)
-}
-
-func newImpl(f func() (Driver, error)) (Interface, error) {
-	if f == nil {
+func New(family k8snet.IPFamily) (Interface, error) {
+	if newDriverFn == nil {
 		return nil, errors.New("no driver registered")
 	}
 
-	driver, err := f()
+	driver, err := newDriverFn(family)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating packet filter Driver")
 	}

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -251,14 +251,6 @@ type ChainIPHook struct {
 	JumpRule *Rule
 }
 
-type SetFamily uint32
-
-const (
-	// IPV4 and IPV6 sets are supported.
-	SetFamilyV4 SetFamily = iota
-	SetFamilyV6
-)
-
 // named set.
 type SetInfo struct {
 	// Name is the set name.
@@ -267,9 +259,6 @@ type SetInfo struct {
 	SetType string
 	// nftables named set attached to tables.
 	Table TableType
-	// SetFamily specifies the protocol family of the IP addresses to be stored in the set.
-	// The default is IPv4.
-	Family SetFamily
 }
 
 type NamedSet interface {

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -35,6 +35,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/set"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -63,7 +64,7 @@ type SyncHandler struct {
 var logger = log.Logger{Logger: logf.Log.WithName("KubeProxy")}
 
 func NewSyncHandler(localClusterCidr, localServiceCidr []string) *SyncHandler {
-	pFilter, err := packetfilter.New()
+	pFilter, err := packetfilter.New(k8snet.IPv4)
 	utilruntime.Must(err)
 
 	return &SyncHandler{

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/port"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 func (kp *SyncHandler) Uninstall() error {
@@ -72,7 +73,7 @@ func deleteVxLANInterface() {
 }
 
 func deleteIPTableChains() {
-	pFilter, err := packetfilter.New()
+	pFilter, err := packetfilter.New(k8snet.IPv4)
 	if err != nil {
 		logger.Errorf(err, "Failed to initialize packetfilter interface")
 		return

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -85,7 +85,7 @@ func (h *mtuHandler) GetName() string {
 func (h *mtuHandler) Init(_ context.Context) error {
 	var err error
 
-	h.pFilter, err = packetfilter.New()
+	h.pFilter, err = packetfilter.New(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrap(err, "error initializing iptables")
 	}

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -220,8 +220,7 @@ func extractIPv4Subnets(endpoint *submV1.EndpointSpec) []string {
 
 func (h *mtuHandler) newNamedSetSet(key string) packetfilter.NamedSet {
 	return h.pFilter.NewNamedSet(&packetfilter.SetInfo{
-		Name:   key,
-		Family: packetfilter.SetFamilyV4,
+		Name: key,
 	})
 }
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -71,7 +72,7 @@ var logger = log.Logger{Logger: logf.Log.WithName("OVN")}
 
 func NewHandler(config *HandlerConfig) *Handler {
 	// We'll panic if env is nil, this is intentional
-	pFilter, err := packetfilter.New()
+	pFilter, err := packetfilter.New(k8snet.IPv4)
 	if err != nil {
 		logger.Fatalf("Error initializing packetfilter in OVN routeagent handler: %s", err)
 	}


### PR DESCRIPTION
Modified the `DriverFn` and `packetfilter.New` functions to take the IP family.

