### PR TITLE
Automated backport of #3346: Handle stale remote Endpoints removed in the route-agent health checker

### DIFF
--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -67,16 +67,15 @@ func (c *handlerController) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) 
 }
 
 func (c *handlerController) handleRemovedRemoteEndpoint(endpoint *smv1.Endpoint) error {
+	c.handlerState.remoteEndpoints.Delete(endpoint.Name)
+
 	lastProcessedTime, ok := c.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
 
 	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
+		return c.handler.StaleRemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	delete(c.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
-	c.handlerState.remoteEndpoints.Delete(endpoint.Name)
 
 	return c.handler.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -67,6 +67,10 @@ type EndpointHandler interface {
 
 	// RemoteEndpointRemoved is called when an endpoint associated with a remote cluster is removed
 	RemoteEndpointRemoved(endpoint *submV1.Endpoint) error
+
+	// StaleRemoteEndpointRemoved is called in lieu of RemoteEndpointRemoved when a notification for an endpoint
+	// associated with a remote cluster is received after a newer endpoint is received from the cluster.
+	StaleRemoteEndpointRemoved(endpoint *submV1.Endpoint) error
 }
 
 type NodeHandler interface {
@@ -161,6 +165,10 @@ func (ev *HandlerBase) RemoteEndpointUpdated(_ *submV1.Endpoint) error {
 }
 
 func (ev *HandlerBase) RemoteEndpointRemoved(_ *submV1.Endpoint) error {
+	return nil
+}
+
+func (ev *HandlerBase) StaleRemoteEndpointRemoved(_ *submV1.Endpoint) error {
 	return nil
 }
 

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -76,13 +76,13 @@ func (l *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 }
 
 func (l *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
-	logger.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
+	logger.V(log.DEBUG).Infof("An Endpoint for remote cluster %q has been updated: %#v",
 		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
-	logger.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
+	logger.V(log.DEBUG).Infof("An Endpoint for remote cluster %q has been removed: %#v",
 		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -125,20 +125,21 @@ func (t *TestHandlerBase) GetNetworkPlugins() []string {
 }
 
 const (
-	EvTransitionToNonGateway = "TransitionToNonGateway"
-	EvTransitionToGateway    = "TransitionToGateway"
-	EvLocalEndpointCreated   = "LocalEndpointCreated"
-	EvLocalEndpointUpdated   = "LocalEndpointUpdated"
-	EvLocalEndpointRemoved   = "LocalEndpointRemoved"
-	EvRemoteEndpointCreated  = "RemoteEndpointCreated"
-	EvRemoteEndpointUpdated  = "RemoteEndpointUpdated"
-	EvRemoteEndpointRemoved  = "RemoteEndpointRemoved"
-	EvNodeCreated            = "NodeCreated"
-	EvNodeUpdated            = "NodeUpdated"
-	EvNodeRemoved            = "NodeRemoved"
-	EvStop                   = "Stop"
-	EvUninstall              = "Uninstall"
-	EvInit                   = "Init"
+	EvTransitionToNonGateway     = "TransitionToNonGateway"
+	EvTransitionToGateway        = "TransitionToGateway"
+	EvLocalEndpointCreated       = "LocalEndpointCreated"
+	EvLocalEndpointUpdated       = "LocalEndpointUpdated"
+	EvLocalEndpointRemoved       = "LocalEndpointRemoved"
+	EvRemoteEndpointCreated      = "RemoteEndpointCreated"
+	EvRemoteEndpointUpdated      = "RemoteEndpointUpdated"
+	EvRemoteEndpointRemoved      = "RemoteEndpointRemoved"
+	EvStaleRemoteEndpointRemoved = "StaleRemoteEndpointRemoved"
+	EvNodeCreated                = "NodeCreated"
+	EvNodeUpdated                = "NodeUpdated"
+	EvNodeRemoved                = "NodeRemoved"
+	EvStop                       = "Stop"
+	EvUninstall                  = "Uninstall"
+	EvInit                       = "Init"
 )
 
 func (t *TestHandlerBase) Stop() error {
@@ -179,6 +180,10 @@ func (t *TestHandlerBase) RemoteEndpointUpdated(endpoint *v1.Endpoint) error {
 
 func (t *TestHandlerBase) RemoteEndpointRemoved(endpoint *v1.Endpoint) error {
 	return t.addEvent(EvRemoteEndpointRemoved, endpoint)
+}
+
+func (t *TestHandlerBase) StaleRemoteEndpointRemoved(endpoint *v1.Endpoint) error {
+	return t.addEvent(EvStaleRemoteEndpointRemoved, endpoint)
 }
 
 func (t *TestHandler) NodeCreated(node *v12.Node) error {

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -160,6 +160,8 @@ func (h *controller) processEndpointCreatedOrUpdated(endpoint *submarinerv1.Endp
 }
 
 func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
+	logger.Infof("Processing removed Endpoint %q", endpoint.Spec.CableName)
+
 	h.Lock()
 	defer h.Unlock()
 
@@ -169,6 +171,10 @@ func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) erro
 	}
 
 	return nil
+}
+
+func (h *controller) StaleRemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
+	return h.RemoteEndpointRemoved(endpoint)
 }
 
 func (h *controller) Init(_ context.Context) error {


### PR DESCRIPTION
Backport of #3346 on release-0.20.

#3346: Add StaleRemoteEndpointRemoved to event Handler interface

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.