### PR TITLE
Automated backport of #3351: Handle stale remote Endpoints removed in the route-agent health checker

### DIFF
--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -67,16 +67,15 @@ func (c *handlerController) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) 
 }
 
 func (c *handlerController) handleRemovedRemoteEndpoint(endpoint *smv1.Endpoint) error {
+	c.handlerState.remoteEndpoints.Delete(endpoint.Name)
+
 	lastProcessedTime, ok := c.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
 
 	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Ignoring deleted remote %#v since a later endpoint was already"+
-			"processed", endpoint)
-		return nil
+		return c.handler.StaleRemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
 	delete(c.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
-	c.handlerState.remoteEndpoints.Delete(endpoint.Name)
 
 	return c.handler.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -66,6 +66,10 @@ type EndpointHandler interface {
 
 	// RemoteEndpointRemoved is called when an endpoint associated with a remote cluster is removed
 	RemoteEndpointRemoved(endpoint *submV1.Endpoint) error
+
+	// StaleRemoteEndpointRemoved is called in lieu of RemoteEndpointRemoved when a notification for an endpoint
+	// associated with a remote cluster is received after a newer endpoint is received from the cluster.
+	StaleRemoteEndpointRemoved(endpoint *submV1.Endpoint) error
 }
 
 type NodeHandler interface {
@@ -160,6 +164,10 @@ func (ev *HandlerBase) RemoteEndpointUpdated(_ *submV1.Endpoint) error {
 }
 
 func (ev *HandlerBase) RemoteEndpointRemoved(_ *submV1.Endpoint) error {
+	return nil
+}
+
+func (ev *HandlerBase) StaleRemoteEndpointRemoved(_ *submV1.Endpoint) error {
 	return nil
 }
 

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -76,13 +76,13 @@ func (l *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 }
 
 func (l *Handler) RemoteEndpointUpdated(endpoint *submV1.Endpoint) error {
-	logger.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been updated: %#v",
+	logger.V(log.DEBUG).Infof("An Endpoint for remote cluster %q has been updated: %#v",
 		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }
 
 func (l *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
-	logger.V(log.DEBUG).Infof("A new Endpoint for remote cluster %q has been removed: %#v",
+	logger.V(log.DEBUG).Infof("An Endpoint for remote cluster %q has been removed: %#v",
 		endpoint.Spec.ClusterID, endpoint.Spec)
 	return nil
 }

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -124,20 +124,21 @@ func (t *TestHandlerBase) GetNetworkPlugins() []string {
 }
 
 const (
-	EvTransitionToNonGateway = "TransitionToNonGateway"
-	EvTransitionToGateway    = "TransitionToGateway"
-	EvLocalEndpointCreated   = "LocalEndpointCreated"
-	EvLocalEndpointUpdated   = "LocalEndpointUpdated"
-	EvLocalEndpointRemoved   = "LocalEndpointRemoved"
-	EvRemoteEndpointCreated  = "RemoteEndpointCreated"
-	EvRemoteEndpointUpdated  = "RemoteEndpointUpdated"
-	EvRemoteEndpointRemoved  = "RemoteEndpointRemoved"
-	EvNodeCreated            = "NodeCreated"
-	EvNodeUpdated            = "NodeUpdated"
-	EvNodeRemoved            = "NodeRemoved"
-	EvStop                   = "Stop"
-	EvUninstall              = "Uninstall"
-	EvInit                   = "Init"
+	EvTransitionToNonGateway     = "TransitionToNonGateway"
+	EvTransitionToGateway        = "TransitionToGateway"
+	EvLocalEndpointCreated       = "LocalEndpointCreated"
+	EvLocalEndpointUpdated       = "LocalEndpointUpdated"
+	EvLocalEndpointRemoved       = "LocalEndpointRemoved"
+	EvRemoteEndpointCreated      = "RemoteEndpointCreated"
+	EvRemoteEndpointUpdated      = "RemoteEndpointUpdated"
+	EvRemoteEndpointRemoved      = "RemoteEndpointRemoved"
+	EvStaleRemoteEndpointRemoved = "StaleRemoteEndpointRemoved"
+	EvNodeCreated                = "NodeCreated"
+	EvNodeUpdated                = "NodeUpdated"
+	EvNodeRemoved                = "NodeRemoved"
+	EvStop                       = "Stop"
+	EvUninstall                  = "Uninstall"
+	EvInit                       = "Init"
 )
 
 func (t *TestHandlerBase) Stop() error {
@@ -178,6 +179,10 @@ func (t *TestHandlerBase) RemoteEndpointUpdated(endpoint *v1.Endpoint) error {
 
 func (t *TestHandlerBase) RemoteEndpointRemoved(endpoint *v1.Endpoint) error {
 	return t.addEvent(EvRemoteEndpointRemoved, endpoint)
+}
+
+func (t *TestHandlerBase) StaleRemoteEndpointRemoved(endpoint *v1.Endpoint) error {
+	return t.addEvent(EvStaleRemoteEndpointRemoved, endpoint)
 }
 
 func (t *TestHandler) NodeCreated(node *v12.Node) error {

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -168,6 +168,8 @@ func (h *controller) processEndpointCreatedOrUpdated(endpoint *submarinerv1.Endp
 }
 
 func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
+	logger.Infof("Processing removed Endpoint %q", endpoint.Spec.CableName)
+
 	h.Lock()
 	defer h.Unlock()
 
@@ -177,6 +179,10 @@ func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) erro
 	}
 
 	return nil
+}
+
+func (h *controller) StaleRemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
+	return h.RemoteEndpointRemoved(endpoint)
 }
 
 func (h *controller) Init() error {

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
@@ -20,7 +20,6 @@ package healthchecker_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -34,9 +33,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/pinger/fake"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubeScheme "k8s.io/client-go/kubernetes/scheme"
@@ -59,27 +56,57 @@ var _ = Describe("RouteAgent syncing", func() {
 
 	When("a remote Endpoint is created/updated/deleted", func() {
 		It("should add/update/delete its RemoteEndpoint information in the RouteAgent resource", func() {
-			endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
+			endpoint := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
 
-			remoteEndpoint := t.awaitRemoteEndpoint(nil)
-			Expect(remoteEndpoint.Spec).To(Equal(endpoint1.Spec))
+			t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+				g.Expect(ep.Spec).To(Equal(endpoint.Spec))
+			})
 
 			By("Updating remote endpoint")
 
-			endpoint1.Spec.Hostname = "newHostName"
-			t.UpdateEndpoint(endpoint1)
+			endpoint.Spec.Hostname = "newHostName"
+			t.UpdateEndpoint(endpoint)
 
-			remoteEndpoint = t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-				return ep.Spec.Hostname == endpoint1.Spec.Hostname
+			t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+				g.Expect(ep.Spec.Hostname).To(Equal(endpoint.Spec.Hostname))
+				g.Expect(ep.Spec).To(Equal(endpoint.Spec))
 			})
-			Expect(remoteEndpoint.Spec).To(Equal(endpoint1.Spec))
 
 			By("Deleting remote endpoint")
 
+			t.DeleteEndpoint(endpoint.Name)
+
+			t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent, g Gomega) {
+				g.Expect(ra.Status.RemoteEndpoints).To(BeEmpty())
+			})
+		})
+	})
+
+	When("a stale remote Endpoint is deleted", func() {
+		It("should remove its RemoteEndpoint information in the RouteAgent resource", func() {
+			endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
+
+			t.awaitRemoteEndpoint(nil)
+
+			By("Creating new remote endpoint")
+
+			endpoint2 := t.newSubmEndpoint(healthCheckIP2)
+			endpoint2.Spec.CableName = "new-cable"
+			endpoint2.Name = "new-endpoint"
+			endpoint2.CreationTimestamp = metav1.Time{Time: metav1.Now().Add(time.Second)}
+			t.CreateEndpoint(endpoint2)
+
+			t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent, g Gomega) {
+				g.Expect(ra.Status.RemoteEndpoints).To(HaveLen(2))
+			})
+
+			By("Deleting stale remote endpoint")
+
 			t.DeleteEndpoint(endpoint1.Name)
 
-			t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent) bool {
-				return len(ra.Status.RemoteEndpoints) == 0
+			t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent, g Gomega) {
+				g.Expect(ra.Status.RemoteEndpoints).To(HaveLen(1))
+				g.Expect(ra.Status.RemoteEndpoints[0].Spec.HealthCheckIP).To(Equal(healthCheckIP2))
 			})
 		})
 	})
@@ -96,12 +123,10 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 			latencyInfo := t.newLatencyInfo()
 			t.setLatencyInfo(healthCheckIP1, latencyInfo)
 
-			remoteEndpoint := t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-				return ep.Status == submarinerv1.Connected
+			t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+				g.Expect(ep.Status).To(Equal(submarinerv1.Connected))
+				g.Expect(ep.LatencyRTT).To(Equal(latencyInfo.Spec))
 			})
-
-			Expect(remoteEndpoint.Status).To(Equal(submarinerv1.Connected))
-			Expect(remoteEndpoint.LatencyRTT).To(Equal(latencyInfo.Spec))
 		})
 
 		Context("with no HealthCheckIP", func() {
@@ -109,12 +134,10 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(""))
 				t.pingerMap[healthCheckIP1].AwaitNoStart()
 
-				remoteEndpoint := t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-					return ep.Status == submarinerv1.ConnectionNone
+				t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+					g.Expect(ep.Status).To(Equal(submarinerv1.ConnectionNone))
+					g.Expect(ep.Spec).To(Equal(endpoint1.Spec))
 				})
-
-				Expect(remoteEndpoint.Status).To(Equal(submarinerv1.ConnectionNone))
-				Expect(remoteEndpoint.Spec).To(Equal(endpoint1.Spec))
 			})
 		})
 
@@ -124,12 +147,10 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
 				t.pingerMap[healthCheckIP1].AwaitNoStart()
 
-				remoteEndpoint := t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-					return ep.Status == submarinerv1.ConnectionNone
+				t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+					g.Expect(ep.Status).To(Equal(submarinerv1.ConnectionNone))
+					g.Expect(ep.Spec).To(Equal(endpoint1.Spec))
 				})
-
-				Expect(remoteEndpoint.Status).To(Equal(submarinerv1.ConnectionNone))
-				Expect(remoteEndpoint.Spec).To(Equal(endpoint1.Spec))
 			})
 		})
 
@@ -142,12 +163,10 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
 				t.pingerMap[healthCheckIP1].AwaitNoStart()
 
-				remoteEndpoint := t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-					return ep.Status == submarinerv1.ConnectionNone
+				t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+					g.Expect(ep.Status).To(Equal(submarinerv1.ConnectionNone))
+					g.Expect(ep.Spec).To(Equal(endpoint1.Spec))
 				})
-
-				Expect(remoteEndpoint.Status).To(Equal(submarinerv1.ConnectionNone))
-				Expect(remoteEndpoint.Spec).To(Equal(endpoint1.Spec))
 			})
 		})
 	})
@@ -158,7 +177,6 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 				endpoint1 := t.CreateEndpoint(t.newSubmEndpoint(healthCheckIP1))
 
 				t.pingerMap[healthCheckIP1].AwaitStart()
-				t.pingerMap[healthCheckIP2] = fake.NewPinger(healthCheckIP2)
 
 				endpoint1.Spec.HealthCheckIP = healthCheckIP2
 
@@ -206,12 +224,10 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 
 			t.setLatencyInfo(healthCheckIP1, latencyInfo)
 
-			remoteEndpoint := t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint) bool {
-				return ep.Status == submarinerv1.ConnectionError
+			t.awaitRemoteEndpoint(func(ep *submarinerv1.RemoteEndpoint, g Gomega) {
+				g.Expect(ep.Status).To(Equal(submarinerv1.ConnectionError))
+				g.Expect(ep.StatusMessage).To(Equal(latencyInfo.ConnectionError))
 			})
-
-			Expect(remoteEndpoint.Status).To(Equal(submarinerv1.ConnectionError))
-			Expect(remoteEndpoint.StatusMessage).To(Equal(latencyInfo.ConnectionError))
 		})
 	})
 })
@@ -268,6 +284,7 @@ func newTestDriver() *testDriver {
 		t.client = clientset.SubmarinerV1().RouteAgents(namespace)
 		t.pingerMap = map[string]*fake.Pinger{
 			healthCheckIP1: fake.NewPinger(healthCheckIP1),
+			healthCheckIP2: fake.NewPinger(healthCheckIP2),
 		}
 	})
 
@@ -313,7 +330,8 @@ func (t *testDriver) newSubmEndpoint(healthCheckIP string) *submarinerv1.Endpoin
 
 	endpoint := &submarinerv1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: endpointName,
+			Name:              endpointName,
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: *endpointSpec,
 	}
@@ -343,30 +361,23 @@ func (t *testDriver) Start(handler event.Handler) {
 	t.ControllerSupport.Start(handler)
 }
 
-func (t *testDriver) awaitRouteAgent(verify func(*submarinerv1.RouteAgent) bool) *submarinerv1.RouteAgent {
-	var routeAgent *submarinerv1.RouteAgent
+func (t *testDriver) awaitRouteAgent(verify func(*submarinerv1.RouteAgent, Gomega)) {
+	Eventually(func(g Gomega) {
+		ra, err := t.client.Get(context.TODO(), localNodeName, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred(), "Error retrieving RouteAgent")
 
-	_ = wait.PollUntilContextTimeout(context.TODO(), 20*time.Millisecond,
-		5*time.Second, true, func(ctx context.Context) (bool, error) {
-			ra, err := t.client.Get(ctx, localNodeName, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) {
-				return false, nil
-			}
-
-			Expect(err).ToNot(HaveOccurred(), "Error retrieving RouteAgent")
-
-			routeAgent = ra
-
-			return verify == nil || verify(routeAgent), nil
-		})
-
-	return routeAgent
+		if verify != nil {
+			verify(ra, g)
+		}
+	}).Within(5 * time.Second).Should(Succeed())
 }
 
-func (t *testDriver) awaitRemoteEndpoint(verify func(*submarinerv1.RemoteEndpoint) bool) *submarinerv1.RemoteEndpoint {
-	routeAgent := t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent) bool {
-		return len(ra.Status.RemoteEndpoints) != 0 && (verify == nil || verify(&ra.Status.RemoteEndpoints[0]))
-	})
+func (t *testDriver) awaitRemoteEndpoint(verify func(*submarinerv1.RemoteEndpoint, Gomega)) {
+	t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent, g Gomega) {
+		g.Expect(ra.Status.RemoteEndpoints).ToNot(BeEmpty())
 
-	return &routeAgent.Status.RemoteEndpoints[0]
+		if verify != nil {
+			verify(&ra.Status.RemoteEndpoints[0], g)
+		}
+	})
 }


### PR DESCRIPTION
Backport of #3351 on release-0.19.

#3351: Add StaleRemoteEndpointRemoved to event Handler interface

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.