### PR TITLE
MTU handler: use shorter names for packet filter sets

### DIFF
--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -27,8 +27,8 @@ const (
 	InputChain         = "INPUT"
 	ForwardChain       = "FORWARD"
 	MangleTable        = "mangle"
-	RemoteCIDRIPSet    = "SUBMARINER-REMOTECIDRS"
-	LocalCIDRIPSet     = "SUBMARINER-LOCALCIDRS"
+	RemoteCIDRIPSet    = "SUBMARINER-RCIDRS"
+	LocalCIDRIPSet     = "SUBMARINER-LCIDRS"
 
 	RouteAgentInterClusterNetworkTableID = 149
 


### PR DESCRIPTION
Since nftables driver ListRules function returns only comments and handles, we set the comment value to rulepec string.
However, nftables comment field is limited to 128 characters. To avoid exceeding this limit, we should use shorter names for SUBMARINER-REMOTECIDRS and SUBMARINER-LOCALCIDRS sets.

Fixes: https://github.com/submariner-io/submariner/issues/3359

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
