### PR TITLE
Add dual-stack support to cable engine health checker

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -240,7 +240,7 @@ func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 		for index := range connections {
 			connection := &connections[index]
 
-			latencyInfo := gs.healthCheck.GetLatencyInfo(&connection.Endpoint)
+			latencyInfo := gs.healthCheck.GetLatencyInfo(&connection.Endpoint, connection.GetFamily())
 			if latencyInfo != nil {
 				connection.LatencyRTT = latencyInfo.Spec
 				connection.Endpoint.SetHealthCheckIP(latencyInfo.IP)

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -400,11 +400,12 @@ func (g *gatewayType) initCableHealthChecker() {
 		watcherConfig := g.WatcherConfig
 
 		g.cableHealthChecker, err = healthchecker.New(&healthchecker.Config{
-			WatcherConfig:      &watcherConfig,
-			EndpointNamespace:  g.Spec.Namespace,
-			ClusterID:          g.Spec.ClusterID,
-			PingInterval:       g.Spec.HealthCheckInterval,
-			MaxPacketLossCount: g.Spec.HealthCheckMaxPacketLossCount,
+			WatcherConfig:       &watcherConfig,
+			SupportedIPFamilies: g.Spec.GetIPFamilies(),
+			EndpointNamespace:   g.Spec.Namespace,
+			ClusterID:           g.Spec.ClusterID,
+			PingInterval:        g.Spec.HealthCheckInterval,
+			MaxPacketLossCount:  g.Spec.HealthCheckMaxPacketLossCount,
 		})
 		if err != nil {
 			logger.Errorf(err, "Error creating healthChecker")


### PR DESCRIPTION
On remote `Endpoint`, for each supported IP family, start a pinger. Also added IP family param to `GetLatencyInfo`.
