### PR TITLE
Change MSS clamp chain name to SUBMARINER-POSTROUTING-MSS

### DIFF
--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -20,15 +20,16 @@ package constants
 
 const (
 	// IPTable chains used by RouteAgent.
-	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
-	SmInputChain       = "SUBMARINER-INPUT"
-	SmForwardChain     = "SUBMARINER-FORWARD"
-	PostRoutingChain   = "POSTROUTING"
-	InputChain         = "INPUT"
-	ForwardChain       = "FORWARD"
-	MangleTable        = "mangle"
-	RemoteCIDRIPSet    = "SUBMARINER-REMOTECIDRS"
-	LocalCIDRIPSet     = "SUBMARINER-LOCALCIDRS"
+	SmPostRoutingChain    = "SUBMARINER-POSTROUTING"
+	SmPostRoutingMssChain = "SUBMARINER-POSTROUTING-MSS"
+	SmInputChain          = "SUBMARINER-INPUT"
+	SmForwardChain        = "SUBMARINER-FORWARD"
+	PostRoutingChain      = "POSTROUTING"
+	InputChain            = "INPUT"
+	ForwardChain          = "FORWARD"
+	MangleTable           = "mangle"
+	RemoteCIDRIPSet       = "SUBMARINER-REMOTECIDRS"
+	LocalCIDRIPSet        = "SUBMARINER-LOCALCIDRS"
 
 	RouteAgentInterClusterNetworkTableID = 149
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -95,12 +95,12 @@ func (h *mtuHandler) Init(_ context.Context) error {
 	h.tableType, h.chainType = h.pFilter.GetMSSClampTypes()
 
 	if err := h.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
-		Name:     constants.SmPostRoutingChain,
+		Name:     constants.SmPostRoutingMssChain,
 		Type:     h.chainType,
 		Hook:     packetfilter.ChainHookPostrouting,
 		Priority: packetfilter.ChainPriorityFirst,
 	}); err != nil {
-		return errors.Wrapf(err, "error creating IPHookChain chain %s", constants.SmPostRoutingChain)
+		return errors.Wrapf(err, "error creating IPHookChain chain %s", constants.SmPostRoutingMssChain)
 	}
 
 	h.remoteIPSet = h.newNamedSetSet(constants.RemoteCIDRIPSet)
@@ -134,11 +134,11 @@ func (h *mtuHandler) Init(_ context.Context) error {
 		ClampType:   packetfilter.ToPMTU,
 	}
 
-	if err := h.pFilter.AppendUnique(h.tableType, constants.SmPostRoutingChain, ruleSpecSource); err != nil {
+	if err := h.pFilter.AppendUnique(h.tableType, constants.SmPostRoutingMssChain, ruleSpecSource); err != nil {
 		return errors.Wrapf(err, "error appending packetfilter rule %q", ruleSpecSource)
 	}
 
-	if err := h.pFilter.AppendUnique(h.tableType, constants.SmPostRoutingChain, ruleSpecDest); err != nil {
+	if err := h.pFilter.AppendUnique(h.tableType, constants.SmPostRoutingMssChain, ruleSpecDest); err != nil {
 		return errors.Wrapf(err, "error appending packetfilter rule %q", ruleSpecDest)
 	}
 
@@ -229,19 +229,19 @@ func (h *mtuHandler) newNamedSetSet(key string) packetfilter.NamedSet {
 }
 
 func (h *mtuHandler) Uninstall() error {
-	logger.Infof("Flushing packetfilter entries in %q chain of table type %q", constants.SmPostRoutingChain, h.tableType.String())
+	logger.Infof("Flushing packetfilter entries in %q chain of table type %q", constants.SmPostRoutingMssChain, h.tableType.String())
 
-	logError(h.pFilter.ClearChain(h.tableType, constants.SmPostRoutingChain),
-		"Error flushing chain %q of table type %q", constants.SmPostRoutingChain, h.tableType.String())
+	logError(h.pFilter.ClearChain(h.tableType, constants.SmPostRoutingMssChain),
+		"Error flushing chain %q of table type %q", constants.SmPostRoutingMssChain, h.tableType.String())
 
-	logger.Infof("Deleting IPHook chain %q of table type %q", constants.SmPostRoutingChain, h.tableType.String())
+	logger.Infof("Deleting IPHook chain %q of table type %q", constants.SmPostRoutingMssChain, h.tableType.String())
 
 	logError(h.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
-		Name:     constants.SmPostRoutingChain,
+		Name:     constants.SmPostRoutingMssChain,
 		Type:     h.chainType,
 		Hook:     packetfilter.ChainHookPostrouting,
 		Priority: packetfilter.ChainPriorityFirst,
-	}), "Error deleting IP hook chain %q of table type %q", constants.SmPostRoutingChain, h.tableType.String())
+	}), "Error deleting IP hook chain %q of table type %q", constants.SmPostRoutingMssChain, h.tableType.String())
 
 	logError(h.localIPSet.Flush(), "Error flushing ipset %q", constants.LocalCIDRIPSet)
 
@@ -292,8 +292,8 @@ func (h *mtuHandler) forceMssClamping(endpoint *submV1.Endpoint) error {
 	},
 	)
 
-	if err := h.pFilter.UpdateChainRules(h.tableType, constants.SmPostRoutingChain, rules); err != nil {
-		return errors.Wrapf(err, "error updating chain %s table type %q", constants.SmPostRoutingChain, h.tableType.String())
+	if err := h.pFilter.UpdateChainRules(h.tableType, constants.SmPostRoutingMssChain, rules); err != nil {
+		return errors.Wrapf(err, "error updating chain %s table type %q", constants.SmPostRoutingMssChain, h.tableType.String())
 	}
 
 	return nil

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -42,12 +42,12 @@ var _ = Describe("MTUHandler", func() {
 		t.pFilter.AwaitSet(Equal(constants.RemoteCIDRIPSet))
 
 		t.pFilter.AwaitRule(t.tableType,
-			constants.SmPostRoutingChain, And(
+			constants.SmPostRoutingMssChain, And(
 				ContainSubstring("\"ClampType\":%d", packetfilter.ToPMTU),
 				ContainSubstring("\"SrcSetName\":%q", constants.RemoteCIDRIPSet),
 				ContainSubstring("\"DestSetName\":%q", constants.LocalCIDRIPSet)))
 		t.pFilter.AwaitRule(t.tableType,
-			constants.SmPostRoutingChain, And(
+			constants.SmPostRoutingMssChain, And(
 				ContainSubstring("\"ClampType\":%d", packetfilter.ToPMTU),
 				ContainSubstring("\"SrcSetName\":%q", constants.LocalCIDRIPSet),
 				ContainSubstring("\"DestSetName\":%q", constants.RemoteCIDRIPSet)))
@@ -119,7 +119,7 @@ var _ = Describe("MTUHandler", func() {
 
 		t.pFilter.AwaitSetDeleted(constants.LocalCIDRIPSet)
 		t.pFilter.AwaitSetDeleted(constants.RemoteCIDRIPSet)
-		t.pFilter.AwaitNoIPHookChain(packetfilter.ChainTypeRoute, Equal(constants.SmPostRoutingChain))
+		t.pFilter.AwaitNoIPHookChain(packetfilter.ChainTypeRoute, Equal(constants.SmPostRoutingMssChain))
 	})
 })
 
@@ -152,19 +152,19 @@ func newTestDriver() *testDriver {
 func (t *testDriver) testForcedMSS(expTCPMssValue int) {
 	t.pFilter.AwaitSet(Equal(constants.LocalCIDRIPSet))
 	t.pFilter.AwaitSet(Equal(constants.RemoteCIDRIPSet))
-	t.pFilter.EnsureNoRule(t.tableType, constants.SmPostRoutingChain,
+	t.pFilter.EnsureNoRule(t.tableType, constants.SmPostRoutingMssChain,
 		ContainSubstring("\"ClampType\":%d", packetfilter.ToPMTU))
 
 	Expect(t.handler.LocalEndpointCreated(newSubmEndpoint([]string{"172.1.0.0/24"}))).To(Succeed())
 
 	t.pFilter.AwaitRule(t.tableType,
-		constants.SmPostRoutingChain, And(
+		constants.SmPostRoutingMssChain, And(
 			ContainSubstring("\"ClampType\":%d", packetfilter.ToValue),
 			ContainSubstring("\"SrcSetName\":%q", constants.RemoteCIDRIPSet),
 			ContainSubstring("\"DestSetName\":%q", constants.LocalCIDRIPSet),
 			ContainSubstring("\"MssValue\":%q", strconv.Itoa(expTCPMssValue))))
 	t.pFilter.AwaitRule(t.tableType,
-		constants.SmPostRoutingChain, And(
+		constants.SmPostRoutingMssChain, And(
 			ContainSubstring("\"ClampType\":%d", packetfilter.ToValue),
 			ContainSubstring("\"SrcSetName\":%q", constants.LocalCIDRIPSet),
 			ContainSubstring("\"DestSetName\":%q", constants.RemoteCIDRIPSet),


### PR DESCRIPTION
In Submariner nftables implementation, all chains are configured within a single table (named submariner).

We cannot name filter/postrouting chain SUBMARINER-POSTROUTING because nat/postrouting chain with this name already exists.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
