### PR TITLE
Implement IPv6 health check IP resolution

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -180,7 +180,7 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 
 	var ipAddress net.IP
 
-	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR)
+	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR, endpointInfo.UseFamily)
 	if err == nil {
 		ipAddress = net.ParseIP(cniIface.IPAddress)
 	} else {

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -161,7 +161,7 @@ func newTestDriver() *testDriver {
 			Spec: subv1.ClusterSpec{
 				ClusterID:   "local",
 				ServiceCIDR: []string{"10.0.0.0/16"},
-				ClusterCIDR: []string{"11.0.0.0/16"},
+				ClusterCIDR: []string{cniIPAddress + "/24"},
 			},
 		}
 
@@ -177,11 +177,11 @@ func newTestDriver() *testDriver {
 			return t.netLink
 		}
 
-		cni.DiscoverFunc = func(_ []string) (*cni.Interface, error) {
-			return &cni.Interface{
-				Name:      "veth0",
-				IPAddress: cniIPAddress,
-			}, nil
+		cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+			return []cni.HostInterface{{
+				Name: "veth0",
+				Addr: cniIPAddress + "/24",
+			}}, nil
 		}
 	})
 

--- a/pkg/cni/cni_iface_test.go
+++ b/pkg/cni/cni_iface_test.go
@@ -1,0 +1,133 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cni_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/cni"
+	k8snet "k8s.io/utils/net"
+)
+
+const (
+	ipV4Addr1 = "192.0.2.1"
+	ipV4CIDR1 = ipV4Addr1 + "/24"
+	ipV4Addr2 = "10.32.1.0"
+	ipV4CIDR2 = ipV4Addr2 + "/24"
+	ipV6Addr  = "2000:0:0:1234::"
+	ipV6CIDR  = ipV6Addr + "/64"
+)
+
+var (
+	v4HostInterface1 = cni.HostInterface{
+		Name: "v4-iface1",
+		Addr: ipV4CIDR1,
+	}
+
+	v4HostInterface2 = cni.HostInterface{
+		Name: "v4-iface2",
+		Addr: ipV4CIDR2,
+	}
+
+	v6HostInterface = cni.HostInterface{
+		Name: "v6-iface",
+		Addr: ipV6CIDR,
+	}
+)
+
+var _ = Describe("Discover", func() {
+	Context("with multiple CIDRs and host interfaces", func() {
+		It("should return the correct interface for the requested IP family", func() {
+			setupHostInterfaces(v4HostInterface1, v4HostInterface2)
+
+			cniInterface, err := cni.Discover([]string{ipV4CIDR1}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v4HostInterface1.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr1))
+
+			cniInterface, err = cni.Discover([]string{ipV4CIDR2}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v4HostInterface2.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr2))
+
+			setupHostInterfaces(v4HostInterface2)
+
+			cniInterface, err = cni.Discover([]string{ipV4CIDR1, ipV4CIDR2}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v4HostInterface2.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr2))
+		})
+	})
+
+	Context("with dual-stack", func() {
+		It("should return the correct interface for the requested IP family", func() {
+			setupHostInterfaces(v4HostInterface1, v6HostInterface)
+
+			cniInterface, err := cni.Discover([]string{ipV4CIDR1, ipV6CIDR}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v4HostInterface1.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr1))
+
+			cniInterface, err = cni.Discover([]string{ipV4CIDR1, ipV6CIDR}, k8snet.IPv6)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v6HostInterface.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV6Addr))
+		})
+	})
+
+	When("no host interface matches the provided CIDRs", func() {
+		It("should return an error", func() {
+			setupHostInterfaces(v4HostInterface1)
+
+			_, err := cni.Discover([]string{ipV4CIDR2}, k8snet.IPv4)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("the address for a host interface is not a CIDR", func() {
+		It("should ignore it", func() {
+			setupHostInterfaces(cni.HostInterface{
+				Name: "no-cidr",
+				Addr: "1.1.1.1",
+			}, v4HostInterface1)
+
+			cniInterface, err := cni.Discover([]string{ipV4CIDR1}, k8snet.IPv4)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cniInterface.Name).To(Equal(v4HostInterface1.Name))
+			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr1))
+		})
+	})
+
+	Specify("should return an error when HostInterface fails", func() {
+		cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+			return nil, errors.New("mock error")
+		}
+
+		_, err := cni.Discover([]string{ipV4CIDR2}, k8snet.IPv4)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+func setupHostInterfaces(intf ...cni.HostInterface) {
+	cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+		return intf, nil
+	}
+}

--- a/pkg/cni/cni_suite_test.go
+++ b/pkg/cni/cni_suite_test.go
@@ -1,0 +1,43 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cni_test
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+func init() {
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=2"})
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestCNI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CNI Suite")
+}

--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -214,22 +214,13 @@ func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, 
 }
 
 func getHealthCheckIP(family k8snet.IPFamily, submSpec *types.SubmarinerSpecification) (string, error) {
-	switch family {
-	case k8snet.IPv4:
-		cniIface, err := cni.Discover(submSpec.ClusterCidr)
-		if err != nil {
-			return "", errors.Wrapf(err, "error getting CNI Interface IP address."+
-				"Please disable the health check if your CNI does not expose a pod IP on the nodes")
-		}
-
-		return cniIface.IPAddress, nil
-	case k8snet.IPv6:
-		// TODO_IPV6: add V6 healthcheck IP
-
-	case k8snet.IPFamilyUnknown:
+	cniIface, err := cni.Discover(submSpec.ClusterCidr, family)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting IPv%v CNI Interface IP address. "+
+			"Please disable the health check if your CNI does not expose a pod IP on the nodes", family)
 	}
 
-	return "", nil
+	return cniIface.IPAddress, nil
 }
 
 func getBackendConfig(nodeObj *v1.Node) (map[string]string, error) {

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -95,9 +95,10 @@ func newPublicIPWatcherTestDriver() *publicIPWatcherTestDriver {
 
 		ipWatcher := endpoint.NewPublicIPWatcher(&endpoint.PublicIPWatcherConfig{
 			SubmSpec: &types.SubmarinerSpecification{
-				ClusterID: clusterID,
-				Namespace: testNamespace,
-				PublicIP:  "lb:" + testServiceName,
+				ClusterID:   clusterID,
+				Namespace:   testNamespace,
+				PublicIP:    "lb:" + testServiceName,
+				ClusterCidr: []string{"127.0.0.1/16"},
 			},
 			Interval:      interval,
 			K8sClient:     t.k8sClient,

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -20,10 +20,8 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -82,15 +80,11 @@ func init() {
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
 
-	cni.DiscoverFunc = func(cidrs []string) (*cni.Interface, error) {
-		if !reflect.DeepEqual(cidrs, []string{localCIDR}) {
-			return nil, fmt.Errorf("invalid CIDRs %v", cidrs)
-		}
-
-		return &cni.Interface{
-			Name:      "veth0",
-			IPAddress: cniInterfaceIP,
-		}, nil
+	cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+		return []cni.HostInterface{{
+			Name: "veth0",
+			Addr: cniInterfaceIP + "/24",
+		}}, nil
 	}
 })
 

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -102,7 +102,7 @@ func NewGatewayMonitor(ctx context.Context, config *GatewayMonitorConfig) (Inter
 
 	gatewayMonitor.nodeName = nodeName
 
-	cniIface, err := cni.Discover(gatewayMonitor.LocalClusterCIDRs)
+	cniIface, err := cni.Discover(gatewayMonitor.LocalClusterCIDRs, k8snet.IPv4)
 	if err == nil {
 		gatewayMonitor.cniIP = cniIface.IPAddress
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -121,7 +121,7 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 		logger.Infof("Waiting for CNI interface discovery: %s", err)
 		return true
 	}, func() error {
-		cniIface, err = cni.Discover(kp.localClusterCidr)
+		cniIface, err = cni.Discover(kp.localClusterCidr, k8snet.IPv4)
 		if err != nil {
 			return errors.Wrapf(err, "Error discovering the CNI interface")
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,8 +20,8 @@ package types
 
 import (
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	k8snet "k8s.io/utils/net"
-	"k8s.io/utils/set"
 )
 
 type SubmarinerCluster struct {
@@ -54,10 +54,5 @@ type SubmarinerSpecification struct {
 }
 
 func (subSpec *SubmarinerSpecification) GetIPFamilies() []k8snet.IPFamily {
-	ipFamilies := set.New[k8snet.IPFamily]()
-
-	// TODO_IPV6: set ipFamilies according to ClusterCidr content
-	ipFamilies.Insert(k8snet.IPv4)
-
-	return ipFamilies.UnsortedList()
+	return cidr.ExtractIPFamilies(subSpec.ClusterCidr)
 }


### PR DESCRIPTION
Use the CNI discovery to obtain an IPv6 IPv6 health check IP as is done for IPv4. The `cni.Discover` function was modified to take an additional IP family param.

Also unit tests were added for `cni.Discover`. To facilitate this, a function hook was added that returns the host interfaces. External unit tests now override this hook rather than the `cni.Discover` function itself.
