### PR TITLE
Enhance route agent health checker to verify IPv6 connectivity

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_suite_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_suite_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	kubeScheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 func init() {
@@ -32,6 +34,7 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
+	Expect(submarinerv1.AddToScheme(kubeScheme.Scheme)).To(Succeed())
 })
 
 func TestHealthChecker(t *testing.T) {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -42,6 +42,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
 	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
+	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/pod"
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/versions"
@@ -397,15 +398,15 @@ func (g *gatewayType) initCableHealthChecker() {
 	if !g.Spec.HealthCheckEnabled {
 		logger.Info("The CableEngine HealthChecker is disabled")
 	} else {
-		watcherConfig := g.WatcherConfig
-
 		g.cableHealthChecker, err = healthchecker.New(&healthchecker.Config{
-			WatcherConfig:       &watcherConfig,
-			SupportedIPFamilies: g.Spec.GetIPFamilies(),
-			EndpointNamespace:   g.Spec.Namespace,
-			ClusterID:           g.Spec.ClusterID,
-			PingInterval:        g.Spec.HealthCheckInterval,
-			MaxPacketLossCount:  g.Spec.HealthCheckMaxPacketLossCount,
+			ControllerConfig: pinger.ControllerConfig{
+				SupportedIPFamilies: g.Spec.GetIPFamilies(),
+				PingInterval:        g.Spec.HealthCheckInterval,
+				MaxPacketLossCount:  g.Spec.HealthCheckMaxPacketLossCount,
+			},
+			WatcherConfig:     g.WatcherConfig,
+			EndpointNamespace: g.Spec.Namespace,
+			ClusterID:         g.Spec.ClusterID,
 		})
 		if err != nil {
 			logger.Errorf(err, "Error creating healthChecker")

--- a/pkg/pinger/controller.go
+++ b/pkg/pinger/controller.go
@@ -1,0 +1,139 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pinger
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	k8snet "k8s.io/utils/net"
+)
+
+type Controller interface {
+	EndpointCreatedOrUpdated(spec *submarinerv1.EndpointSpec)
+	EndpointRemoved(spec *submarinerv1.EndpointSpec)
+	Get(spec *submarinerv1.EndpointSpec, family k8snet.IPFamily) Interface
+	Stop()
+}
+
+type ControllerConfig struct {
+	SupportedIPFamilies []k8snet.IPFamily
+	PingInterval        int
+	MaxPacketLossCount  int
+	NewPinger           func(Config) Interface
+}
+
+type controller struct {
+	ControllerConfig
+	sync.RWMutex
+	pingers map[string]Interface
+}
+
+func NewController(config ControllerConfig) Controller {
+	if len(config.SupportedIPFamilies) == 0 {
+		panic(errors.New("SupportedIPFamilies must not be empty"))
+	}
+
+	return &controller{
+		ControllerConfig: config,
+		pingers:          map[string]Interface{},
+	}
+}
+
+func (c *controller) EndpointCreatedOrUpdated(spec *submarinerv1.EndpointSpec) {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, family := range c.SupportedIPFamilies {
+		healthCheckIP := spec.GetHealthCheckIP(family)
+		if healthCheckIP == "" {
+			logger.Infof("IPv%v HealthCheckIP for Endpoint %q is empty - will not monitor endpoint health",
+				family, spec.CableName)
+			continue
+		}
+
+		c.startPinger(spec.GetFamilyCableName(family), healthCheckIP)
+	}
+}
+
+func (c *controller) startPinger(familyCableName, healthCheckIP string) {
+	if pingerObject, found := c.pingers[familyCableName]; found {
+		if pingerObject.GetIP() == healthCheckIP {
+			return
+		}
+
+		logger.V(log.DEBUG).Infof("HealthChecker is already running for %q - stopping", familyCableName)
+		pingerObject.Stop()
+		delete(c.pingers, familyCableName)
+	}
+
+	pingerConfig := Config{
+		IP:                 healthCheckIP,
+		MaxPacketLossCount: c.MaxPacketLossCount,
+	}
+
+	if c.PingInterval != 0 {
+		pingerConfig.Interval = time.Second * time.Duration(c.PingInterval)
+	}
+
+	newPingerFunc := c.NewPinger
+	if newPingerFunc == nil {
+		newPingerFunc = NewPinger
+	}
+
+	pingerObject := newPingerFunc(pingerConfig)
+	c.pingers[familyCableName] = pingerObject
+	pingerObject.Start()
+
+	logger.Infof("HealthChecker started pinger for CableName: %q with HealthCheckIP %q", familyCableName, healthCheckIP)
+}
+
+func (c *controller) EndpointRemoved(spec *submarinerv1.EndpointSpec) {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, family := range c.SupportedIPFamilies {
+		familyCableName := spec.GetFamilyCableName(family)
+		if pingerObject, found := c.pingers[familyCableName]; found {
+			pingerObject.Stop()
+			delete(c.pingers, familyCableName)
+		}
+	}
+}
+
+func (c *controller) Get(spec *submarinerv1.EndpointSpec, family k8snet.IPFamily) Interface {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.pingers[spec.GetFamilyCableName(family)]
+}
+
+func (c *controller) Stop() {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, p := range c.pingers {
+		p.Stop()
+	}
+
+	c.pingers = map[string]Interface{}
+}

--- a/pkg/pinger/controller_test.go
+++ b/pkg/pinger/controller_test.go
@@ -1,0 +1,198 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pinger_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/pinger"
+	"github.com/submariner-io/submariner/pkg/pinger/fake"
+	k8snet "k8s.io/utils/net"
+)
+
+var _ = Describe("Controller", func() {
+	const (
+		remoteClusterID1   = "west"
+		remoteClusterID2   = "north"
+		healthCheckIP1     = "1.1.1.1"
+		healthCheckIP2     = "2.2.2.2"
+		healthCheckIP3     = "3.3.3.3"
+		pingInterval       = 3
+		maxPacketLossCount = 4
+	)
+
+	var (
+		controller          pinger.Controller
+		supportedIPFamilies []k8snet.IPFamily
+		pingerMap           map[string]*fake.Pinger
+	)
+
+	BeforeEach(func() {
+		supportedIPFamilies = []k8snet.IPFamily{k8snet.IPv4}
+		pingerMap = map[string]*fake.Pinger{
+			healthCheckIP1: fake.NewPinger(healthCheckIP1),
+			healthCheckIP2: fake.NewPinger(healthCheckIP2),
+		}
+	})
+
+	JustBeforeEach(func() {
+		controller = pinger.NewController(pinger.ControllerConfig{
+			SupportedIPFamilies: supportedIPFamilies,
+			PingInterval:        pingInterval,
+			MaxPacketLossCount:  maxPacketLossCount,
+			NewPinger: func(pingerCfg pinger.Config) pinger.Interface {
+				defer GinkgoRecover()
+				Expect(pingerCfg.Interval).To(Equal(time.Second * time.Duration(pingInterval)))
+				Expect(pingerCfg.MaxPacketLossCount).To(Equal(maxPacketLossCount))
+
+				p, ok := pingerMap[pingerCfg.IP]
+				Expect(ok).To(BeTrue())
+				return p
+			},
+		})
+	})
+
+	When("Endpoints are created/removed", func() {
+		It("should start/stop Pingers", func() {
+			endpoint1 := newEndpointSpec(remoteClusterID1, healthCheckIP1)
+			controller.EndpointCreatedOrUpdated(endpoint1)
+
+			pingerMap[healthCheckIP1].AwaitStart()
+			Expect(controller.Get(endpoint1, k8snet.IPv4)).To(Equal(pingerMap[healthCheckIP1]))
+
+			endpoint2 := newEndpointSpec(remoteClusterID2, healthCheckIP2)
+			controller.EndpointCreatedOrUpdated(endpoint2)
+
+			pingerMap[healthCheckIP2].AwaitStart()
+			Expect(controller.Get(endpoint2, k8snet.IPv4)).To(Equal(pingerMap[healthCheckIP2]))
+
+			By("Removing Endpoints")
+
+			controller.EndpointRemoved(endpoint1)
+
+			pingerMap[healthCheckIP1].AwaitStop()
+			Expect(controller.Get(endpoint1, k8snet.IPv4)).To(BeNil())
+
+			controller.EndpointRemoved(endpoint2)
+
+			pingerMap[healthCheckIP2].AwaitStop()
+			Expect(controller.Get(endpoint2, k8snet.IPv4)).To(BeNil())
+		})
+	})
+
+	When("an Endpoint is created/removed with dual-stack health check IPs", func() {
+		const healthCheckIPv6 = "2001:db8:3333:4444:5555:6666:7777:8888"
+
+		BeforeEach(func() {
+			supportedIPFamilies = []k8snet.IPFamily{k8snet.IPv4, k8snet.IPv6}
+			pingerMap[healthCheckIPv6] = fake.NewPinger(healthCheckIPv6)
+		})
+
+		It("should start/stop Pingers", func() {
+			endpoint := newEndpointSpec(remoteClusterID1, healthCheckIP1, healthCheckIPv6)
+			controller.EndpointCreatedOrUpdated(endpoint)
+
+			pingerMap[healthCheckIP1].AwaitStart()
+			pingerMap[healthCheckIPv6].AwaitStart()
+
+			Expect(controller.Get(endpoint, k8snet.IPv4)).To(Equal(pingerMap[healthCheckIP1]))
+			Expect(controller.Get(endpoint, k8snet.IPv6)).To(Equal(pingerMap[healthCheckIPv6]))
+
+			By("Removing Endpoint")
+
+			controller.EndpointRemoved(endpoint)
+
+			pingerMap[healthCheckIP1].AwaitStop()
+			Expect(controller.Get(endpoint, k8snet.IPv4)).To(BeNil())
+
+			pingerMap[healthCheckIPv6].AwaitStop()
+			Expect(controller.Get(endpoint, k8snet.IPv6)).To(BeNil())
+		})
+	})
+
+	When("an Endpoint is updated", func() {
+		var endpoint *submarinerv1.EndpointSpec
+
+		JustBeforeEach(func() {
+			endpoint = newEndpointSpec(remoteClusterID1, healthCheckIP1)
+			controller.EndpointCreatedOrUpdated(endpoint)
+			pingerMap[healthCheckIP1].AwaitStart()
+		})
+
+		When("the HealthCheckIP was changed", func() {
+			BeforeEach(func() {
+				pingerMap[healthCheckIP3] = fake.NewPinger(healthCheckIP3)
+			})
+
+			It("should stop the Pinger and start a new one", func() {
+				endpoint.HealthCheckIPs = []string{healthCheckIP3}
+
+				controller.EndpointCreatedOrUpdated(endpoint)
+				pingerMap[healthCheckIP1].AwaitStop()
+				pingerMap[healthCheckIP3].AwaitStart()
+			})
+		})
+
+		When("the HealthCheckIP did not changed", func() {
+			It("should not start a new Pinger", func() {
+				controller.EndpointCreatedOrUpdated(endpoint)
+				pingerMap[healthCheckIP1].AwaitNoStop()
+			})
+		})
+	})
+
+	When("an Endpoint has no HealthCheckIP", func() {
+		It("should not start a Pinger", func() {
+			controller.EndpointCreatedOrUpdated(newEndpointSpec(remoteClusterID1, ""))
+			pingerMap[healthCheckIP1].AwaitNoStart()
+		})
+	})
+
+	When("no supported IP families are provided", func() {
+		It("should panic", func() {
+			Expect(func() {
+				pinger.NewController(pinger.ControllerConfig{})
+			}).To(Panic())
+		})
+	})
+
+	Specify("Stop should stop all pingers", func() {
+		controller.EndpointCreatedOrUpdated(newEndpointSpec(remoteClusterID1, healthCheckIP1))
+		pingerMap[healthCheckIP1].AwaitStart()
+
+		controller.EndpointCreatedOrUpdated(newEndpointSpec(remoteClusterID2, healthCheckIP2))
+		pingerMap[healthCheckIP2].AwaitStart()
+
+		controller.Stop()
+		pingerMap[healthCheckIP1].AwaitStop()
+		pingerMap[healthCheckIP2].AwaitStop()
+	})
+})
+
+func newEndpointSpec(clusterID string, healthCheckIPs ...string) *submarinerv1.EndpointSpec {
+	return &submarinerv1.EndpointSpec{
+		ClusterID:      clusterID,
+		CableName:      fmt.Sprintf("submariner-cable-%s-192-68-1-20", clusterID),
+		HealthCheckIPs: healthCheckIPs,
+	}
+}

--- a/pkg/pinger/pinger_suite_test.go
+++ b/pkg/pinger/pinger_suite_test.go
@@ -23,7 +23,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
 
 func TestPinger(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -39,6 +39,7 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
+	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/calico"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
@@ -53,6 +54,7 @@ import (
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	k8snet "k8s.io/utils/net"
 )
 
 var _ = Describe("", func() {
@@ -127,10 +129,11 @@ var _ = Describe("", func() {
 		Expect(calicoHandler.Init(ctx)).To(Succeed())
 
 		healthCheckerHandler := healthchecker.New(&healthchecker.Config{
-			PingInterval:             1,
-			MaxPacketLossCount:       1,
-			HealthCheckerEnabled:     true,
-			RouteAgentUpdateInterval: 100 * time.Millisecond,
+			ControllerConfig: pinger.ControllerConfig{
+				SupportedIPFamilies: []k8snet.IPFamily{k8snet.IPv4},
+			},
+			HealthCheckerEnabled:     false,
+			RouteAgentUpdateInterval: time.Hour,
 		}, submClient.SubmarinerV1().RouteAgents(testing.Namespace), "v1", "test-node")
 		Expect(healthCheckerHandler.Init(ctx)).To(Succeed())
 	})


### PR DESCRIPTION
In addition, a reusable Pinger controller was refactored to the pinger module shared by the cable engine and route agent health checkers.

See commits for details.

