### PR TITLE
Use k8snet.IPFamily in the netlink wrapper methods

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -682,5 +682,5 @@ func (i *libreswan) waitForControlSocket() error {
 func (i *libreswan) Cleanup() error {
 	logger.Info("Uninstalling the libreswan cable driver")
 
-	return netlink.DeleteXfrmRules() //nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules(k8snet.IPFamilyUnknown) //nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -99,7 +99,7 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		return errors.Wrapf(err, "failed to derive the vxlan vtepIP for %s", ipAddr)
 	}
 
-	defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
+	defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s",
 			v.localEndpoint.Hostname)

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Vxlan", func() {
 		link, err := t.netLink.LinkByName(vxlan.VxlanIface)
 		Expect(err).To(Succeed())
 
-		routes, err := t.netLink.RouteList(link, 0)
+		routes, err := t.netLink.RouteList(link, k8snet.IPFamilyUnknown)
 		Expect(err).To(Succeed())
 
 		var actualRoutes []map[string]string
@@ -126,7 +126,7 @@ var _ = Describe("Vxlan", func() {
 		link, err := t.netLink.LinkByName(vxlan.VxlanIface)
 		Expect(err).To(Succeed())
 
-		routes, err := t.netLink.RouteList(link, 0)
+		routes, err := t.netLink.RouteList(link, k8snet.IPFamilyUnknown)
 		Expect(err).To(Succeed())
 		Expect(routes).To(BeEmpty())
 	})

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -427,7 +427,7 @@ func (n *basicType) XfrmPolicyDel(_ *netlink.XfrmPolicy) error {
 	return nil
 }
 
-func (n *basicType) XfrmPolicyList(_ int) ([]netlink.XfrmPolicy, error) {
+func (n *basicType) XfrmPolicyList(_ k8snet.IPFamily) ([]netlink.XfrmPolicy, error) {
 	return []netlink.XfrmPolicy{}, nil
 }
 

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -403,14 +403,14 @@ func (n *basicType) RuleDel(rule *netlink.Rule) error {
 	return nil
 }
 
-func (n *basicType) RuleList(family int) ([]netlink.Rule, error) {
+func (n *basicType) RuleList(family k8snet.IPFamily) ([]netlink.Rule, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
 	var rules []netlink.Rule
 	for _, r := range n.rules {
 		for i := range r {
-			if r[i].Family == family {
+			if r[i].Family == netlinkAPI.ToNetlinkFamily(family) {
 				rules = append(rules, r[i])
 			}
 		}

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/slices"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 type linkType struct {
@@ -332,7 +333,7 @@ func (n *basicType) RouteGet(destination net.IP) ([]netlink.Route, error) {
 	return routes, nil
 }
 
-func (n *basicType) RouteList(link netlink.Link, _ int) ([]netlink.Route, error) {
+func (n *basicType) RouteList(link netlink.Link, _ k8snet.IPFamily) ([]netlink.Route, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -491,7 +492,7 @@ func routeList[T any](n *NetLink, linkIndex, table int, f func(r *netlink.Route)
 		LinkAttrs: netlink.LinkAttrs{
 			Index: linkIndex,
 		},
-	}, 0)
+	}, k8snet.IPFamilyUnknown)
 
 	result := []T{}
 

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -198,7 +198,7 @@ func (n *basicType) AddrDel(link netlink.Link, addr *netlink.Addr) error {
 	return nil
 }
 
-func (n *basicType) AddrList(link netlink.Link, _ int) ([]netlink.Addr, error) {
+func (n *basicType) AddrList(link netlink.Link, _ k8snet.IPFamily) ([]netlink.Addr, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -58,7 +58,7 @@ type Basic interface {
 	RuleList(family k8snet.IPFamily) ([]netlink.Rule, error)
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
-	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
+	XfrmPolicyList(family k8snet.IPFamily) ([]netlink.XfrmPolicy, error)
 	EnableLooseModeReversePathFilter(interfaceName string) error
 	EnsureLooseModeIsConfigured(interfaceName string) error
 	EnableForwarding(interfaceName string) error
@@ -175,8 +175,8 @@ func (n *netlinkType) XfrmPolicyDel(policy *netlink.XfrmPolicy) error {
 	return netlink.XfrmPolicyDel(policy)
 }
 
-func (n *netlinkType) XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error) {
-	return netlink.XfrmPolicyList(family)
+func (n *netlinkType) XfrmPolicyList(family k8snet.IPFamily) ([]netlink.XfrmPolicy, error) {
+	return netlink.XfrmPolicyList(ToNetlinkFamily(family))
 }
 
 func (n *netlinkType) EnableLooseModeReversePathFilter(interfaceName string) error {
@@ -332,10 +332,10 @@ func DeleteIfaceAndAssociatedRoutes(iface string, tableID int) error {
 	return nil
 }
 
-func DeleteXfrmRules() error {
+func DeleteXfrmRules(family k8snet.IPFamily) error {
 	n := New()
 
-	currentXfrmPolicyList, err := n.XfrmPolicyList(syscall.AF_INET)
+	currentXfrmPolicyList, err := n.XfrmPolicyList(family)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving current xfrm policies")
 	}

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -43,7 +43,7 @@ type Basic interface {
 	LinkSetUp(link netlink.Link) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
 	AddrDel(link netlink.Link, addr *netlink.Addr) error
-	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+	AddrList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Addr, error)
 	AddrSubscribe(addrCh chan netlink.AddrUpdate, doneCh chan struct{}) error
 	NeighAppend(neigh *netlink.Neigh) error
 	NeighDel(neigh *netlink.Neigh) error
@@ -119,8 +119,8 @@ func (n *netlinkType) AddrDel(link netlink.Link, addr *netlink.Addr) error {
 	return netlink.AddrDel(link, addr)
 }
 
-func (n *netlinkType) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
-	return netlink.AddrList(link, family)
+func (n *netlinkType) AddrList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Addr, error) {
+	return netlink.AddrList(link, ToNetlinkFamily(family))
 }
 
 func (n *netlinkType) AddrSubscribe(addrCh chan netlink.AddrUpdate, doneCh chan struct{}) error {

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -50,7 +51,7 @@ type Basic interface {
 	RouteDel(route *netlink.Route) error
 	RouteReplace(route *netlink.Route) error
 	RouteGet(destination net.IP) ([]netlink.Route, error)
-	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
+	RouteList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Route, error)
 	FlushRouteTable(tableID int) error
 	RuleAdd(rule *netlink.Rule) error
 	RuleDel(rule *netlink.Rule) error
@@ -150,8 +151,8 @@ func (n *netlinkType) RouteGet(destination net.IP) ([]netlink.Route, error) {
 	return netlink.RouteGet(destination)
 }
 
-func (n *netlinkType) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
-	return netlink.RouteList(link, family)
+func (n *netlinkType) RouteList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Route, error) {
+	return netlink.RouteList(link, ToNetlinkFamily(family))
 }
 
 func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
@@ -307,7 +308,7 @@ func DeleteIfaceAndAssociatedRoutes(iface string, tableID int) error {
 		return nil
 	}
 
-	currentRouteList, err := n.RouteList(link, syscall.AF_INET)
+	currentRouteList, err := n.RouteList(link, k8snet.IPv4)
 
 	if err != nil {
 		logger.Warningf("Unable to cleanup routes, error retrieving routes on the link %s: %v", iface, err)
@@ -367,4 +368,17 @@ func NewTableRule(tableID int) *netlink.Rule {
 	rule.Priority = tableID
 
 	return rule
+}
+
+func ToNetlinkFamily(family k8snet.IPFamily) int {
+	switch family {
+	case k8snet.IPv4:
+		return netlink.FAMILY_V4
+	case k8snet.IPv6:
+		return netlink.FAMILY_V6
+	case k8snet.IPFamilyUnknown:
+		return netlink.FAMILY_ALL
+	}
+
+	return netlink.FAMILY_ALL
 }

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -55,7 +55,7 @@ type Basic interface {
 	FlushRouteTable(tableID int) error
 	RuleAdd(rule *netlink.Rule) error
 	RuleDel(rule *netlink.Rule) error
-	RuleList(family int) ([]netlink.Rule, error)
+	RuleList(family k8snet.IPFamily) ([]netlink.Rule, error)
 	XfrmPolicyAdd(policy *netlink.XfrmPolicy) error
 	XfrmPolicyDel(policy *netlink.XfrmPolicy) error
 	XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error)
@@ -163,8 +163,8 @@ func (n *netlinkType) RuleDel(rule *netlink.Rule) error {
 	return netlink.RuleDel(rule)
 }
 
-func (n *netlinkType) RuleList(family int) ([]netlink.Rule, error) {
-	return netlink.RuleList(family)
+func (n *netlinkType) RuleList(family k8snet.IPFamily) ([]netlink.Rule, error) {
+	return netlink.RuleList(ToNetlinkFamily(family))
 }
 
 func (n *netlinkType) XfrmPolicyAdd(policy *netlink.XfrmPolicy) error {

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -271,8 +270,8 @@ func ipv4ConfPath(interfaceName string) string {
 }
 
 //nolint:wrapcheck // Let the caller wrap external errors
-func GetDefaultGatewayInterface() (*net.Interface, error) {
-	routes, err := netlink.RouteList(nil, syscall.AF_INET)
+func GetDefaultGatewayInterface(family k8snet.IPFamily) (*net.Interface, error) {
+	routes, err := netlink.RouteList(nil, ToNetlinkFamily(family))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
@@ -21,6 +21,7 @@ package cabledriver
 import (
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 type xrfmCleanup struct {
@@ -42,5 +43,5 @@ func (h *xrfmCleanup) GetNetworkPlugins() []string {
 func (h *xrfmCleanup) TransitionToNonGateway() error {
 	logger.Info("Transitioned to non-Gateway, cleaning up the IPsec xfrm rules")
 
-	return netlink.DeleteXfrmRules() //nolint:wrapcheck  // No need to wrap this error
+	return netlink.DeleteXfrmRules(k8snet.IPv4) //nolint:wrapcheck  // No need to wrap this error
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -112,7 +112,7 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 		return errors.Wrapf(err, "unable to determine hostname")
 	}
 
-	kp.defaultHostIface, err = netlink.GetDefaultGatewayInterface()
+	kp.defaultHostIface, err = netlink.GetDefaultGatewayInterface(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s", kp.hostname)
 	}

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -21,13 +21,13 @@ package kubeproxy
 import (
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
+	k8snet "k8s.io/utils/net"
 )
 
 func (kp *SyncHandler) updateRoutingRulesForHostNetworkSupport(inputCidrBlocks []string, operation Operation) {
@@ -167,7 +167,7 @@ func (kp *SyncHandler) cleanVxSubmarinerRoutes() {
 		return
 	}
 
-	currentRouteList, err := kp.netLink.RouteList(link, syscall.AF_INET)
+	currentRouteList, err := kp.netLink.RouteList(link, k8snet.IPv4)
 	if err != nil {
 		logger.Errorf(err, "Unable to cleanup routes, error retrieving routes on the link %s", VxLANIface)
 		return
@@ -197,7 +197,7 @@ func (kp *SyncHandler) reconcileRoutes(vxlanGw net.IP) error {
 		return errors.Wrapf(err, "error retrieving link by name %s", VxLANIface)
 	}
 
-	currentRouteList, err := kp.netLink.RouteList(link, syscall.AF_INET)
+	currentRouteList, err := kp.netLink.RouteList(link, k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving routes for link %s", VxLANIface)
 	}
@@ -205,7 +205,7 @@ func (kp *SyncHandler) reconcileRoutes(vxlanGw net.IP) error {
 	// First lets delete all of the routes that don't match.
 	kp.removeUnknownRoutes(vxlanGw, currentRouteList)
 
-	currentRouteList, err = kp.netLink.RouteList(link, syscall.AF_INET)
+	currentRouteList, err = kp.netLink.RouteList(link, k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving routes for link %s", VxLANIface)
 	}

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -369,7 +369,7 @@ func newTestDriver() *testDriver {
 	}
 
 	BeforeEach(func() {
-		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
+		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
 		Expect(err).To(Succeed())
 
 		t.hostInterfaceIndex = defaultHostIface.Index

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -259,7 +259,7 @@ func (h *mtuHandler) forceMssClamping(endpoint *submV1.Endpoint) error {
 	tcpMssValue := h.tcpMssValue
 
 	if tcpMssValue == 0 {
-		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
+		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to find the default interface on host")
 		}

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler_test.go
@@ -30,6 +30,7 @@ import (
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
+	k8snet "k8s.io/utils/net"
 )
 
 const localCIDR = "10.1.0.0/24"
@@ -107,7 +108,7 @@ var _ = Describe("MTUHandler", func() {
 		})
 
 		It("should use the MTU value from the default gateway and add expected IP table rules", func() {
-			defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface()
+			defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
 			Expect(err).To(Succeed())
 
 			t.testForcedMSS(defaultHostIface.MTU - mtu.MaxIPSecOverhead)

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -153,7 +153,7 @@ func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 			return errors.Wrapf(err, "error getting local endpoint interface %q", interfaceName)
 		}
 	} else {
-		if routingInterface, err = netlink.GetDefaultGatewayInterface(); err != nil {
+		if routingInterface, err = netlink.GetDefaultGatewayInterface(k8snet.IPv4); err != nil {
 			logger.Fatalf("Unable to find the default interface on host: %s", err.Error())
 		}
 	}

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -81,7 +81,7 @@ func (ovn *Handler) updateHostNetworkDataplane() error {
 func (ovn *Handler) getExistingIPv4HostNetworkRoutes() (set.Set[string], error) {
 	currentRuleRemotes := set.New[string]()
 
-	rules, err := ovn.netLink.RuleList(netlink.FAMILY_V4)
+	rules, err := ovn.netLink.RuleList(k8snet.IPv4)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error listing rules")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/set"
 )
 
@@ -120,7 +120,7 @@ func (ovn *Handler) getNextHopOnK8sMgmtIntf() (*net.IP, error) {
 		return nil, errors.Wrapf(err, "error retrieving link by name %q", OVNK8sMgmntIntfName)
 	}
 
-	currentRouteList, err := ovn.netLink.RouteList(link, syscall.AF_INET)
+	currentRouteList, err := ovn.netLink.RouteList(link, k8snet.IPv4)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving routes on the link %s", OVNK8sMgmntIntfName)
 	}

--- a/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
+++ b/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	k8snet "k8s.io/utils/net"
 )
 
 func (ovn *Handler) startRouteConfigSyncer(stop chan struct{}) {
@@ -61,7 +62,7 @@ func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
 	var prevIP net.IP
 
 	assignPrevIP := func() {
-		addrs, err := ovn.netLink.AddrList(iface, netlink.FAMILY_V4)
+		addrs, err := ovn.netLink.AddrList(iface, k8snet.IPv4)
 		if err != nil {
 			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
 		} else if len(addrs) > 0 {
@@ -80,7 +81,7 @@ func (ovn *Handler) monitorRoutingTable(stop chan struct{}) error {
 			return
 		}
 
-		addrs, err := ovn.netLink.AddrList(iface, netlink.FAMILY_V4)
+		addrs, err := ovn.netLink.AddrList(iface, k8snet.IPv4)
 		if err != nil {
 			logger.Warningf("Failed to get the IP4 address list for interface %q: %v", OVNK8sMgmntIntfName, err)
 			return

--- a/pkg/routeagent_driver/handlers/ovn/south_rules.go
+++ b/pkg/routeagent_driver/handlers/ovn/south_rules.go
@@ -25,6 +25,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/set"
 )
 
@@ -86,7 +87,7 @@ func (ovn *Handler) getRuleSpec(dest, src string, tableID int) (*netlink.Rule, e
 func (ovn *Handler) getExistingIPv4RuleSubnets() (set.Set[string], error) {
 	currentRuleRemotes := set.New[string]()
 
-	rules, err := ovn.netLink.RuleList(netlink.FAMILY_V4)
+	rules, err := ovn.netLink.RuleList(k8snet.IPv4)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error listing rules")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -23,7 +23,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn/vsctl"
-	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 func (ovn *Handler) Stop() error {
@@ -86,7 +86,7 @@ func (ovn *Handler) Uninstall() error {
 }
 
 func (ovn *Handler) cleanupRoutes() error {
-	rules, err := ovn.netLink.RuleList(netlink.FAMILY_V4)
+	rules, err := ovn.netLink.RuleList(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "error listing rules")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/utils.go
+++ b/pkg/routeagent_driver/handlers/ovn/utils.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	subMNetLink "github.com/submariner-io/submariner/pkg/netlink"
-	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 func getNextHopOnK8sMgmtIntf() (string, error) {
@@ -36,7 +36,7 @@ func getNextHopOnK8sMgmtIntf() (string, error) {
 		return "", errors.Wrapf(err, "failed to retrieve link by name %q", OVNK8sMgmntIntfName)
 	}
 
-	addrs, err := netLink.AddrList(link, netlink.FAMILY_V4)
+	addrs, err := netLink.AddrList(link, k8snet.IPv4)
 	if err != nil || len(addrs) == 0 {
 		return "", errors.Wrapf(err, "failed to retrieve addresses for link")
 	}

--- a/pkg/vxlan/vxlan_test.go
+++ b/pkg/vxlan/vxlan_test.go
@@ -27,6 +27,7 @@ import (
 	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
 	"github.com/submariner-io/submariner/pkg/vxlan"
 	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
 )
 
 func TestVxlan(t *testing.T) {
@@ -170,7 +171,7 @@ var _ = Describe("Interface", func() {
 		t.netLink.AwaitDstRoutes(0, 100, destCIDR1, destCIDR2)
 
 		Expect(vxlanInterface.AddRoutes(net.ParseIP("240.17.2.3"), net.ParseIP("120.17.2.3"), 100, *ipNet1, *ipNet2)).To(Succeed())
-		list, err := t.netLink.RouteList(&netlink.GenericLink{}, 0)
+		list, err := t.netLink.RouteList(&netlink.GenericLink{}, k8snet.IPFamilyUnknown)
 		Expect(err).To(Succeed())
 		Expect(list).To(HaveLen(2))
 


### PR DESCRIPTION
 The underlying lib API takes an int for the family so change to `k8snet.IPFamily` in the wrapper for better typing. Using `k8snet.IPFamily` will also simplify implementing dual-stack support in the various components that use the netlink API.

See commits for details.