### PR TITLE
Remove air-gap flag from dual-stack GHA

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,8 +53,8 @@ jobs:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
-          - extra-toggles: dual-stack, air-gap
-          - extra-toggles: dual-stack, globalnet, air-gap
+          - extra-toggles: dual-stack
+          - extra-toggles: dual-stack, globalnet
           - extra-toggles: nftables
           - extra-toggles: nftables, ovn
           - extra-toggles: nftables, globalnet


### PR DESCRIPTION
This is no longer needed as the public IP annotation is now set with dual-stack enabled.
