### PR TITLE
Remove IPv4-only restriction for Cluster/Endpoint CIDRs

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -31,7 +31,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/util"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	"github.com/submariner-io/submariner/pkg/cidr"
 	"github.com/submariner-io/submariner/pkg/cni"
 	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/port"
@@ -155,9 +154,8 @@ func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, 
 		localSubnets = submSpec.GlobalCidr
 		globalnetEnabled = true
 	} else {
-		// TODO_IPV6: set localSubnets to submSpec.ServiceCidr + submSpec.ClusterCidr
-		localSubnets = append(localSubnets, cidr.ExtractIPv4Subnets(submSpec.ServiceCidr)...)
-		localSubnets = append(localSubnets, cidr.ExtractIPv4Subnets(submSpec.ClusterCidr)...)
+		localSubnets = append(localSubnets, submSpec.ServiceCidr...)
+		localSubnets = append(localSubnets, submSpec.ClusterCidr...)
 	}
 
 	backendConfig, err := getBackendConfig(gwNode)

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -36,7 +36,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
 	"github.com/submariner-io/submariner/pkg/cableengine/syncer"
-	"github.com/submariner-io/submariner/pkg/cidr"
 	submclientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner/pkg/controllers/datastoresyncer"
 	"github.com/submariner-io/submariner/pkg/controllers/tunnel"
@@ -444,11 +443,10 @@ func submarinerClusterFrom(submSpec *types.SubmarinerSpecification) *types.Subma
 	return &types.SubmarinerCluster{
 		ID: submSpec.ClusterID,
 		Spec: subv1.ClusterSpec{
-			ClusterID:  submSpec.ClusterID,
-			ColorCodes: []string{"blue"}, // This is a fake value, used only for upgrade purposes
-			// TODO_IPV6: delete cidr.ExtractIPv4Subnets
-			ServiceCIDR: cidr.ExtractIPv4Subnets(submSpec.ServiceCidr),
-			ClusterCIDR: cidr.ExtractIPv4Subnets(submSpec.ClusterCidr),
+			ClusterID:   submSpec.ClusterID,
+			ColorCodes:  []string{"blue"}, // This is a fake value, used only for upgrade purposes
+			ServiceCIDR: submSpec.ServiceCidr,
+			ClusterCIDR: submSpec.ClusterCidr,
 			GlobalCIDR:  globalCIDR,
 		},
 	}

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -90,13 +90,15 @@ func (kp *SyncHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
-	if err := cidr.OverlappingSubnets(kp.localServiceCidr, kp.localClusterCidr, endpoint.Spec.Subnets); err != nil {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+
+	if err := cidr.OverlappingSubnets(kp.localServiceCidr, kp.localClusterCidr, subnets); err != nil {
 		// Skip processing the endpoint when CIDRs overlap and return nil to avoid re-queuing.
 		logger.Errorf(err, "overlappingSubnets for new remote %#v returned error", endpoint)
 		return nil
 	}
 
-	for _, inputCidrBlock := range endpoint.Spec.Subnets {
+	for _, inputCidrBlock := range subnets {
 		if !kp.remoteSubnets.Has(inputCidrBlock) {
 			kp.remoteSubnets.Insert(inputCidrBlock)
 		}
@@ -105,33 +107,35 @@ func (kp *SyncHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 		kp.remoteSubnetGw[inputCidrBlock] = gwIP
 	}
 
-	if err := kp.updateRoutingRulesForInterClusterSupport(endpoint.Spec.Subnets, Add); err != nil {
+	if err := kp.updateRoutingRulesForInterClusterSupport(subnets, Add); err != nil {
 		logger.Errorf(err, "updateRoutingRulesForInterClusterSupport for new remote %#v returned error",
 			endpoint)
 		return err
 	}
 
 	// Add routes to the new endpoint on the GatewayNode.
-	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Add)
-	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Add)
+	kp.updateRoutingRulesForHostNetworkSupport(subnets, Add)
+	kp.updateIptableRulesForInterClusterTraffic(subnets, Add)
 
 	return nil
 }
 
 func (kp *SyncHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
-	for _, inputCidrBlock := range endpoint.Spec.Subnets {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+
+	for _, inputCidrBlock := range subnets {
 		kp.remoteSubnets.Delete(inputCidrBlock)
 		delete(kp.remoteSubnetGw, inputCidrBlock)
 	}
 
-	if err := kp.updateRoutingRulesForInterClusterSupport(endpoint.Spec.Subnets, Delete); err != nil {
+	if err := kp.updateRoutingRulesForInterClusterSupport(subnets, Delete); err != nil {
 		logger.Errorf(err, "updateRoutingRulesForInterClusterSupport for removed remote %#v returned error",
 			endpoint)
 		return err
 	}
 
-	kp.updateRoutingRulesForHostNetworkSupport(endpoint.Spec.Subnets, Delete)
-	kp.updateIptableRulesForInterClusterTraffic(endpoint.Spec.Subnets, Delete)
+	kp.updateRoutingRulesForHostNetworkSupport(subnets, Delete)
+	kp.updateIptableRulesForInterClusterTraffic(subnets, Delete)
 
 	return nil
 }


### PR DESCRIPTION
This enables processing of IPv6 Endpoints and reveals dual-stack E2E failures/errors that will be addressed in subsequent PRs.