### PR TITLE
Move GetDefaultGatewayInterface to the netlink wrapper Interface

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -99,7 +99,7 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		return errors.Wrapf(err, "failed to derive the vxlan vtepIP for %s", ipAddr)
 	}
 
-	defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
+	defaultHostIface, err := v.netLink.GetDefaultGatewayInterface(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s",
 			v.localEndpoint.Hostname)
@@ -111,7 +111,7 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		Group:    nil,
 		SrcAddr:  nil,
 		VtepPort: port,
-		Mtu:      defaultHostIface.MTU,
+		Mtu:      defaultHostIface.MTU(),
 	}
 
 	v.vxlanIface, err = vxlan.NewInterface(attrs, v.netLink)

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -21,6 +21,7 @@ package vxlan_test
 import (
 	"flag"
 	"fmt"
+	"net"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -176,6 +177,8 @@ func newTestDriver() *testDriver {
 		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
 			return t.netLink
 		}
+
+		t.netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{MTU: 10})
 
 		cni.HostInterfaces = func() ([]cni.HostInterface, error) {
 			return []cni.HostInterface{{

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -192,7 +192,7 @@ func (w *wireguard) Init() error {
 	}
 
 	logger.V(log.DEBUG).Infof("WireGuard device %s, is up on i/f number %d, listening on port :%d, with key %s",
-		w.link.Attrs().Name, l.Index, d.ListenPort, d.PublicKey)
+		w.link.Attrs().Name, l.Index(), d.ListenPort, d.PublicKey)
 
 	return nil
 }

--- a/pkg/netlink/network_interface.go
+++ b/pkg/netlink/network_interface.go
@@ -1,0 +1,54 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlink
+
+import "net"
+
+type NetworkInterface interface {
+	Index() int
+	MTU() int
+	Name() string
+	HardwareAddr() net.HardwareAddr
+	Flags() net.Flags
+	Addrs() ([]net.Addr, error)
+}
+
+type DefaultNetworkInterface struct {
+	net.Interface
+}
+
+func (i *DefaultNetworkInterface) Index() int {
+	return i.Interface.Index
+}
+
+func (i *DefaultNetworkInterface) MTU() int {
+	return i.Interface.MTU
+}
+
+func (i *DefaultNetworkInterface) Name() string {
+	return i.Interface.Name
+}
+
+func (i *DefaultNetworkInterface) HardwareAddr() net.HardwareAddr {
+	return i.Interface.HardwareAddr
+}
+
+func (i *DefaultNetworkInterface) Flags() net.Flags {
+	return i.Interface.Flags
+}

--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -92,6 +92,10 @@ var _ = Describe("", func() {
 				Addr: localClusterCIDRs[0],
 			}}, nil
 		}
+
+		netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{
+			Name: "gw-intf",
+		}, &net.IPNet{IP: net.ParseIP("1.2.3.4"), Mask: net.CIDRMask(8, 32)})
 	})
 
 	Specify("All Route Agent handlers should successfully instantiate and initialize", func() {

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -146,7 +146,7 @@ func (kp *SyncHandler) getHostIfaceIPAddress() (net.IP, error) {
 		for i := range addrs {
 			ipAddr, _, err := net.ParseCIDR(addrs[i].String())
 			if err != nil {
-				logger.Errorf(err, "Unable to ParseCIDR  %v", addrs)
+				return nil, errors.Errorf("unable to parse CIDR : %s", addrs[i])
 			}
 
 			if ipAddr.To4() != nil {
@@ -155,5 +155,5 @@ func (kp *SyncHandler) getHostIfaceIPAddress() (net.IP, error) {
 		}
 	}
 
-	return nil, nil
+	return nil, errors.Errorf("no default host interface IP found: %v", addrs)
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -57,7 +57,7 @@ type SyncHandler struct {
 	vxlanGwIP              *net.IP
 	hostname               string
 	cniIface               *cni.Interface
-	defaultHostIface       *net.Interface
+	defaultHostIface       netlink.NetworkInterface
 	activeEndpointHostname string
 }
 
@@ -112,7 +112,7 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 		return errors.Wrapf(err, "unable to determine hostname")
 	}
 
-	kp.defaultHostIface, err = netlink.GetDefaultGatewayInterface(k8snet.IPv4)
+	kp.defaultHostIface, err = kp.netLink.GetDefaultGatewayInterface(k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to find the default interface on host: %s", kp.hostname)
 	}

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -112,7 +112,7 @@ func (kp *SyncHandler) configureRoute(remoteSubnet string, operation Operation, 
 		return errors.Wrapf(err, "error parsing cidr block %s", remoteSubnet)
 	}
 
-	ifaceIndex := kp.defaultHostIface.Index
+	ifaceIndex := kp.defaultHostIface.Index()
 
 	if kp.localEndpointIfaceName != "" {
 		if iface, err := net.InterfaceByName(kp.localEndpointIfaceName); err == nil {

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -369,14 +369,17 @@ func newTestDriver() *testDriver {
 	}
 
 	BeforeEach(func() {
-		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
-		Expect(err).To(Succeed())
-
-		t.hostInterfaceIndex = defaultHostIface.Index
-		t.vxLanInterfaceIndex = t.hostInterfaceIndex + 1
+		t.hostInterfaceIndex = 100
+		t.vxLanInterfaceIndex = 200
 
 		t.netLink = fakeNetlink.New()
 		t.netLink.SetLinkIndex(kubeproxy.VxLANIface, t.vxLanInterfaceIndex)
+
+		t.netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{
+			Index: t.hostInterfaceIndex,
+			MTU:   100,
+			Name:  "gw-intf",
+		}, &net.IPNet{IP: net.ParseIP("1.2.3.4"), Mask: net.CIDRMask(8, 32)})
 
 		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
 			return t.netLink

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -56,7 +56,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			Name:     VxLANIface,
 			VxlanID:  100,
 			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU,
+			Mtu:      kp.defaultHostIface.MTU(),
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)
@@ -84,7 +84,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			VxlanID:  100,
 			Group:    gatewayNodeIP,
 			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU,
+			Mtu:      kp.defaultHostIface.MTU(),
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -259,7 +259,7 @@ func (h *mtuHandler) forceMssClamping(endpoint *submV1.Endpoint) error {
 	tcpMssValue := h.tcpMssValue
 
 	if tcpMssValue == 0 {
-		defaultHostIface, err := netlinkAPI.GetDefaultGatewayInterface(k8snet.IPv4)
+		defaultHostIface, err := netlinkAPI.New().GetDefaultGatewayInterface(k8snet.IPv4)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to find the default interface on host")
 		}
@@ -269,7 +269,7 @@ func (h *mtuHandler) forceMssClamping(endpoint *submV1.Endpoint) error {
 			overHeadSize = vxlan.MTUOverhead
 		}
 
-		tcpMssValue = defaultHostIface.MTU - overHeadSize
+		tcpMssValue = defaultHostIface.MTU() - overHeadSize
 		tcpMssSrc = "default"
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -113,14 +113,14 @@ func (ovn *Handler) getForwardingRuleSpecs() ([]*packetfilter.Rule, error) {
 		rules = append(rules, &packetfilter.Rule{
 			DestCIDR:     remoteCIDR,
 			Action:       packetfilter.RuleActionAccept,
-			OutInterface: ovn.cableRoutingInterface.Name,
+			OutInterface: ovn.cableRoutingInterface.Name(),
 			InInterface:  OVNK8sMgmntIntfName,
 		},
 			&packetfilter.Rule{
 				SrcCIDR:      remoteCIDR,
 				Action:       packetfilter.RuleActionAccept,
 				OutInterface: OVNK8sMgmntIntfName,
-				InInterface:  ovn.cableRoutingInterface.Name,
+				InInterface:  ovn.cableRoutingInterface.Name(),
 			},
 		)
 	}

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	k8snet "k8s.io/utils/net"
 )
 
 const (
@@ -112,6 +113,8 @@ func newTestDriver() *testDriver {
 		Expect(t.netLink.AddrAdd(link, addr)).To(Succeed())
 
 		t.mgmntIntfIP = addr.IPNet.IP.String()
+
+		t.netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{Name: "gw-intf"})
 	})
 
 	return t


### PR DESCRIPTION
...so it can be mocked by unit tests. Also add an interface abstraction for `net.Interface` so the `Addrs` methods can be mocked.