### PR TITLE
Fix data race while stopping RA health checker

### DIFF
--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -75,10 +75,7 @@ func (h *controller) Stop() error {
 	h.pingerController.Stop()
 
 	h.stopOnce.Do(func() {
-		if h.stopCh != nil {
-			close(h.stopCh)
-			h.stopCh = nil
-		}
+		close(h.stopCh)
 	})
 
 	err := h.client.Delete(context.TODO(),


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c0000f8ad0 by goroutine 231:
  github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/
                                  healthchecker.(*controller).Stop.func1()
      /go/src/github.com/submariner-io/submariner/pkg/routeagent_driver/
           handlers/healthchecker/healthchecker.go:80 +0x97
```

```
  h.stopOnce.Do(func() {
      if h.stopCh != nil {
          close(h.stopCh)
          h.stopCh = nil <-- line 80
      }
  })
```

```
Previous read at 0x00c0000f8ad0 by goroutine 217:
  github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/
                                  healthchecker.(*controller).Init.func1()
      /go/src/github.com/submariner-io/submariner/pkg/routeagent_driver/
           handlers/healthchecker/healthchecker.go:130 +0x9
```

Since closing the `stopCh` is enclosed in `h.stopOnce.Do`, we don't need to nil it out.
