### PR TITLE
Add IsLinkNotFoundError function to the netlink API

### DIFF
--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -444,7 +444,11 @@ func (w *wireguard) Cleanup() error {
 	logger.Info("Uninstalling the wireguard cable driver")
 
 	link, err := w.netLink.LinkByName(DefaultDeviceName)
-	if err != nil && !errors.Is(err, netlink.LinkNotFoundError{}) {
+	if netlinkAPI.IsLinkNotFoundError(err) {
+		return nil
+	}
+
+	if err != nil {
 		return errors.Wrapf(err, "error retrieving the wireguard interface %q", DefaultDeviceName)
 	}
 

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -307,9 +307,8 @@ func DeleteIfaceAndAssociatedRoutes(iface string, tableID int) error {
 
 	link, err := n.LinkByName(iface)
 	if err != nil {
-		//nolint:errorlint // netlink.LinkNotFoundError does not implement method Is(error) bool
-		if _, ok := err.(netlink.LinkNotFoundError); !ok {
-			logger.Warningf("Failed to retrieve the vxlan-tunnel interface: %v", err)
+		if !IsLinkNotFoundError(err) {
+			logger.Warningf("Failed to retrieve link %q: %v", iface, err)
 		}
 
 		return nil
@@ -389,4 +388,8 @@ func ToNetlinkFamily(family k8snet.IPFamily) int {
 	}
 
 	return netlink.FAMILY_ALL
+}
+
+func IsLinkNotFoundError(err error) bool {
+	return errors.As(err, &netlink.LinkNotFoundError{}) || (err != nil && err.Error() == "Link not found")
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/routes_iface.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -158,7 +159,7 @@ func (kp *SyncHandler) cleanVxSubmarinerRoutes() {
 	// This must be called with kp.syncHandlerMutex held
 	link, err := kp.netLink.LinkByName(kp.vxlanIface)
 	if err != nil {
-		if !errors.Is(err, netlink.LinkNotFoundError{}) {
+		if !netlinkAPI.IsLinkNotFoundError(err) {
 			logger.Errorf(err, "Error retrieving link by name %q", kp.vxlanIface)
 		}
 

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -116,8 +116,7 @@ func (ovn *Handler) programRulesForRemoteSubnets(subnets []string, ruleFunc func
 
 func (ovn *Handler) getNextHopOnK8sMgmtIntf() (*net.IP, error) {
 	link, err := ovn.netLink.LinkByName(OVNK8sMgmntIntfName)
-
-	if err != nil && !errors.Is(err, netlink.LinkNotFoundError{}) {
+	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving link by name %q", OVNK8sMgmntIntfName)
 	}
 


### PR DESCRIPTION
The `netlink` lib defines `LinkNotFoundError` but it does not implement method `Is(error) bool` so it can't be used with
`errors.Is(err, netlink.LinkNotFoundError{})`. So add a helper function to determine if an err indicates link not found.
