### PR TITLE
Add IP family support to EnableForwarding and skip rp_filter updates for IPv6

### DIFF
--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -124,7 +124,7 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		return errors.Wrap(err, "failed to add ip rule")
 	}
 
-	err = v.netLink.EnsureLooseModeIsConfigured(VxlanIface)
+	err = v.netLink.EnsureLooseModeIsConfigured(VxlanIface, k8snet.IPv4)
 	if err != nil {
 		return errors.Wrap(err, "error while validating loose mode")
 	}
@@ -136,7 +136,7 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		return errors.Wrap(err, "failed to configure vxlan interface ipaddress on the Gateway Node")
 	}
 
-	err = v.netLink.EnableForwarding(VxlanIface)
+	err = v.netLink.EnableForwarding(VxlanIface, k8snet.IPv4)
 	if err != nil {
 		return errors.Wrapf(err, "error enabling forwarding on the %q iface", VxlanIface)
 	}

--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -489,20 +489,16 @@ func (n *basicType) XfrmPolicyList(_ k8snet.IPFamily) ([]netlink.XfrmPolicy, err
 	return []netlink.XfrmPolicy{}, nil
 }
 
-func (n *basicType) EnableLooseModeReversePathFilter(_ string) error {
+func (n *basicType) EnableLooseModeReversePathFilter(_ string, _ k8snet.IPFamily) error {
 	return nil
 }
 
-func (n *basicType) EnsureLooseModeIsConfigured(_ string) error {
+func (n *basicType) EnsureLooseModeIsConfigured(_ string, _ k8snet.IPFamily) error {
 	return nil
 }
 
-func (n *basicType) EnableForwarding(_ string) error {
+func (n *basicType) EnableForwarding(_ string, _ k8snet.IPFamily) error {
 	return nil
-}
-
-func (n *basicType) GetReversePathFilter(_ string) ([]byte, error) {
-	return []byte("2"), nil
 }
 
 func (n *basicType) ConfigureTCPMTUProbe(_, _ string) error {

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -153,7 +153,7 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 		// Configure CNI Specific changes
 		kp.cniIface = cniIface
 
-		err := kp.netLink.EnableLooseModeReversePathFilter(kp.cniIface.Name)
+		err := kp.netLink.EnableLooseModeReversePathFilter(kp.cniIface.Name, kp.ipFamily)
 		if err != nil {
 			return errors.Wrap(err, "error enabling loose mode")
 		}

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -77,7 +77,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			}
 		}
 
-		err = kp.netLink.EnsureLooseModeIsConfigured(kp.vxlanIface)
+		err = kp.netLink.EnsureLooseModeIsConfigured(kp.vxlanIface, kp.ipFamily)
 		if err != nil {
 			return errors.Wrap(err, "error while validating loose mode")
 		}
@@ -109,7 +109,7 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 		return errors.Wrap(err, "failed to configure vxlan interface ipaddress on the Gateway Node")
 	}
 
-	err = kp.netLink.EnableForwarding(kp.vxlanIface)
+	err = kp.netLink.EnableForwarding(kp.vxlanIface, kp.ipFamily)
 	if err != nil {
 		return errors.Wrapf(err, "error enabling forwarding on the %q iface", kp.vxlanIface)
 	}


### PR DESCRIPTION
Avoid calling netlink rp_filter related functions for IPv6 interfaces,
    as rp_filter is only applicable for IPv4.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
