### PR TITLE
Ensure ip6tables binary is installed 

### DIFF
--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -22,6 +22,8 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/globalnet 
     glibc bash glibc-minimal-langpack coreutils-single \
     iproute iptables-legacy iptables-nft nftables ipset grep
 
+RUN ln -sf /usr/sbin/ip6tables-nft /usr/sbin/ip6tables
+
 FROM scratch
 ARG SOURCE
 ARG TARGETPLATFORM

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -23,6 +23,8 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/route-agen
     glibc bash glibc-minimal-langpack coreutils-single \
     iproute iptables-legacy iptables-nft nftables ipset openvswitch procps-ng grep
 
+RUN ln -sf /usr/sbin/ip6tables-nft /usr/sbin/ip6tables
+
 FROM scratch
 ARG SOURCE
 ARG TARGETPLATFORM


### PR DESCRIPTION
The existing route-agent and globalnet container images relied on the presence of iptables/ip6tables from the host node environment. It seems that ip6tables is misisng in Kind IPv6 cluster environment.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
