### PR TITLE
Fix ip6tables binary provisioning in containers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,7 @@ jobs:
         include:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
+          - extra-toggles: ipv6-stack
           - extra-toggles: nftables
           - extra-toggles: nftables, ovn
           - extra-toggles: nftables, globalnet

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -22,8 +22,6 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/globalnet 
     glibc bash glibc-minimal-langpack coreutils-single \
     iproute iptables-legacy iptables-nft nftables ipset grep
 
-RUN ln -sf /usr/sbin/ip6tables-nft /usr/sbin/ip6tables
-
 FROM scratch
 ARG SOURCE
 ARG TARGETPLATFORM

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -23,8 +23,6 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/route-agen
     glibc bash glibc-minimal-langpack coreutils-single \
     iproute iptables-legacy iptables-nft nftables ipset openvswitch procps-ng grep
 
-RUN ln -sf /usr/sbin/ip6tables-nft /usr/sbin/ip6tables
-
 FROM scratch
 ARG SOURCE
 ARG TARGETPLATFORM

--- a/package/iptables-wrapper-installer.sh
+++ b/package/iptables-wrapper-installer.sh
@@ -190,9 +190,9 @@ case "${altstyle}" in
             --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
             --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
             --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables iptables /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables-restore iptables-restore /usr/sbin/iptables-wrapper \
-            --slave /usr/sbin/ip6tables-save iptables-save /usr/sbin/iptables-wrapper
+            --slave /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
 	;;
 
     debian)


### PR DESCRIPTION
The iptables wrapper installer used an alternatives setup which no longer works correctly on Fedora 41, and ended up skipping ip6tables (and even removing it, which is why the earlier link is removed). This updates the alternatives setup to use different names for the ip6tables alternatives, restoring ip6tables features before and after the wrapper is called.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
