### PR TITLE
Set IPv6 health check IP if globalnet is enabled in GetLocalSpec

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -193,12 +193,16 @@ func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, 
 		endpointSpec.SetPublicIP(publicIP)
 	}
 
-	if submSpec.HealthCheckEnabled && !globalnetEnabled {
+	if submSpec.HealthCheckEnabled {
 		// When globalnet is enabled, HealthCheckIP will be the globalIP assigned to the Active GatewayNode.
 		// In a fresh deployment, globalIP annotation for the node might take few seconds. So we listen on NodeEvents
 		// and update the endpoint HealthCheckIP (to globalIP) in datastoreSyncer at a later stage. This will trigger
 		// the HealthCheck between the clusters.
 		for _, family := range submSpec.GetIPFamilies() {
+			if globalnetEnabled && family == k8snet.IPv4 {
+				continue
+			}
+
 			healthcheckIP, err := getHealthCheckIP(family, submSpec)
 			if err != nil {
 				return nil, fmt.Errorf("error getting HealthCheckIPv%v: %w", family, err)

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -246,6 +246,18 @@ var _ = Describe("GetLocalSpec", func() {
 				Expect(spec.HealthCheckIPs).To(ContainElements(cniInterfaceIPv4, cniInterfaceIPv6))
 				Expect(spec.HealthCheckIPs).To(HaveLen(2))
 			})
+
+			Context("and globalnet enabled", func() {
+				BeforeEach(func() {
+					submSpec.GlobalCidr = []string{"242.10.0.0/24"}
+				})
+
+				It("should set the IPv6 HealthCheckIP", func() {
+					spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(spec.HealthCheckIPs).To(Equal([]string{cniInterfaceIPv6}))
+				})
+			})
 		})
 
 		Context("and globalnet is enabled", func() {


### PR DESCRIPTION
We want to only skip setting it for IPv4.

