### PR TITLE
Dynamically select IP families for e2e dataplane and redundancy tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/submariner-io/admiral v0.21.0-m2
-	github.com/submariner-io/shipyard v0.21.0-m2
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/net v0.39.0
 	golang.org/x/sys v0.32.0
@@ -77,6 +76,7 @@ require (
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2 // indirect
 	github.com/urfave/cli/v2 v2.4.0 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,8 @@ github.com/submariner-io/admiral v0.21.0-m2 h1:SoDFEfd651Ql4BjN29J2AA86AycjvSjvi
 github.com/submariner-io/admiral v0.21.0-m2/go.mod h1:bVLQLEKc8ioOQPg8DpplPhgmrmhF+FufKj/CUgQtMPw=
 github.com/submariner-io/shipyard v0.21.0-m2 h1:tkPO6fMi2C8HKgoiNLMDWb6LBXpIl7QIEzdvdTS5Vnc=
 github.com/submariner-io/shipyard v0.21.0-m2/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
+github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2 h1:1qdAtXdnYLz8sQ1Euuy3yWeQPsatL3JYupQZq7rJ4Pk=
+github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -41,7 +41,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		Expect(gatewayNode).To(BeEmpty(), fmt.Sprintf("Expected no gateway node on %q", framework.ClusterC))
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a pod in cluster %q", clusterAName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterA,
 			FromClusterScheduling: framework.GatewayNode,
@@ -50,7 +50,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		})
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a service in cluster %q", clusterBName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterB,
@@ -69,7 +69,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		framework.By(fmt.Sprintf("Found submariner gateway pod %q on %q", gatewayPod.Name, clusterCName))
 
 		framework.By("Checking connectivity between clusters")
-		tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterB,
 			FromClusterScheduling: framework.GatewayNode,
@@ -77,7 +77,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 			ToClusterScheduling:   framework.GatewayNode,
 		})
 
-		tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterA,
@@ -92,7 +92,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		f.DeletePod(framework.ClusterC, gatewayPod.Name, framework.TestContext.SubmarinerNamespace)
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a service in cluster %q", clusterAName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterA,
 			FromClusterScheduling: framework.GatewayNode,
@@ -101,7 +101,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		})
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a pod in cluster %q", clusterBName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterB,

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -61,7 +61,7 @@ var _ = Describe("Basic TCP connectivity tests across overlapping clusters witho
 				return
 			}
 
-			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+			subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -19,122 +19,168 @@ limitations under the License.
 package dataplane
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
+	k8snet "k8s.io/utils/net"
 )
 
 const TestLabel = "dataplane"
 
+func GetActualIPFamilies(fromType, toType framework.IPFamilyType) []k8snet.IPFamily {
+	var families []k8snet.IPFamily
+
+	if (fromType == framework.SingleStackIPv4 || fromType == framework.DualStack) &&
+		(toType == framework.SingleStackIPv4 || toType == framework.DualStack) {
+		families = append(families, k8snet.IPv4)
+	}
+
+	if (fromType == framework.SingleStackIPv6 || fromType == framework.DualStack) &&
+		(toType == framework.SingleStackIPv6 || toType == framework.DualStack) {
+		families = append(families, k8snet.IPv6)
+	}
+
+	return families
+}
+
 var _ = Describe("Basic TCP connectivity tests across clusters without discovery", Label(TestLabel), func() {
 	f := framework.NewFramework("dataplane-conn-nd")
-	var toEndpointType tcp.EndpointType
-	var networking framework.NetworkingType
-	var fromCluster framework.ClusterIndex
-	var toCluster framework.ClusterIndex
 
-	verifyInteraction := func(fromClusterScheduling, toClusterScheduling framework.NetworkPodScheduling) {
-		It("should have sent the expected data from the pod to the other pod", func() {
-			if framework.TestContext.GlobalnetEnabled {
-				framework.Skipf("Globalnet enabled, skipping the test...")
-				return
+	var supportedFamilies []k8snet.IPFamily
+
+	BeforeEach(func() {
+		supportedFamilies = GetActualIPFamilies(f.DetermineIPFamilyType(framework.ClusterA), f.DetermineIPFamilyType(framework.ClusterB))
+	})
+
+	for _, fam := range []k8snet.IPFamily{k8snet.IPv4, k8snet.IPv6} {
+		family := fam
+
+		When(fmt.Sprintf("IPv%v connectivity used", family), func() {
+			var toEndpointType tcp.EndpointType
+			var networking framework.NetworkingType
+			var fromCluster, toCluster framework.ClusterIndex
+
+			BeforeEach(func() {
+				// Skip this family if it's not supported
+				skip := true
+				for _, f := range supportedFamilies {
+					if f == family {
+						skip = false
+						break
+					}
+				}
+				if skip {
+					Skip(fmt.Sprintf("IPv%v not supported in this environment", family))
+				}
+			})
+
+			verifyInteraction := func(fromClusterScheduling, toClusterScheduling framework.NetworkPodScheduling) {
+				It("should have sent the expected data from the pod to the other pod", func() {
+					if framework.TestContext.GlobalnetEnabled {
+						framework.Skipf("Globalnet enabled, skipping the test...")
+						return
+					}
+
+					if !subFramework.CanExecuteNonGatewayConnectivityTest(fromClusterScheduling, toClusterScheduling,
+						framework.ClusterA, framework.ClusterB) {
+						return
+					}
+
+					tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
+						Framework:             f,
+						ToEndpointType:        toEndpointType,
+						Networking:            networking,
+						FromCluster:           fromCluster,
+						FromClusterScheduling: fromClusterScheduling,
+						ToCluster:             toCluster,
+						ToClusterScheduling:   toClusterScheduling,
+						IPFamily:              family,
+					})
+				})
 			}
 
-			if !subFramework.CanExecuteNonGatewayConnectivityTest(fromClusterScheduling, toClusterScheduling,
-				framework.ClusterA, framework.ClusterB) {
-				return
-			}
+			When("a pod connects via TCP to a remote pod", func() {
+				BeforeEach(func() {
+					toEndpointType = tcp.PodIP
+					networking = framework.PodNetworking
+					fromCluster = framework.ClusterA
+					toCluster = framework.ClusterB
+				})
 
-			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
-				Framework:             f,
-				ToEndpointType:        toEndpointType,
-				Networking:            networking,
-				FromCluster:           fromCluster,
-				FromClusterScheduling: fromClusterScheduling,
-				ToCluster:             toCluster,
-				ToClusterScheduling:   toClusterScheduling,
+				When("the pod is not on a gateway and the remote pod is not on a gateway", Label(framework.BasicTestLabel), func() {
+					verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
+				})
+
+				When("the pod is not on a gateway and the remote pod is on a gateway", func() {
+					verifyInteraction(framework.NonGatewayNode, framework.GatewayNode)
+				})
+
+				When("the pod is on a gateway and the remote pod is not on a gateway", func() {
+					verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
+				})
+
+				When("the pod is on a gateway and the remote pod is on a gateway", Label(framework.BasicTestLabel), func() {
+					verifyInteraction(framework.GatewayNode, framework.GatewayNode)
+				})
+			})
+
+			When("a pod connects via TCP to a remote service", func() {
+				BeforeEach(func() {
+					toEndpointType = tcp.ServiceIP
+					networking = framework.PodNetworking
+					fromCluster = framework.ClusterA
+					toCluster = framework.ClusterB
+				})
+
+				When("the pod is not on a gateway and the remote service is not on a gateway", Label(framework.BasicTestLabel), func() {
+					verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
+				})
+
+				When("the pod is not on a gateway and the remote service is on a gateway", func() {
+					verifyInteraction(framework.NonGatewayNode, framework.GatewayNode)
+				})
+
+				When("the pod is on a gateway and the remote service is not on a gateway", func() {
+					verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
+				})
+
+				When("the pod is on a gateway and the remote service is on a gateway", Label(framework.BasicTestLabel), func() {
+					verifyInteraction(framework.GatewayNode, framework.GatewayNode)
+				})
+			})
+
+			When("a pod with HostNetworking connects via TCP to a remote pod", func() {
+				BeforeEach(func() {
+					toEndpointType = tcp.PodIP
+					networking = framework.HostNetworking
+					fromCluster = framework.ClusterA
+					toCluster = framework.ClusterB
+				})
+
+				When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
+					verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
+				})
+
+				When("the pod is on a gateway and the remote pod is not on a gateway", func() {
+					verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
+				})
+			})
+
+			When("a pod connects via TCP to a remote pod in reverse direction", func() {
+				BeforeEach(func() {
+					toEndpointType = tcp.PodIP
+					networking = framework.PodNetworking
+					fromCluster = framework.ClusterB
+					toCluster = framework.ClusterA
+				})
+
+				When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
+					verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
+				})
 			})
 		})
 	}
-
-	When("a pod connects via TCP to a remote pod", func() {
-		BeforeEach(func() {
-			toEndpointType = tcp.PodIP
-			networking = framework.PodNetworking
-			fromCluster = framework.ClusterA
-			toCluster = framework.ClusterB
-		})
-
-		When("the pod is not on a gateway and the remote pod is not on a gateway", Label(framework.BasicTestLabel), func() {
-			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
-		})
-
-		When("the pod is not on a gateway and the remote pod is on a gateway", func() {
-			verifyInteraction(framework.NonGatewayNode, framework.GatewayNode)
-		})
-
-		When("the pod is on a gateway and the remote pod is not on a gateway", func() {
-			verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
-		})
-
-		When("the pod is on a gateway and the remote pod is on a gateway", Label(framework.BasicTestLabel), func() {
-			verifyInteraction(framework.GatewayNode, framework.GatewayNode)
-		})
-	})
-
-	When("a pod connects via TCP to a remote service", func() {
-		BeforeEach(func() {
-			toEndpointType = tcp.ServiceIP
-			networking = framework.PodNetworking
-			fromCluster = framework.ClusterA
-			toCluster = framework.ClusterB
-		})
-
-		When("the pod is not on a gateway and the remote service is not on a gateway", Label(framework.BasicTestLabel), func() {
-			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
-		})
-
-		When("the pod is not on a gateway and the remote service is on a gateway", func() {
-			verifyInteraction(framework.NonGatewayNode, framework.GatewayNode)
-		})
-
-		When("the pod is on a gateway and the remote service is not on a gateway", func() {
-			verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
-		})
-
-		When("the pod is on a gateway and the remote service is on a gateway", Label(framework.BasicTestLabel), func() {
-			verifyInteraction(framework.GatewayNode, framework.GatewayNode)
-		})
-	})
-
-	When("a pod with HostNetworking connects via TCP to a remote pod", func() {
-		BeforeEach(func() {
-			toEndpointType = tcp.PodIP
-			networking = framework.HostNetworking
-			fromCluster = framework.ClusterA
-			toCluster = framework.ClusterB
-		})
-
-		When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
-			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
-		})
-
-		When("the pod is on a gateway and the remote pod is not on a gateway", func() {
-			verifyInteraction(framework.GatewayNode, framework.NonGatewayNode)
-		})
-	})
-
-	When("a pod connects via TCP to a remote pod in reverse direction", func() {
-		BeforeEach(func() {
-			toEndpointType = tcp.PodIP
-			networking = framework.PodNetworking
-			fromCluster = framework.ClusterB
-			toCluster = framework.ClusterA
-		})
-
-		When("the pod is not on a gateway and the remote pod is not on a gateway", func() {
-			verifyInteraction(framework.NonGatewayNode, framework.NonGatewayNode)
-		})
-	})
 })

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -68,7 +68,7 @@ type GlobalnetTestParams struct {
 	RunAdditionalTest RunAdditionalTestFn
 }
 
-func VerifyDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
+func VerifyDatapathConnectivity(p *tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
 	if gn.GlobalnetEnabled {
 		verifyGlobalnetDatapathConnectivity(p, gn)
 	} else {
@@ -76,7 +76,7 @@ func VerifyDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestPa
 	}
 }
 
-func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
+func verifyGlobalnetDatapathConnectivity(p *tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
 	Expect(p.ToEndpointType).To(BeElementOf([]tcp.EndpointType{tcp.GlobalServiceIP, tcp.GlobalPodIP}))
 
 	if p.ConnectionTimeout == 0 {
@@ -213,7 +213,7 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, gn Global
 	p.Framework.DeleteService(p.ToCluster, service.Name)
 }
 
-func getGlobalIngressIP(p tcp.ConnectivityTestParams, service *v1.Service) string {
+func getGlobalIngressIP(p *tcp.ConnectivityTestParams, service *v1.Service) string {
 	if p.ToEndpointType == tcp.GlobalServiceIP {
 		return p.Framework.AwaitGlobalIngressIP(p.ToCluster, service.Name, service.Namespace)
 	} else if p.ToEndpointType == tcp.GlobalPodIP {

--- a/test/external/dataplane/gn_connectivity.go
+++ b/test/external/dataplane/gn_connectivity.go
@@ -513,7 +513,7 @@ func getPodGlobalIPs(p testParams, g globalnetTestParams, np *framework.NetworkP
 func createHeadlessTCPServiceWithoutSelector(f *framework.Framework, cluster framework.ClusterIndex,
 	svcName, portName string, port int32,
 ) *v1.Service {
-	serviceSpec := f.NewService(svcName, portName, port, v1.ProtocolTCP, nil, true)
+	serviceSpec := f.NewService(svcName, portName, port, v1.ProtocolTCP, nil, true, nil)
 	sc := framework.KubeClients[cluster].CoreV1().Services(f.Namespace)
 
 	return f.CreateService(sc, serviceSpec)


### PR DESCRIPTION
Adjust e2e dataplane and redundancy tests to dynamically select which IP family tests to run based on clusters IP families.
This ensures dataplane connectivity tests match the actual supported IP families between clusters.
