### PR TITLE
Pass ConnectivityTestParams using pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/submariner-io/admiral v0.21.0-m2
-	github.com/submariner-io/shipyard v0.21.0-m2
+	github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/net v0.39.0
 	golang.org/x/sys v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/submariner-io/admiral v0.21.0-m2 h1:SoDFEfd651Ql4BjN29J2AA86AycjvSjviACU0cDEP7w=
 github.com/submariner-io/admiral v0.21.0-m2/go.mod h1:bVLQLEKc8ioOQPg8DpplPhgmrmhF+FufKj/CUgQtMPw=
-github.com/submariner-io/shipyard v0.21.0-m2 h1:tkPO6fMi2C8HKgoiNLMDWb6LBXpIl7QIEzdvdTS5Vnc=
-github.com/submariner-io/shipyard v0.21.0-m2/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
+github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2 h1:1qdAtXdnYLz8sQ1Euuy3yWeQPsatL3JYupQZq7rJ4Pk=
+github.com/submariner-io/shipyard v0.21.0-m2.0.20250512150441-ff6a84565ac2/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -41,7 +41,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		Expect(gatewayNode).To(BeEmpty(), fmt.Sprintf("Expected no gateway node on %q", framework.ClusterC))
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a pod in cluster %q", clusterAName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterA,
 			FromClusterScheduling: framework.GatewayNode,
@@ -50,7 +50,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		})
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a service in cluster %q", clusterBName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterB,
@@ -69,7 +69,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		framework.By(fmt.Sprintf("Found submariner gateway pod %q on %q", gatewayPod.Name, clusterCName))
 
 		framework.By("Checking connectivity between clusters")
-		tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterB,
 			FromClusterScheduling: framework.GatewayNode,
@@ -77,7 +77,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 			ToClusterScheduling:   framework.GatewayNode,
 		})
 
-		tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterA,
@@ -92,7 +92,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		f.DeletePod(framework.ClusterC, gatewayPod.Name, framework.TestContext.SubmarinerNamespace)
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a service in cluster %q", clusterAName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			FromCluster:           framework.ClusterA,
 			FromClusterScheduling: framework.GatewayNode,
@@ -101,7 +101,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		})
 
 		framework.By(fmt.Sprintf("Verifying that a pod in cluster %q cannot connect to a pod in cluster %q", clusterBName, clusterCName))
-		tcp.RunNoConnectivityTest(tcp.ConnectivityTestParams{
+		tcp.RunNoConnectivityTest(&tcp.ConnectivityTestParams{
 			Framework:             f,
 			ToEndpointType:        tcp.ServiceIP,
 			FromCluster:           framework.ClusterB,

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -61,7 +61,7 @@ var _ = Describe("Basic TCP connectivity tests across overlapping clusters witho
 				return
 			}
 
-			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+			subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,

--- a/test/e2e/dataplane/tcp_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_pod_connectivity.go
@@ -46,7 +46,7 @@ var _ = Describe("Basic TCP connectivity tests across clusters without discovery
 				return
 			}
 
-			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+			tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        toEndpointType,
 				Networking:            networking,

--- a/test/e2e/framework/dataplane.go
+++ b/test/e2e/framework/dataplane.go
@@ -68,7 +68,7 @@ type GlobalnetTestParams struct {
 	RunAdditionalTest RunAdditionalTestFn
 }
 
-func VerifyDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
+func VerifyDatapathConnectivity(p *tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
 	if gn.GlobalnetEnabled {
 		verifyGlobalnetDatapathConnectivity(p, gn)
 	} else {
@@ -76,7 +76,7 @@ func VerifyDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestPa
 	}
 }
 
-func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
+func verifyGlobalnetDatapathConnectivity(p *tcp.ConnectivityTestParams, gn GlobalnetTestParams) {
 	Expect(p.ToEndpointType).To(BeElementOf([]tcp.EndpointType{tcp.GlobalServiceIP, tcp.GlobalPodIP}))
 
 	if p.ConnectionTimeout == 0 {
@@ -213,7 +213,7 @@ func verifyGlobalnetDatapathConnectivity(p tcp.ConnectivityTestParams, gn Global
 	p.Framework.DeleteService(p.ToCluster, service.Name)
 }
 
-func getGlobalIngressIP(p tcp.ConnectivityTestParams, service *v1.Service) string {
+func getGlobalIngressIP(p *tcp.ConnectivityTestParams, service *v1.Service) string {
 	if p.ToEndpointType == tcp.GlobalServiceIP {
 		return p.Framework.AwaitGlobalIngressIP(p.ToCluster, service.Name, service.Namespace)
 	} else if p.ToEndpointType == tcp.GlobalPodIP {

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -101,7 +101,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", secondaryClusterName,
 		primaryClusterName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           secondaryCluster,
 		FromClusterScheduling: framework.GatewayNode,
@@ -117,7 +117,7 @@ func testGatewayPodRestartScenario(f *subFramework.Framework) {
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q",
 		secondaryClusterName, primaryClusterName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           secondaryCluster,
 		FromClusterScheduling: framework.NonGatewayNode,
@@ -214,7 +214,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	f.AwaitSubmarinerEndpointRemoved(framework.ClusterIndex(secondaryCluster), submEndpoint.Name)
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterIndex(secondaryCluster),
 		FromClusterScheduling: framework.GatewayNode,
@@ -229,7 +229,7 @@ func testGatewayFailOverScenario(f *subFramework.Framework) {
 	}
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterIndex(secondaryCluster),
 		FromClusterScheduling: framework.NonGatewayNode,

--- a/test/e2e/redundancy/leader_election.go
+++ b/test/e2e/redundancy/leader_election.go
@@ -69,7 +69,7 @@ var _ = Describe("Leader election tests", func() {
 
 			f.AwaitGatewaysWithStatus(cluster, subv1.HAStatusPassive)
 
-			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+			subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 				Framework:             f.Framework,
 				FromCluster:           framework.ClusterA,
 				FromClusterScheduling: framework.NonGatewayNode,
@@ -87,7 +87,7 @@ var _ = Describe("Leader election tests", func() {
 
 			f.AwaitGatewayWithStatus(cluster, gatewayPod.Spec.NodeName, subv1.HAStatusActive)
 
-			subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+			subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 				Framework:             f.Framework,
 				FromCluster:           framework.ClusterA,
 				FromClusterScheduling: framework.GatewayNode,

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -73,7 +73,7 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	framework.By(fmt.Sprintf("Found new route agent pod %q on node %q", newRouteAgentPod.Name, node.Name))
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from gateway node on %q to gateway node on %q", clusterBName, clusterAName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.GatewayNode,
@@ -83,7 +83,7 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool) {
 	}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 
 	framework.By(fmt.Sprintf("Verifying TCP connectivity from non-gateway node on %q to non-gateway node on %q", clusterBName, clusterAName))
-	subFramework.VerifyDatapathConnectivity(tcp.ConnectivityTestParams{
+	subFramework.VerifyDatapathConnectivity(&tcp.ConnectivityTestParams{
 		Framework:             f.Framework,
 		FromCluster:           framework.ClusterB,
 		FromClusterScheduling: framework.NonGatewayNode,


### PR DESCRIPTION
The Shipyard framework was recently changed to take ConnectivityTestParams structs as pointers; this updates Submariner to match.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
