### PR TITLE
Fix issues in Ipv6 OVN  Kubernetes dual stack

### DIFF
--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -116,14 +116,14 @@ var _ = Describe("", func() {
 			NewOVSDBClient: func(_ model.ClientDBModel, _ ...libovsdbclient.Option) (libovsdbclient.Client, error) {
 				return fakeovn.NewOVSDBClient(), nil
 			},
-			TransitSwitchIP: ovn.NewTransitSwitchIP(),
+			TransitSwitchIP: ovn.NewTransitSwitchIP(k8snet.IPv4),
 		})
 		Expect(ovnHandler.Init(ctx)).To(Succeed())
 
 		gwRouteHandler := ovn.NewGatewayRouteHandler(k8snet.IPv4, submClient)
 		Expect(gwRouteHandler.Init(ctx)).To(Succeed())
 
-		ngwRouteHandler := ovn.NewNonGatewayRouteHandler(submClient, ovn.NewTransitSwitchIP())
+		ngwRouteHandler := ovn.NewNonGatewayRouteHandler(k8snet.IPv4, submClient, ovn.NewTransitSwitchIP(k8snet.IPv4))
 		Expect(ngwRouteHandler.Init(ctx)).To(Succeed())
 
 		mtuHandler := mtu.NewHandler(k8snet.IPv4, localClusterCIDRs, false, 0)

--- a/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_route_handler_test.go
@@ -49,18 +49,14 @@ var _ = Describe("GatewayRouteHandler", func() {
 			t.CreateLocalHostEndpoint()
 		})
 
-		It("should create/delete GatewayRoutes for both IP families", func() {
+		It("should create/delete GatewayRoutes for Ipv4", func() {
 			endpointV4 := t.CreateEndpoint(testing.NewEndpoint("remote-cluster-v4", "host", "192.0.4.0/24"))
-			endpointV6 := t.CreateEndpoint(testing.NewEndpoint("remote-cluster-v6", "host", "192.0.4.0/24", "fd00:100::/64"))
 
 			awaitGatewayRoute(endpointV4)
-			awaitGatewayRoute(endpointV6)
 
 			t.DeleteEndpoint(endpointV4.Name)
-			t.DeleteEndpoint(endpointV6.Name)
 
 			test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpointV4.Spec.ClusterID)
-			test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpointV6.Spec.ClusterID)
 		})
 
 		Context("and the GatewayRoute operations initially fail", func() {
@@ -76,7 +72,7 @@ var _ = Describe("GatewayRouteHandler", func() {
 				awaitGatewayRoute(endpoint)
 
 				t.DeleteEndpoint(endpoint.Name)
-				test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID)
+				test.AwaitNoResource(ovn.GatewayResourceInterface(t.submClient, testing.Namespace), endpoint.Spec.ClusterID+"-v4")
 			})
 		})
 	})

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -135,7 +135,8 @@ func (ovn *Handler) Init(ctx context.Context) error {
 		return err
 	}
 
-	nonGatewayRouteController, err := NewNonGatewayRouteController(*ovn.WatcherConfig, connectionHandler, ovn.Namespace, ovn.TransitSwitchIP)
+	nonGatewayRouteController, err := NewNonGatewayRouteController(ovn.ipFamily, *ovn.WatcherConfig, connectionHandler,
+		ovn.Namespace, ovn.TransitSwitchIP)
 	if err != nil {
 		return err
 	}

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Handler", func() {
 
 		restMapper := test.GetRESTMapperFor(&submarinerv1.GatewayRoute{}, &submarinerv1.NonGatewayRoute{})
 
-		transitSwitchIP = ovn.NewTransitSwitchIP()
+		transitSwitchIP = ovn.NewTransitSwitchIP(k8snet.IPv4)
 
 		t.Start(ovn.NewHandler(k8snet.IPv4, &ovn.HandlerConfig{
 			Namespace:   testing.Namespace,

--- a/pkg/routeagent_driver/handlers/ovn/host_networking.go
+++ b/pkg/routeagent_driver/handlers/ovn/host_networking.go
@@ -27,7 +27,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
-	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/set"
 )
 
@@ -39,7 +38,7 @@ func (ovn *Handler) updateHostNetworkDataplane() error {
 	ovn.mutex.Lock()
 	defer ovn.mutex.Unlock()
 
-	currentRuleRemotes, err := ovn.getExistingIPv4HostNetworkRoutes()
+	currentRuleRemotes, err := ovn.getExistingHostNetworkRoutes()
 	if err != nil {
 		return errors.Wrapf(err, "error reading ip rule list for IPv4")
 	}
@@ -78,10 +77,10 @@ func (ovn *Handler) updateHostNetworkDataplane() error {
 	return nil
 }
 
-func (ovn *Handler) getExistingIPv4HostNetworkRoutes() (set.Set[string], error) {
+func (ovn *Handler) getExistingHostNetworkRoutes() (set.Set[string], error) {
 	currentRuleRemotes := set.New[string]()
 
-	rules, err := ovn.netLink.RuleList(k8snet.IPv4)
+	rules, err := ovn.netLink.RuleList(ovn.ipFamily)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error listing rules")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/subnets.go
+++ b/pkg/routeagent_driver/handlers/ovn/subnets.go
@@ -18,16 +18,17 @@ limitations under the License.
 
 package ovn
 
-import "k8s.io/utils/set"
+import (
+	"github.com/submariner-io/submariner/pkg/cidr"
+	"k8s.io/utils/set"
+)
 
 func (ovn *Handler) getRemoteSubnets() set.Set[string] {
 	endpointSubnets := set.New[string]()
 
 	endpoints := ovn.State().GetRemoteEndpoints()
 	for i := range endpoints {
-		for _, subnet := range endpoints[i].Spec.Subnets {
-			endpointSubnets.Insert(subnet)
-		}
+		endpointSubnets.Insert(cidr.ExtractSubnets(ovn.ipFamily, endpoints[i].Spec.Subnets)...)
 	}
 
 	return endpointSubnets

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	k8snet "k8s.io/utils/net"
 )
 
 var _ = Describe("TransitSwitchIP", func() {
@@ -39,7 +40,7 @@ var _ = Describe("TransitSwitchIP", func() {
 	)
 
 	BeforeEach(func() {
-		transitSwitchIP = ovn.NewTransitSwitchIP()
+		transitSwitchIP = ovn.NewTransitSwitchIP(k8snet.IPv4)
 		nodeIP = ""
 	})
 


### PR DESCRIPTION
Some of the rules programmed by Ipv4 was getting overwritten by the ipv6 handler ( or vice versa) fixed the issues.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
