### PR TITLE
Ignore link index 0 in GetDefaultGatewayInterface

### DIFF
--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/vishvananda/netlink"
 	k8snet "k8s.io/utils/net"
 )
@@ -119,14 +120,10 @@ func (a *Adapter) GetDefaultGatewayInterface(family k8snet.IPFamily) (NetworkInt
 	}
 
 	for i := range routes {
-		if routes[i].Dst == nil || routes[i].Dst.String() == allZeroesFamilyAddress[family] {
-			if routes[i].LinkIndex == 0 {
-				return nil, errors.New("default gateway interface could not be determined")
-			}
-
+		if (routes[i].Dst == nil || routes[i].Dst.String() == allZeroesFamilyAddress[family]) && routes[i].LinkIndex > 0 {
 			return a.InterfaceByIndex(routes[i].LinkIndex)
 		}
 	}
 
-	return nil, errors.New("unable to find default route")
+	return nil, errors.Errorf("default gateway interface could not be determined from routes: %s", resource.ToJSON(routes))
 }


### PR DESCRIPTION
Previously `GetDefaultGatewayInterface` returned an error if it found a route with `LinkIndex == 0` which caused an intermittent unit test failure. The unit tests first set up a default gateway which adds a route with link index 99 and, most of the time, this is the first one returned from `RouteList`. But the fake netlink implementation stores the routes in a map keyed by link index so sometimes `RouteList` returns the first route with link index 0 since iterating a map occurs in random order.

So instead of `GetDefaultGatewayInterface` returning an error if a route has a 0 LinkIndex, simply ignore it.