### PR TITLE
Annotate remote subnets to prevent SNAT by OVNK

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -20,6 +20,7 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"time"
 
@@ -41,6 +42,8 @@ var (
 	PollTimeout  = time.Second * 30
 	PollInterval = time.Second
 )
+
+type AnnotationListModifier func(currentValue, newElement string, isAdd bool) (string, bool, error)
 
 func GetLocalNode(ctx context.Context, clientset kubernetes.Interface) (*v1.Node, error) {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
@@ -89,4 +92,144 @@ func WaitForLocalNodeReady(ctx context.Context, client kubernetes.Interface) {
 	if err != nil {
 		logger.Error(err, "Error waiting for local node")
 	}
+}
+
+func ModifyLocalNodeAnnotationList(
+	ctx context.Context,
+	client kubernetes.Interface,
+	annotationKey, newElement string,
+	isAdd bool,
+	modifierFunc AnnotationListModifier,
+) error {
+	node, err := GetLocalNode(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+
+	currentValue := node.Annotations[annotationKey]
+	newListValue, shouldUpdate, err := modifierFunc(currentValue, newElement, isAdd)
+
+	if err != nil {
+		return errors.Wrapf(err, "error processing modifierFunc for %v,%v", currentValue, newElement)
+	}
+
+	if !shouldUpdate {
+		return nil
+	}
+
+	node.Annotations[annotationKey] = newListValue
+
+	updateErr := wait.PollUntilContextTimeout(ctx, PollInterval, PollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+
+		if err != nil {
+			logger.Warningf("Error updating node annotation %v — retrying: %v", annotationKey, err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if updateErr != nil {
+		return errors.Wrapf(updateErr, "failed to update element %v in node annotation %v after retries", newElement, annotationKey)
+	}
+
+	if isAdd {
+		logger.Infof("Added %v to node annotation[%v] successfully", newElement, annotationKey)
+	} else {
+		logger.Infof("Deleted %v from node annotation[%v] successfully", newElement, annotationKey)
+	}
+
+	return nil
+}
+
+func JSONListAnnotationModifier(currentListValue, newElement string, isAdd bool) (string, bool, error) {
+	var list []string
+
+	if currentListValue != "" {
+		if err := json.Unmarshal([]byte(currentListValue), &list); err != nil {
+			return "", false, errors.Wrap(err, "failed to unmarshal annotation list")
+		}
+	}
+
+	exists := false
+
+	for _, v := range list {
+		if v == newElement {
+			exists = true
+			break
+		}
+	}
+
+	if isAdd {
+		if exists {
+			return currentListValue, false, nil
+		}
+
+		list = append(list, newElement)
+	} else {
+		if !exists {
+			return currentListValue, false, nil
+		}
+
+		newList := []string{}
+
+		for _, v := range list {
+			if v != newElement {
+				newList = append(newList, v)
+			}
+		}
+
+		list = newList
+	}
+
+	newBytes, err := json.Marshal(list)
+	if err != nil {
+		return "", false, errors.Wrap(err, "failed to marshal annotation list")
+	}
+
+	return string(newBytes), true, nil
+}
+
+func ClearLocalNodeAnnotation(
+	ctx context.Context,
+	client kubernetes.Interface,
+	annotationKey string,
+) error {
+	node, err := GetLocalNode(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if node.Annotations == nil {
+		return nil
+	}
+
+	if _, exists := node.Annotations[annotationKey]; !exists {
+		return nil
+	}
+
+	delete(node.Annotations, annotationKey)
+
+	updateErr := wait.PollUntilContextTimeout(ctx, PollInterval, PollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+		if err != nil {
+			logger.Warningf("Error clearing node annotation %v — retrying: %v", annotationKey, err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if updateErr != nil {
+		return errors.Wrapf(updateErr, "failed to clear annotation %v after retries", annotationKey)
+	}
+
+	logger.Infof("Cleared node annotation[%v] successfully", annotationKey)
+
+	return nil
 }

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -19,15 +19,19 @@ limitations under the License.
 package ovn
 
 import (
+	"context"
 	"os"
 	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 )
+
+const ovnNodeDontSNATSubnets = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
 
 func (ovn *Handler) cleanupGatewayDataplane() error {
 	currentRemoteSubnets, err := ovn.getExistingIPv4RuleSubnets()
@@ -166,6 +170,13 @@ func (ovn *Handler) setupForwardingIptables() error {
 }
 
 func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
+	// to prevent SNAT by OVNK (with nftables) subnet should added to node annotation
+	err := nodeutil.ModifyLocalNodeAnnotationList(context.Background(),
+		ovn.K8sClient, ovnNodeDontSNATSubnets, subnet, add, nodeutil.JSONListAnnotationModifier)
+	if err != nil {
+		return errors.Wrapf(err, "error adding subnet %v to nodes annotation[%v]", subnet, ovnNodeDontSNATSubnets)
+	}
+
 	rules := []packetfilter.Rule{
 		{
 			DestCIDR: subnet,

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -19,7 +19,10 @@ limitations under the License.
 package ovn
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
+	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn/vsctl"
@@ -82,6 +85,8 @@ func (ovn *Handler) Uninstall() error {
 			constants.SmPostRoutingChain)
 	}
 
+	// TODO: delete only subnets added by Submariner
+	nodeutil.ClearLocalNodeAnnotation(context.Background(), ovn.K8sClient, ovnNodeDontSNATSubnets)
 	return nil
 }
 


### PR DESCRIPTION
After OVN transition from iptables to nftables
the source IP of inter-cluster traffic is SNATed.

This PR adds remote subnets to node annotation, OVNK should read these annotations and exclude traffic from these source IP ranges from SNAT.

Depends on: ovn-kubernetes/ovn-kubernetes#5113
Depends on: https://github.com/submariner-io/submariner-operator/pull/3487
Fixes: #3307

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
