### PR TITLE
Annotate remote subnets to prevent SNAT by OVNK

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -42,11 +42,17 @@ var (
 	PollInterval = time.Second
 )
 
-func GetLocalNode(ctx context.Context, clientset kubernetes.Interface) (*v1.Node, error) {
+func GetLocalNodeName() string {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
 	if !ok {
-		return nil, errors.New("error reading the NODE_NAME from the environment")
+		panic("Error reading the NODE_NAME from the environment")
 	}
+
+	return nodeName
+}
+
+func GetLocalNode(ctx context.Context, clientset kubernetes.Interface) (*v1.Node, error) {
+	nodeName := GetLocalNodeName()
 
 	var node *v1.Node
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -71,9 +71,10 @@ var _ = Describe("GetLocalNode", func() {
 			os.Unsetenv("NODE_NAME")
 		})
 
-		It("should return an error", func() {
-			_, err := node.GetLocalNode(context.TODO(), t.client)
-			Expect(err).To(HaveOccurred())
+		It("should panic", func() {
+			Expect(func() {
+				_, _ = node.GetLocalNode(context.TODO(), t.client)
+			}).To(Panic())
 		})
 	})
 })

--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -21,16 +21,17 @@ package ovn
 import "time"
 
 const (
-	ovnK8sSubmarinerInterface     = "ovn-k8s-sub0"
-	ovnK8sSubmarinerBridge        = "br-submariner"
-	ovsDBTimeout                  = 20 * time.Second
-	ovnCert                       = "secret://openshift-ovn-kubernetes/ovn-cert/tls.crt"
-	ovnPrivKey                    = "secret://openshift-ovn-kubernetes/ovn-cert/tls.key"
-	ovnCABundle                   = "configmap://openshift-ovn-kubernetes/ovn-ca/ca-bundle.crt"
-	ovnKubeService                = "ovnkube-db"
-	defaultOVNUnixSocket          = "unix:/var/run/openvswitch/ovnnb_db.sock"
-	defaultOVNOpenshiftUnixSocket = "unix:/var/run/ovn-ic/ovnnb_db.sock"
-	ovnNBDBDefaultPort            = 6641
-	defaultOpenshiftOVNNBDB       = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
-	ovnPodLabel                   = "app=ovnkube-node"
+	ovnK8sSubmarinerInterface        = "ovn-k8s-sub0"
+	ovnK8sSubmarinerBridge           = "br-submariner"
+	ovsDBTimeout                     = 20 * time.Second
+	ovnCert                          = "secret://openshift-ovn-kubernetes/ovn-cert/tls.crt"
+	ovnPrivKey                       = "secret://openshift-ovn-kubernetes/ovn-cert/tls.key"
+	ovnCABundle                      = "configmap://openshift-ovn-kubernetes/ovn-ca/ca-bundle.crt"
+	ovnKubeService                   = "ovnkube-db"
+	defaultOVNUnixSocket             = "unix:/var/run/openvswitch/ovnnb_db.sock"
+	defaultOVNOpenshiftUnixSocket    = "unix:/var/run/ovn-ic/ovnnb_db.sock"
+	ovnNBDBDefaultPort               = 6641
+	defaultOpenshiftOVNNBDB          = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
+	ovnPodLabel                      = "app=ovnkube-node"
+	OVNKSNATExcludeSubnetsAnnotation = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
 )

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -160,6 +160,8 @@ var _ = Describe("Handler", func() {
 					t.pFilter.AwaitRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"DestCIDR\":%q", s))
 				}
 
+				t.awaitOVNKNodeAnnotationContaining(endpoint.Spec.Subnets...)
+
 				By("Updating remote Endpoint")
 
 				oldSubnets := endpoint.Spec.Subnets
@@ -187,6 +189,10 @@ var _ = Describe("Handler", func() {
 					t.pFilter.AwaitNoRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"SrcCIDR\":%q", s))
 					t.pFilter.AwaitNoRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"DestCIDR\":%q", s))
 				}
+
+				// Since we updated the subnets above, the original second one will remain b/c the annotation isn't currently
+				// updated on an Endpoint update.
+				t.awaitOVNKNodeAnnotationContaining("192.0.2.0/24")
 			})
 		})
 	})
@@ -204,6 +210,8 @@ var _ = Describe("Handler", func() {
 				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
 			}
 
+			t.awaitOVNKNodeAnnotationContaining(endpoint.Spec.Subnets...)
+
 			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
 
 			By("Deleting local gateway Endpoint")
@@ -214,6 +222,8 @@ var _ = Describe("Handler", func() {
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
 			}
+
+			t.awaitOVNKNodeAnnotationContaining()
 
 			t.netLink.AwaitNoGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
 		})

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
@@ -69,9 +69,9 @@ var _ = Describe("TransitSwitchIP", func() {
 			})
 		})
 
-		When("the local node isn't found due to missing NODE_NAME env var", func() {
+		When("the local node isn't found", func() {
 			JustBeforeEach(func() {
-				os.Unsetenv("NODE_NAME")
+				os.Setenv("NODE_NAME", "bogus")
 			})
 
 			It("should fail", func() {


### PR DESCRIPTION
After OVN transition from iptables to nftables the source IP of inter-cluster traffic is SNATed.

This PR adds remote subnets to node annotation, OVNK should read these annotations and exclude traffic from these source IP ranges from SNAT.

Fixes https://github.com/submariner-io/submariner/issues/3307
