### PR TITLE
Fix incorrect IP returned for private ip for OVN IPV6

### DIFF
--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -116,6 +116,12 @@ var _ = Describe("GetLocalSpec", func() {
 
 		Expect(netLink.RouteAdd(&netlink.Route{
 			LinkIndex: 2,
+			Src:       net.ParseIP("fd69::2"),
+			Gw:        net.ParseIP("2001:0:0:0::"),
+		})).To(Succeed())
+
+		Expect(netLink.RouteAdd(&netlink.Route{
+			LinkIndex: 2,
 			Src:       net.ParseIP(ipv6LocalIP),
 			Gw:        net.ParseIP("2001:0:0:0::"),
 		})).To(Succeed())

--- a/pkg/endpoint/local_ip.go
+++ b/pkg/endpoint/local_ip.go
@@ -44,8 +44,16 @@ func getLocalIPFromRoutes(family k8snet.IPFamily) (string, error) {
 	}
 
 	for i := range routes {
-		if routes[i].Gw != nil {
-			return routes[i].Src.String(), nil
+		if routes[i].Gw != nil && routes[i].Src != nil {
+			// OVNK configures special internal masquerade IPs,
+			// these IPs are used internally by OVNK infra dataplane, and they should
+			// not be selected as private IPs.
+			ip := routes[i].Src
+			if family == k8snet.IPv6 && !isValidGlobalIPv6(ip) {
+				continue
+			}
+
+			return ip.String(), nil
 		}
 	}
 
@@ -53,12 +61,24 @@ func getLocalIPFromRoutes(family k8snet.IPFamily) (string, error) {
 }
 
 func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
-	conn, err := Dial("udp"+string(family), "["+dst+"]:53")
+	conn, err := Dial("udp"+string(family), net.JoinHostPort(dst, "53"))
 	if err == nil {
 		defer conn.Close()
 		localAddr := conn.LocalAddr().(*net.UDPAddr)
 
-		return localAddr.IP.String()
+		if family == k8snet.IPv4 || isValidGlobalIPv6(localAddr.IP) {
+			return localAddr.IP.String()
+		}
+
+		logger.Warningf("IP %q returned from Dial isn't usable - trying to find another IP from the same interface", localAddr.IP)
+
+		// Try to find a valid global-scope IP from the same interface
+		ifaceIP, err := getValidGlobalIPv6FromSameInterface(localAddr.IP)
+		if err == nil {
+			return ifaceIP
+		} else {
+			logger.Warningf("Failed to retrieve valid IPv6 address for %q: %v", localAddr.IP, err)
+		}
 	}
 
 	// connection failed try fallback method
@@ -66,6 +86,74 @@ func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
 	logger.FatalOnError(err, fmt.Sprintf("Error getting local IPv%v", family))
 
 	return localIP
+}
+
+func isValidGlobalIPv6(ip net.IP) bool {
+	// fd00::/8 - avoid locally assigned ULA
+	if ip.To16() == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip[0] == 0xfd {
+		return false
+	}
+	// Accept fc00::/8 or global unicast (2000::/3)
+	return ip[0] == 0xfc || (ip[0]&0xe0 == 0x20)
+}
+
+func getValidGlobalIPv6FromSameInterface(ip net.IP) (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to list interfaces")
+	}
+	var (
+		ownedIfaceName  string
+		ownedIfaceAddrs []net.Addr
+	)
+
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			logger.Warningf("Failed to list the address from the interface %v", iface.Name)
+			continue
+		}
+
+		// Confirm this interface owns the original (non-global) IP
+		ownsIP := false
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok || ipNet.IP.To4() != nil {
+				continue
+			}
+
+			if ipNet.Contains(ip) {
+				ownsIP = true
+				break
+			}
+		}
+
+		if ownsIP {
+			ownedIfaceName = iface.Name
+			ownedIfaceAddrs = addrs
+
+			break
+		}
+	}
+
+	if len(ownedIfaceAddrs) == 0 {
+		return "", fmt.Errorf("no interface for IP %q was found", ip)
+	}
+	// Scan for a valid global IPv6 on the same interface
+	for _, addr := range ownedIfaceAddrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+
+		if isValidGlobalIPv6(ipNet.IP) {
+			return ipNet.IP.String(), nil
+		}
+	}
+
+	return "", fmt.Errorf("no valid global IPv6 found on interface %q for IP %q", ownedIfaceName, ip)
 }
 
 func GetLocalIP(family k8snet.IPFamily) string {


### PR DESCRIPTION
With OVN-Kubenetenes CNI for IPV6 private ip instead of global ip of the interface a wrong ip is returned for an. This change checks if the ip is a valid global ip if not tries to find one

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
