### PR TITLE
Automated backport of #3462: Annotate remote subnets to prevent SNAT by OVNK

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -42,11 +42,17 @@ var (
 	PollInterval = time.Second
 )
 
-func GetLocalNode(ctx context.Context, clientset kubernetes.Interface) (*v1.Node, error) {
+func GetLocalNodeName() string {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
 	if !ok {
-		return nil, errors.New("error reading the NODE_NAME from the environment")
+		panic("Error reading the NODE_NAME from the environment")
 	}
+
+	return nodeName
+}
+
+func GetLocalNode(ctx context.Context, clientset kubernetes.Interface) (*v1.Node, error) {
+	nodeName := GetLocalNodeName()
 
 	var node *v1.Node
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -71,9 +71,10 @@ var _ = Describe("GetLocalNode", func() {
 			os.Unsetenv("NODE_NAME")
 		})
 
-		It("should return an error", func() {
-			_, err := node.GetLocalNode(context.TODO(), t.client)
-			Expect(err).To(HaveOccurred())
+		It("should panic", func() {
+			Expect(func() {
+				_, _ = node.GetLocalNode(context.TODO(), t.client)
+			}).To(Panic())
 		})
 	})
 })

--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -21,16 +21,17 @@ package ovn
 import "time"
 
 const (
-	ovnK8sSubmarinerInterface     = "ovn-k8s-sub0"
-	ovnK8sSubmarinerBridge        = "br-submariner"
-	ovsDBTimeout                  = 20 * time.Second
-	ovnCert                       = "secret://openshift-ovn-kubernetes/ovn-cert/tls.crt"
-	ovnPrivKey                    = "secret://openshift-ovn-kubernetes/ovn-cert/tls.key"
-	ovnCABundle                   = "configmap://openshift-ovn-kubernetes/ovn-ca/ca-bundle.crt"
-	ovnKubeService                = "ovnkube-db"
-	defaultOVNUnixSocket          = "unix:/var/run/openvswitch/ovnnb_db.sock"
-	defaultOVNOpenshiftUnixSocket = "unix:/var/run/ovn-ic/ovnnb_db.sock"
-	ovnNBDBDefaultPort            = 6641
-	defaultOpenshiftOVNNBDB       = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
-	ovnPodLabel                   = "app=ovnkube-node"
+	ovnK8sSubmarinerInterface        = "ovn-k8s-sub0"
+	ovnK8sSubmarinerBridge           = "br-submariner"
+	ovsDBTimeout                     = 20 * time.Second
+	ovnCert                          = "secret://openshift-ovn-kubernetes/ovn-cert/tls.crt"
+	ovnPrivKey                       = "secret://openshift-ovn-kubernetes/ovn-cert/tls.key"
+	ovnCABundle                      = "configmap://openshift-ovn-kubernetes/ovn-ca/ca-bundle.crt"
+	ovnKubeService                   = "ovnkube-db"
+	defaultOVNUnixSocket             = "unix:/var/run/openvswitch/ovnnb_db.sock"
+	defaultOVNOpenshiftUnixSocket    = "unix:/var/run/ovn-ic/ovnnb_db.sock"
+	ovnNBDBDefaultPort               = 6641
+	defaultOpenshiftOVNNBDB          = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
+	ovnPodLabel                      = "app=ovnkube-node"
+	OVNKSNATExcludeSubnetsAnnotation = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
 )

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
@@ -176,10 +177,8 @@ func (ovn *Handler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 	}
 
 	if ovn.State().IsOnGateway() {
-		for _, subnet := range endpoint.Spec.Subnets {
-			if err = ovn.addNoMasqueradeIPTables(subnet); err != nil {
-				return errors.Wrapf(err, "error adding no-masquerade rules for subnet %q", subnet)
-			}
+		if err = ovn.processEndpointSubnets(true, *endpoint); err != nil {
+			return errors.Wrapf(err, "error processing created Endpoint %s", resource.ToJSON(endpoint))
 		}
 
 		return ovn.updateGatewayDataplane()
@@ -214,10 +213,8 @@ func (ovn *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	}
 
 	if ovn.State().IsOnGateway() {
-		for _, subnet := range endpoint.Spec.Subnets {
-			if err = ovn.removeNoMasqueradeIPTables(subnet); err != nil {
-				return errors.Wrapf(err, "error removing no-masquerade rules for subnet %q", subnet)
-			}
+		if err = ovn.processEndpointSubnets(false, *endpoint); err != nil {
+			return errors.Wrapf(err, "error processing removed Endpoint %s", resource.ToJSON(endpoint))
 		}
 
 		return ovn.updateGatewayDataplane()
@@ -227,26 +224,16 @@ func (ovn *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (ovn *Handler) TransitionToNonGateway() error {
-	endpoints := ovn.State().GetRemoteEndpoints()
-	for i := range endpoints {
-		for _, subnet := range endpoints[i].Spec.Subnets {
-			if err := ovn.removeNoMasqueradeIPTables(subnet); err != nil {
-				return errors.Wrapf(err, "error removing no-masquerade rules for subnet %q", subnet)
-			}
-		}
+	if err := ovn.processEndpointSubnets(false, ovn.State().GetRemoteEndpoints()...); err != nil {
+		return errors.Wrapf(err, "error processing Endpoints on non-gateway transiton")
 	}
 
 	return ovn.cleanupGatewayDataplane()
 }
 
 func (ovn *Handler) TransitionToGateway() error {
-	endpoints := ovn.State().GetRemoteEndpoints()
-	for i := range endpoints {
-		for _, subnet := range endpoints[i].Spec.Subnets {
-			if err := ovn.addNoMasqueradeIPTables(subnet); err != nil {
-				return errors.Wrapf(err, "error adding no-masquerade rules for subnet %q", subnet)
-			}
-		}
+	if err := ovn.processEndpointSubnets(true, ovn.State().GetRemoteEndpoints()...); err != nil {
+		return errors.Wrapf(err, "error processing Endpoints on gateway transiton")
 	}
 
 	return ovn.updateGatewayDataplane()

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -159,6 +159,8 @@ var _ = Describe("Handler", func() {
 					t.pFilter.AwaitRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"DestCIDR\":%q", s))
 				}
 
+				t.awaitOVNKNodeAnnotationContaining(endpoint.Spec.Subnets...)
+
 				By("Updating remote Endpoint")
 
 				oldSubnets := endpoint.Spec.Subnets
@@ -186,6 +188,10 @@ var _ = Describe("Handler", func() {
 					t.pFilter.AwaitNoRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"SrcCIDR\":%q", s))
 					t.pFilter.AwaitNoRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"DestCIDR\":%q", s))
 				}
+
+				// Since we updated the subnets above, the original second one will remain b/c the annotation isn't currently
+				// updated on an Endpoint update.
+				t.awaitOVNKNodeAnnotationContaining("192.0.2.0/24")
 			})
 		})
 	})
@@ -203,6 +209,8 @@ var _ = Describe("Handler", func() {
 				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
 			}
 
+			t.awaitOVNKNodeAnnotationContaining(endpoint.Spec.Subnets...)
+
 			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
 
 			By("Deleting local gateway Endpoint")
@@ -213,6 +221,8 @@ var _ = Describe("Handler", func() {
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, clusterCIDR)
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, serviceCIDR)
 			}
+
+			t.awaitOVNKNodeAnnotationContaining()
 
 			t.netLink.AwaitNoGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, OVNK8sMgmntIntGw)
 		})

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -23,7 +23,9 @@ import (
 	"encoding/json"
 	"net"
 	"os"
+	"sort"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +36,7 @@ import (
 	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn"
@@ -128,6 +131,29 @@ func (t *testDriver) createNode() *corev1.Node {
 	return createNode(t.k8sClient, t.transitSwitchIP)
 }
 
+func (t *testDriver) awaitOVNKNodeAnnotationContaining(expected ...string) {
+	if expected == nil {
+		expected = []string{}
+	}
+
+	Eventually(func(g Gomega) {
+		node, err := t.k8sClient.CoreV1().Nodes().Get(context.TODO(), nodeutil.GetLocalNodeName(), metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		var actual []string
+
+		if node.Annotations[ovn.OVNKSNATExcludeSubnetsAnnotation] != "" {
+			err = json.Unmarshal([]byte(node.Annotations[ovn.OVNKSNATExcludeSubnetsAnnotation]), &actual)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		sort.Strings(expected)
+		sort.Strings(actual)
+
+		g.Expect(actual).To(Equal(expected))
+	}).Within(3 * time.Second).Should(Succeed())
+}
+
 func createNode(k8sClient kubernetes.Interface, transitSwitchIP string) *corev1.Node {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,6 +169,9 @@ func createNode(k8sClient kubernetes.Interface, transitSwitchIP string) *corev1.
 	Expect(err).To(Succeed())
 
 	os.Setenv("NODE_NAME", node.Name)
+
+	nodeutil.PollTimeout = 100 * time.Millisecond
+	nodeutil.PollInterval = 10 * time.Millisecond
 
 	return node
 }

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
@@ -69,9 +69,9 @@ var _ = Describe("TransitSwitchIP", func() {
 			})
 		})
 
-		When("the local node isn't found due to missing NODE_NAME env var", func() {
+		When("the local node isn't found", func() {
 			JustBeforeEach(func() {
-				os.Unsetenv("NODE_NAME")
+				os.Setenv("NODE_NAME", "bogus")
 			})
 
 			It("should fail", func() {

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -19,11 +19,17 @@ limitations under the License.
 package ovn
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/util"
+	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/ovn/vsctl"
 	"github.com/vishvananda/netlink"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (ovn *Handler) Stop() error {
@@ -80,6 +86,16 @@ func (ovn *Handler) Uninstall() error {
 	}); err != nil {
 		logger.Errorf(err, "DeleteIPHookChain %s returned error",
 			constants.SmPostRoutingChain)
+	}
+
+	err = util.Update[*corev1.Node](context.TODO(), ovn.nodeResourceInterface(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeutil.GetLocalNodeName()},
+	}, func(existing *corev1.Node) (*corev1.Node, error) {
+		delete(existing.Annotations, OVNKSNATExcludeSubnetsAnnotation)
+		return existing, nil
+	})
+	if err != nil {
+		logger.Errorf(err, "Error removing node annotation %q", OVNKSNATExcludeSubnetsAnnotation)
 	}
 
 	return nil


### PR DESCRIPTION
Backport of #3462 on release-0.20.

#3462: Annotate remote subnets to prevent SNAT by OVNK

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.