### PR TITLE
Use IPv6 private address for endpoint cable name in IPv6 cluster

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -183,8 +183,16 @@ func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, 
 		endpointSpec.SetPrivateIP(GetLocalIP(family))
 	}
 
-	endpointSpec.CableName = fmt.Sprintf("submariner-cable-%s-%s", submSpec.ClusterID,
-		strings.ReplaceAll(endpointSpec.GetPrivateIP(k8snet.IPv4), ".", "-"))
+	var replacedIP string
+
+	if ip := endpointSpec.GetPrivateIP(k8snet.IPv4); ip != "" {
+		replacedIP = strings.ReplaceAll(ip, ".", "-")
+	} else {
+		ip := endpointSpec.GetPrivateIP(k8snet.IPv6)
+		replacedIP = strings.ReplaceAll(ip, ":", "-")
+	}
+
+	endpointSpec.CableName = fmt.Sprintf("submariner-cable-%s-%s", submSpec.ClusterID, replacedIP)
 
 	for _, family := range submSpec.GetIPFamilies() {
 		publicIP, resolver, err := GetPublicIP(family, submSpec, k8sClient, backendConfig, airGappedDeployment)


### PR DESCRIPTION
Currently, endpoint's cable name is generated using IPv4 private IP. This PR updates the logic to fallback to the IPv6 private IP if no IPv4 address is available.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
