### PR TITLE
Switch to libreswan-minimal in the gateway

### DIFF
--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -24,7 +24,7 @@ COPY package/dnf_install /
 # kmod is required so that libreswan can load modules
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/gateway \
     glibc bash glibc-minimal-langpack coreutils-single \
-    libcurl-minimal iproute libreswan kmod \
+    libcurl-minimal iproute libreswan-minimal kmod \
     openssl nss-tools
 
 FROM scratch

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH=devel
-ARG FEDORA_VERSION=42
+ARG FEDORA_VERSION=43
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH=devel
-ARG FEDORA_VERSION=42
+ARG FEDORA_VERSION=43
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -1,5 +1,5 @@
 ARG BASE_BRANCH=devel
-ARG FEDORA_VERSION=42
+ARG FEDORA_VERSION=43
 ARG SOURCE=/go/src/github.com/submariner-io/submariner
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder


### PR DESCRIPTION
This reduces the image size (211MiB instead of 234MiB) and drops all the systemd dependencies.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images from Fedora 42 to Fedora 43 for gateway, globalnet, and route-agent services.
  * Reduced gateway runtime footprint by switching to a minimal VPN package and adjusting base runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->