### PR TITLE
Automated backport of #3491: Use named Kubernetes versions in GHAs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.28']
+        k8s_version: ['k8s-latest']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
@@ -56,12 +56,11 @@ jobs:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet
           # Oldest Kubernetes version thought to work with SubM.
-          # This should match minK8sMajor.minK8sMinor in subctl/pkg/version/version.go.
           # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/
-          - k8s_version: '1.19'
+          - k8s_version: 'k8s-oldest-working'
           # Test top and bottom of supported K8s version range
-          - k8s_version: '1.26'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -20,13 +20,13 @@ jobs:
         extra-toggles: ['', 'ovn']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.28']
+        k8s_version: ['k8s-latest']
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
         include:
           # Test top and bottom of supported K8s version range
-          - k8s_version: '1.26'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Backport of #3491 on release-0.17.

#3491: Use named Kubernetes versions in GHAs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.