### PR TITLE
Add local cluster CIDR to exclude SNAT list

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	k8snet "k8s.io/utils/net"
 )
 
@@ -291,6 +292,19 @@ func (ovn *Handler) processEndpointSubnets(add bool, endpoints ...submarinerv1.E
 			}
 
 			allSubnets = append(allSubnets, subnet)
+		}
+	}
+
+	// for GlobalNet case, add IPv4 cluster CIDRs to avoid SNAT annotation list
+	localSubnetsSet := sets.NewString(ovn.localSubnets...)
+
+	for _, cidr := range ovn.HandlerConfig.ClusterCIDR {
+		if k8snet.IPFamilyOfCIDRString(cidr) != k8snet.IPv4 {
+			continue
+		}
+
+		if !localSubnetsSet.Has(cidr) {
+			allSubnets = append(allSubnets, cidr)
 		}
 	}
 

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -68,6 +68,7 @@ type Handler struct {
 	nonGatewayRouteController *NonGatewayRouteController
 	stopCh                    chan struct{}
 	ipFamily                  k8snet.IPFamily
+	localSubnets              []string
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("OVN")}
@@ -151,6 +152,8 @@ func (ovn *Handler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 	var err error
 
 	interfaceName := endpoint.Spec.BackendConfig[cable.InterfaceNameConfig]
+	ovn.localSubnets = endpoint.Spec.Subnets
+
 	if interfaceName != "" {
 		// NOTE: This assumes that LocalEndpointCreated happens before than TransitionToGatewayNode
 		intf, err := net.InterfaceByName(interfaceName)

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 )
@@ -79,12 +80,12 @@ var _ = Describe("Handler", func() {
 			t.clusterCIDR = ipv4ClusterCIDR
 			t.serviceCIDR = ipv4serviceCIDR
 			t.OVNK8sMgmntIntGw = ipv4OVNK8sMgmntIntGw
+			t.localSubnets = []string{ipv4ClusterCIDR}
 		} else {
 			t.clusterCIDR = ipv6ClusterCIDR
 			t.serviceCIDR = ipv6serviceCIDR
 			t.OVNK8sMgmntIntGw = ipv6OVNK8sMgmntIntGw
 		}
-
 		_, err := t.k8sClient.CoreV1().Pods(testing.Namespace).Create(context.Background(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "ovn-pod",
@@ -208,6 +209,7 @@ type handlerTestDriver struct {
 	serviceCIDR      string
 	OVNK8sMgmntIntGw string
 	ovsdbClient      *fakeovn.OVSDBClient
+	localSubnets     []string
 }
 
 func (t *handlerTestDriver) Start(handler event.Handler) {
@@ -290,7 +292,13 @@ func (t *handlerTestDriver) testRemoteEndpoint(ipFamilySubnets, nonIPFamilySubne
 					t.pFilter.AwaitRule(packetfilter.TableTypeNAT, constants.SmPostRoutingChain, ContainSubstring("\"DestCIDR\":%q", s))
 				}
 
-				t.awaitOVNKNodeAnnotationContaining(endpointSubnets...)
+				s := sets.NewString(endpointSubnets...)
+				if t.ipFamily == k8snet.IPv4 {
+					s.Insert(t.localSubnets...)
+				}
+
+				uniqueSubnets := s.List()
+				t.awaitOVNKNodeAnnotationContaining(uniqueSubnets...)
 
 				By("Updating remote Endpoint")
 
@@ -350,7 +358,14 @@ func (t *handlerTestDriver) testGatewayTransitions(ipFamilySubnets, nonIPFamilyS
 				t.netLink.EnsureNoRule(constants.RouteAgentInterClusterNetworkTableID, s, t.clusterCIDR)
 			}
 
-			t.awaitOVNKNodeAnnotationContaining(ipFamilySubnets...)
+			s := sets.NewString(ipFamilySubnets...)
+			if t.ipFamily == k8snet.IPv4 {
+				s.Insert(t.localSubnets...)
+			}
+
+			uniqueSubnets := s.List()
+
+			t.awaitOVNKNodeAnnotationContaining(uniqueSubnets...)
 
 			t.netLink.AwaitGwRoutes(0, constants.RouteAgentInterClusterNetworkTableID, t.OVNK8sMgmntIntGw)
 


### PR DESCRIPTION
Datapath E2E tests fail when Submariner GlobalNet is deployed on environment using latest OVN-K sources.
The root cause appears to be related to OVN-K applying SNAT on egress traffic on the gateway node, which interferes for some reason with Submariner-configured SNAT to GlobalNet IPs.

This patch adds the local IPv4 CIDR to the OVN-K node-ingress-snat-exclude-subnets annotation on the gateway node, effectively bypassing OVN-K’s SNAT for this traffic and allowing Submariner’s SNAT rules to take effect as intended.