### PR TITLE
Address SNAT-related issues in nftables mode with kube-proxy

### DIFF
--- a/pkg/packetfilter/fake/driver.go
+++ b/pkg/packetfilter/fake/driver.go
@@ -34,6 +34,10 @@ type driverImpl struct {
 	family  k8snet.IPFamily
 }
 
+func (d *driverImpl) SelfSNAT(table packetfilter.TableType, chain, sourceCIDR string) error {
+	return nil
+}
+
 func (d *driverImpl) GetMSSClampTypes() (packetfilter.TableType, packetfilter.ChainType) {
 	return d.pfilter.GetMSSClampTypes()
 }

--- a/pkg/packetfilter/iptables/iptables.go
+++ b/pkg/packetfilter/iptables/iptables.go
@@ -98,6 +98,10 @@ func New(family k8snet.IPFamily) (packetfilter.Driver, error) {
 	}, nil
 }
 
+func (p *packetFilter) SelfSNAT(table packetfilter.TableType, chain, sourceCIDR string) error {
+	return nil
+}
+
 func (p *packetFilter) GetMSSClampTypes() (packetfilter.TableType, packetfilter.ChainType) {
 	return packetfilter.TableTypeRoute, packetfilter.ChainTypeRoute
 }

--- a/pkg/packetfilter/nftables/nftables.go
+++ b/pkg/packetfilter/nftables/nftables.go
@@ -95,6 +95,16 @@ func NewWithNft(nft knftables.Interface, family k8snet.IPFamily) packetfilter.Dr
 	}
 }
 
+func (p *packetFilter) SelfSNAT(table packetfilter.TableType, chain, sourceCIDR string) error {
+	ruleSpec := packetfilter.Rule{
+		SrcCIDR:  sourceCIDR,
+		SnatCIDR: "ip saddr", // self SNAT
+		Action:   packetfilter.RuleActionSNAT,
+	}
+
+	return p.AppendUnique(table, chain, &ruleSpec)
+}
+
 func (p *packetFilter) GetMSSClampTypes() (packetfilter.TableType, packetfilter.ChainType) {
 	return packetfilter.TableTypeFilter, packetfilter.ChainTypeFilter
 }
@@ -131,6 +141,8 @@ func (p *packetFilter) CreateIPHookChainIfNotExists(chain *packetfilter.ChainIPH
 
 	if chain.Priority == packetfilter.ChainPriorityFirst {
 		chainPriority += "-10"
+	} else if chain.Priority == packetfilter.ChainPriorityMiddle {
+		chainPriority += "-5"
 	}
 
 	tx.Add(&knftables.Chain{

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -161,6 +161,7 @@ type ChainPriority uint32
 
 const (
 	ChainPriorityFirst ChainPriority = iota
+	ChainPriorityMiddle
 	ChainPriorityLast
 )
 
@@ -168,6 +169,8 @@ func (c ChainPriority) String() string {
 	switch c {
 	case ChainPriorityFirst:
 		return "First"
+	case ChainPriorityMiddle:
+		return "Middle"
 	case ChainPriorityLast:
 		return "Last"
 	}
@@ -296,6 +299,9 @@ type Driver interface {
 	// named Sets.
 	NewNamedSet(set *SetInfo) NamedSet
 	DestroySets(nameFilter func(string) bool) error
+
+	// SNAT to the packet's source IP address (applicable only when using nftables)
+	SelfSNAT(table TableType, chain, sourceCIDR string) error
 }
 
 type Interface interface {

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	SmPostRoutingMssChain = "SUBMARINER-POSTROUTING-MSS"
 	SmInputChain          = "SUBMARINER-INPUT"
 	SmForwardChain        = "SUBMARINER-FORWARD"
+	SmSelfSnatChain       = "SUBMARINER-SELF-SNAT-WA"
 	PostRoutingChain      = "POSTROUTING"
 	InputChain            = "INPUT"
 	ForwardChain          = "FORWARD"

--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_handler.go
@@ -25,6 +25,8 @@ import (
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/vxlan"
 	k8snet "k8s.io/utils/net"
 )
@@ -68,9 +70,14 @@ func (kp *SyncHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
 		if err != nil {
 			return errors.Wrap(err, "error while reconciling routes")
 		}
+
 	} else {
 		// Store local endpoint's private IP to use as the source address for the IPv6 VxLAN interface on GW.
 		kp.vxlanGwIP = &localClusterGwNodeIP
+	}
+
+	if err := kp.pFilter.SelfSNAT(packetfilter.TableTypeNAT, constants.SmSelfSnatChain, kp.localClusterCidr[0]); err != nil {
+		return errors.Wrapf(err, "error creating SelfSNAT rule for %v", kp.localClusterCidr[0])
 	}
 
 	return nil

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"time"
 
 	"github.com/pkg/errors"
@@ -165,6 +166,9 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 		logger.Errorf(err, "Error discovering the CNI interface")
 	}
 
+	// workaround to avoid ingress SNAT by kube-proxy nftables
+	go flushKubeProxyNatPostroutingPeriodically(context.TODO())
+
 	// Create the necessary IPTable chains in the filter and nat tables.
 	err = kp.createPFilterChains()
 	if err != nil {
@@ -172,4 +176,23 @@ func (kp *SyncHandler) Init(_ context.Context) error {
 	}
 
 	return nil
+}
+
+func flushKubeProxyNatPostroutingPeriodically(ctx context.Context) {
+	ticker := time.NewTicker(2 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cmd := exec.Command("/sbin/nft", "flush", "chain", "ip", "kube-proxy", "nat-postrouting")
+			output, err := cmd.CombinedOutput()
+
+			if err != nil {
+				logger.Errorf(err, "Error flushing kube-proxy nat-postrouting chain %s", output)
+			}
+		}
+	}
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/packetfilter_iface.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/packetfilter_iface.go
@@ -53,6 +53,12 @@ func (kp *SyncHandler) createPFilterChains() error {
 			Hook:     packetfilter.ChainHookForward,
 			Priority: packetfilter.ChainPriorityFirst,
 		},
+		{
+			Name:     constants.SmSelfSnatChain,
+			Type:     packetfilter.ChainTypeNAT,
+			Hook:     packetfilter.ChainHookPostrouting,
+			Priority: packetfilter.ChainPriorityMiddle,
+		},
 	}
 
 	for i := range ipHookChains {

--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -122,4 +122,23 @@ func (kp *SyncHandler) deleteIPTableChains() {
 		logger.Errorf(err, "Error deleting IPHook chain %q of %q table", constants.InputChain,
 			constants.FilterTable)
 	}
+
+	logger.Infof("Flushing packetfilter entries in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	if err := pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmSelfSnatChain); err != nil {
+		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmSelfSnatChain,
+			constants.NATTable)
+	}
+
+	chain = packetfilter.ChainIPHook{
+		Name:     constants.SmSelfSnatChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityMiddle,
+	}
+
+	if err := pFilter.DeleteIPHookChain(&chain); err != nil {
+		logger.Errorf(err, "Error deleting IPHook chain %q of %q table", constants.SmSelfSnatChain,
+			constants.NATTable)
+	}
 }


### PR DESCRIPTION
This PR introduces two changes to address SNAT-related issues with kube-proxy in nftables mode and KindNet:

**Avoiding KindNet Egress SNAT:**
Adds support for SelfSNAT in the kube-proxy handler to bypass KindNet's egress SNAT, which rewrites pod source IPs and breaks IPSec-based Submariner datapath on gateway nodes.

**Disabling Ingress SNAT by kube-proxy:**
Adds a workaround for kube-proxy in nftables mode by periodically flushing the relevant chain to prevent unintended ingress SNAT, which cannot be overridden via higher-priority rules.

Both changes aim to preserve the original pod source IP to maintain correct Submariner datapath behavior.

Fixes: https://github.com/submariner-io/submariner/issues/3541