### PR TITLE
Use non-root in Konflux images

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -65,6 +65,8 @@ RUN chown 0:0 /usr/local/bin/* && \
 
 COPY --from=builder ${SOURCE}/LICENSE /licenses/LICENSE
 
+USER 1001010000
+
 ENTRYPOINT ["/usr/local/bin/submariner.sh"]
 
 LABEL com.redhat.component="submariner-gateway-container" \

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -51,6 +51,8 @@ RUN chown 0:0 /usr/local/bin/* && \
 
 COPY --from=builder ${SOURCE}/LICENSE /licenses/LICENSE
 
+USER 1001010000
+
 ENTRYPOINT ["/usr/local/bin/submariner-globalnet.sh"]
 
 LABEL com.redhat.component="submariner-globalnet-container" \

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -44,6 +44,8 @@ RUN dnf -y update && \
     dnf -y install --nodocs iproute iptables-nft nftables ipset procps-ng openvswitch2.17 grep && \
     dnf clean all
 
+RUN adduser -r -l -u 1001010000 submariner
+
 WORKDIR /var/submariner
 
 COPY --from=builder \
@@ -60,6 +62,8 @@ RUN chown 0:0 /usr/local/bin/* && \
               /usr/local/bin/await-node-ready.sh
 
 COPY --from=builder ${SOURCE}/LICENSE /licenses/LICENSE
+
+USER 1001010000
 
 ENTRYPOINT ["/usr/local/bin/submariner-route-agent.sh"]
 


### PR DESCRIPTION
Fixes `ecosystem-cert-preflight-checks` errors.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
