### PR TITLE
Correct submariner-gateway Konflux build path

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -24,8 +24,7 @@ RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -X github.com/submariner-io/submariner/pkg/versions.version=${BASE_BRANCH} \
     -X github.com/submariner-io/submariner/pkg/versions.gitCommitHash=$(git rev-parse --short HEAD)" \
     -tags "${BUILD_TAGS}" \
-    -v -o ${SOURCE}/bin/${TARGETPLATFORM}/submariner-gateway \
-    ${SOURCE}/pkg/gateway
+    -v -o ${SOURCE}/bin/${TARGETPLATFORM}/submariner-gateway ${SOURCE}
 
 RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -ldflags "-s -w \


### PR DESCRIPTION
The Konflux build for submariner-gateway was failing because it was attempting to build a non-main package. The `go build` command was pointing to `pkg/gateway`, which is a library, instead of the project root where the `main.go` for the gateway is located.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
