### PR TITLE
Introduce avoid-SNAT handler for OVN and add nftables support alongside iptables

### DIFF
--- a/pkg/packetfilter/configure/configure.go
+++ b/pkg/packetfilter/configure/configure.go
@@ -54,6 +54,7 @@ func DriverFromConfigMap(cm *corev1.ConfigMap) error {
 	} else {
 		logger.Info("Using iptables packet filter driver")
 		packetfilter.SetNewDriverFn(iptables.New)
+		packetfilter.SetSecondaryDriverFn(nftables.New)
 	}
 
 	return nil

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -312,10 +312,17 @@ type Interface interface {
 
 type DriverFn func(family k8snet.IPFamily) (Driver, error)
 
-var newDriverFn DriverFn
+var (
+	newDriverFn       DriverFn
+	secondaryDriverFn DriverFn
+)
 
 func SetNewDriverFn(f DriverFn) {
 	newDriverFn = f
+}
+
+func SetSecondaryDriverFn(f DriverFn) {
+	secondaryDriverFn = f
 }
 
 func GetNewDriverFn() DriverFn {
@@ -327,11 +334,19 @@ type Adapter struct {
 }
 
 func New(family k8snet.IPFamily) (Interface, error) {
-	if newDriverFn == nil {
+	return newWithFn(family, newDriverFn)
+}
+
+func NewSecondary(family k8snet.IPFamily) (Interface, error) {
+	return newWithFn(family, secondaryDriverFn)
+}
+
+func newWithFn(family k8snet.IPFamily, fn DriverFn) (Interface, error) {
+	if fn == nil {
 		return nil, errors.New("no driver registered")
 	}
 
-	driver, err := newDriverFn(family)
+	driver, err := fn(family)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating packet filter Driver")
 	}

--- a/pkg/routeagent_driver/handlers/ovn/avoid_snat_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/avoid_snat_handler.go
@@ -1,0 +1,225 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/cni"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	k8snet "k8s.io/utils/net"
+)
+
+const (
+	RemoteCIDRIPSetIPv4 = "SUBMARINER-REMOTECIDRS"
+	LocalCIDRIPSetIPv4  = "SUBMARINER-LOCALCIDRS"
+	RemoteCIDRIPSetIPv6 = "SUBMARINER-REMOTECIDRS-V6"
+	LocalCIDRIPSetIPv6  = "SUBMARINER-LOCALCIDRS-V6"
+)
+
+type AvoidSNATHandler struct {
+	event.HandlerBase
+	ipFamily        k8snet.IPFamily
+	pFilter         packetfilter.Interface
+	remoteIPSet     packetfilter.NamedSet
+	localIPSet      packetfilter.NamedSet
+	localCIDRIPSet  string
+	remoteCIDRIPSet string
+}
+
+type noopAvoidSNATHandler struct {
+	event.HandlerBase
+}
+
+func (h *noopAvoidSNATHandler) GetName() string {
+	return "submariner-noop-avoid-snat-handler"
+}
+
+func (h *noopAvoidSNATHandler) GetNetworkPlugins() []string {
+	return []string{cni.OVNKubernetes}
+}
+
+func NewAvoidSNATHandler(ipFamily k8snet.IPFamily) event.Handler {
+	// if no secondary driver is defined (primary driver is nftables) or its IPv6 return noop handler
+	_, err := packetfilter.NewSecondary(ipFamily)
+	if err != nil || ipFamily != k8snet.IPv4 {
+		return &noopAvoidSNATHandler{}
+	}
+
+	h := &AvoidSNATHandler{
+		ipFamily:        ipFamily,
+		localCIDRIPSet:  LocalCIDRIPSetIPv4,
+		remoteCIDRIPSet: RemoteCIDRIPSetIPv4,
+	}
+
+	if ipFamily == k8snet.IPv6 {
+		h.localCIDRIPSet = LocalCIDRIPSetIPv6
+		h.remoteCIDRIPSet = RemoteCIDRIPSetIPv6
+	}
+
+	return h
+}
+
+func (h *AvoidSNATHandler) Init(_ context.Context) error {
+	logger.Info("Starting AvoidSNATHandler")
+
+	var err error
+
+	h.pFilter, err = packetfilter.NewSecondary(h.ipFamily)
+	if err != nil {
+		return errors.Wrap(err, "error initializing packetfilter")
+	}
+
+	if err := h.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
+		Name:     constants.SmSelfSnatChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityMiddle,
+	}); err != nil {
+		return errors.Wrapf(err, "error reating IPHookChain chain %s", constants.SmSelfSnatChain)
+	}
+
+	// when nftables is set as primary driver this call should move to LocalEndpointCreated.
+	return h.createSelfSNATRules()
+}
+
+func (h *AvoidSNATHandler) GetName() string {
+	return "submariner-avoid-snat-handler"
+}
+
+func (h *AvoidSNATHandler) GetNetworkPlugins() []string {
+	return []string{cni.OVNKubernetes}
+}
+
+func (h *AvoidSNATHandler) newNamedSetSet(key string) packetfilter.NamedSet {
+	return h.pFilter.NewNamedSet(&packetfilter.SetInfo{
+		Name: key,
+	})
+}
+
+func (h *AvoidSNATHandler) createSelfSNATRules() error {
+	// when nftables is set as primary driver , we can reuse sets created in MTUhandler.
+	h.remoteIPSet = h.newNamedSetSet(h.remoteCIDRIPSet)
+	if err := h.remoteIPSet.Create(true); err != nil {
+		return errors.Wrapf(err, "error creating ipset %q", h.remoteCIDRIPSet)
+	}
+
+	h.localIPSet = h.newNamedSetSet(h.localCIDRIPSet)
+	if err := h.localIPSet.Create(true); err != nil {
+		return errors.Wrapf(err, "error creating ipset %q", h.localCIDRIPSet)
+	}
+
+	logger.Info("Creating packetfilter self-snat rules")
+
+	ruleSpecIngress := packetfilter.Rule{
+		SrcSetName:  h.remoteCIDRIPSet,
+		DestSetName: h.localCIDRIPSet,
+		Action:      packetfilter.RuleActionSelfSNAT,
+	}
+
+	if err := h.pFilter.AppendUnique(packetfilter.TableTypeNAT, constants.SmSelfSnatChain, &ruleSpecIngress); err != nil {
+		return errors.Wrapf(err, "unable to append rule %+v", &ruleSpecIngress)
+	}
+
+	return nil
+}
+
+// when nftables is set as primary driver , we can remove these functions.
+func (h *AvoidSNATHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		err := h.localIPSet.AddEntry(subnet, true)
+		if err != nil {
+			return errors.Wrap(err, "error adding local IP set entry")
+		}
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		logError(h.localIPSet.DelEntry(subnet), "Error deleting the subnet %q from the local IPSet", subnet)
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		err := h.remoteIPSet.AddEntry(subnet, true)
+		if err != nil {
+			return errors.Wrap(err, "error adding remote IP set entry")
+		}
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		logError(h.remoteIPSet.DelEntry(subnet), "Error deleting the subnet %q from the remote IPSet", subnet)
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) Uninstall() error {
+	logger.Infof("Flushing packetfilter entry in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	if err := h.pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmSelfSnatChain); err != nil {
+		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmSelfSnatChain,
+			constants.NATTable)
+	}
+
+	logger.Infof("Deleting packetfilter entry in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	logError(h.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
+		Name:     constants.SmSelfSnatChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityMiddle,
+	}), "Error deleting IP hook chain %q of table type %q", constants.SmSelfSnatChain, packetfilter.ChainTypeNAT)
+
+	logger.Infof("Flushing packetfilter entries in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	logError(h.localIPSet.Flush(), "Error flushing ipset %q", h.localCIDRIPSet)
+
+	logError(h.localIPSet.Destroy(), "Error deleting ipset %q", h.localCIDRIPSet)
+
+	logError(h.remoteIPSet.Flush(), "Error flushing ipset %q", h.remoteCIDRIPSet)
+
+	logError(h.remoteIPSet.Destroy(), "Error deleting ipset %q", h.remoteCIDRIPSet)
+
+	return nil
+}
+
+func logError(err error, format string, args ...interface{}) {
+	if err != nil {
+		logger.Errorf(err, format, args...)
+	}
+}

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -19,23 +19,17 @@ limitations under the License.
 package ovn
 
 import (
-	"context"
-	"encoding/json"
 	"os"
 	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
-	"github.com/submariner-io/admiral/pkg/slices"
-	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
-	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8snet "k8s.io/utils/net"
 )
 
@@ -294,45 +288,7 @@ func (ovn *Handler) processEndpointSubnets(add bool, endpoints ...submarinerv1.E
 		}
 	}
 
-	if len(allSubnets) == 0 {
-		return nil
-	}
-
-	// To prevent SNAT by OVNK (with nftables), the subnets should be added to the node annotation.
-
-	err := util.MustUpdate[*corev1.Node](context.TODO(), ovn.nodeResourceInterface(), &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeutil.GetLocalNodeName()},
-	}, func(existing *corev1.Node) (*corev1.Node, error) {
-		var list []string
-
-		currentJSON := existing.Annotations[OVNKSNATExcludeSubnetsAnnotation]
-		if currentJSON != "" {
-			if err := json.Unmarshal([]byte(currentJSON), &list); err != nil {
-				return nil, errors.Wrap(err, "failed to unmarshal annotation list")
-			}
-		}
-
-		for _, subnet := range allSubnets {
-			if add {
-				list, _ = slices.AppendIfNotPresent(list, subnet, slices.Key[string])
-			} else {
-				list, _ = slices.Remove(list, subnet, slices.Key[string])
-			}
-		}
-
-		newBytes, err := json.Marshal(list)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal annotation list")
-		}
-
-		existing.Annotations[OVNKSNATExcludeSubnetsAnnotation] = string(newBytes)
-
-		logger.Infof("Updating local Node's %q annotation to %q", OVNKSNATExcludeSubnetsAnnotation, string(newBytes))
-
-		return existing, nil
-	})
-
-	return errors.Wrapf(err, "error updating node annotation %q", OVNKSNATExcludeSubnetsAnnotation)
+	return nil
 }
 
 func (ovn *Handler) nodeResourceInterface() resource.Interface[*corev1.Node] {

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -152,7 +152,8 @@ func main() {
 				TransitSwitchIP: transitSwitchIP,
 			}),
 			ovn.NewGatewayRouteHandler(family, smClientset),
-			ovn.NewNonGatewayRouteHandler(family, smClientset, transitSwitchIP))
+			ovn.NewNonGatewayRouteHandler(family, smClientset, transitSwitchIP),
+			ovn.NewAvoidSNATHandler(family))
 	}
 
 	handlers = append(handlers,


### PR DESCRIPTION
This PR introduces an avoid-SNAT handler for OVN that resolves ingress SNAT issues by defining high-priority nftables self-SNAT rules.

It also adds support for running an nftables driver as secondary to iptables, enabling definition of higher-priority nftables rules required to properly handle SNAT with OVN CNI.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
