### PR TITLE
release 0.20: introduce Avoid SNAT handler for OVN using nftables

### DIFF
--- a/package/Dockerfile.submariner-globalnet
+++ b/package/Dockerfile.submariner-globalnet
@@ -20,7 +20,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/globalnet \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables-legacy iptables-nft ipset grep
+    iproute iptables-legacy iptables-nft nftables ipset grep
 
 FROM scratch
 ARG SOURCE

--- a/package/Dockerfile.submariner-route-agent
+++ b/package/Dockerfile.submariner-route-agent
@@ -21,7 +21,7 @@ COPY package/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/route-agent \
     glibc bash glibc-minimal-langpack coreutils-single \
-    iproute iptables-legacy iptables-nft ipset openvswitch procps-ng grep
+    iproute iptables-legacy iptables-nft nftables ipset openvswitch procps-ng grep
 
 FROM scratch
 ARG SOURCE

--- a/pkg/packetfilter/iptables/iptables.go
+++ b/pkg/packetfilter/iptables/iptables.go
@@ -102,7 +102,13 @@ func (p *packetFilter) ChainExists(table packetfilter.TableType, chain string) (
 }
 
 func (p *packetFilter) AppendUnique(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if rule.Action == packetfilter.RuleActionSelfSNAT {
+		// No-op for iptables driver
+		return nil
+	}
+
 	ruleSpec := ToRuleSpec(rule)
+
 	return errors.Wrapf(p.ipt.AppendUnique(tableTypeToStr[table], chain, ruleSpec...), "AppendUnique failed for table %q, chain %q, rule %q",
 		tableTypeToStr[table], chain, ruleSpec)
 }
@@ -173,6 +179,11 @@ func (p *packetFilter) ClearChain(table packetfilter.TableType, chain string) er
 }
 
 func (p *packetFilter) Delete(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if rule.Action == packetfilter.RuleActionSelfSNAT {
+		// No-op for iptables driver
+		return nil
+	}
+
 	ruleSpec := ToRuleSpec(rule)
 	err := p.ipt.Delete(tableTypeToStr[table], chain, ruleSpec...)
 
@@ -215,13 +226,25 @@ func (p *packetFilter) List(table packetfilter.TableType, chain string) ([]*pack
 }
 
 func (p *packetFilter) Insert(table packetfilter.TableType, chain string, pos int, rule *packetfilter.Rule) error {
+	if rule.Action == packetfilter.RuleActionSelfSNAT {
+		// No-op for iptables driver
+		return nil
+	}
+
 	ruleSpec := ToRuleSpec(rule)
+
 	return errors.Wrapf(p.ipt.Insert(tableTypeToStr[table], chain, pos, ruleSpec...), "Insert failed for table %q, chain %q, rule %q",
 		tableTypeToStr[table], chain, ruleSpec)
 }
 
 func (p *packetFilter) Append(table packetfilter.TableType, chain string, rule *packetfilter.Rule) error {
+	if rule.Action == packetfilter.RuleActionSelfSNAT {
+		// No-op for iptables driver
+		return nil
+	}
+
 	ruleSpec := ToRuleSpec(rule)
+
 	return errors.Wrapf(p.ipt.Append(tableTypeToStr[table], chain, ruleSpec...), "Append failed for table %q, chain %q, rule %q",
 		tableTypeToStr[table], chain, ruleSpec)
 }

--- a/pkg/packetfilter/nftables/namedset.go
+++ b/pkg/packetfilter/nftables/namedset.go
@@ -38,8 +38,9 @@ func (p *packetFilter) NewNamedSet(set *packetfilter.SetInfo) packetfilter.Named
 
 	return &namedSet{
 		set: knftables.Set{
-			Name: set.Name,
-			Type: setType,
+			Name:  set.Name,
+			Type:  setType,
+			Flags: []knftables.SetFlag{knftables.IntervalFlag},
 		},
 		nftables: p.nftables,
 	}

--- a/pkg/packetfilter/nftables/nftables.go
+++ b/pkg/packetfilter/nftables/nftables.go
@@ -58,12 +58,13 @@ var (
 	}
 
 	ruleActionToStr = map[packetfilter.RuleAction][]string{
-		packetfilter.RuleActionAccept: {"accept"},
-		packetfilter.RuleActionMss:    {"tcp", "option", "maxseg"},
-		packetfilter.RuleActionMark:   {"meta", "mark"},
-		packetfilter.RuleActionSNAT:   {"snat"},
-		packetfilter.RuleActionDNAT:   {"dnat"},
-		packetfilter.RuleActionJump:   {"jump"},
+		packetfilter.RuleActionAccept:   {"accept"},
+		packetfilter.RuleActionMss:      {"tcp", "option", "maxseg"},
+		packetfilter.RuleActionMark:     {"meta", "mark"},
+		packetfilter.RuleActionSNAT:     {"snat"},
+		packetfilter.RuleActionDNAT:     {"dnat"},
+		packetfilter.RuleActionJump:     {"jump"},
+		packetfilter.RuleActionSelfSNAT: {"snat to ip saddr"},
 	}
 
 	logger = log.Logger{Logger: logf.Log.WithName("NFTables")}
@@ -126,6 +127,8 @@ func (p *packetFilter) CreateIPHookChainIfNotExists(chain *packetfilter.ChainIPH
 
 	if chain.Priority == packetfilter.ChainPriorityFirst {
 		chainPriority += "-10"
+	} else if chain.Priority == packetfilter.ChainPriorityMiddle {
+		chainPriority += "-5"
 	}
 
 	tx.Add(&knftables.Chain{

--- a/pkg/packetfilter/nftables/nftables_test.go
+++ b/pkg/packetfilter/nftables/nftables_test.go
@@ -349,17 +349,17 @@ var _ = Describe("Interface", func() {
 		err := set.Create(true)
 		Expect(err).To(Succeed())
 
-		err = set.AddEntry("entry1", false)
+		err = set.AddEntry("1.2.3.4", false)
 		Expect(err).To(Succeed())
-		assertEntries(set, "entry1")
+		assertEntries(set, "1.2.3.4")
 
-		err = set.AddEntry("entry2", false)
+		err = set.AddEntry("10.1.2.0/16", false)
 		Expect(err).To(Succeed())
-		assertEntries(set, "entry1", "entry2")
+		assertEntries(set, "1.2.3.4", "10.1.2.0/16")
 
-		err = set.DelEntry("entry1")
+		err = set.DelEntry("1.2.3.4")
 		Expect(err).To(Succeed())
-		assertEntries(set, "entry2")
+		assertEntries(set, "10.1.2.0/16")
 
 		err = set.Flush()
 		Expect(err).To(Succeed())

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -60,6 +60,7 @@ const (
 	RuleActionMark
 	RuleActionSNAT
 	RuleActionDNAT
+	RuleActionSelfSNAT
 )
 
 func (r RuleAction) String() string {
@@ -76,6 +77,8 @@ func (r RuleAction) String() string {
 		return "SNAT"
 	case RuleActionDNAT:
 		return "DNAT"
+	case RuleActionSelfSNAT:
+		return "SelfSNAT"
 	}
 
 	return unknown
@@ -160,6 +163,7 @@ type ChainPriority uint32
 
 const (
 	ChainPriorityFirst ChainPriority = iota
+	ChainPriorityMiddle
 	ChainPriorityLast
 )
 
@@ -167,6 +171,8 @@ func (c ChainPriority) String() string {
 	switch c {
 	case ChainPriorityFirst:
 		return "First"
+	case ChainPriorityMiddle:
+		return "Middle"
 	case ChainPriorityLast:
 		return "Last"
 	}

--- a/pkg/packetfilter/packetfilter.go
+++ b/pkg/packetfilter/packetfilter.go
@@ -339,6 +339,10 @@ func NewV6() (Interface, error) {
 	return newImpl(newDriverFnV6)
 }
 
+func NewWithDriver(f func() (Driver, error)) (Interface, error) {
+	return newImpl(f)
+}
+
 func newImpl(f func() (Driver, error)) (Interface, error) {
 	if f == nil {
 		return nil, errors.New("no driver registered")

--- a/pkg/routeagent_driver/constants/constants.go
+++ b/pkg/routeagent_driver/constants/constants.go
@@ -23,6 +23,7 @@ const (
 	SmPostRoutingChain = "SUBMARINER-POSTROUTING"
 	SmInputChain       = "SUBMARINER-INPUT"
 	SmForwardChain     = "SUBMARINER-FORWARD"
+	SmSelfSnatChain    = "SUBMARINER-SELF-SNAT"
 	PostRoutingChain   = "POSTROUTING"
 	InputChain         = "INPUT"
 	ForwardChain       = "FORWARD"

--- a/pkg/routeagent_driver/handlers/ovn/avoid_snat_handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/avoid_snat_handler.go
@@ -1,0 +1,211 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ovn
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/pkg/errors"
+	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/cni"
+	"github.com/submariner-io/submariner/pkg/event"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
+	"github.com/submariner-io/submariner/pkg/packetfilter/nftables"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	enableSNATHandlerKey = "enable-snat-handler"
+	remoteCIDRIPSetIPv4  = "SUBMARINER-REMOTECIDRS"
+	localCIDRIPSetIPv4   = "SUBMARINER-LOCALCIDRS"
+)
+
+type AvoidSNATHandler struct {
+	event.HandlerBase
+	pFilter     packetfilter.Interface
+	remoteIPSet packetfilter.NamedSet
+	localIPSet  packetfilter.NamedSet
+}
+
+func NeedToEnableAvoidSNATHandler(cm *corev1.ConfigMap) (bool, error) {
+	enableHandler := false
+
+	if cm != nil {
+		if value, ok := cm.Data[enableSNATHandlerKey]; ok {
+			var err error
+
+			enableHandler, err = strconv.ParseBool(value)
+			if err != nil {
+				return false, errors.Wrapf(err, "unable to parse %q from ConfigMap %q", enableSNATHandlerKey, cm.Name)
+			}
+		}
+	}
+
+	return enableHandler, nil
+}
+
+func NewAvoidSNATHandler() event.Handler {
+
+	h := &AvoidSNATHandler{}
+
+	return h
+}
+
+func (h *AvoidSNATHandler) Init(_ context.Context) error {
+	logger.Info("Starting AvoidSNATHandler")
+
+	var err error
+
+	h.pFilter, err = packetfilter.NewWithDriver(nftables.New)
+	if err != nil {
+		return errors.Wrap(err, "error initializing packetfilter with nftables driver")
+	}
+
+	if err := h.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
+		Name:     constants.SmSelfSnatChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityMiddle,
+	}); err != nil {
+		return errors.Wrapf(err, "error creating IPHookChain chain %s", constants.SmSelfSnatChain)
+	}
+
+	return h.createSelfSNATRules()
+}
+
+func (h *AvoidSNATHandler) GetName() string {
+	return "submariner-avoid-snat-handler"
+}
+
+func (h *AvoidSNATHandler) GetNetworkPlugins() []string {
+	return []string{cni.OVNKubernetes}
+}
+
+func (h *AvoidSNATHandler) newNamedSetSet(key string) packetfilter.NamedSet {
+	return h.pFilter.NewNamedSet(&packetfilter.SetInfo{
+		Name: key,
+	})
+}
+
+func (h *AvoidSNATHandler) createSelfSNATRules() error {
+	h.remoteIPSet = h.newNamedSetSet(remoteCIDRIPSetIPv4)
+	if err := h.remoteIPSet.Create(true); err != nil {
+		return errors.Wrapf(err, "error creating set %q", remoteCIDRIPSetIPv4)
+	}
+
+	h.localIPSet = h.newNamedSetSet(localCIDRIPSetIPv4)
+	if err := h.localIPSet.Create(true); err != nil {
+		return errors.Wrapf(err, "error creating set %q", localCIDRIPSetIPv4)
+	}
+
+	logger.Info("Creating packetfilter self-snat rules")
+
+	ruleSpecIngress := packetfilter.Rule{
+		SrcSetName:  remoteCIDRIPSetIPv4,
+		DestSetName: localCIDRIPSetIPv4,
+		Action:      packetfilter.RuleActionSelfSNAT,
+	}
+
+	if err := h.pFilter.AppendUnique(packetfilter.TableTypeNAT, constants.SmSelfSnatChain, &ruleSpecIngress); err != nil {
+		return errors.Wrapf(err, "unable to append rule %+v", &ruleSpecIngress)
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) LocalEndpointCreated(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		err := h.localIPSet.AddEntry(subnet, true)
+		if err != nil {
+			return errors.Wrap(err, "error adding local IP set entry")
+		}
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		logError(h.localIPSet.DelEntry(subnet), "Error deleting the subnet %q from the local IPSet", subnet)
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		err := h.remoteIPSet.AddEntry(subnet, true)
+		if err != nil {
+			return errors.Wrap(err, "error adding remote IP set entry")
+		}
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	subnets := cidr.ExtractIPv4Subnets(endpoint.Spec.Subnets)
+	for _, subnet := range subnets {
+		logError(h.remoteIPSet.DelEntry(subnet), "Error deleting the subnet %q from the remote IPSet", subnet)
+	}
+
+	return nil
+}
+
+func (h *AvoidSNATHandler) Uninstall() error {
+	logger.Infof("Flushing packetfilter entry in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	if err := h.pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmSelfSnatChain); err != nil {
+		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmSelfSnatChain,
+			constants.NATTable)
+	}
+
+	logger.Infof("Deleting packetfilter entry in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	logError(h.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
+		Name:     constants.SmSelfSnatChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityMiddle,
+	}), "Error deleting IP hook chain %q of table type %q", constants.SmSelfSnatChain, packetfilter.ChainTypeNAT)
+
+	logger.Infof("Flushing packetfilter entries in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+
+	logError(h.localIPSet.Flush(), "Error flushing ipset %q", localCIDRIPSetIPv4)
+
+	logError(h.localIPSet.Destroy(), "Error deleting ipset %q", localCIDRIPSetIPv4)
+
+	logError(h.remoteIPSet.Flush(), "Error flushing ipset %q", remoteCIDRIPSetIPv4)
+
+	logError(h.remoteIPSet.Destroy(), "Error deleting ipset %q", remoteCIDRIPSetIPv4)
+
+	return nil
+}
+
+func logError(err error, format string, args ...interface{}) {
+	if err != nil {
+		logger.Errorf(err, format, args...)
+	}
+}

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -59,6 +60,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
+
+const globalConfigMapName = "submariner-global"
 
 var (
 	masterURL   string
@@ -136,7 +139,7 @@ func main() {
 		RouteAgentUpdateInterval: 60 * time.Second,
 	}
 
-	registry, err := event.NewRegistry(ctx, "routeagent_driver", np,
+	handlers := []event.Handler{
 		kubeproxy.NewSyncHandler(env.ClusterCidr, env.ServiceCidr),
 		ovn.NewHandler(&ovn.HandlerConfig{
 			Namespace:       env.Namespace,
@@ -155,8 +158,21 @@ func main() {
 		mtu.NewMTUHandler(env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(localNode)),
 		calico.NewCalicoIPPoolHandler(cfg, env.Namespace, k8sClientSet),
 		healthchecker.New(healthcheckerConfig,
-			smClientset.SubmarinerV1().RouteAgents(submSpec.Namespace), versions.Submariner(), localNode.Name))
+			smClientset.SubmarinerV1().RouteAgents(submSpec.Namespace), versions.Submariner(), localNode.Name),
+	}
 
+	globalConfigMap, err := k8sClientSet.CoreV1().ConfigMaps(env.Namespace).Get(ctx, globalConfigMapName, metav1.GetOptions{})
+	enableAvoidSNAT, err := ovn.NeedToEnableAvoidSNATHandler(globalConfigMap)
+	logger.FatalOnError(err, "Error determining avoid SNAT enablement")
+
+	if err == nil && enableAvoidSNAT {
+		logger.Info("avoid SNAT handler is enabled")
+		handlers = append(handlers, ovn.NewAvoidSNATHandler())
+	} else {
+		logger.Info("avoid SNAT handler is disabled")
+	}
+
+	registry, err := event.NewRegistry(ctx, "routeagent_driver", np, handlers...)
 	logger.FatalOnError(err, "Error registering the handlers")
 
 	if env.Uninstall {


### PR DESCRIPTION
This PR introduces an Avoid SNAT handler for OVN to mitigate ingress SNAT issues by installing high-priority nftables self-SNAT rules.

The handler is controlled via the **enable-snat-handler** key in **submariner-global** ConfigMap, and it specifically uses the nftables driver, while rest of clients continue to use the default iptables driver.

In addition, this PR includes supporting changes:
*  Added support for storing CIDR elements in nftables sets 

* Updated packetfilter/nftables to support self-SNAT rules, including a new middle-priority IP hook chain for improved rule ordering.

* Added the nftables binary to GlobalNet and RouteAgent images to support these new rules.