### PR TITLE
Handle ErrDumpInterrupted in vishvananda/netlink v1.3.1

### DIFF
--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:wrapcheck // Most of the functions are simple wrappers so we'll let the caller wrap errors.
 package netlink
 
 import (
@@ -95,7 +94,7 @@ func (a *Adapter) DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableI
 			Table:     tableID,
 		}
 
-		err := netlink.RouteDel(route)
+		err := a.RouteDel(route)
 		if err != nil {
 			return errors.Wrapf(err, "unable to delete the route entry %#v", route)
 		}
@@ -105,7 +104,7 @@ func (a *Adapter) DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableI
 }
 
 func (a *Adapter) AddrAddIfNotPresent(link netlink.Link, addr *netlink.Addr) error {
-	err := netlink.AddrAdd(link, addr)
+	err := a.AddrAdd(link, addr)
 	if err != nil && !errors.Is(err, syscall.EEXIST) {
 		return nil
 	}

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -31,6 +31,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -93,6 +95,34 @@ var (
 	}
 )
 
+const (
+	// MaxRetries is the maximum number of retries for interrupted netlink operations.
+	MaxRetries = 5
+)
+
+// retryOnInterrupted wraps netlink operations that can be interrupted and retries them using exponential backoff.
+func retryOnInterrupted[T any](operation func() (T, error)) (T, error) {
+	var result T
+
+	backOff := wait.Backoff{
+		Steps:    MaxRetries,
+		Duration: 10 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
+
+	err := retry.OnError(backOff, func(err error) bool {
+		return errors.Is(err, netlink.ErrDumpInterrupted)
+	}, func() error {
+		var opErr error
+		result, opErr = operation()
+
+		return opErr
+	})
+
+	return result, err
+}
+
 type netlinkType struct{}
 
 func New() Interface {
@@ -112,7 +142,9 @@ func (n *netlinkType) LinkDel(link netlink.Link) error {
 }
 
 func (n *netlinkType) LinkByName(name string) (netlink.Link, error) {
-	return netlink.LinkByName(name)
+	return retryOnInterrupted(func() (netlink.Link, error) {
+		return netlink.LinkByName(name)
+	})
 }
 
 func (n *netlinkType) LinkSetUp(link netlink.Link) error {
@@ -128,7 +160,9 @@ func (n *netlinkType) AddrDel(link netlink.Link, addr *netlink.Addr) error {
 }
 
 func (n *netlinkType) AddrList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Addr, error) {
-	return netlink.AddrList(link, ToNetlinkFamily(family))
+	return retryOnInterrupted(func() ([]netlink.Addr, error) {
+		return netlink.AddrList(link, ToNetlinkFamily(family))
+	})
 }
 
 func (n *netlinkType) AddrSubscribe(addrCh chan netlink.AddrUpdate, doneCh chan struct{}) error {
@@ -156,11 +190,15 @@ func (n *netlinkType) RouteReplace(route *netlink.Route) error {
 }
 
 func (n *netlinkType) RouteGet(destination net.IP) ([]netlink.Route, error) {
-	return netlink.RouteGet(destination)
+	return retryOnInterrupted(func() ([]netlink.Route, error) {
+		return netlink.RouteGet(destination)
+	})
 }
 
 func (n *netlinkType) RouteList(link netlink.Link, family k8snet.IPFamily) ([]netlink.Route, error) {
-	return netlink.RouteList(link, ToNetlinkFamily(family))
+	return retryOnInterrupted(func() ([]netlink.Route, error) {
+		return netlink.RouteList(link, ToNetlinkFamily(family))
+	})
 }
 
 func (n *netlinkType) RuleAdd(rule *netlink.Rule) error {
@@ -172,7 +210,9 @@ func (n *netlinkType) RuleDel(rule *netlink.Rule) error {
 }
 
 func (n *netlinkType) RuleList(family k8snet.IPFamily) ([]netlink.Rule, error) {
-	return netlink.RuleList(ToNetlinkFamily(family))
+	return retryOnInterrupted(func() ([]netlink.Rule, error) {
+		return netlink.RuleList(ToNetlinkFamily(family))
+	})
 }
 
 func (n *netlinkType) XfrmPolicyAdd(policy *netlink.XfrmPolicy) error {
@@ -184,7 +224,9 @@ func (n *netlinkType) XfrmPolicyDel(policy *netlink.XfrmPolicy) error {
 }
 
 func (n *netlinkType) XfrmPolicyList(family k8snet.IPFamily) ([]netlink.XfrmPolicy, error) {
-	return netlink.XfrmPolicyList(ToNetlinkFamily(family))
+	return retryOnInterrupted(func() ([]netlink.XfrmPolicy, error) {
+		return netlink.XfrmPolicyList(ToNetlinkFamily(family))
+	})
 }
 
 func (n *netlinkType) EnableLooseModeReversePathFilter(interfaceName string, family k8snet.IPFamily) error {

--- a/pkg/netlink/netlink_internal_test.go
+++ b/pkg/netlink/netlink_internal_test.go
@@ -1,0 +1,74 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlink
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+)
+
+var _ = Describe("retryOnInterrupted", func() {
+	It("should succeed on first attempt", func() {
+		result, err := retryOnInterrupted(func() (string, error) {
+			return "success", nil
+		})
+		Expect(err).To(Succeed())
+		Expect(result).To(Equal("success"))
+	})
+
+	It("should retry on interrupted error and eventually succeed", func() {
+		callCount := 0
+		result, err := retryOnInterrupted(func() (string, error) {
+			callCount++
+			if callCount < 4 {
+				return "", netlink.ErrDumpInterrupted
+			}
+			return "success after retries", nil
+		})
+		Expect(err).To(Succeed())
+		Expect(result).To(Equal("success after retries"))
+		Expect(callCount).To(Equal(4))
+	})
+
+	It("should give up after MaxRetries attempts", func() {
+		callCount := 0
+		result, err := retryOnInterrupted(func() (string, error) {
+			callCount++
+			return "", netlink.ErrDumpInterrupted
+		})
+		Expect(err).To(Equal(netlink.ErrDumpInterrupted))
+		Expect(result).To(Equal(""))
+		Expect(callCount).To(Equal(MaxRetries))
+	})
+
+	It("should not retry on non-interrupt errors", func() {
+		otherError := errors.New("some other error")
+		callCount := 0
+		result, err := retryOnInterrupted(func() (string, error) {
+			callCount++
+			return "", otherError
+		})
+		Expect(err).To(Equal(otherError))
+		Expect(result).To(Equal(""))
+		Expect(callCount).To(Equal(1))
+	})
+})

--- a/pkg/netlink/netlink_suite_test.go
+++ b/pkg/netlink/netlink_suite_test.go
@@ -1,0 +1,41 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlink_test
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+var _ = BeforeSuite(func() {
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	_ = flags.Parse([]string{"-v=4"})
+
+	kzerolog.InitK8sLogging()
+})
+
+func TestNetlink(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Netlink Suite")
+}


### PR DESCRIPTION
Add retry logic for netlink operations that can be interrupted due to 
breaking changes in vishvananda/netlink v1.2.1+.

Note: the core of this code proposed by Cursor

Fixes: https://github.com/submariner-io/submariner/issues/3500

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
