### PR TITLE
Improve close detection and check for truncated messages in natDiscovery.listenerLoop

### DIFF
--- a/pkg/natdiscovery/listener.go
+++ b/pkg/natdiscovery/listener.go
@@ -95,17 +95,31 @@ func createServerConnection(port int32, family k8snet.IPFamily) (ServerConnectio
 }
 
 func (nd *natDiscovery) listenerLoop(serverConnection ServerConnection) {
-	buf := make([]byte, 2048)
+	const maxUDPMessageSize = 2048
+
+	buf := make([]byte, maxUDPMessageSize)
 
 	for {
 		length, addr, err := serverConnection.ReadFromUDP(buf)
-		if length == 0 {
-			logger.Info("Stopping NAT listener")
-			return
-		} else if err != nil {
-			logger.Errorf(err, "Error receiving from udp")
-		} else if err := nd.parseAndHandleMessageFromAddress(buf[:length], addr); err != nil {
-			logger.Errorf(err, "Error handling message from address %s:\n%s", addr.String(), hex.Dump(buf[:length]))
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				logger.Info("Stopping NAT listener")
+				return
+			}
+
+			logger.Error(err, "Error receiving from UDP")
+
+			continue
+		}
+
+		if length > 0 {
+			if err := nd.parseAndHandleMessageFromAddress(buf[:length], addr); err != nil {
+				if length == maxUDPMessageSize {
+					logger.Warningf("UDP message from %s may have been truncated (received %d bytes)", addr.String(), length)
+				}
+
+				logger.Errorf(err, "Error handling message from address %s:\n%s", addr.String(), hex.Dump(buf[:length]))
+			}
 		}
 	}
 }


### PR DESCRIPTION
The Cursor AI tool identified a couple potential issues:

The code assumes that `length == 0` from `ReadFromUDP` only means the connection is closed. However, UDP can legitimately receive zero-length packets. To be safe, check the returned error for `net.ErrClosed`.

A fixed buffer size of 2048 is used but a UDP message larger than that will be silently truncated which would cause a parsing error. Add a warning re: truncation if the returned length is 2048.
