### PR TITLE
Remove unused netlink.Adapter methods

### DIFF
--- a/pkg/netlink/adapter.go
+++ b/pkg/netlink/adapter.go
@@ -19,7 +19,6 @@ limitations under the License.
 package netlink
 
 import (
-	"net"
 	"os"
 	"syscall"
 
@@ -56,57 +55,6 @@ func (a *Adapter) RouteAddOrReplace(route *netlink.Route) error {
 
 	if errors.Is(err, syscall.EEXIST) {
 		err = a.RouteReplace(route)
-	}
-
-	return err
-}
-
-func (a *Adapter) AddDestinationRoutes(destIPs []net.IPNet, gwIP, srcIP net.IP, linkIndex, tableID int) error {
-	for i := range destIPs {
-		route := &netlink.Route{
-			LinkIndex: linkIndex,
-			Src:       srcIP,
-			Dst:       &destIPs[i],
-			Gw:        gwIP,
-			Type:      netlink.NDA_DST,
-			Flags:     netlink.NTF_SELF,
-			Priority:  100,
-			Table:     tableID,
-		}
-
-		err := a.RouteAddOrReplace(route)
-		if err != nil {
-			return errors.Wrapf(err, "unable to add the route entry %#v", route)
-		}
-	}
-
-	return nil
-}
-
-func (a *Adapter) DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableID int) error {
-	for i := range destIPs {
-		route := &netlink.Route{
-			LinkIndex: linkIndex,
-			Dst:       &destIPs[i],
-			Type:      netlink.NDA_DST,
-			Flags:     netlink.NTF_SELF,
-			Priority:  100,
-			Table:     tableID,
-		}
-
-		err := a.RouteDel(route)
-		if err != nil {
-			return errors.Wrapf(err, "unable to delete the route entry %#v", route)
-		}
-	}
-
-	return nil
-}
-
-func (a *Adapter) AddrAddIfNotPresent(link netlink.Link, addr *netlink.Addr) error {
-	err := a.AddrAdd(link, addr)
-	if err != nil && !errors.Is(err, syscall.EEXIST) {
-		return nil
 	}
 
 	return err

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -70,12 +70,9 @@ type Basic interface {
 
 type Interface interface {
 	Basic
-	AddrAddIfNotPresent(link netlink.Link, addr *netlink.Addr) error
 	RuleAddIfNotPresent(rule *netlink.Rule) error
 	RuleDelIfPresent(rule *netlink.Rule) error
 	RouteAddOrReplace(route *netlink.Route) error
-	AddDestinationRoutes(destIPs []net.IPNet, gwIP, srcIP net.IP, linkIndex, tableID int) error
-	DeleteDestinationRoutes(destIPs []net.IPNet, linkIndex, tableID int) error
 	GetDefaultGatewayInterface(family k8snet.IPFamily) (NetworkInterface, error)
 }
 


### PR DESCRIPTION
The Cursor AI tool identified a logic error in `AddrAddIfNotPresent` but, as it turns out, this method is actually not used anywhere so we can remove it. Also `AddDestinationRoutes` and `DeleteDestinationRoutes` aren't used either.

These were added by https://github.com/submariner-io/submariner/pull/1741 to support a new cable driver implementation that was abandoned.
