### PR TITLE
Add IPv6 support to VxLAN cable driver

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,8 @@ jobs:
           - extra-toggles: nftables, globalnet, ovn
           - extra-toggles: nftables, ovn, dual-stack
           - extra-toggles: dual-stack, ovn
+          - extra-toggles: dual-stack, vxlan
+          - extra-toggles: dual-stack, ovn, vxlan
           # Oldest Kubernetes version thought to work with SubM.
           # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -39,11 +39,12 @@ import (
 )
 
 const (
-	VxlanIface                 = "vxlan-tunnel"
-	VxlanVTepNetworkPrefixCIDR = "241.0.0.0/8"
-	CableDriverName            = "vxlan"
-	TableID                    = 100
-	DefaultPort                = 4500
+	VxlanIface                   = "vxlan-tunnel"
+	VxlanVTepNetworkPrefixCIDR   = "241.0.0.0/8"
+	VxlanVTepNetworkPrefixCIDRv6 = "fd00:100:200::/96"
+	CableDriverName              = "vxlan"
+	TableID                      = 100
+	DefaultPort                  = 4500
 )
 
 type vxLan struct {
@@ -51,12 +52,27 @@ type vxLan struct {
 	localCluster  types.SubmarinerCluster
 	connections   []v1.Connection
 	mutex         sync.Mutex
-	vxlanIface    *vxlan.Interface
+	vxlanIfaces   map[k8snet.IPFamily]*vxlan.Interface
 	netLink       netlinkAPI.Interface
-	vtepIP        net.IP
+	vtepIPs       map[k8snet.IPFamily]net.IP
 }
 
-var logger = log.Logger{Logger: logf.Log.WithName("vxlan")}
+var (
+	vtepPrefixCIDRByFamily = map[k8snet.IPFamily]string{
+		k8snet.IPv4: VxlanVTepNetworkPrefixCIDR,
+		k8snet.IPv6: VxlanVTepNetworkPrefixCIDRv6,
+	}
+
+	logger = log.Logger{Logger: logf.Log.WithName("vxlan")}
+)
+
+func GetVxlanInterfaceName(ipFamily k8snet.IPFamily) string {
+	if ipFamily == k8snet.IPv6 {
+		return VxlanIface + "-6"
+	}
+
+	return VxlanIface
+}
 
 func init() {
 	cable.AddDriver(CableDriverName, NewDriver)
@@ -70,6 +86,8 @@ func NewDriver(localEndpoint *submendpoint.Local, localCluster *types.Submariner
 		localEndpoint: *localEndpoint.Spec(),
 		netLink:       netlinkAPI.New(),
 		localCluster:  *localCluster,
+		vxlanIfaces:   make(map[k8snet.IPFamily]*vxlan.Interface),
+		vtepIPs:       make(map[k8snet.IPFamily]net.IP),
 	}
 
 	if strings.EqualFold(v.localEndpoint.CableName, CableDriverName) && v.localEndpoint.NATEnabled {
@@ -81,31 +99,38 @@ func NewDriver(localEndpoint *submendpoint.Local, localCluster *types.Submariner
 		return nil, errors.Wrap(err, "failed to get the UDP port configuration")
 	}
 
-	if err = v.createVxlanInterface(int(port)); err != nil {
-		return nil, errors.Wrap(err, "failed to setup Vxlan link")
+	// Create VXLAN interface for each IP family supported by the endpoint
+	for _, family := range v.localEndpoint.GetIPFamilies() {
+		if err = v.createVxlanInterface(int(port), family); err != nil {
+			return nil, errors.Wrapf(err, "failed to setup Vxlan link for IPv%v", family)
+		}
 	}
 
 	return &v, nil
 }
 
-func (v *vxLan) createVxlanInterface(port int) error {
-	ipAddr := v.localEndpoint.GetPrivateIP(k8snet.IPv4)
+func (v *vxLan) createVxlanInterface(port int, family k8snet.IPFamily) error {
+	ipAddr := v.localEndpoint.GetPrivateIP(family)
 
-	var err error
+	vtepPrefixCIDR := vtepPrefixCIDRByFamily[family]
 
-	v.vtepIP, err = vxlan.GetVtepIPAddressFrom(ipAddr, VxlanVTepNetworkPrefixCIDR, k8snet.IPv4)
+	vtepIP, err := vxlan.GetVtepIPAddressFrom(ipAddr, vtepPrefixCIDR, family)
 	if err != nil {
 		return errors.Wrapf(err, "failed to derive the vxlan vtepIP for %s", ipAddr)
 	}
 
-	defaultHostIface, err := v.netLink.GetDefaultGatewayInterface(k8snet.IPv4)
+	v.vtepIPs[family] = vtepIP
+
+	logger.V(log.DEBUG).Infof("Derived VTEP IPv%v %s from private IP %s", family, vtepIP, ipAddr)
+
+	defaultHostIface, err := v.netLink.GetDefaultGatewayInterface(family)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to find the default interface on host: %s",
-			v.localEndpoint.Hostname)
+		return errors.Wrapf(err, "Unable to find the default IPv%v interface on host: %s", family, v.localEndpoint.Hostname)
 	}
 
+	interfaceName := GetVxlanInterfaceName(family)
 	attrs := &vxlan.Attributes{
-		Name:     VxlanIface,
+		Name:     interfaceName,
 		VxlanID:  1000,
 		Group:    nil,
 		SrcAddr:  nil,
@@ -113,32 +138,52 @@ func (v *vxLan) createVxlanInterface(port int) error {
 		Mtu:      defaultHostIface.MTU(),
 	}
 
-	v.vxlanIface, err = vxlan.NewInterface(attrs, v.netLink)
-	if err != nil {
-		return errors.Wrap(err, "failed to create vxlan interface on Gateway Node")
+	// For IPv6 VxLAN interface SrcAddr should be set with local IP
+	if family == k8snet.IPv6 {
+		localIP := net.ParseIP(ipAddr)
+		attrs.SrcAddr = localIP
 	}
 
-	err = v.netLink.RuleAddIfNotPresent(netlinkAPI.NewTableRule(TableID, k8snet.IPv4))
+	vxlanIface, err := vxlan.NewInterface(attrs, v.netLink)
 	if err != nil {
-		return errors.Wrap(err, "failed to add ip rule")
+		return errors.Wrapf(err, "failed to create vxlan interface %s on Gateway Node", interfaceName)
 	}
 
-	err = v.netLink.EnsureLooseModeIsConfigured(VxlanIface, k8snet.IPv4)
+	v.vxlanIfaces[family] = vxlanIface
+
+	err = vxlanIface.SetupLink()
 	if err != nil {
-		return errors.Wrap(err, "error while validating loose mode")
+		return errors.Wrapf(err, "failed to setup link for vxlan interface %s", interfaceName)
 	}
 
-	logger.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on %s", VxlanIface)
-
-	err = v.vxlanIface.ConfigureIPAddress(v.vtepIP, net.CIDRMask(8, 32))
+	err = v.netLink.RuleAddIfNotPresent(netlinkAPI.NewTableRule(TableID, family))
 	if err != nil {
-		return errors.Wrap(err, "failed to configure vxlan interface ipaddress on the Gateway Node")
+		return errors.Wrapf(err, "failed to add IPv%v ip rule", family)
 	}
 
-	err = v.netLink.EnableForwarding(VxlanIface, k8snet.IPv4)
+	err = v.netLink.EnsureLooseModeIsConfigured(interfaceName, family)
 	if err != nil {
-		return errors.Wrapf(err, "error enabling forwarding on the %q iface", VxlanIface)
+		return errors.Wrapf(err, "error while validating loose mode for IPv%v", family)
 	}
+
+	logger.V(log.DEBUG).Infof("Successfully configured rp_filter to loose mode(2) on %s for IPv%v", interfaceName, family)
+
+	_, ipNet, err := net.ParseCIDR(vtepPrefixCIDR)
+	if err != nil {
+		return errors.Wrapf(err, "invalid VTEP CIDR %q", vtepPrefixCIDR)
+	}
+
+	err = vxlanIface.ConfigureIPAddress(vtepIP, ipNet.Mask)
+	if err != nil {
+		return errors.Wrapf(err, "failed to configure vxlan interface ipaddress on %s", interfaceName)
+	}
+
+	err = v.netLink.EnableForwarding(interfaceName, family)
+	if err != nil {
+		return errors.Wrapf(err, "error enabling forwarding on the %q iface for IPv%v", interfaceName, family)
+	}
+
+	logger.V(log.DEBUG).Infof("Successfully configured VXLAN interface for IPv%v with VTEP IP %s", family, vtepIP)
 
 	return nil
 }
@@ -151,35 +196,44 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 		return "", nil
 	}
 
+	family := endpointInfo.UseFamily
 	remoteIP := net.ParseIP(endpointInfo.UseIP)
+
 	if remoteIP == nil {
 		return "", fmt.Errorf("failed to parse remote IP %s", endpointInfo.UseIP)
 	}
 
-	allowedIPs := remoteEndpoint.Spec.ParseSubnets(endpointInfo.UseFamily)
+	allowedIPs := remoteEndpoint.Spec.ParseSubnets(family)
 
-	logger.V(log.DEBUG).Infof("Connecting cluster %s endpoint %s",
-		remoteEndpoint.Spec.ClusterID, remoteIP)
+	logger.V(log.DEBUG).Infof("Connecting cluster %s endpoint %s for IPv%v",
+		remoteEndpoint.Spec.ClusterID, remoteIP, family)
+
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 
-	cable.RecordConnection(CableDriverName, &v.localEndpoint, &remoteEndpoint.Spec, string(v1.Connected), true, endpointInfo.UseFamily)
+	vxlanIface, exists := v.vxlanIfaces[family]
+	if !exists {
+		return "", fmt.Errorf("no VXLAN interface configured for IPv%v", family)
+	}
 
-	privateIP := endpointInfo.Endpoint.Spec.GetPrivateIP(endpointInfo.UseFamily)
+	cable.RecordConnection(CableDriverName, &v.localEndpoint, &remoteEndpoint.Spec, string(v1.Connected), true, family)
 
-	remoteVtepIP, err := vxlan.GetVtepIPAddressFrom(privateIP, VxlanVTepNetworkPrefixCIDR, k8snet.IPv4)
+	privateIP := endpointInfo.Endpoint.Spec.GetPrivateIP(family)
+	vtepPrefixCIDR := vtepPrefixCIDRByFamily[family]
+
+	remoteVtepIP, err := vxlan.GetVtepIPAddressFrom(privateIP, vtepPrefixCIDR, family)
 	if err != nil {
 		return endpointInfo.UseIP, fmt.Errorf("failed to derive the vxlan vtepIP for %s: %w", privateIP, err)
 	}
 
-	err = v.vxlanIface.AddFDB(remoteIP, "00:00:00:00:00:00")
+	err = vxlanIface.AddFDB(remoteIP, "00:00:00:00:00:00")
 	if err != nil {
 		return endpointInfo.UseIP, fmt.Errorf("failed to add remoteIP %q to the forwarding database: %w", remoteIP, err)
 	}
 
 	var ipAddress net.IP
 
-	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR, endpointInfo.UseFamily)
+	cniIface, err := cni.Discover(v.localCluster.Spec.ClusterCIDR, family)
 	if err == nil {
 		ipAddress = net.ParseIP(cniIface.IPAddress)
 	} else {
@@ -187,10 +241,10 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 			v.localCluster.Spec.ClusterCIDR[0])
 	}
 
-	err = v.vxlanIface.AddRoutes(remoteVtepIP, ipAddress, TableID, allowedIPs...)
+	err = vxlanIface.AddRoutes(remoteVtepIP, ipAddress, TableID, allowedIPs...)
 	if err != nil {
-		return endpointInfo.UseIP, fmt.Errorf("failed to add route for the CIDR %q with remoteVtepIP %q and vxlanInterfaceIP %q: %w",
-			allowedIPs, remoteVtepIP, v.vtepIP, err)
+		return endpointInfo.UseIP, fmt.Errorf("failed to add route for the CIDR %q with remoteVtepIP %q: %w",
+			allowedIPs, remoteVtepIP, err)
 	}
 
 	v.connections = append(v.connections, v1.Connection{
@@ -198,7 +252,8 @@ func (v *vxLan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (s
 		UsingIP: endpointInfo.UseIP, UsingNAT: endpointInfo.UseNAT,
 	})
 
-	logger.V(log.DEBUG).Infof("Done adding endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
+	logger.V(log.DEBUG).Infof("Done adding IPv%v endpoint for cluster %s with VTEP %s -> %s",
+		family, remoteEndpoint.Spec.ClusterID, v.vtepIPs[family], remoteVtepIP)
 
 	return endpointInfo.UseIP, nil
 }
@@ -215,10 +270,15 @@ func (v *vxLan) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpoint,
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 
+	vxlanIface, exists := v.vxlanIfaces[family]
+	if !exists {
+		return fmt.Errorf("no VXLAN interface configured for IPv%v", family)
+	}
+
 	var ip string
 
 	for i := range v.connections {
-		if v.connections[i].Endpoint.CableName == remoteEndpoint.Spec.CableName {
+		if v.connections[i].Endpoint.CableName == remoteEndpoint.Spec.CableName && v.connections[i].GetFamily() == family {
 			ip = v.connections[i].UsingIP
 		}
 	}
@@ -229,24 +289,23 @@ func (v *vxLan) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpoint,
 	}
 
 	remoteIP := net.ParseIP(ip)
-
 	if remoteIP == nil {
 		return fmt.Errorf("failed to parse remote IP %s", ip)
 	}
 
-	allowedIPs := remoteEndpoint.Spec.ParseSubnets(k8snet.IPv4)
+	allowedIPs := remoteEndpoint.Spec.ParseSubnets(family)
 
-	err := v.vxlanIface.DelFDB(remoteIP, "00:00:00:00:00:00")
+	err := vxlanIface.DelFDB(remoteIP, "00:00:00:00:00:00")
 	if err != nil {
 		return fmt.Errorf("failed to delete remoteIP %q from the forwarding database: %w", remoteIP, err)
 	}
 
-	err = v.vxlanIface.DelRoutes(TableID, allowedIPs...)
+	err = vxlanIface.DelRoutes(TableID, allowedIPs...)
 	if err != nil {
 		return fmt.Errorf("failed to remove route for the CIDR %q: %w", allowedIPs, err)
 	}
 
-	v.connections = removeConnectionForEndpoint(v.connections, remoteEndpoint)
+	v.connections = removeConnectionForEndpoint(v.connections, remoteEndpoint, family)
 	cable.RecordDisconnected(CableDriverName, &v.localEndpoint, &remoteEndpoint.Spec, family)
 
 	logger.V(log.DEBUG).Infof("Done removing endpoint for cluster %s", remoteEndpoint.Spec.ClusterID)
@@ -254,9 +313,9 @@ func (v *vxLan) DisconnectFromEndpoint(remoteEndpoint *types.SubmarinerEndpoint,
 	return nil
 }
 
-func removeConnectionForEndpoint(connections []v1.Connection, endpoint *types.SubmarinerEndpoint) []v1.Connection {
+func removeConnectionForEndpoint(connections []v1.Connection, endpoint *types.SubmarinerEndpoint, family k8snet.IPFamily) []v1.Connection {
 	for j := range connections {
-		if connections[j].Endpoint.CableName == endpoint.Spec.CableName {
+		if connections[j].Endpoint.CableName == endpoint.Spec.CableName && connections[j].GetFamily() == family {
 			copy(connections[j:], connections[j+1:])
 			return connections[:len(connections)-1]
 		}
@@ -284,14 +343,24 @@ func (v *vxLan) GetName() string {
 func (v *vxLan) Cleanup() error {
 	logger.Infof("Uninstalling the vxlan cable driver")
 
-	err := netlinkAPI.DeleteIfaceAndAssociatedRoutes(VxlanIface, TableID)
-	if err != nil {
-		logger.Errorf(nil, "Unable to delete interface %s and associated routes from table %d", VxlanIface, TableID)
+	// Clean up rules for all configured families
+	families := v.localEndpoint.GetIPFamilies()
+	if len(families) == 0 {
+		families = []k8snet.IPFamily{k8snet.IPv4}
 	}
 
-	err = v.netLink.RuleDelIfPresent(netlinkAPI.NewTableRule(TableID, k8snet.IPv4))
-	if err != nil {
-		return errors.Wrapf(err, "unable to delete IP rule pointing to %d table", TableID)
+	for _, family := range families {
+		interfaceName := GetVxlanInterfaceName(family)
+
+		err := netlinkAPI.DeleteIfaceAndAssociatedRoutes(interfaceName, TableID, family)
+		if err != nil {
+			logger.Errorf(nil, "Unable to delete interface %s and associated routes from table %d", interfaceName, TableID)
+		}
+
+		err = v.netLink.RuleDelIfPresent(netlinkAPI.NewTableRule(TableID, family))
+		if err != nil {
+			logger.Errorf(err, "Unable to delete IPv%v IP rule pointing to %d table", family, TableID)
+		}
 	}
 
 	return nil

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -36,6 +36,7 @@ import (
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
 	"github.com/submariner-io/submariner/pkg/types"
+	pkgvxlan "github.com/submariner-io/submariner/pkg/vxlan"
 	"github.com/vishvananda/netlink"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -59,15 +60,16 @@ func TestVxlan(t *testing.T) {
 	RunSpecs(t, "Vxlan Cable Driver Suite")
 }
 
-const cniIPAddress = "192.168.5.1"
+const (
+	cniIPAddress   = "192.168.5.1"
+	cniIPv6Address = "fd12:3456:789a:1::1"
+)
 
 var _ = Describe("Vxlan", func() {
 	t := newTestDriver()
 
-	var natInfo *natdiscovery.NATEndpointInfo
-
-	BeforeEach(func() {
-		natInfo = &natdiscovery.NATEndpointInfo{
+	Context("IPv4", func() {
+		testVxlanConnectivity(t, &natdiscovery.NATEndpointInfo{
 			Endpoint: subv1.Endpoint{
 				Spec: subv1.EndpointSpec{
 					ClusterID:  "east",
@@ -79,11 +81,55 @@ var _ = Describe("Vxlan", func() {
 			UseIP:     "172.93.2.1",
 			UseNAT:    true,
 			UseFamily: k8snet.IPv4,
+		})
+	})
+
+	Context("IPv6", func() {
+		testVxlanConnectivity(t, &natdiscovery.NATEndpointInfo{
+			Endpoint: subv1.Endpoint{
+				Spec: subv1.EndpointSpec{
+					ClusterID:  "east",
+					CableName:  "submariner-cable-east-2002-1234-abcd-ffff-c0a8-101",
+					PrivateIPs: []string{"2002::1234:abcd:ffff:c0a8:101"},
+					Subnets:    []string{"2001::1234:abcd:ffff:c0a8:101/64"},
+				},
+			},
+			UseIP:     "2003:db8:3333:4444:5555:6666:7777:8888",
+			UseFamily: k8snet.IPv6,
+		})
+	})
+
+	Context("dual stack", func() {
+		testVxlanConnectivity(t, &natdiscovery.NATEndpointInfo{
+			Endpoint: subv1.Endpoint{
+				Spec: subv1.EndpointSpec{
+					ClusterID:  "east",
+					CableName:  "submariner-cable-east-dual-stack",
+					PrivateIPs: []string{"192.68.2.1", "2002::1234:abcd:ffff:c0a8:101"},
+					Subnets:    []string{"20.0.0.0/16", "2001::1234:abcd:ffff:c0a8:101/64"},
+				},
+			},
+			UseIP:     "172.93.2.1", // Test with IPv4 on dual-stack endpoint
+			UseFamily: k8snet.IPv4,
+		})
+	})
+})
+
+func testVxlanConnectivity(t *testDriver, natInfo *natdiscovery.NATEndpointInfo) {
+	var expectedVTepPrefix string
+
+	BeforeEach(func() {
+		if natInfo.UseFamily == k8snet.IPv6 {
+			expectedVTepPrefix = vxlan.VxlanVTepNetworkPrefixCIDRv6
+		} else {
+			expectedVTepPrefix = vxlan.VxlanVTepNetworkPrefixCIDR
 		}
 	})
 
 	JustBeforeEach(func() {
-		link := t.netLink.AwaitLink(vxlan.VxlanIface)
+		// Wait for the family-specific interface
+		interfaceName := vxlan.GetVxlanInterfaceName(natInfo.UseFamily)
+		link := t.netLink.AwaitLink(interfaceName)
 		vxLan, ok := link.(*netlink.Vxlan)
 		Expect(ok).To(BeTrue(), "Unexpected Link type: %T", link)
 
@@ -98,9 +144,13 @@ var _ = Describe("Vxlan", func() {
 		Expect(ip).To(Equal(natInfo.UseIP))
 
 		t.assertConnection(natInfo)
+
+		// FDB entries should use endpoint IP, not VTEP IP (matches working devel branch)
 		t.netLink.AwaitNeighbors(0, natInfo.UseIP)
 
-		link, err := t.netLink.LinkByName(vxlan.VxlanIface)
+		// Use family-specific interface name
+		interfaceName := vxlan.GetVxlanInterfaceName(natInfo.UseFamily)
+		link, err := t.netLink.LinkByName(interfaceName)
 		Expect(err).To(Succeed())
 
 		routes, err := t.netLink.RouteList(link, k8snet.IPFamilyUnknown)
@@ -111,26 +161,53 @@ var _ = Describe("Vxlan", func() {
 			actualRoutes = append(actualRoutes, routeFieldMap(routes[i].Src.String(), routes[i].Gw.String(), routes[i].Dst.String()))
 		}
 
-		_, cidrNet, err := net.ParseCIDR(vxlan.VxlanVTepNetworkPrefixCIDR)
+		_, cidrNet, err := net.ParseCIDR(expectedVTepPrefix)
 		Expect(err).To(Succeed())
 
-		prefix := cidrNet.IP.To4()
-		Expect(prefix).ToNot(BeNil(), "invalid IPv4 prefix in "+vxlan.VxlanVTepNetworkPrefixCIDR)
+		var gw string
 
-		gw := fmt.Sprintf("%d.68.2.1", prefix[0])
-		Expect(actualRoutes).To(HaveExactElements(routeFieldMap(cniIPAddress, gw, natInfo.Endpoint.Spec.Subnets[0]),
-			routeFieldMap(cniIPAddress, gw, natInfo.Endpoint.Spec.Subnets[1])))
+		if natInfo.UseFamily == k8snet.IPv6 {
+			// For IPv6, derive VTEP IP from the private IP
+			privateIP := natInfo.Endpoint.Spec.GetPrivateIP(natInfo.UseFamily)
+			vtepIP, err := pkgvxlan.GetVtepIPAddressFrom(privateIP, expectedVTepPrefix, natInfo.UseFamily)
+			Expect(err).To(Succeed())
+
+			gw = vtepIP.String()
+		} else {
+			// For IPv4, use the original logic
+			prefix := cidrNet.IP.To4()
+			Expect(prefix).ToNot(BeNil(), "invalid IPv4 prefix in "+expectedVTepPrefix)
+			gw = fmt.Sprintf("%d.68.2.1", prefix[0])
+		}
+
+		// Filter subnets by the family we're testing
+		allowedIPs := natInfo.Endpoint.Spec.ParseSubnets(natInfo.UseFamily)
+
+		// Use the appropriate CNI IP based on the family
+		cniIP := cniIPAddress
+		if natInfo.UseFamily == k8snet.IPv6 {
+			cniIP = cniIPv6Address
+		}
+
+		var expectedRoutes []map[string]string
+		for _, subnet := range allowedIPs {
+			expectedRoutes = append(expectedRoutes, routeFieldMap(cniIP, gw, subnet.String()))
+		}
+
+		Expect(actualRoutes).To(HaveExactElements(expectedRoutes))
 	})
 
 	Specify("DisconnectFromEndpoint should remove the Connection and its data-plane components", func() {
 		_, err := t.driver.ConnectToEndpoint(natInfo)
 		Expect(err).To(Succeed())
 
-		Expect(t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, k8snet.IPv4)).To(Succeed())
+		Expect(t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, natInfo.UseFamily)).To(Succeed())
 		t.assertNoConnection(natInfo)
 		t.netLink.AwaitNoNeighbors(0, natInfo.UseIP)
 
-		link, err := t.netLink.LinkByName(vxlan.VxlanIface)
+		// Use family-specific interface name
+		interfaceName := vxlan.GetVxlanInterfaceName(natInfo.UseFamily)
+		link, err := t.netLink.LinkByName(interfaceName)
 		Expect(err).To(Succeed())
 
 		routes, err := t.netLink.RouteList(link, k8snet.IPFamilyUnknown)
@@ -143,7 +220,7 @@ var _ = Describe("Vxlan", func() {
 		t.netLink.AwaitNoLink(vxlan.VxlanIface)
 		t.netLink.AwaitNoRule(vxlan.TableID, "", "")
 	})
-})
+}
 
 func routeFieldMap(src, gw, dst string) map[string]string {
 	return map[string]string{
@@ -167,15 +244,15 @@ func newTestDriver() *testDriver {
 		t.localCluster = &types.SubmarinerCluster{
 			Spec: subv1.ClusterSpec{
 				ClusterID:   "local",
-				ServiceCIDR: []string{"10.0.0.0/16"},
-				ClusterCIDR: []string{cniIPAddress + "/24"},
+				ServiceCIDR: []string{"10.0.0.0/16", "fd12:3456:789a:1::/112"},
+				ClusterCIDR: []string{cniIPAddress + "/24", cniIPv6Address + "/64"},
 			},
 		}
 
 		t.localEndpoint = subv1.EndpointSpec{
 			ClusterID:  t.localCluster.Spec.ClusterID,
 			CableName:  "submariner-cable-local-192-68-1-1",
-			PrivateIPs: []string{"192.68.1.1"},
+			PrivateIPs: []string{"192.68.1.1", "fd12:3456:789a:1::1"}, // Add IPv6 for dual-stack testing
 			Subnets:    append(t.localCluster.Spec.ServiceCIDR, t.localCluster.Spec.ClusterCIDR...),
 		}
 
@@ -184,13 +261,20 @@ func newTestDriver() *testDriver {
 			return t.netLink
 		}
 
-		t.netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{MTU: 10})
+		t.netLink.SetupDefaultGateway(k8snet.IPv4, net.Interface{Index: 99, MTU: 10})
+		t.netLink.SetupDefaultGateway(k8snet.IPv6, net.Interface{Index: 100, MTU: 10})
 
 		cni.HostInterfaces = func() ([]cni.HostInterface, error) {
-			return []cni.HostInterface{{
-				Name: "veth0",
-				Addr: cniIPAddress + "/24",
-			}}, nil
+			return []cni.HostInterface{
+				{
+					Name: "veth0",
+					Addr: cniIPAddress + "/24",
+				},
+				{
+					Name: "veth0",
+					Addr: cniIPv6Address + "/64",
+				},
+			}, nil
 		}
 	})
 

--- a/pkg/netlink/netlink.go
+++ b/pkg/netlink/netlink.go
@@ -341,7 +341,7 @@ func ipConfPath(interfaceName string, family k8snet.IPFamily) string {
 	return "/proc/sys/net/ipv" + string(family) + "/conf/" + interfaceName
 }
 
-func DeleteIfaceAndAssociatedRoutes(iface string, tableID int) error {
+func DeleteIfaceAndAssociatedRoutes(iface string, tableID int, family k8snet.IPFamily) error {
 	n := New()
 
 	link, err := n.LinkByName(iface)
@@ -353,10 +353,10 @@ func DeleteIfaceAndAssociatedRoutes(iface string, tableID int) error {
 		return nil
 	}
 
-	currentRouteList, err := n.RouteList(link, k8snet.IPv4)
+	currentRouteList, err := n.RouteList(link, family)
 
 	if err != nil {
-		logger.Warningf("Unable to cleanup routes, error retrieving routes on the link %s: %v", iface, err)
+		logger.Warningf("Unable to cleanup routes, error retrieving IPv%v routes on the link %s: %v", family, iface, err)
 	} else {
 		for i := range currentRouteList {
 			logger.V(log.DEBUG).Infof("Processing route %v", currentRouteList[i])

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -19,10 +19,13 @@ limitations under the License.
 package cabledriver
 
 import (
+	"errors"
+
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/submariner/pkg/cable/vxlan"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -47,5 +50,8 @@ func (h *vxlanCleanup) GetName() string {
 func (h *vxlanCleanup) TransitionToNonGateway() error {
 	logger.Infof("Cleaning up the routes")
 
-	return netlink.DeleteIfaceAndAssociatedRoutes(vxlan.VxlanIface, vxlan.TableID) //nolint:wrapcheck  // No need to wrap this error
+	errv6 := netlink.DeleteIfaceAndAssociatedRoutes(vxlan.GetVxlanInterfaceName(k8snet.IPv6), vxlan.TableID, k8snet.IPv6)
+	errv4 := netlink.DeleteIfaceAndAssociatedRoutes(vxlan.GetVxlanInterfaceName(k8snet.IPv4), vxlan.TableID, k8snet.IPv4)
+
+	return errors.Join(errv6, errv4)
 }


### PR DESCRIPTION
 Implement VxLAN inter-cluster tunnels with separate interfaces per IP family.

Fixes https://github.com/submariner-io/submariner/issues/3464

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
