### PR TITLE
Skip JSON error checking when unnecessary

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,13 @@ linters:
           deny:
             - pkg: github.com/submariner-io/submariner/pkg/cable/wireguard
               desc: Breaks Windows builds
+    errcheck:
+      exclude-functions:
+        - encoding/json.Marshal
+        - encoding/json.MarshalIndent
+    errchkjson:
+      check-error-free-encoding: true
+      report-no-exported: true
     gocritic:
       disabled-checks:
         - ifElseChain

--- a/pkg/packetfilter/fake/packetfilter.go
+++ b/pkg/packetfilter/fake/packetfilter.go
@@ -153,10 +153,8 @@ func fromRuleString(str string) *packetfilter.Rule {
 }
 
 func toRuleString(rule *packetfilter.Rule) string {
-	b, err := json.Marshal(*rule)
-	if err != nil {
-		panic(err)
-	}
+	// The definition of Rule ensures it can be encoded, no need to check for errors
+	b, _ := json.Marshal(*rule)
 
 	return string(b)
 }

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -198,8 +198,8 @@ func toTransitSwitchIPAnnotation(ips ...string) string {
 		return ""
 	}
 
-	bytes, err := json.Marshal(data)
-	Expect(err).To(Succeed())
+	// Maps of strings can always be encoded, no need to check for errors
+	bytes, _ := json.Marshal(data)
 
 	return string(bytes)
 }


### PR DESCRIPTION
It is possible to determine statically that the argument to json.Marshal or json.MarshalIndent is safe to encode, and can't produce an error. In such cases there is no point in checking the returned error. As a side benefit, removing the "if err" blocks reduces measured cyclomatic complexity and increases code coverage.

errchkjson can detect this, but even when enabled, its checks default to disabled. This enables the checks and configures errcheck to ignore json.Marshal and json.MarshalIndent (this is safe because they are checked by errchkjson).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
