### PR TITLE
Delete SUBMARINER-FORWARD chain when Submariner uninstalled

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/uninstall.go
@@ -78,14 +78,14 @@ func (kp *SyncHandler) deleteIPTableChains() {
 		return
 	}
 
-	logger.Infof("Flushing packetfilter entries in %q chain of %q table", constants.SmPostRoutingChain, constants.NATTable)
+	logger.Infof("Flushing IPv%v packetfilter entries in %q chain of %q table", kp.ipFamily, constants.SmPostRoutingChain, constants.NATTable)
 
 	if err := pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmPostRoutingChain); err != nil {
 		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmPostRoutingChain,
 			constants.NATTable)
 	}
 
-	logger.Infof("Deleting iptable entry in %q chain of %q table", constants.PostRoutingChain, constants.NATTable)
+	logger.Infof("Deleting IPv%v packetfilter entry in %q chain of %q table", kp.ipFamily, constants.PostRoutingChain, constants.NATTable)
 
 	chain := packetfilter.ChainIPHook{
 		Name:     constants.SmPostRoutingChain,
@@ -94,18 +94,18 @@ func (kp *SyncHandler) deleteIPTableChains() {
 		Priority: packetfilter.ChainPriorityFirst,
 	}
 	if err := pFilter.DeleteIPHookChain(&chain); err != nil {
-		logger.Errorf(err, "Error deleting IPHook chain %q of %q table", constants.SmPostRoutingChain,
+		logger.Errorf(err, "Error deleting IPv%v IPHook chain %q of %q table", kp.ipFamily, constants.SmPostRoutingChain,
 			constants.NATTable)
 	}
 
-	logger.Infof("Flushing iptable entries in %q chain of %q table", constants.SmInputChain, constants.FilterTable)
+	logger.Infof("Flushing IPv%v packetfilter entries in %q chain of %q table", kp.ipFamily, constants.SmInputChain, constants.FilterTable)
 
 	if err := pFilter.ClearChain(packetfilter.TableTypeFilter, constants.SmInputChain); err != nil {
-		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmInputChain,
+		logger.Errorf(err, "Error flushing IPv%v packetfilter chain %q of %q table", kp.ipFamily, constants.SmInputChain,
 			constants.FilterTable)
 	}
 
-	logger.Infof("Deleting iptable entry in %q chain of %q table", constants.InputChain, constants.FilterTable)
+	logger.Infof("Deleting IPv%v packetfilter entry in %q chain of %q table", kp.ipFamily, constants.InputChain, constants.FilterTable)
 
 	chain = packetfilter.ChainIPHook{
 		Name:     constants.SmInputChain,
@@ -119,14 +119,14 @@ func (kp *SyncHandler) deleteIPTableChains() {
 		},
 	}
 	if err := pFilter.DeleteIPHookChain(&chain); err != nil {
-		logger.Errorf(err, "Error deleting IPHook chain %q of %q table", constants.InputChain,
+		logger.Errorf(err, "Error deleting IPv%v IPHook chain %q of %q table", kp.ipFamily, constants.InputChain,
 			constants.FilterTable)
 	}
 
-	logger.Infof("Flushing packetfilter entries in %q chain of %q table", constants.SmSelfSnatChain, constants.NATTable)
+	logger.Infof("Flushing IPv%v packetfilter entries in %q chain of %q table", kp.ipFamily, constants.SmSelfSnatChain, constants.NATTable)
 
 	if err := pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmSelfSnatChain); err != nil {
-		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmSelfSnatChain,
+		logger.Errorf(err, "Error flushing IPv%v packetfilter chain %q of %q table", kp.ipFamily, constants.SmSelfSnatChain,
 			constants.NATTable)
 	}
 
@@ -138,7 +138,26 @@ func (kp *SyncHandler) deleteIPTableChains() {
 	}
 
 	if err := pFilter.DeleteIPHookChain(&chain); err != nil {
-		logger.Errorf(err, "Error deleting IPHook chain %q of %q table", constants.SmSelfSnatChain,
+		logger.Errorf(err, "Error deleting IPv%v IPHook chain %q of %q table", kp.ipFamily, constants.SmSelfSnatChain,
 			constants.NATTable)
+	}
+
+	logger.Infof("Flushing IPv%v packetfilter entries in %q chain of %q table", kp.ipFamily, constants.SmForwardChain, constants.FilterTable)
+
+	if err := pFilter.ClearChain(packetfilter.TableTypeFilter, constants.SmForwardChain); err != nil {
+		logger.Errorf(err, "Error flushing IPv%v packetfilter chain %q of %q table", kp.ipFamily, constants.SmForwardChain,
+			constants.FilterTable)
+	}
+
+	chain = packetfilter.ChainIPHook{
+		Name:     constants.SmForwardChain,
+		Type:     packetfilter.ChainTypeFilter,
+		Hook:     packetfilter.ChainHookForward,
+		Priority: packetfilter.ChainPriorityFirst,
+	}
+
+	if err := pFilter.DeleteIPHookChain(&chain); err != nil {
+		logger.Errorf(err, "Error deleting IPv%v IPHook chain %q of %q table", kp.ipFamily, constants.SmForwardChain,
+			constants.FilterTable)
 	}
 }


### PR DESCRIPTION
In kube-proxy–based deployments, SUBMARINER-FORWARD chain in Filter table isn’t removed when Submariner is uninstalled. This commit fixes that issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
