### PR TITLE
Automated backport of #3613: Switch from --forceencaps to --encapsulation for Libreswan

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -52,7 +52,7 @@ const (
 	whackTimeout     = 5 * time.Second
 	dpdDelay         = 30 // seconds
 	encryptArg       = "--encrypt"
-	forceencapsArg   = "--forceencaps"
+	forceencapsArg   = "--encapsulation=yes"
 	nameArg          = "--name"
 	hostArg          = "--host"
 	clientArg        = "--client"


### PR DESCRIPTION
Backport of #3613 on release-0.21.

#3613: Switch from --forceencaps to --encapsulation for Libreswan

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.