### PR TITLE
Align Libreswan startup with the current package

### DIFF
--- a/package/pluto
+++ b/package/pluto
@@ -6,8 +6,8 @@ set -e
 
 # These are the ExecStartPre lines from the systemd service definition
 /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-/usr/libexec/ipsec/_stackmanager start
-/usr/sbin/ipsec --checknss
+/usr/sbin/ipsec checknss
+/usr/sbin/ipsec checknflog
 
 # Start the daemon itself with any additional arguments passed in
 exec /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork  "$@"


### PR DESCRIPTION
The systemd unit no longer uses _stackmanager.

This is required before Submariner can switch to Libreswan 5.3.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
