### PR TITLE
Automated backport of #3621: Align Libreswan startup with the current package

### DIFF
--- a/package/pluto
+++ b/package/pluto
@@ -6,8 +6,8 @@ set -e
 
 # These are the ExecStartPre lines from the systemd service definition
 /usr/libexec/ipsec/addconn --config /etc/ipsec.conf --checkconfig
-/usr/libexec/ipsec/_stackmanager start
-/usr/sbin/ipsec --checknss
+/usr/sbin/ipsec checknss
+/usr/sbin/ipsec checknflog
 
 # Start the daemon itself with any additional arguments passed in
 exec /usr/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork  "$@"


### PR DESCRIPTION
Backport of #3621 on release-0.19.

#3621: Align Libreswan startup with the current package

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.