### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for submariner-gateway-0-21

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -77,4 +77,5 @@ LABEL com.redhat.component="submariner-gateway-container" \
       io.openshift.tags="submariner, submariner-gateway, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}"
+      com.github.commit="${BASE_BRANCH}" \
+      cpe="cpe:/a:redhat:acm:2.14::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
