### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for submariner-globalnet-0-21

### DIFF
--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -55,6 +55,7 @@ USER submariner
 ENTRYPOINT ["/usr/local/bin/submariner-globalnet.sh"]
 
 LABEL com.redhat.component="submariner-globalnet-container" \
+      com.redhat.component.cpe="cpe:/a:redhat:acm:2.14::el9" \
       name="rhacm2/submariner-globalnet-rhel9" \
       version="${BASE_BRANCH}" \
       summary="Submariner Globalnet" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
