### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for submariner-route-agent-0-21

### DIFF
--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -73,5 +73,6 @@ LABEL com.redhat.component="submariner-route-agent-container" \
       io.k8s.description="The Submariner Route Agent programs network routes on each node." \
       io.openshift.tags="submariner, submariner-route-agent, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       com.github.url="https://github.com/submariner-io/submariner" \
       com.github.commit="${BASE_BRANCH}"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
