### PR TITLE
Switch from tcp.GlobalIP to tcp.GlobalServiceIP

### DIFF
--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -176,7 +176,7 @@ func AwaitNewSubmarinerGatewayFullyConnected(f *subFramework.Framework, cluster 
 
 func defaultEndpointType() tcp.EndpointType {
 	if framework.TestContext.GlobalnetEnabled {
-		return tcp.GlobalIP
+		return tcp.GlobalServiceIP
 	}
 
 	return tcp.PodIP


### PR DESCRIPTION
The GlobalIP constant is supposed to be replaced by GlobalServiceIP.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
