### PR TITLE
Add certificate mode in libreswan cabledriver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/projectcalico/api v0.0.0-20230602153125-fb7148692637
 	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/submariner-io/admiral v0.22.0-m2
+	github.com/submariner-io/admiral v0.22.0-m2.0.20250922120533-cf7a419a6959
 	github.com/submariner-io/shipyard v0.22.0-m2.0.20251001113420-533a08875d8a
 	github.com/tigera/operator/api v0.0.0-20250829192342-96fd517a8419
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/submariner-io/admiral v0.22.0-m2 h1:xqTAG4K3KZK/njZzFhHvHSUmySFccH5tjt7eZyAQbS4=
-github.com/submariner-io/admiral v0.22.0-m2/go.mod h1:hUo1VXXN4u1MUF0S6KS4Zro4NsjvGo7Rb0QjhGOhHU0=
+github.com/submariner-io/admiral v0.22.0-m2.0.20250922120533-cf7a419a6959 h1:mh952jf9nCbK5xrSC5zmjTR6Vihti3JNh8M/jXMKfNw=
+github.com/submariner-io/admiral v0.22.0-m2.0.20250922120533-cf7a419a6959/go.mod h1:hUo1VXXN4u1MUF0S6KS4Zro4NsjvGo7Rb0QjhGOhHU0=
 github.com/submariner-io/shipyard v0.22.0-m2.0.20251001113420-533a08875d8a h1:Lu5bHDhke8X5RGuSliBkjQMyRbtE7leJBOrQSxOekr4=
 github.com/submariner-io/shipyard v0.22.0-m2.0.20251001113420-533a08875d8a/go.mod h1:TmDIW/DT0VABavNDZ7/gX05GxK9J6mskGszXhpyayWY=
 github.com/tigera/operator/api v0.0.0-20250829192342-96fd517a8419 h1:Shdwa7T6XNY6oKRiJVKkbH9L4V9iyAb6xb8k4FJ9OB4=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/http"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
@@ -126,14 +125,6 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 
-	signingRequestor, err := certificate.StartSigningRequestor(broker.SyncerConfig{
-		LocalRestConfig: restConfig,
-		LocalClient:     dynClient,
-		RestMapper:      restMapper,
-		Scheme:          scheme.Scheme,
-	}, ctx.Done())
-	logger.FatalOnError(err, "Error creating SigningRequestor")
-
 	gw, err := gateway.New(ctx, &gateway.Config{
 		LeaderElectionConfig: gateway.LeaderElectionConfig{
 			LeaseDuration: time.Duration(gwLeadershipConfig.LeaseDuration) * time.Second,
@@ -155,7 +146,6 @@ func main() {
 		LeaderElectionClient: leClient,
 		NewCableEngine:       cableengine.NewEngine,
 		NewNATDiscovery:      natdiscovery.New,
-		SigningRequestor:     signingRequestor,
 	})
 	logger.FatalOnError(err, "Error creating gateway instance")
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/http"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
@@ -125,6 +126,14 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 
+	signingRequestor, err := certificate.StartSigningRequestor(broker.SyncerConfig{
+		LocalRestConfig: restConfig,
+		LocalClient:     dynClient,
+		RestMapper:      restMapper,
+		Scheme:          scheme.Scheme,
+	}, ctx.Done())
+	logger.FatalOnError(err, "Error creating SigningRequestor")
+
 	gw, err := gateway.New(ctx, &gateway.Config{
 		LeaderElectionConfig: gateway.LeaderElectionConfig{
 			LeaseDuration: time.Duration(gwLeadershipConfig.LeaseDuration) * time.Second,
@@ -136,6 +145,7 @@ func main() {
 			LocalRestConfig: restConfig,
 			LocalClient:     dynClient,
 			RestMapper:      restMapper,
+			Scheme:          scheme.Scheme,
 		},
 		WatcherConfig: watcher.Config{
 			RestConfig: restConfig,
@@ -145,6 +155,7 @@ func main() {
 		LeaderElectionClient: leClient,
 		NewCableEngine:       cableengine.NewEngine,
 		NewNATDiscovery:      natdiscovery.New,
+		SigningRequestor:     signingRequestor,
 	})
 	logger.FatalOnError(err, "Error creating gateway instance")
 

--- a/package/Dockerfile.submariner-gateway
+++ b/package/Dockerfile.submariner-gateway
@@ -24,7 +24,8 @@ COPY package/dnf_install /
 # kmod is required so that libreswan can load modules
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/gateway \
     glibc bash glibc-minimal-langpack coreutils-single \
-    libcurl-minimal iproute libreswan kmod
+    libcurl-minimal iproute libreswan kmod \
+    openssl nss-tools
 
 FROM scratch
 ARG SOURCE

--- a/pkg/cable/driver.go
+++ b/pkg/cable/driver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/endpoint"
@@ -57,7 +58,8 @@ type Driver interface {
 }
 
 // Function prototype to create a new driver.
-type DriverCreateFunc func(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster) (Driver, error)
+type DriverCreateFunc func(localEndpoint *endpoint.Local,
+	localCluster *types.SubmarinerCluster, signingRequestor certificate.SigningRequestor) (Driver, error)
 
 const (
 	InterfaceNameConfig = "interface-name"
@@ -82,7 +84,9 @@ func AddDriver(name string, driverCreate DriverCreateFunc) {
 }
 
 // Returns a new driver according the required Backend.
-func NewDriver(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster) (Driver, error) {
+func NewDriver(localEndpoint *endpoint.Local, localCluster *types.SubmarinerCluster,
+	signingRequestor certificate.SigningRequestor,
+) (Driver, error) {
 	// We'll panic if localEndpoint or localCluster are nil, this is intentional
 	spec := localEndpoint.Spec()
 
@@ -101,7 +105,7 @@ func NewDriver(localEndpoint *endpoint.Local, localCluster *types.SubmarinerClus
 		return nil, fmt.Errorf("unsupported cable type %s; supported types: %s", spec.Backend, driverList.String())
 	}
 
-	return driverCreate(localEndpoint, localCluster)
+	return driverCreate(localEndpoint, localCluster, signingRequestor)
 }
 
 // Sets the default cable driver name, if it is not specified by user.

--- a/pkg/cable/libreswan/certificate_auth_mode.go
+++ b/pkg/cable/libreswan/certificate_auth_mode.go
@@ -1,0 +1,183 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libreswan
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/command"
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/natdiscovery"
+)
+
+func appendConnectionStanza(stanza, connName string) error {
+	if err := removeConnectionStanza(connName); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(SubmarinerConfPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return errors.Wrap(err, "error opening file")
+	}
+
+	defer f.Close()
+
+	if !strings.HasSuffix(stanza, "\n") {
+		stanza += "\n"
+	}
+
+	_, err = f.WriteString(stanza)
+
+	return errors.Wrap(err, "error writing to file")
+}
+
+func removeConnectionStanza(connName string) error {
+	data, err := os.ReadFile(SubmarinerConfPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "error reading file")
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	inStanza := false
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == ("conn " + connName) {
+			inStanza = true
+			continue
+		}
+
+		if inStanza && strings.HasPrefix(line, "conn ") && strings.TrimSpace(line) != ("conn "+connName) {
+			inStanza = false
+		}
+
+		if !inStanza {
+			out = append(out, line)
+		}
+	}
+
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+
+	if len(out) == 0 {
+		return errors.Wrap(os.Remove(SubmarinerConfPath()), "error removing file")
+	}
+
+	return errors.Wrap(os.WriteFile(SubmarinerConfPath(), []byte(strings.Join(out, "\n")+"\n"), 0o600), "error writing file")
+}
+
+func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
+	endpoint := &endpointInfo.Endpoint
+	leftID := "submariner-client-" + i.localEndpoint.ClusterID
+	left := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
+	right := endpointInfo.UseIP
+
+	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
+	rightSubnets := endpoint.Spec.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
+
+	for lsi, leftSubnet := range leftSubnets {
+		for rsi, rightSubnet := range rightSubnets {
+			connName := toConnectionName(endpoint.Spec.CableName, endpointInfo.UseFamily, lsi, rsi)
+
+			encapsulationLine := ""
+			if endpointInfo.UseNAT || i.forceUDPEncapsulation {
+				encapsulationLine = "    encapsulation=yes\n"
+			}
+
+			conf := fmt.Sprintf(`conn %s
+    left=%s
+    leftid=%%fromcert
+    leftcert=%s
+    leftrsasigkey=%%cert
+    leftsubnet=%s
+    leftmodecfgclient=false
+    right=%s
+    rightid=%%fromcert
+    rightsubnet=%s
+%s    auto=add
+    ikev2=insist
+    authby=rsasig
+    type=tunnel`,
+				connName,
+				left,
+				leftID,
+				leftSubnet,
+				right,
+				rightSubnet,
+				encapsulationLine,
+			)
+			if err := appendConnectionStanza(conf, connName); err != nil {
+				return "", errors.Wrapf(err, "failed to append connection stanza to %s", SubmarinerConfPath())
+			}
+
+			logger.Infof("Appended Libreswan connection config for %s to %s", connName, SubmarinerConfPath())
+
+			output, err := command.New(exec.Command("ipsec", "auto", "--add", connName)).CombinedOutput()
+			if err != nil {
+				return "", errors.Wrapf(err, "failed to add connection with ipsec auto --add: %s", string(output))
+			}
+
+			logger.Infof("Added connection with ipsec auto --add: %s", string(output))
+
+			connectionMode := i.calculateOperationMode(&endpoint.Spec)
+
+			logger.Infof("Connection mode for %s: %v", connName, connectionMode)
+
+			if connectionMode == operationModeClient || connectionMode == operationModeBidirectional {
+				whackArgs := []string{"--name", connName, "--initiate"}
+				//nolint:gosec // ipsec whack args are from trusted config
+				output, err = command.New(exec.Command("ipsec", append([]string{"whack"}, whackArgs...)...)).CombinedOutput()
+				if err != nil {
+					return "", errors.Wrapf(err, "failed to bring up connection %s with whack: %s", connName, string(output))
+				}
+
+				logger.Infof("Brought up connection %s with whack: %s", connName, string(output))
+			}
+		}
+	}
+
+	i.connections = append(i.connections,
+		subv1.Connection{
+			Endpoint: endpoint.Spec,
+			UsingIP:  endpointInfo.UseIP,
+			UsingNAT: endpointInfo.UseNAT,
+			Status:   subv1.Connected,
+		})
+
+	return endpointInfo.UseIP, nil
+}
+
+func (i *libreswan) disconnectCertMode(connectionName string) error {
+	if err := removeConnectionStanza(connectionName); err != nil {
+		return errors.Wrapf(err, "failed to remove connection stanza for %q", connectionName)
+	}
+
+	logger.Infof("Removed Libreswan connection config for %q", connectionName)
+
+	return nil
+}

--- a/pkg/cable/libreswan/certificate_controller.go
+++ b/pkg/cable/libreswan/certificate_controller.go
@@ -1,0 +1,197 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libreswan
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
+	"github.com/submariner-io/admiral/pkg/command"
+	"github.com/submariner-io/admiral/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var certLogger = log.Logger{Logger: logf.Log.WithName("certificate-controller")}
+
+func initNSSDatabase(nssDBDir string) error {
+	if _, err := os.Stat(nssDBDir + "/cert9.db"); err == nil {
+		certLogger.Info("NSS database already exists , using existing database")
+		return nil
+	}
+
+	certLogger.Info("NSS database does not exist, initializing new database")
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	//nolint:gosec // certutil args are from trusted config
+	cmd := command.New(exec.CommandContext(ctx, "certutil", "-N", "-d", "sql:"+nssDBDir, "--empty-password"))
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "failed to initialize NSS database")
+	}
+
+	certLogger.Info("NSS database initialized successfully")
+
+	return nil
+}
+
+func loadCertificatesIntoNSS(nssDBDir string, tlsCert, tlsKey, caCert []byte) error {
+	// Load CA certificate
+	if err := loadCertificate(nssDBDir, caCert, "ca-cert", "C,,", "c"); err != nil {
+		return errors.Wrap(err, "failed to load CA certificate")
+	}
+
+	// Load client certificate
+	if err := loadCertificate(nssDBDir, tlsCert, "client-cert", "C,,", "c"); err != nil {
+		return errors.Wrap(err, "failed to load client certificate")
+	}
+
+	// Load client private key
+	if err := loadPrivateKey(nssDBDir, tlsKey, "client-key"); err != nil {
+		return errors.Wrap(err, "failed to load client private key")
+	}
+
+	certLogger.Info("Certificates successfully loaded into NSS database")
+
+	return nil
+}
+
+func loadCertificate(nssDBDir string, certData []byte, nickname, trustFlags, certType string) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	//nolint:gosec // certutil args are from trusted config
+	execCmd := exec.CommandContext(ctx, "certutil", "-A", "-d", "sql:"+nssDBDir, "-n", nickname, "-t", trustFlags, "-i", "-", "-a")
+	execCmd.Stdin = bytes.NewReader(certData)
+
+	cmd := command.New(execCmd)
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrapf(err, "failed to load %s", certType)
+	}
+
+	return nil
+}
+
+func loadPrivateKey(nssDBDir string, keyData []byte, nickname string) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	//nolint:gosec // certutil args are from trusted config
+	execCmd := exec.CommandContext(ctx, "certutil", "-A", "-d", "sql:"+nssDBDir, "-n", nickname, "-t", "u,u,u", "-i", "-", "-a")
+	execCmd.Stdin = bytes.NewReader(keyData)
+
+	cmd := command.New(execCmd)
+
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "failed to load private key")
+	}
+
+	return nil
+}
+
+// CertificateHandler handles NSS database operations for certificates.
+type CertificateHandler struct {
+	clusterID    string
+	nssDBDir     string
+	lastCertHash string
+}
+
+func NewCertificateHandler(clusterID string) *CertificateHandler {
+	return &CertificateHandler{
+		clusterID: clusterID,
+		nssDBDir:  "/var/lib/ipsec/nss",
+	}
+}
+
+func (c *CertificateHandler) Cleanup() {
+	certLogger.Info("Cleaning up certificate handler")
+	c.cleanupCertificateFromNSS()
+}
+
+func (c *CertificateHandler) cleanupCertificateFromNSS() {
+	certName := "submariner-client-" + c.clusterID
+	caName := "submariner-ca"
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+
+	defer cancel()
+
+	// Delete client certificate
+	//nolint:gosec // certutil args are from trusted config
+	cmd := command.New(exec.CommandContext(ctx, "certutil", "-D", "-d", "sql:"+c.nssDBDir, "-n", certName))
+
+	if err := cmd.Run(); err != nil {
+		certLogger.Warningf("Failed to delete client certificate from NSS database: %v", err)
+	} else {
+		certLogger.Infof("Deleted Submariner client certificate from NSS database: %s", certName)
+	}
+
+	// Delete CA certificate
+	//nolint:gosec // certutil args are from trusted config
+	cmd = command.New(exec.CommandContext(ctx, "certutil", "-D", "-d", "sql:"+c.nssDBDir, "-n", caName))
+
+	if err := cmd.Run(); err != nil {
+		certLogger.Warningf("Failed to delete CA certificate from NSS database: %v", err)
+	} else {
+		certLogger.Infof("Deleted Submariner CA certificate from NSS database: %s", caName)
+	}
+}
+
+// OnSignedCallback implements the OnSignedFn callback for admiral's SigningRequestor.
+func (c *CertificateHandler) OnSignedCallback(secretData map[string][]byte) error {
+	// Extract certificate data
+	tlsCert := secretData[certificate.TLSDataKey]
+	tlsKey := secretData[certificate.PrivateKeyDataKey]
+	caCert := secretData[certificate.CADataKey]
+
+	// Compute hash of cert+key+ca to avoid reloading the same certificates
+	certData := string(tlsCert) + string(tlsKey) + string(caCert)
+	certHash := fmt.Sprintf("%x", sha256.Sum256([]byte(certData)))
+
+	if certHash == c.lastCertHash {
+		certLogger.V(log.TRACE).Info("Certificate data unchanged, skipping NSS loading")
+		return nil
+	}
+
+	certLogger.Info("Certificate ready, loading into NSS database")
+
+	if err := initNSSDatabase(c.nssDBDir); err != nil {
+		certLogger.Error(err, "Failed to initialize NSS database")
+		return errors.Wrap(err, "failed to initialize NSS database")
+	}
+
+	if err := loadCertificatesIntoNSS(c.nssDBDir, tlsCert, tlsKey, caCert); err != nil {
+		certLogger.Error(err, "Failed to load certificates into NSS database")
+		return errors.Wrap(err, "failed to load certificates into NSS database")
+	}
+
+	certLogger.Info("Certificates successfully loaded into NSS database via callback")
+
+	c.lastCertHash = certHash
+
+	return nil
+}

--- a/pkg/cable/libreswan/certificate_handler.go
+++ b/pkg/cable/libreswan/certificate_handler.go
@@ -34,7 +34,21 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var certLogger = log.Logger{Logger: logf.Log.WithName("certificate-controller")}
+var certLogger = log.Logger{Logger: logf.Log.WithName("CertHandler")}
+
+// CertificateHandler handles NSS database operations for certificates.
+type CertificateHandler struct {
+	clusterID    string
+	nssDBDir     string
+	lastCertHash string
+}
+
+func NewCertificateHandler(clusterID string) *CertificateHandler {
+	return &CertificateHandler{
+		clusterID: clusterID,
+		nssDBDir:  "/var/lib/ipsec/nss",
+	}
+}
 
 func initNSSDatabase(nssDBDir string) error {
 	if _, err := os.Stat(nssDBDir + "/cert9.db"); err == nil {
@@ -44,7 +58,7 @@ func initNSSDatabase(nssDBDir string) error {
 
 	certLogger.Info("NSS database does not exist, initializing new database")
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	//nolint:gosec // certutil args are from trusted config
@@ -114,20 +128,6 @@ func loadPrivateKey(nssDBDir string, keyData []byte, nickname string) error {
 	return nil
 }
 
-// CertificateHandler handles NSS database operations for certificates.
-type CertificateHandler struct {
-	clusterID    string
-	nssDBDir     string
-	lastCertHash string
-}
-
-func NewCertificateHandler(clusterID string) *CertificateHandler {
-	return &CertificateHandler{
-		clusterID: clusterID,
-		nssDBDir:  "/var/lib/ipsec/nss",
-	}
-}
-
 func (c *CertificateHandler) Cleanup() {
 	certLogger.Info("Cleaning up certificate handler")
 	c.cleanupCertificateFromNSS()
@@ -180,12 +180,10 @@ func (c *CertificateHandler) OnSignedCallback(secretData map[string][]byte) erro
 	certLogger.Info("Certificate ready, loading into NSS database")
 
 	if err := initNSSDatabase(c.nssDBDir); err != nil {
-		certLogger.Error(err, "Failed to initialize NSS database")
 		return errors.Wrap(err, "failed to initialize NSS database")
 	}
 
 	if err := loadCertificatesIntoNSS(c.nssDBDir, tlsCert, tlsKey, caCert); err != nil {
-		certLogger.Error(err, "Failed to load certificates into NSS database")
 		return errors.Wrap(err, "failed to load certificates into NSS database")
 	}
 

--- a/pkg/cable/libreswan/certificate_handler_test.go
+++ b/pkg/cable/libreswan/certificate_handler_test.go
@@ -1,0 +1,152 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libreswan_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
+	fakecommand "github.com/submariner-io/admiral/pkg/command/fake"
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable/libreswan"
+	"github.com/submariner-io/submariner/pkg/endpoint"
+	"github.com/submariner-io/submariner/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+type mockSigningRequestor struct{}
+
+func (m *mockSigningRequestor) Issue(ctx context.Context, name string, sanIPs []string, callback certificate.OnSignedFn) error {
+	certData := map[string][]byte{
+		certificate.TLSDataKey:        []byte("mock-tls-cert"),
+		certificate.PrivateKeyDataKey: []byte("mock-tls-key"),
+		certificate.CADataKey:         []byte("mock-ca-cert"),
+	}
+
+	return callback(certData)
+}
+
+func (m *mockSigningRequestor) Uninstall(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSigningRequestor) Remove(ctx context.Context, name string) error {
+	return nil
+}
+
+func testCertificate() {
+	_ = newTestDriver()
+
+	When("certificate authentication mode is enabled", func() {
+		It("should create driver with certificate mode", func() {
+			os.Setenv(authModeEnvVar, "cert")
+			defer os.Unsetenv(authModeEnvVar)
+
+			endpointSpec := subv1.EndpointSpec{
+				ClusterID:  "local",
+				CableName:  "submariner-cable-local-192-68-1-1",
+				PrivateIPs: []string{"192.68.1.1"},
+				Subnets:    []string{"10.0.0.0/16"},
+			}
+			localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
+
+			driver, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(driver).NotTo(BeNil())
+			Expect(driver.GetName()).To(Equal("libreswan"))
+		})
+	})
+
+	Context("Certificate loading", func() {
+		var cmdExecutor *fakecommand.Executor
+		var handler *libreswan.CertificateHandler
+
+		BeforeEach(func() {
+			cmdExecutor = fakecommand.New()
+			handler = libreswan.NewCertificateHandler("test-cluster")
+			Expect(handler).NotTo(BeNil())
+			DeferCleanup(cmdExecutor.Clear)
+		})
+
+		It("should successfully load certificates into NSS database", func() {
+			certData := map[string][]byte{
+				certificate.CADataKey:         []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				certificate.TLSDataKey:        []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				certificate.PrivateKeyDataKey: []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := handler.OnSignedCallback(certData)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-N", "--empty-password")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "ca-cert")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "client-cert")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "client-key")
+		})
+
+		It("should handle NSS database initialization failure", func() {
+			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
+				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-N", "--empty-password") {
+					return fakecommand.InterceptorFuncs{Run: func() error {
+						return errors.New("database init failed")
+					}}
+				}
+
+				return fakecommand.InterceptorFuncs{}
+			})
+
+			certData := map[string][]byte{
+				certificate.CADataKey:         []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				certificate.TLSDataKey:        []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				certificate.PrivateKeyDataKey: []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := handler.OnSignedCallback(certData)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should handle certificate loading failure", func() {
+			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
+				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-A", "ca-cert") {
+					return fakecommand.InterceptorFuncs{Run: func() error {
+						return errors.New("certificate load failed")
+					}}
+				}
+
+				return fakecommand.InterceptorFuncs{}
+			})
+
+			certData := map[string][]byte{
+				certificate.CADataKey:         []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				certificate.TLSDataKey:        []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				certificate.PrivateKeyDataKey: []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := handler.OnSignedCallback(certData)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -59,8 +59,6 @@ const (
 	ikeportArg       = "--ikeport"
 	dpdactionHoldArg = "--dpdaction=hold"
 	dpddelayArg      = "--dpddelay"
-	certArg          = "--cert"
-	caArg            = "--ca"
 )
 
 // AuthMode defines the authentication mode for libreswan.
@@ -108,9 +106,8 @@ type libreswan struct {
 	plutoStarted          bool
 	authMode              AuthMode
 
-	stopCh                chan struct{}
-	certificateController *CertificateHandler
-	signingRequestor      certificate.SigningRequestor
+	certificateHandler *CertificateHandler
+	signingRequestor   certificate.SigningRequestor
 }
 
 type specification struct {
@@ -137,12 +134,6 @@ func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster,
 
 	// Parse and validate authentication mode with fallback to PSK
 	authModeStr := ipSecSpec.AuthMode
-	if authModeStr == "" {
-		// Fallback to default PSK mode if not set
-		authModeStr = string(AuthModePSK)
-
-		logger.Info("CE_IPSEC_AUTHMODE not set, defaulting to psk authentication")
-	}
 
 	authMode := AuthMode(authModeStr)
 	if authMode != AuthModePSK && authMode != AuthModeCert {
@@ -227,27 +218,23 @@ func (i *libreswan) Init() error {
 
 		fmt.Fprintf(file, "%%any %%any : PSK \"%s\"\n", i.secretKey)
 	} else if i.authMode == AuthModeCert {
-		logger.Info("Setting up certificate authentication")
-
-		logger.Infof("Starting certificate creation with Private IPs %s Public IPs %s", i.localEndpoint.PrivateIPs, i.localEndpoint.PublicIPs)
+		logger.Infof("Issuing certificate with Private IPs %s Public IPs %s", i.localEndpoint.PrivateIPs, i.localEndpoint.PublicIPs)
 		sanIPs := make([]string, 0, len(i.localEndpoint.PrivateIPs)+len(i.localEndpoint.PublicIPs))
 		sanIPs = append(sanIPs, i.localEndpoint.PrivateIPs...)
 		sanIPs = append(sanIPs, i.localEndpoint.PublicIPs...)
 
-		i.stopCh = make(chan struct{})
-
 		var err error
 
-		i.certificateController = NewCertificateHandler(i.localEndpoint.ClusterID)
+		i.certificateHandler = NewCertificateHandler(i.localEndpoint.ClusterID)
 
-		err = i.signingRequestor.Issue(context.TODO(), "submariner-certificate", sanIPs, i.certificateController.OnSignedCallback)
+		err = i.signingRequestor.Issue(context.TODO(), "libreswan-"+i.localEndpoint.Hostname, sanIPs, i.certificateHandler.OnSignedCallback)
 		if err != nil {
 			logger.Warningf("Unable to issue certificate: %v", err)
 		}
 
-		logger.Info("Started certificate syncers and controller")
-	} else {
-		return fmt.Errorf("unsupported authentication mode: %s", i.authMode)
+		i.plutoStarted = true
+
+		logger.Info("Successfully issued certificate")
 	}
 
 	return nil
@@ -431,156 +418,6 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 	}
 
 	return i.connectToEndpointPSKMode(endpointInfo)
-}
-
-func appendConnectionStanza(confPath, stanza, connName string) error {
-	if err := removeConnectionStanza(confPath, connName); err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(confPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return errors.Wrap(err, "error opening file")
-	}
-
-	defer f.Close()
-
-	if !strings.HasSuffix(stanza, "\n") {
-		stanza += "\n"
-	}
-
-	_, err = f.WriteString(stanza)
-
-	return errors.Wrap(err, "error writing to file")
-}
-
-func removeConnectionStanza(confPath, connName string) error {
-	data, err := os.ReadFile(confPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return errors.Wrap(err, "error reading file")
-	}
-
-	lines := strings.Split(string(data), "\n")
-	var out []string
-	inStanza := false
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "conn ") && strings.TrimSpace(line) == ("conn "+connName) {
-			inStanza = true
-			continue
-		}
-
-		if inStanza && strings.HasPrefix(line, "conn ") && strings.TrimSpace(line) != ("conn "+connName) {
-			inStanza = false
-		}
-
-		if !inStanza {
-			out = append(out, line)
-		}
-	}
-
-	for len(out) > 0 && out[len(out)-1] == "" {
-		out = out[:len(out)-1]
-	}
-
-	if len(out) == 0 {
-		return errors.Wrap(os.Remove(confPath), "error removing file")
-	}
-
-	return errors.Wrap(os.WriteFile(confPath, []byte(strings.Join(out, "\n")+"\n"), 0o600), "error writing file")
-}
-
-func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
-	logger.Info("Certificate mode: skipping pluto start and whack; assuming pluto is managed externally and config/NSS DB are updated.")
-
-	confPath := SubmarinerConfPath()
-	endpoint := &endpointInfo.Endpoint
-	leftID := "submariner-client-" + i.localEndpoint.ClusterID
-	left := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
-	right := endpointInfo.UseIP
-
-	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
-	rightSubnets := endpoint.Spec.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
-
-	for lsi, leftSubnet := range leftSubnets {
-		for rsi, rightSubnet := range rightSubnets {
-			connName := toConnectionName(endpoint.Spec.CableName, endpointInfo.UseFamily, lsi, rsi)
-
-			encapsulationLine := ""
-			if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-				encapsulationLine = "    encapsulation=yes\n"
-			}
-
-			conf := fmt.Sprintf(`conn %s
-    left=%s
-    leftid=%%fromcert
-    leftcert=%s
-    leftrsasigkey=%%cert
-    leftsubnet=%s
-    leftmodecfgclient=false
-    right=%s
-    rightid=%%fromcert
-    rightsubnet=%s
-%s    auto=add
-    ikev2=insist
-    authby=rsasig
-    type=tunnel`,
-				connName,
-				left,
-				leftID,
-				leftSubnet,
-				right,
-				rightSubnet,
-				encapsulationLine,
-			)
-			if err := appendConnectionStanza(confPath, conf, connName); err != nil {
-				logger.Errorf(err, "Failed to append connection stanza to %s", confPath)
-				return "", err
-			}
-
-			logger.Infof("Appended Libreswan connection config for %s to %s", connName, confPath)
-
-			output, err := command.New(exec.Command("ipsec", "auto", "--add", connName)).CombinedOutput()
-			if err != nil {
-				logger.Errorf(err, "Failed to add connection with ipsec auto --add: %s", string(output))
-				return "", errors.Wrap(err, "failed to add connection")
-			} else {
-				logger.Infof("Added connection with ipsec auto --add: %s", string(output))
-			}
-
-			connectionMode := i.calculateOperationMode(&endpoint.Spec)
-
-			logger.Infof("Connection mode for %s: %v", connName, connectionMode)
-
-			if connectionMode == operationModeClient || connectionMode == operationModeBidirectional {
-				whackArgs := []string{"--name", connName, "--initiate"}
-				//nolint:gosec // ipsec whack args are from trusted config
-				output, err = command.New(exec.Command("ipsec", append([]string{"whack"}, whackArgs...)...)).CombinedOutput()
-				if err != nil {
-					logger.Errorf(err, "Failed to bring up connection %s with whack: %s", connName, string(output))
-					return "", errors.Wrap(err, "failed to bring up connection")
-				} else {
-					logger.Infof("Brought up connection %s with whack: %s", connName, string(output))
-				}
-			}
-		}
-	}
-
-	i.connections = append(i.connections,
-		subv1.Connection{
-			Endpoint: endpoint.Spec,
-			UsingIP:  endpointInfo.UseIP,
-			UsingNAT: endpointInfo.UseNAT,
-			Status:   subv1.Connected,
-		})
-
-	i.plutoStarted = true
-
-	return endpointInfo.UseIP, nil
 }
 
 func (i *libreswan) connectToEndpointPSKMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
@@ -815,16 +652,6 @@ func (i *libreswan) DisconnectFromEndpoint(endpoint *types.SubmarinerEndpoint, f
 	return nil
 }
 
-func (i *libreswan) disconnectCertMode(connectionName string) error {
-	if err := removeConnectionStanza(SubmarinerConfPath(), connectionName); err != nil {
-		return errors.Wrapf(err, "failed to remove connection stanza for %q", connectionName)
-	}
-
-	logger.Infof("Removed Libreswan connection config for %q", connectionName)
-
-	return nil
-}
-
 func (i *libreswan) disconnectPSKMode(connectionName string) error {
 	args := []string{"--delete", nameArg, connectionName}
 
@@ -935,12 +762,8 @@ func (i *libreswan) waitForControlSocket() error {
 func (i *libreswan) Cleanup() error {
 	logger.Info("Uninstalling the libreswan cable driver")
 
-	if i.certificateController != nil {
-		i.certificateController.Cleanup()
-	}
-
-	if i.stopCh != nil {
-		close(i.stopCh)
+	if i.certificateHandler != nil {
+		i.certificateHandler.Cleanup()
 	}
 
 	// Delete submariner.conf on uninstall

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -48,20 +48,19 @@ import (
 )
 
 const (
-	cableDriverName    = "libreswan"
-	submarinerConfPath = "/etc/ipsec.d/submariner.conf"
-	whackTimeout       = 5 * time.Second
-	dpdDelay           = 30 // seconds
-	encryptArg         = "--encrypt"
-	forceencapsArg     = "--encapsulation=yes"
-	nameArg            = "--name"
-	hostArg            = "--host"
-	clientArg          = "--client"
-	ikeportArg         = "--ikeport"
-	dpdactionHoldArg   = "--dpdaction=hold"
-	dpddelayArg        = "--dpddelay"
-	certArg            = "--cert"
-	caArg              = "--ca"
+	cableDriverName  = "libreswan"
+	whackTimeout     = 5 * time.Second
+	dpdDelay         = 30 // seconds
+	encryptArg       = "--encrypt"
+	forceencapsArg   = "--encapsulation=yes"
+	nameArg          = "--name"
+	hostArg          = "--host"
+	clientArg        = "--client"
+	ikeportArg       = "--ikeport"
+	dpdactionHoldArg = "--dpdaction=hold"
+	dpddelayArg      = "--dpddelay"
+	certArg          = "--cert"
+	caArg            = "--ca"
 )
 
 // AuthMode defines the authentication mode for libreswan.
@@ -498,13 +497,14 @@ func removeConnectionStanza(confPath, connName string) error {
 func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
 	logger.Info("Certificate mode: skipping pluto start and whack; assuming pluto is managed externally and config/NSS DB are updated.")
 
-	confPath := submarinerConfPath
+	confPath := SubmarinerConfPath()
 	endpoint := &endpointInfo.Endpoint
 	leftID := "submariner-client-" + i.localEndpoint.ClusterID
 	left := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
 	right := endpointInfo.UseIP
-	leftSubnets := i.localEndpoint.Subnets
-	rightSubnets := endpoint.Spec.Subnets
+
+	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
+	rightSubnets := endpoint.Spec.ExtractSubnetsExcludingIP(endpointInfo.UseIP)
 
 	for lsi, leftSubnet := range leftSubnets {
 		for rsi, rightSubnet := range rightSubnets {
@@ -544,9 +544,7 @@ func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndp
 
 			logger.Infof("Appended Libreswan connection config for %s to %s", connName, confPath)
 
-			cmd := exec.Command("ipsec", "auto", "--add", connName)
-
-			output, err := cmd.CombinedOutput()
+			output, err := command.New(exec.Command("ipsec", "auto", "--add", connName)).CombinedOutput()
 			if err != nil {
 				logger.Errorf(err, "Failed to add connection with ipsec auto --add: %s", string(output))
 				return "", errors.Wrap(err, "failed to add connection")
@@ -561,9 +559,7 @@ func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndp
 			if connectionMode == operationModeClient || connectionMode == operationModeBidirectional {
 				whackArgs := []string{"--name", connName, "--initiate"}
 				//nolint:gosec // ipsec whack args are from trusted config
-				cmd = exec.Command("ipsec", append([]string{"whack"}, whackArgs...)...)
-
-				output, err = cmd.CombinedOutput()
+				output, err = command.New(exec.Command("ipsec", append([]string{"whack"}, whackArgs...)...)).CombinedOutput()
 				if err != nil {
 					logger.Errorf(err, "Failed to bring up connection %s with whack: %s", connName, string(output))
 					return "", errors.Wrap(err, "failed to bring up connection")
@@ -571,19 +567,20 @@ func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndp
 					logger.Infof("Brought up connection %s with whack: %s", connName, string(output))
 				}
 			}
-
-			i.connections = append(i.connections,
-				subv1.Connection{
-					Endpoint: endpoint.Spec,
-					UsingIP:  endpointInfo.UseIP,
-					UsingNAT: endpointInfo.UseNAT,
-				})
 		}
 	}
 
+	i.connections = append(i.connections,
+		subv1.Connection{
+			Endpoint: endpoint.Spec,
+			UsingIP:  endpointInfo.UseIP,
+			UsingNAT: endpointInfo.UseNAT,
+			Status:   subv1.Connected,
+		})
+
 	i.plutoStarted = true
 
-	return "", nil
+	return endpointInfo.UseIP, nil
 }
 
 func (i *libreswan) connectToEndpointPSKMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
@@ -786,19 +783,6 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 
 // DisconnectFromEndpoint disconnects from the connection to the given endpoint.
 func (i *libreswan) DisconnectFromEndpoint(endpoint *types.SubmarinerEndpoint, family k8snet.IPFamily) error {
-	if i.authMode == AuthModeCert {
-		confPath := submarinerConfPath
-
-		connName := endpoint.Spec.CableName
-		if err := removeConnectionStanza(confPath, connName); err != nil {
-			logger.Errorf(err, "Failed to remove connection stanza for %s from %s", connName, confPath)
-			return err
-		}
-
-		logger.Infof("Removed Libreswan connection config for %s from %s", connName, confPath)
-
-		return nil
-	}
 	// We'll panic if endpoint is nil, this is intentional
 	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(i.localEndpoint.GetPrivateIP(family))
 	rightSubnets := endpoint.Spec.ExtractSubnetsExcludingIP(endpoint.Spec.GetPrivateIP(family))
@@ -809,15 +793,17 @@ func (i *libreswan) DisconnectFromEndpoint(endpoint *types.SubmarinerEndpoint, f
 		for lsi := range leftSubnets {
 			for rsi := range rightSubnets {
 				connectionName := toConnectionName(endpoint.Spec.CableName, family, lsi, rsi)
-				args := []string{"--delete", nameArg, connectionName}
 
-				if err := whack(args...); err != nil {
-					var exitError *exec.ExitError
-					if errors.As(err, &exitError) {
-						logger.Errorf(err, "Error deleting a connection with args %v; got exit code %d", args, exitError.ExitCode())
-					} else {
-						return errors.Wrapf(err, "error deleting a connection with args %v", args)
-					}
+				var err error
+
+				if i.authMode == AuthModeCert {
+					err = i.disconnectCertMode(connectionName)
+				} else {
+					err = i.disconnectPSKMode(connectionName)
+				}
+
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -825,6 +811,31 @@ func (i *libreswan) DisconnectFromEndpoint(endpoint *types.SubmarinerEndpoint, f
 
 	i.connections = removeConnectionForEndpoint(i.connections, endpoint, family)
 	cable.RecordDisconnected(cableDriverName, &i.localEndpoint, &endpoint.Spec, family)
+
+	return nil
+}
+
+func (i *libreswan) disconnectCertMode(connectionName string) error {
+	if err := removeConnectionStanza(SubmarinerConfPath(), connectionName); err != nil {
+		return errors.Wrapf(err, "failed to remove connection stanza for %q", connectionName)
+	}
+
+	logger.Infof("Removed Libreswan connection config for %q", connectionName)
+
+	return nil
+}
+
+func (i *libreswan) disconnectPSKMode(connectionName string) error {
+	args := []string{"--delete", nameArg, connectionName}
+
+	if err := whack(args...); err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			logger.Errorf(err, "Error deleting a connection with args %v; got exit code %d", args, exitError.ExitCode())
+		} else {
+			return errors.Wrapf(err, "error deleting a connection with args %v", args)
+		}
+	}
 
 	return nil
 }
@@ -933,8 +944,11 @@ func (i *libreswan) Cleanup() error {
 	}
 
 	// Delete submariner.conf on uninstall
-	confPath := submarinerConfPath
-	os.Remove(confPath)
+	os.Remove(SubmarinerConfPath())
 
 	return nil
+}
+
+func SubmarinerConfPath() string {
+	return RootDir + "/etc/ipsec.d/submariner.conf"
 }

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -34,13 +34,13 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/command"
 	"github.com/submariner-io/admiral/pkg/log"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
-	"github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8snet "k8s.io/utils/net"
@@ -48,17 +48,30 @@ import (
 )
 
 const (
-	cableDriverName  = "libreswan"
-	whackTimeout     = 5 * time.Second
-	dpdDelay         = 30 // seconds
-	encryptArg       = "--encrypt"
-	forceencapsArg   = "--encapsulation=yes"
-	nameArg          = "--name"
-	hostArg          = "--host"
-	clientArg        = "--client"
-	ikeportArg       = "--ikeport"
-	dpdactionHoldArg = "--dpdaction=hold"
-	dpddelayArg      = "--dpddelay"
+	cableDriverName    = "libreswan"
+	submarinerConfPath = "/etc/ipsec.d/submariner.conf"
+	whackTimeout       = 5 * time.Second
+	dpdDelay           = 30 // seconds
+	encryptArg         = "--encrypt"
+	forceencapsArg     = "--encapsulation=yes"
+	nameArg            = "--name"
+	hostArg            = "--host"
+	clientArg          = "--client"
+	ikeportArg         = "--ikeport"
+	dpdactionHoldArg   = "--dpdaction=hold"
+	dpddelayArg        = "--dpddelay"
+	certArg            = "--cert"
+	caArg              = "--ca"
+)
+
+// AuthMode defines the authentication mode for libreswan.
+type AuthMode string
+
+const (
+	// AuthModePSK uses Pre-Shared Key authentication.
+	AuthModePSK AuthMode = "psk"
+	// AuthModeCert uses certificate-based authentication.
+	AuthModeCert AuthMode = "cert"
 )
 
 var (
@@ -94,6 +107,11 @@ type libreswan struct {
 	debug                 bool
 	forceUDPEncapsulation bool
 	plutoStarted          bool
+	authMode              AuthMode
+
+	stopCh                chan struct{}
+	certificateController *CertificateHandler
+	signingRequestor      certificate.SigningRequestor
 }
 
 type specification struct {
@@ -103,16 +121,33 @@ type specification struct {
 	PSKSecret   string
 	LogFile     string
 	NATTPort    string `default:"4500"`
+	AuthMode    string `default:"psk"` // Authentication mode: "psk" or "cert"
 }
 
 // NewLibreswan starts an IKE daemon using Libreswan and configures it to manage Submariner's endpoints.
-func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
+func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster,
+	signingRequestor certificate.SigningRequestor,
+) (cable.Driver, error) {
 	// We'll panic if localEndpoint is nil, this is intentional
 	ipSecSpec := specification{}
 
 	err := envconfig.Process(cable.IPSecEnvPrefix, &ipSecSpec)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error processing environment config for %s", cable.IPSecEnvPrefix)
+	}
+
+	// Parse and validate authentication mode with fallback to PSK
+	authModeStr := ipSecSpec.AuthMode
+	if authModeStr == "" {
+		// Fallback to default PSK mode if not set
+		authModeStr = string(AuthModePSK)
+
+		logger.Info("CE_IPSEC_AUTHMODE not set, defaulting to psk authentication")
+	}
+
+	authMode := AuthMode(authModeStr)
+	if authMode != AuthModePSK && authMode != AuthModeCert {
+		return nil, fmt.Errorf("invalid authentication mode %q, must be 'psk' or 'cert'", authModeStr)
 	}
 
 	port, err := strconv.ParseUint(ipSecSpec.NATTPort, 10, 16)
@@ -132,26 +167,30 @@ func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster)
 		return nil, err
 	}
 
-	encodedPsk := ipSecSpec.PSK
+	var encodedPsk string
 
-	if ipSecSpec.PSKSecret != "" {
-		pskBytes, err := os.ReadFile(RootDir + fmt.Sprintf("/var/run/secrets/submariner.io/%s/psk", ipSecSpec.PSKSecret))
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reading secret %s", ipSecSpec.PSKSecret)
+	if authMode == AuthModePSK {
+		encodedPsk = ipSecSpec.PSK
+
+		if ipSecSpec.PSKSecret != "" {
+			pskBytes, err := os.ReadFile(RootDir + fmt.Sprintf("/var/run/secrets/submariner.io/%s/psk", ipSecSpec.PSKSecret))
+			if err != nil {
+				return nil, errors.Wrapf(err, "error reading secret %s", ipSecSpec.PSKSecret)
+			}
+			var psk strings.Builder
+			encoder := base64.NewEncoder(base64.StdEncoding, &psk)
+
+			if _, err := encoder.Write(pskBytes); err != nil {
+				return nil, errors.Wrap(err, "error encoding secret")
+			}
+
+			encoder.Close()
+
+			encodedPsk = psk.String()
 		}
-		var psk strings.Builder
-		encoder := base64.NewEncoder(base64.StdEncoding, &psk)
-
-		if _, err := encoder.Write(pskBytes); err != nil {
-			return nil, errors.Wrap(err, "error encoding secret")
-		}
-
-		encoder.Close()
-
-		encodedPsk = psk.String()
 	}
 
-	logger.Infof("Using NATT UDP port %d", nattPort)
+	logger.Infof("Using NATT UDP port %d with authentication mode: %s", nattPort, authMode)
 
 	return &libreswan{
 		secretKey:             encodedPsk,
@@ -163,6 +202,8 @@ func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster)
 		connections:           []subv1.Connection{},
 		forceUDPEncapsulation: ipSecSpec.ForceEncaps,
 		plutoStarted:          false,
+		authMode:              authMode,
+		signingRequestor:      signingRequestor,
 	}, nil
 }
 
@@ -173,15 +214,42 @@ func (i *libreswan) GetName() string {
 
 // Init initializes the driver with any state it needs.
 func (i *libreswan) Init() error {
-	// Write the secrets file:
-	// %any %any : PSK "secret"
-	file, err := os.Create(RootDir + "/etc/ipsec.d/submariner.secrets")
-	if err != nil {
-		return errors.Wrap(err, "error creating the secrets file")
-	}
-	defer file.Close()
+	logger.Infof("Initializing libreswan driver with authentication mode: %s", i.authMode)
 
-	fmt.Fprintf(file, "%%any %%any : PSK \"%s\"\n", i.secretKey)
+	if i.authMode == AuthModePSK {
+		logger.Info("Setting up PSK authentication")
+
+		// Write the secrets file: %any %any : PSK "secret"
+		file, err := os.Create(RootDir + "/etc/ipsec.d/submariner.secrets")
+		if err != nil {
+			return errors.Wrap(err, "error creating the secrets file")
+		}
+		defer file.Close()
+
+		fmt.Fprintf(file, "%%any %%any : PSK \"%s\"\n", i.secretKey)
+	} else if i.authMode == AuthModeCert {
+		logger.Info("Setting up certificate authentication")
+
+		logger.Infof("Starting certificate creation with Private IPs %s Public IPs %s", i.localEndpoint.PrivateIPs, i.localEndpoint.PublicIPs)
+		sanIPs := make([]string, 0, len(i.localEndpoint.PrivateIPs)+len(i.localEndpoint.PublicIPs))
+		sanIPs = append(sanIPs, i.localEndpoint.PrivateIPs...)
+		sanIPs = append(sanIPs, i.localEndpoint.PublicIPs...)
+
+		i.stopCh = make(chan struct{})
+
+		var err error
+
+		i.certificateController = NewCertificateHandler(i.localEndpoint.ClusterID)
+
+		err = i.signingRequestor.Issue(context.TODO(), "submariner-certificate", sanIPs, i.certificateController.OnSignedCallback)
+		if err != nil {
+			logger.Warningf("Unable to issue certificate: %v", err)
+		}
+
+		logger.Info("Started certificate syncers and controller")
+	} else {
+		return fmt.Errorf("unsupported authentication mode: %s", i.authMode)
+	}
 
 	return nil
 }
@@ -243,7 +311,7 @@ func retrieveActiveConnectionStats() (map[string]int, map[string]int, error) {
 				activeConnectionsTx[matches[1]] += outBytes
 			}
 		} else {
-			logger.V(log.DEBUG).Infof("Ignoring whack output line: %q", line)
+			logger.V(log.TRACE).Infof("Ignoring whack output line: %q", line)
 		}
 	}
 
@@ -359,6 +427,166 @@ func whack(args ...string) error {
 // ConnectToEndpoint establishes a connection to the given endpoint and returns a string
 // representation of the IP address of the target endpoint.
 func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
+	if i.authMode == AuthModeCert {
+		return i.connectToEndpointCertMode(endpointInfo)
+	}
+
+	return i.connectToEndpointPSKMode(endpointInfo)
+}
+
+func appendConnectionStanza(confPath, stanza, connName string) error {
+	if err := removeConnectionStanza(confPath, connName); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(confPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return errors.Wrap(err, "error opening file")
+	}
+
+	defer f.Close()
+
+	if !strings.HasSuffix(stanza, "\n") {
+		stanza += "\n"
+	}
+
+	_, err = f.WriteString(stanza)
+
+	return errors.Wrap(err, "error writing to file")
+}
+
+func removeConnectionStanza(confPath, connName string) error {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "error reading file")
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	inStanza := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "conn ") && strings.TrimSpace(line) == ("conn "+connName) {
+			inStanza = true
+			continue
+		}
+
+		if inStanza && strings.HasPrefix(line, "conn ") && strings.TrimSpace(line) != ("conn "+connName) {
+			inStanza = false
+		}
+
+		if !inStanza {
+			out = append(out, line)
+		}
+	}
+
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+
+	if len(out) == 0 {
+		return errors.Wrap(os.Remove(confPath), "error removing file")
+	}
+
+	return errors.Wrap(os.WriteFile(confPath, []byte(strings.Join(out, "\n")+"\n"), 0o600), "error writing file")
+}
+
+func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
+	logger.Info("Certificate mode: skipping pluto start and whack; assuming pluto is managed externally and config/NSS DB are updated.")
+
+	confPath := submarinerConfPath
+	endpoint := &endpointInfo.Endpoint
+	leftID := "submariner-client-" + i.localEndpoint.ClusterID
+	left := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
+	right := endpointInfo.UseIP
+	leftSubnets := i.localEndpoint.Subnets
+	rightSubnets := endpoint.Spec.Subnets
+
+	for lsi, leftSubnet := range leftSubnets {
+		for rsi, rightSubnet := range rightSubnets {
+			connName := toConnectionName(endpoint.Spec.CableName, endpointInfo.UseFamily, lsi, rsi)
+
+			encapsulationLine := ""
+			if endpointInfo.UseNAT || i.forceUDPEncapsulation {
+				encapsulationLine = "    encapsulation=yes\n"
+			}
+
+			conf := fmt.Sprintf(`conn %s
+    left=%s
+    leftid=%%fromcert
+    leftcert=%s
+    leftrsasigkey=%%cert
+    leftsubnet=%s
+    leftmodecfgclient=false
+    right=%s
+    rightid=%%fromcert
+    rightsubnet=%s
+%s    auto=add
+    ikev2=insist
+    authby=rsasig
+    type=tunnel`,
+				connName,
+				left,
+				leftID,
+				leftSubnet,
+				right,
+				rightSubnet,
+				encapsulationLine,
+			)
+			if err := appendConnectionStanza(confPath, conf, connName); err != nil {
+				logger.Errorf(err, "Failed to append connection stanza to %s", confPath)
+				return "", err
+			}
+
+			logger.Infof("Appended Libreswan connection config for %s to %s", connName, confPath)
+
+			cmd := exec.Command("ipsec", "auto", "--add", connName)
+
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				logger.Errorf(err, "Failed to add connection with ipsec auto --add: %s", string(output))
+				return "", errors.Wrap(err, "failed to add connection")
+			} else {
+				logger.Infof("Added connection with ipsec auto --add: %s", string(output))
+			}
+
+			connectionMode := i.calculateOperationMode(&endpoint.Spec)
+
+			logger.Infof("Connection mode for %s: %v", connName, connectionMode)
+
+			if connectionMode == operationModeClient || connectionMode == operationModeBidirectional {
+				whackArgs := []string{"--name", connName, "--initiate"}
+				//nolint:gosec // ipsec whack args are from trusted config
+				cmd = exec.Command("ipsec", append([]string{"whack"}, whackArgs...)...)
+
+				output, err = cmd.CombinedOutput()
+				if err != nil {
+					logger.Errorf(err, "Failed to bring up connection %s with whack: %s", connName, string(output))
+					return "", errors.Wrap(err, "failed to bring up connection")
+				} else {
+					logger.Infof("Brought up connection %s with whack: %s", connName, string(output))
+				}
+			}
+
+			i.connections = append(i.connections,
+				subv1.Connection{
+					Endpoint: endpoint.Spec,
+					UsingIP:  endpointInfo.UseIP,
+					UsingNAT: endpointInfo.UseNAT,
+				})
+		}
+	}
+
+	i.plutoStarted = true
+
+	return "", nil
+}
+
+func (i *libreswan) connectToEndpointPSKMode(endpointInfo *natdiscovery.NATEndpointInfo) (string, error) {
 	if !i.plutoStarted {
 		// Ensure Pluto is started
 		if err := i.runPluto(); err != nil {
@@ -387,7 +615,8 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 
 	connectionMode := i.calculateOperationMode(&endpoint.Spec)
 
-	logger.Infof("Creating IPv%v connection(s) for %v in %s mode", endpointInfo.UseFamily, endpoint, connectionMode)
+	logger.Infof("Creating IPv%v connection(s) for %v in %s mode with %s authentication",
+		endpointInfo.UseFamily, endpoint, connectionMode, i.authMode)
 
 	if len(leftSubnets) > 0 && len(rightSubnets) > 0 {
 		for lsi, leftSubnet := range leftSubnets {
@@ -557,6 +786,19 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 
 // DisconnectFromEndpoint disconnects from the connection to the given endpoint.
 func (i *libreswan) DisconnectFromEndpoint(endpoint *types.SubmarinerEndpoint, family k8snet.IPFamily) error {
+	if i.authMode == AuthModeCert {
+		confPath := submarinerConfPath
+
+		connName := endpoint.Spec.CableName
+		if err := removeConnectionStanza(confPath, connName); err != nil {
+			logger.Errorf(err, "Failed to remove connection stanza for %s from %s", connName, confPath)
+			return err
+		}
+
+		logger.Infof("Removed Libreswan connection config for %s from %s", connName, confPath)
+
+		return nil
+	}
 	// We'll panic if endpoint is nil, this is intentional
 	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(i.localEndpoint.GetPrivateIP(family))
 	rightSubnets := endpoint.Spec.ExtractSubnetsExcludingIP(endpoint.Spec.GetPrivateIP(family))
@@ -682,5 +924,17 @@ func (i *libreswan) waitForControlSocket() error {
 func (i *libreswan) Cleanup() error {
 	logger.Info("Uninstalling the libreswan cable driver")
 
-	return netlink.DeleteXfrmRules(k8snet.IPFamilyUnknown) //nolint:wrapcheck  // No need to wrap this error
+	if i.certificateController != nil {
+		i.certificateController.Cleanup()
+	}
+
+	if i.stopCh != nil {
+		close(i.stopCh)
+	}
+
+	// Delete submariner.conf on uninstall
+	confPath := submarinerConfPath
+	os.Remove(confPath)
+
+	return nil
 }

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	fakecommand "github.com/submariner-io/admiral/pkg/command/fake"
+	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cable/libreswan"
@@ -750,7 +751,7 @@ func newTestDriver() *testDriver {
 
 		var err error
 
-		t.driver, err = libreswan.NewLibreswan(t.localEndpoint, &types.SubmarinerCluster{})
+		t.driver, err = libreswan.NewLibreswan(&broker.SyncerConfig{}, t.localEndpoint, &types.SubmarinerCluster{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package libreswan_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,8 +32,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	fakecommand "github.com/submariner-io/admiral/pkg/command/fake"
-	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
 	"github.com/submariner-io/submariner/pkg/cable/libreswan"
@@ -51,6 +52,26 @@ const (
 	remoteNATTPort = "6789"
 )
 
+type mockSigningRequestor struct{}
+
+func (m *mockSigningRequestor) Issue(ctx context.Context, name string, sanIPs []string, callback certificate.OnSignedFn) error {
+	certData := map[string][]byte{
+		"tls.crt": []byte("mock-tls-cert"),
+		"tls.key": []byte("mock-tls-key"),
+		"ca.crt":  []byte("mock-ca-cert"),
+	}
+
+	return callback(certData)
+}
+
+func (m *mockSigningRequestor) Uninstall(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSigningRequestor) Remove(ctx context.Context, name string) error {
+	return nil
+}
+
 var _ = Describe("Libreswan", func() {
 	Describe("NATT port configuration", testNATTPortConfiguration)
 	Describe("TrafficStatusRE", testTrafficStatusRE)
@@ -60,6 +81,7 @@ var _ = Describe("Libreswan", func() {
 	Describe("Preferred server config", testPreferredServerConfig)
 	Describe("Pluto", testPluto)
 	Describe("Init", testInit)
+	Describe("Certificate", testCertificate)
 
 	Context("", func() {
 		t := newTestDriver()
@@ -751,7 +773,7 @@ func newTestDriver() *testDriver {
 
 		var err error
 
-		t.driver, err = libreswan.NewLibreswan(&broker.SyncerConfig{}, t.localEndpoint, &types.SubmarinerCluster{})
+		t.driver, err = libreswan.NewLibreswan(t.localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -763,6 +785,9 @@ func (t *testDriver) setupPluto() {
 
 	path := libreswan.RootDir + "/run/pluto"
 	Expect(os.MkdirAll(path, 0o700)).To(Succeed())
+
+	ipsecDir := libreswan.RootDir + "/etc/ipsec.d"
+	Expect(os.MkdirAll(ipsecDir, 0o700)).To(Succeed())
 
 	var err error
 
@@ -801,4 +826,167 @@ func (t *testDriver) assertNoActiveConnection(natInfo *natdiscovery.NATEndpointI
 		UsingIP:  natInfo.UseIP,
 		UsingNAT: natInfo.UseNAT,
 	}))
+}
+
+func testCertificate() {
+	t := newTestDriver()
+
+	Context("Authentication mode", func() {
+		When("certificate authentication mode is enabled", func() {
+			It("should create driver with certificate mode", func() {
+				const authModeEnvVar = "CE_IPSEC_AUTHMODE"
+				os.Setenv(authModeEnvVar, "cert")
+				defer os.Unsetenv(authModeEnvVar)
+
+				endpointSpec := subv1.EndpointSpec{
+					ClusterID:  "local",
+					CableName:  "submariner-cable-local-192-68-1-1",
+					PrivateIPs: []string{"192.68.1.1"},
+					Subnets:    []string{"10.0.0.0/16"},
+				}
+				localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
+
+				driver, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(driver).NotTo(BeNil())
+				Expect(driver.GetName()).To(Equal("libreswan"))
+			})
+		})
+
+		When("invalid authentication mode is specified", func() {
+			It("should return an error", func() {
+				const authModeEnvVar = "CE_IPSEC_AUTHMODE"
+				os.Setenv(authModeEnvVar, "invalid")
+				defer os.Unsetenv(authModeEnvVar)
+
+				endpointSpec := subv1.EndpointSpec{
+					ClusterID:  "local",
+					CableName:  "submariner-cable-local-192-68-1-1",
+					PrivateIPs: []string{"192.68.1.1"},
+					Subnets:    []string{"10.0.0.0/16"},
+				}
+				localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
+
+				_, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid authentication mode"))
+			})
+		})
+	})
+
+	Context("Certificate loading", func() {
+		var cmdExecutor *fakecommand.Executor
+
+		BeforeEach(func() {
+			cmdExecutor = fakecommand.New()
+		})
+
+		AfterEach(func() {
+			cmdExecutor.Clear()
+		})
+
+		It("should successfully load certificates into NSS database", func() {
+			controller := libreswan.NewCertificateHandler("test-cluster")
+			Expect(controller).NotTo(BeNil())
+
+			certData := map[string][]byte{
+				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := controller.OnSignedCallback(certData)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-N", "-d", "sql:/var/lib/ipsec/nss", "--empty-password")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
+				"-n", "ca-cert", "-t", "C,,", "-i", "-", "-a")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
+				"-n", "client-cert", "-t", "C,,", "-i", "-", "-a")
+			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
+				"-n", "client-key", "-t", "u,u,u", "-i", "-", "-a")
+		})
+
+		It("should handle NSS database initialization failure", func() {
+			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
+				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-N", "-d", "sql:/var/lib/ipsec/nss", "--empty-password") {
+					return fakecommand.InterceptorFuncs{Run: func() error {
+						return errors.New("database init failed")
+					}}
+				}
+
+				return fakecommand.InterceptorFuncs{}
+			})
+
+			controller := libreswan.NewCertificateHandler("test-cluster")
+			Expect(controller).NotTo(BeNil())
+
+			certData := map[string][]byte{
+				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := controller.OnSignedCallback(certData)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to initialize NSS database"))
+		})
+
+		It("should handle certificate loading failure", func() {
+			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
+				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
+					"-n", "ca-cert", "-t", "C,,", "-i", "-", "-a") {
+					return fakecommand.InterceptorFuncs{Run: func() error {
+						return errors.New("certificate load failed")
+					}}
+				}
+
+				return fakecommand.InterceptorFuncs{}
+			})
+
+			controller := libreswan.NewCertificateHandler("test-cluster")
+			Expect(controller).NotTo(BeNil())
+
+			certData := map[string][]byte{
+				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
+				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
+				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
+			}
+
+			err := controller.OnSignedCallback(certData)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to load certificates into NSS database"))
+		})
+	})
+
+	Context("Certificate connection", func() {
+		When("connecting and disconnecting in certificate mode", func() {
+			It("should create and remove certificate-based connection", func() {
+				os.Setenv("CE_IPSEC_AUTHMODE", "cert")
+				defer os.Unsetenv("CE_IPSEC_AUTHMODE")
+
+				Expect(t.driver.Init()).To(Succeed())
+
+				natInfo := &natdiscovery.NATEndpointInfo{
+					Endpoint: subv1.Endpoint{
+						Spec: subv1.EndpointSpec{
+							ClusterID:  "remote",
+							CableName:  "submariner-cable-remote-192-68-2-1",
+							PrivateIPs: []string{"192.68.2.1"},
+							Subnets:    []string{"20.0.0.0/16"},
+						},
+					},
+					UseIP:     "172.93.2.1",
+					UseFamily: k8snet.IPv4,
+				}
+
+				_, err := t.driver.ConnectToEndpoint(natInfo)
+				Expect(err).To(Succeed())
+
+				err = t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, k8snet.IPv4)
+				Expect(err).To(Succeed())
+			})
+		})
+	})
 }

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -48,6 +48,7 @@ import (
 )
 
 const (
+	authModeEnvVar = "CE_IPSEC_AUTHMODE"
 	localNATTPort  = "1234"
 	remoteNATTPort = "6789"
 )
@@ -76,7 +77,9 @@ var _ = Describe("Libreswan", func() {
 	Describe("NATT port configuration", testNATTPortConfiguration)
 	Describe("TrafficStatusRE", testTrafficStatusRE)
 	Describe("ConnectToEndpoint", testConnectToEndpoint)
-	Describe("DisconnectFromEndpoint", testDisconnectFromEndpoint)
+	DescribeTableSubtree("DisconnectFromEndpoint", testDisconnectFromEndpoint,
+		Entry("psk auth mode", libreswan.AuthModePSK),
+		Entry("cert auth mode", libreswan.AuthModeCert))
 	Describe("GetConnections", testGetConnections)
 	Describe("Preferred server config", testPreferredServerConfig)
 	Describe("Pluto", testPluto)
@@ -177,7 +180,7 @@ func testNATTPortConfiguration() {
 	})
 }
 
-func testConnectToEndpointWithNATInfo(natInfo *natdiscovery.NATEndpointInfo) {
+func testConnectToEndpointWithNATInfo(natInfo *natdiscovery.NATEndpointInfo, authMode libreswan.AuthMode) {
 	natInfo.Endpoint.Spec.ClusterID = "east"
 	natInfo.Endpoint.Spec.CableName = "submariner-cable-east-192-68-2-1"
 	natInfo.Endpoint.Spec.BackendConfig = map[string]string{subv1.UDPPortConfig: remoteNATTPort}
@@ -196,36 +199,54 @@ func testConnectToEndpointWithNATInfo(natInfo *natdiscovery.NATEndpointInfo) {
 		Expect(ip).To(Equal(natInfo.UseIP))
 
 		t.assertActiveConnection(natInfo)
+
+		if authMode == libreswan.AuthModeCert {
+			data, err := os.ReadFile(libreswan.SubmarinerConfPath())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring("conn " + natInfo.Endpoint.Spec.CableName))
+
+			t.cmdExecutor.AwaitCommand(nil, "ipsec", "--add")
+		}
 	}
 
 	testBiDirectionalMode := func() {
 		connectToEndpoint()
 
-		family := k8snet.IPFamilyOfString(natInfo.UseIP)
-		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), natInfo.UseIP,
-			t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
-			localNATTPort, remoteNATTPort)
-		t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
+		if authMode == libreswan.AuthModePSK {
+			family := k8snet.IPFamilyOfString(natInfo.UseIP)
+			t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), natInfo.UseIP,
+				t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
+				localNATTPort, remoteNATTPort)
+			t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
+		} else {
+			t.cmdExecutor.AwaitCommand(nil, "ipsec", "whack", "--initiate")
+		}
 	}
 
 	testClientMode := func() {
 		connectToEndpoint()
 
-		family := k8snet.IPFamilyOfString(natInfo.UseIP)
-		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), natInfo.UseIP,
-			t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
-			Not(ContainElement(localNATTPort)), remoteNATTPort)
-		t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
+		if authMode == libreswan.AuthModePSK {
+			family := k8snet.IPFamilyOfString(natInfo.UseIP)
+			t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), natInfo.UseIP,
+				t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
+				Not(ContainElement(localNATTPort)), remoteNATTPort)
+			t.cmdExecutor.AwaitCommand(nil, "whack", "--initiate")
+		} else {
+			t.cmdExecutor.AwaitCommand(nil, "ipsec", "whack", "--initiate")
+		}
 	}
 
 	testServerMode := func() {
 		connectToEndpoint()
 
-		family := k8snet.IPFamilyOfString(natInfo.UseIP)
-		t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), "%any",
-			t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
-			localNATTPort, Not(ContainElement(remoteNATTPort)))
-		t.cmdExecutor.EnsureNoCommand("whack", "--initiate")
+		if authMode == libreswan.AuthModePSK {
+			family := k8snet.IPFamilyOfString(natInfo.UseIP)
+			t.cmdExecutor.AwaitCommand(nil, "whack", t.endpointSpec.GetPrivateIP(family), "%any",
+				t.endpointSpec.ParseSubnets(family)[0].String(), natInfo.Endpoint.Spec.ParseSubnets(family)[0].String(),
+				localNATTPort, Not(ContainElement(remoteNATTPort)))
+			t.cmdExecutor.EnsureNoCommand("whack", "--initiate")
+		}
 	}
 
 	When("only the local side prefers to be a server", func() {
@@ -290,7 +311,7 @@ func testConnectToEndpoint() {
 			},
 			UseIP:     "172.93.2.1",
 			UseFamily: k8snet.IPv4,
-		})
+		}, libreswan.AuthModePSK)
 	})
 
 	Context("IPv6", func() {
@@ -303,7 +324,7 @@ func testConnectToEndpoint() {
 			},
 			UseIP:     "2003:db8:3333:4444:5555:6666:7777:8888",
 			UseFamily: k8snet.IPv6,
-		})
+		}, libreswan.AuthModePSK)
 	})
 
 	Context("dual stack", func() {
@@ -316,12 +337,55 @@ func testConnectToEndpoint() {
 			},
 			UseIP:     "172.93.2.1",
 			UseFamily: k8snet.IPv4,
+		}, libreswan.AuthModePSK)
+	})
+
+	Context("cert auth mode", func() {
+		BeforeEach(func() {
+			os.Setenv(authModeEnvVar, "cert")
+			DeferCleanup(func() {
+				os.Unsetenv(authModeEnvVar)
+			})
 		})
+
+		testConnectToEndpointWithNATInfo(&natdiscovery.NATEndpointInfo{
+			Endpoint: subv1.Endpoint{
+				Spec: subv1.EndpointSpec{
+					PrivateIPs: []string{"192.68.2.1"},
+					Subnets:    []string{"20.0.0.0/16"},
+				},
+			},
+			UseIP:     "172.93.2.1",
+			UseFamily: k8snet.IPv4,
+		}, libreswan.AuthModeCert)
 	})
 }
 
-func testDisconnectFromEndpoint() {
+func testDisconnectFromEndpoint(authMode libreswan.AuthMode) {
 	t := newTestDriver()
+
+	BeforeEach(func() {
+		os.Setenv(authModeEnvVar, string(authMode))
+		DeferCleanup(func() {
+			os.Unsetenv(authModeEnvVar)
+		})
+	})
+
+	verifyConnectionRemoved := func(name string, expNoneRemaining bool) {
+		if authMode == libreswan.AuthModeCert {
+			if expNoneRemaining {
+				_, err := os.Stat(libreswan.SubmarinerConfPath())
+				Expect(errors.Is(err, os.ErrNotExist)).To(BeTrue())
+			} else {
+				data, err := os.ReadFile(libreswan.SubmarinerConfPath())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).NotTo(ContainSubstring("conn " + name))
+			}
+		} else {
+			t.cmdExecutor.AwaitCommand(nil, "whack", "--delete")
+			t.cmdExecutor.Clear()
+		}
+	}
 
 	It("should remove the Connection", func() {
 		natInfo1 := &natdiscovery.NATEndpointInfo{
@@ -376,19 +440,16 @@ func testDisconnectFromEndpoint() {
 
 		Expect(t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo1.Endpoint.Spec}, k8snet.IPv4)).To(Succeed())
 		t.assertNoActiveConnection(natInfo1)
-		t.cmdExecutor.AwaitCommand(nil, "whack", "--delete")
-		t.cmdExecutor.Clear()
+		verifyConnectionRemoved(natInfo1.Endpoint.Spec.CableName, false)
 
 		Expect(t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfoIPv6.Endpoint.Spec}, k8snet.IPv6)).To(Succeed())
 		t.assertNoActiveConnection(natInfoIPv6)
-		t.cmdExecutor.AwaitCommand(nil, "whack", "--delete")
 		t.assertActiveConnection(natInfo2)
-		t.cmdExecutor.Clear()
+		verifyConnectionRemoved(natInfoIPv6.Endpoint.Spec.CableName, false)
 
 		Expect(t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo2.Endpoint.Spec}, k8snet.IPv4)).To(Succeed())
 		t.assertNoActiveConnection(natInfo2)
-		t.cmdExecutor.AwaitCommand(nil, "whack", "--delete")
-		t.cmdExecutor.Clear()
+		verifyConnectionRemoved(natInfo2.Endpoint.Spec.CableName, true)
 	})
 }
 

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package libreswan_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -32,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"github.com/submariner-io/admiral/pkg/certificate"
 	fakecommand "github.com/submariner-io/admiral/pkg/command/fake"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
@@ -52,26 +50,6 @@ const (
 	localNATTPort  = "1234"
 	remoteNATTPort = "6789"
 )
-
-type mockSigningRequestor struct{}
-
-func (m *mockSigningRequestor) Issue(ctx context.Context, name string, sanIPs []string, callback certificate.OnSignedFn) error {
-	certData := map[string][]byte{
-		"tls.crt": []byte("mock-tls-cert"),
-		"tls.key": []byte("mock-tls-key"),
-		"ca.crt":  []byte("mock-ca-cert"),
-	}
-
-	return callback(certData)
-}
-
-func (m *mockSigningRequestor) Uninstall(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockSigningRequestor) Remove(ctx context.Context, name string) error {
-	return nil
-}
 
 var _ = Describe("Libreswan", func() {
 	Describe("NATT port configuration", testNATTPortConfiguration)
@@ -95,6 +73,31 @@ var _ = Describe("Libreswan", func() {
 
 		Specify("Cleanup should succeed", func() {
 			Expect(t.driver.Cleanup()).To(Succeed())
+		})
+
+		When("an invalid authentication mode is specified", func() {
+			BeforeEach(func() {
+				os.Setenv(authModeEnvVar, "invalid")
+				DeferCleanup(func() {
+					os.Unsetenv(authModeEnvVar)
+				})
+
+				t.expectErr = true
+			})
+
+			It("should return an error", func() {
+				endpointSpec := subv1.EndpointSpec{
+					ClusterID:  "local",
+					CableName:  "submariner-cable-local-192-68-1-1",
+					PrivateIPs: []string{"192.68.1.1"},
+					Subnets:    []string{"10.0.0.0/16"},
+				}
+				localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
+
+				_, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid authentication mode"))
+			})
 		})
 	})
 })
@@ -803,6 +806,7 @@ type testDriver struct {
 	cmdExecutor   *fakecommand.Executor
 	driver        cable.Driver
 	plutoCtlFile  *os.File
+	expectErr     bool
 }
 
 func newTestDriver() *testDriver {
@@ -835,7 +839,12 @@ func newTestDriver() *testDriver {
 		var err error
 
 		t.driver, err = libreswan.NewLibreswan(t.localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
-		Expect(err).NotTo(HaveOccurred())
+
+		if t.expectErr {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 
 	return t
@@ -887,167 +896,4 @@ func (t *testDriver) assertNoActiveConnection(natInfo *natdiscovery.NATEndpointI
 		UsingIP:  natInfo.UseIP,
 		UsingNAT: natInfo.UseNAT,
 	}))
-}
-
-func testCertificate() {
-	t := newTestDriver()
-
-	Context("Authentication mode", func() {
-		When("certificate authentication mode is enabled", func() {
-			It("should create driver with certificate mode", func() {
-				const authModeEnvVar = "CE_IPSEC_AUTHMODE"
-				os.Setenv(authModeEnvVar, "cert")
-				defer os.Unsetenv(authModeEnvVar)
-
-				endpointSpec := subv1.EndpointSpec{
-					ClusterID:  "local",
-					CableName:  "submariner-cable-local-192-68-1-1",
-					PrivateIPs: []string{"192.68.1.1"},
-					Subnets:    []string{"10.0.0.0/16"},
-				}
-				localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
-
-				driver, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(driver).NotTo(BeNil())
-				Expect(driver.GetName()).To(Equal("libreswan"))
-			})
-		})
-
-		When("invalid authentication mode is specified", func() {
-			It("should return an error", func() {
-				const authModeEnvVar = "CE_IPSEC_AUTHMODE"
-				os.Setenv(authModeEnvVar, "invalid")
-				defer os.Unsetenv(authModeEnvVar)
-
-				endpointSpec := subv1.EndpointSpec{
-					ClusterID:  "local",
-					CableName:  "submariner-cable-local-192-68-1-1",
-					PrivateIPs: []string{"192.68.1.1"},
-					Subnets:    []string{"10.0.0.0/16"},
-				}
-				localEndpoint := endpoint.NewLocal(&endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
-
-				_, err := libreswan.NewLibreswan(localEndpoint, &types.SubmarinerCluster{}, &mockSigningRequestor{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("invalid authentication mode"))
-			})
-		})
-	})
-
-	Context("Certificate loading", func() {
-		var cmdExecutor *fakecommand.Executor
-
-		BeforeEach(func() {
-			cmdExecutor = fakecommand.New()
-		})
-
-		AfterEach(func() {
-			cmdExecutor.Clear()
-		})
-
-		It("should successfully load certificates into NSS database", func() {
-			controller := libreswan.NewCertificateHandler("test-cluster")
-			Expect(controller).NotTo(BeNil())
-
-			certData := map[string][]byte{
-				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
-				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
-				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
-			}
-
-			err := controller.OnSignedCallback(certData)
-			Expect(err).NotTo(HaveOccurred())
-
-			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-N", "-d", "sql:/var/lib/ipsec/nss", "--empty-password")
-			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
-				"-n", "ca-cert", "-t", "C,,", "-i", "-", "-a")
-			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
-				"-n", "client-cert", "-t", "C,,", "-i", "-", "-a")
-			cmdExecutor.AwaitCommand(ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
-				"-n", "client-key", "-t", "u,u,u", "-i", "-", "-a")
-		})
-
-		It("should handle NSS database initialization failure", func() {
-			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
-				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-N", "-d", "sql:/var/lib/ipsec/nss", "--empty-password") {
-					return fakecommand.InterceptorFuncs{Run: func() error {
-						return errors.New("database init failed")
-					}}
-				}
-
-				return fakecommand.InterceptorFuncs{}
-			})
-
-			controller := libreswan.NewCertificateHandler("test-cluster")
-			Expect(controller).NotTo(BeNil())
-
-			certData := map[string][]byte{
-				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
-				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
-				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
-			}
-
-			err := controller.OnSignedCallback(certData)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to initialize NSS database"))
-		})
-
-		It("should handle certificate loading failure", func() {
-			cmdExecutor = fakecommand.NewWithInterceptor(func(cmd *exec.Cmd) fakecommand.InterceptorFuncs {
-				if fakecommand.CmdMatches(cmd, ContainSubstring("certutil"), "-A", "-d", "sql:/var/lib/ipsec/nss",
-					"-n", "ca-cert", "-t", "C,,", "-i", "-", "-a") {
-					return fakecommand.InterceptorFuncs{Run: func() error {
-						return errors.New("certificate load failed")
-					}}
-				}
-
-				return fakecommand.InterceptorFuncs{}
-			})
-
-			controller := libreswan.NewCertificateHandler("test-cluster")
-			Expect(controller).NotTo(BeNil())
-
-			certData := map[string][]byte{
-				"ca.crt":  []byte("-----BEGIN CERTIFICATE-----\nMOCK_CA_CERT\n-----END CERTIFICATE-----"),
-				"tls.crt": []byte("-----BEGIN CERTIFICATE-----\nMOCK_CLIENT_CERT\n-----END CERTIFICATE-----"),
-				"tls.key": []byte("-----BEGIN PRIVATE KEY-----\nMOCK_CLIENT_KEY\n-----END PRIVATE KEY-----"),
-			}
-
-			err := controller.OnSignedCallback(certData)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to load certificates into NSS database"))
-		})
-	})
-
-	Context("Certificate connection", func() {
-		When("connecting and disconnecting in certificate mode", func() {
-			It("should create and remove certificate-based connection", func() {
-				os.Setenv("CE_IPSEC_AUTHMODE", "cert")
-				defer os.Unsetenv("CE_IPSEC_AUTHMODE")
-
-				Expect(t.driver.Init()).To(Succeed())
-
-				natInfo := &natdiscovery.NATEndpointInfo{
-					Endpoint: subv1.Endpoint{
-						Spec: subv1.EndpointSpec{
-							ClusterID:  "remote",
-							CableName:  "submariner-cable-remote-192-68-2-1",
-							PrivateIPs: []string{"192.68.2.1"},
-							Subnets:    []string{"20.0.0.0/16"},
-						},
-					},
-					UseIP:     "172.93.2.1",
-					UseFamily: k8snet.IPv4,
-				}
-
-				_, err := t.driver.ConnectToEndpoint(natInfo)
-				Expect(err).To(Succeed())
-
-				err = t.driver.DisconnectFromEndpoint(&types.SubmarinerEndpoint{Spec: natInfo.Endpoint.Spec}, k8snet.IPv4)
-				Expect(err).To(Succeed())
-			})
-		})
-	})
 }

--- a/pkg/cable/vxlan/vxlan.go
+++ b/pkg/cable/vxlan/vxlan.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
@@ -78,7 +79,9 @@ func init() {
 	cable.AddDriver(CableDriverName, NewDriver)
 }
 
-func NewDriver(localEndpoint *submendpoint.Local, localCluster *types.SubmarinerCluster) (cable.Driver, error) {
+func NewDriver(localEndpoint *submendpoint.Local,
+	localCluster *types.SubmarinerCluster, signingRequestor certificate.SigningRequestor,
+) (cable.Driver, error) {
 	// We'll panic if localEndpoint or localCluster are nil, this is intentional
 	var err error
 

--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -279,8 +279,9 @@ func newTestDriver() *testDriver {
 	})
 
 	JustBeforeEach(func() {
-		d, err := vxlan.NewDriver(endpoint.NewLocal(&t.localEndpoint, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), ""),
-			t.localCluster)
+		d, err := vxlan.NewDriver(
+			endpoint.NewLocal(&t.localEndpoint, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), ""),
+			t.localCluster, nil)
 		Expect(err).To(Succeed())
 
 		Expect(d.Init()).To(Succeed())

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -86,7 +87,9 @@ type wireguard struct {
 }
 
 // NewDriver creates a new WireGuard driver.
-func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
+func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster,
+	signingRequestor certificate.SigningRequestor,
+) (cable.Driver, error) {
 	// We'll panic if localEndpoint is nil, this is intentional
 	var err error
 

--- a/pkg/cable/wireguard/wireguard_suite_test.go
+++ b/pkg/cable/wireguard/wireguard_suite_test.go
@@ -108,7 +108,7 @@ func newTestDriver() *testDriver {
 
 		t.localEndpoint = endpoint.NewLocal(&t.endpointSpec, dynamicfake.NewSimpleDynamicClient(scheme.Scheme), "")
 
-		t.driver, err = wireguard.NewDriver(t.localEndpoint, &types.SubmarinerCluster{})
+		t.driver, err = wireguard.NewDriver(t.localEndpoint, &types.SubmarinerCluster{}, nil)
 		t.checkNewDriverErr(err)
 	})
 

--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
@@ -46,7 +47,7 @@ import (
 // a secure connection to remote clusters.
 type Engine interface {
 	// StartEngine performs any general set up work needed independent of any remote connections.
-	StartEngine() error
+	StartEngine(signingRequestor certificate.SigningRequestor) error
 	Stop()
 	// InstallCable performs any set up work needed for connecting to given remote endpoint.
 	// Once InstallCable completes, it should be possible to connect to remote
@@ -99,11 +100,11 @@ func (i *engine) GetLocalEndpoint() *types.SubmarinerEndpoint {
 	}
 }
 
-func (i *engine) StartEngine() error {
+func (i *engine) StartEngine(signingRequestor certificate.SigningRequestor) error {
 	i.Lock()
 	defer i.Unlock()
 
-	if err := i.startDriver(); err != nil {
+	if err := i.startDriver(signingRequestor); err != nil {
 		return err
 	}
 
@@ -123,14 +124,14 @@ func (i *engine) Stop() {
 	logger.Info("CableEngine stopped")
 }
 
-func (i *engine) startDriver() error {
+func (i *engine) startDriver(signingRequestor certificate.SigningRequestor) error {
 	if i.driver != nil {
 		return nil
 	}
 
 	var err error
 
-	if i.driver, err = cable.NewDriver(i.localEndpoint, &i.localCluster); err != nil {
+	if i.driver, err = cable.NewDriver(i.localEndpoint, &i.localCluster, signingRequestor); err != nil {
 		return errors.Wrap(err, "error creating the cable driver")
 	}
 

--- a/pkg/cableengine/cableengine_test.go
+++ b/pkg/cableengine/cableengine_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	. "github.com/submariner-io/admiral/pkg/gomega"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -49,7 +50,9 @@ var fakeDriver *fake.Driver
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
-	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster,
+		_ certificate.SigningRequestor,
+	) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 })
@@ -228,7 +231,7 @@ func newTestDriver() *testDriver {
 			return
 		}
 
-		err := t.engine.StartEngine()
+		err := t.engine.StartEngine(nil)
 		if fakeDriver.ErrOnInit != nil {
 			Expect(err).To(ContainErrorSubstring(fakeDriver.ErrOnInit))
 		} else {

--- a/pkg/cableengine/fake/cableengine.go
+++ b/pkg/cableengine/fake/cableengine.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
@@ -56,7 +57,7 @@ func New() *Engine {
 	}
 }
 
-func (e *Engine) StartEngine() error {
+func (e *Engine) StartEngine(signingRequestor certificate.SigningRequestor) error {
 	return e.ErrOnStart
 }
 

--- a/pkg/controllers/tunnel/tunnel_test.go
+++ b/pkg/controllers/tunnel/tunnel_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -60,7 +61,9 @@ var fakeDriver *fake.Driver
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
-	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *submendpoint.Local, _ *types.SubmarinerCluster,
+		_ certificate.SigningRequestor,
+	) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 })
@@ -125,7 +128,7 @@ var _ = Describe("Managing tunnels", func() {
 
 		engine.SetupNATDiscovery(nat)
 
-		Expect(engine.StartEngine()).To(Succeed())
+		Expect(engine.StartEngine(nil)).To(Succeed())
 
 		stopCh = make(chan struct{})
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
@@ -81,8 +82,10 @@ type Config struct {
 	SubmarinerClient     submclientset.Interface
 	KubeClient           kubernetes.Interface
 	LeaderElectionClient kubernetes.Interface
-	NewCableEngine       func(localCluster *types.SubmarinerCluster, localEndpoint *endpoint.Local) cableengine.Engine
-	NewNATDiscovery      func(localEndpoint *endpoint.Local) (natdiscovery.Interface, error)
+	NewCableEngine       func(localCluster *types.SubmarinerCluster,
+		localEndpoint *endpoint.Local) cableengine.Engine
+	NewNATDiscovery  func(localEndpoint *endpoint.Local) (natdiscovery.Interface, error)
+	SigningRequestor certificate.SigningRequestor
 }
 
 type gatewayType struct {
@@ -152,8 +155,6 @@ func New(ctx context.Context, config *Config) (Interface, error) {
 
 	g.localEndpoint = endpoint.NewLocal(localEndpointSpec, g.SyncerConfig.LocalClient, g.Spec.Namespace)
 
-	g.cableEngine = g.NewCableEngine(localCluster, g.localEndpoint)
-
 	g.natDiscovery, err = g.NewNATDiscovery(g.localEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating the NAT discovery handler")
@@ -164,6 +165,8 @@ func New(ctx context.Context, config *Config) (Interface, error) {
 	g.SyncerConfig.LocalNamespace = g.Spec.Namespace
 
 	g.datastoreSyncer = datastoresyncer.New(&g.SyncerConfig, localCluster, g.localEndpoint)
+
+	g.cableEngine = g.NewCableEngine(localCluster, g.localEndpoint)
 
 	g.initCableHealthChecker()
 
@@ -283,7 +286,7 @@ func (g *gatewayType) onStartedLeading(ctx context.Context) {
 
 	logger.Info("Leadership acquired - starting controllers")
 
-	if err := g.cableEngine.StartEngine(); err != nil {
+	if err := g.cableEngine.StartEngine(g.SigningRequestor); err != nil {
 		g.fatalError <- errors.Wrap(err, "error starting the cable engine")
 		return
 	}
@@ -337,6 +340,10 @@ func (g *gatewayType) onStoppedLeading(ctx context.Context) {
 	}
 
 	g.cableEngine.Stop()
+
+	if g.SigningRequestor != nil {
+		_ = g.SigningRequestor.Uninstall(ctx)
+	}
 
 	logger.Info("Controllers stopped")
 
@@ -414,7 +421,7 @@ func (g *gatewayType) initCableHealthChecker() {
 }
 
 func (g *gatewayType) uninstall(ctx context.Context) error {
-	err := g.cableEngine.StartEngine()
+	err := g.cableEngine.StartEngine(nil)
 	if err != nil {
 		// As we are in the process of cleaning up, ignore any initialization errors.
 		logger.Errorf(err, "Error starting the cable driver")

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -286,6 +286,15 @@ func (g *gatewayType) onStartedLeading(ctx context.Context) {
 
 	logger.Info("Leadership acquired - starting controllers")
 
+	if g.SigningRequestor == nil {
+		signingRequestor, err := certificate.StartSigningRequestor(g.SyncerConfig, ctx.Done())
+		if err != nil {
+			g.fatalError <- errors.Wrap(err, "error creating SigningRequestor")
+		}
+
+		g.SigningRequestor = signingRequestor
+	}
+
 	if err := g.cableEngine.StartEngine(g.SigningRequestor); err != nil {
 		g.fatalError <- errors.Wrap(err, "error starting the cable engine")
 		return
@@ -340,10 +349,6 @@ func (g *gatewayType) onStoppedLeading(ctx context.Context) {
 	}
 
 	g.cableEngine.Stop()
-
-	if g.SigningRequestor != nil {
-		_ = g.SigningRequestor.Uninstall(ctx)
-	}
 
 	logger.Info("Controllers stopped")
 
@@ -421,7 +426,11 @@ func (g *gatewayType) initCableHealthChecker() {
 }
 
 func (g *gatewayType) uninstall(ctx context.Context) error {
-	err := g.cableEngine.StartEngine(nil)
+	if g.SigningRequestor != nil {
+		_ = g.SigningRequestor.Uninstall(ctx)
+	}
+
+	err := g.cableEngine.StartEngine(g.SigningRequestor)
 	if err != nil {
 		// As we are in the process of cleaning up, ignore any initialization errors.
 		logger.Errorf(err, "Error starting the cable driver")

--- a/pkg/gateway/gateway_suite_test.go
+++ b/pkg/gateway/gateway_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
@@ -44,7 +45,9 @@ var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
 	Expect(submarinerv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	cable.AddDriver(fake.DriverName, func(_ *endpoint.Local, _ *types.SubmarinerCluster) (cable.Driver, error) {
+	cable.AddDriver(fake.DriverName, func(_ *endpoint.Local, _ *types.SubmarinerCluster,
+		_ certificate.SigningRequestor,
+	) (cable.Driver, error) {
 		return fakeDriver, nil
 	})
 

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/federate"
 	. "github.com/submariner-io/admiral/pkg/gomega"
@@ -55,10 +56,26 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	k8snet "k8s.io/utils/net"
 )
 
 const publicIP = "1.2.3.4"
+
+type mockSigningRequestor struct{}
+
+func (m *mockSigningRequestor) Issue(ctx context.Context, name string, sanIPs []string, callback certificate.OnSignedFn,
+) error {
+	return callback(map[string][]byte{})
+}
+
+func (m *mockSigningRequestor) Uninstall(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSigningRequestor) Remove(ctx context.Context, name string) error {
+	return nil
+}
 
 var _ = Describe("Run", func() {
 	t := newTestDriver()
@@ -257,7 +274,8 @@ func newTestDriver() *testDriver {
 		t.expectedRunErr = nil
 		t.remoteIPCounter = 1
 
-		restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{}, &submarinerv1.Cluster{}, &submarinerv1.Gateway{}, &corev1.Node{})
+		restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{}, &submarinerv1.Cluster{},
+			&submarinerv1.Gateway{}, &corev1.Node{}, &corev1.Secret{})
 
 		t.dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
 		t.kubeClient = k8sfake.NewClientset()
@@ -276,10 +294,17 @@ func newTestDriver() *testDriver {
 				CableDriver:        fakecable.DriverName,
 			},
 			SyncerConfig: broker.SyncerConfig{
+				LocalRestConfig: &rest.Config{
+					Host: "https://localhost:6443",
+				},
+				BrokerRestConfig: &rest.Config{
+					Host: "https://localhost:6443",
+				},
 				LocalClient:     t.dynClient,
 				BrokerClient:    t.dynClient,
 				BrokerNamespace: "broker-ns",
 				RestMapper:      restMapper,
+				Scheme:          scheme.Scheme,
 			},
 			WatcherConfig: watcher.Config{
 				RestMapper: restMapper,
@@ -288,6 +313,7 @@ func newTestDriver() *testDriver {
 			SubmarinerClient:     submfake.NewSimpleClientset(),
 			KubeClient:           t.kubeClient,
 			LeaderElectionClient: t.kubeClient,
+			SigningRequestor:     &mockSigningRequestor{},
 			NewCableEngine: func(_ *types.SubmarinerCluster, lep *submendpoint.Local) cableengine.Engine {
 				t.cableEngine.LocalEndPoint = &types.SubmarinerEndpoint{Spec: *lep.Spec()}
 				return t.cableEngine


### PR DESCRIPTION
Add certificate mode in libreswan cabledriver
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
