### PR TITLE
Set RA pod as the owner of the RouteAgent resource

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor_test.go
+++ b/pkg/globalnet/controllers/gateway_monitor_test.go
@@ -75,6 +75,10 @@ func testEndpointMonitoring() {
 		})
 
 		Context("", func() {
+			BeforeEach(func() {
+				t.createGlobalEgressIP(newGlobalEgressIP(globalEgressIPName, nil, nil))
+			})
+
 			AfterEach(func() {
 				t.awaitGlobalnetChainsCleared()
 			})
@@ -82,7 +86,6 @@ func testEndpointMonitoring() {
 			It("should start the controllers", func() {
 				t.awaitControllersStarted()
 
-				t.createGlobalEgressIP(newGlobalEgressIP(globalEgressIPName, nil, nil))
 				t.awaitGlobalEgressIPStatusAllocated(globalEgressIPName, 1)
 
 				t.createServiceExport(t.createService(newClusterIPService()))
@@ -94,7 +97,12 @@ func testEndpointMonitoring() {
 				backendPod := newHeadlessServicePod(service.Name)
 				t.createPod(backendPod)
 				t.createServiceExport(t.createService(service))
-				t.awaitHeadlessGlobalIngressIP(service.Name, backendPod.Name)
+
+				Eventually(func(g Gomega) {
+					gip := t.awaitHeadlessGlobalIngressIP(service.Name, backendPod.Name)
+					g.Expect(gip.Status.AllocatedIP).NotTo(BeEmpty(), resource.ToJSON(gip))
+				}).To(Succeed())
+
 				t.awaitGatewayGlobalIP("")
 			})
 		})

--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -138,7 +138,15 @@ var _ = Describe("", func() {
 			},
 			HealthCheckerEnabled:     false,
 			RouteAgentUpdateInterval: time.Hour,
-		}, submClient.SubmarinerV1().RouteAgents(testing.Namespace), "v1", "test-node")
+			LocalNodeName:            "test-node",
+			Version:                  "v1",
+			Namespace:                testing.Namespace,
+			RouteAgentOwner: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "owner",
+				},
+			},
+		}, submClient.SubmarinerV1())
 		Expect(healthCheckerHandler.Init(ctx)).To(Succeed())
 	})
 })

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -37,7 +37,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 	k8snet "k8s.io/utils/net"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -45,13 +47,15 @@ type Config struct {
 	pinger.ControllerConfig
 	HealthCheckerEnabled     bool
 	RouteAgentUpdateInterval time.Duration
+	RouteAgentOwner          metav1.Object
+	Namespace                string
+	LocalNodeName            string
+	Version                  string
 }
 
 type controller struct {
 	event.HandlerBase
 	pingerController pinger.Controller
-	localNodeName    string
-	version          string
 	config           Config
 	stopCh           chan struct{}
 	stopOnce         sync.Once
@@ -60,14 +64,12 @@ type controller struct {
 
 var logger = log.Logger{Logger: logf.Log.WithName("HealthChecker")}
 
-func New(config *Config, client v1typed.RouteAgentInterface, version, nodeName string) event.Handler {
+func New(config *Config, client v1typed.SubmarinerV1Interface) event.Handler {
 	return &controller{
 		pingerController: pinger.NewController(config.ControllerConfig),
 		config:           *config,
-		version:          version,
-		client:           client,
+		client:           client.RouteAgents(config.Namespace),
 		stopCh:           make(chan struct{}),
-		localNodeName:    nodeName,
 	}
 }
 
@@ -79,9 +81,9 @@ func (h *controller) Stop() error {
 	})
 
 	err := h.client.Delete(context.TODO(),
-		h.localNodeName, metav1.DeleteOptions{})
+		h.config.LocalNodeName, metav1.DeleteOptions{})
 	if err != nil && !apiError.IsNotFound(err) {
-		return errors.Wrapf(err, "Error deleting RouteAgent: %s", h.localNodeName)
+		return errors.Wrapf(err, "Error deleting RouteAgent: %s", h.config.LocalNodeName)
 	}
 
 	return nil
@@ -241,6 +243,7 @@ func (h *controller) syncRouteAgentStatus() {
 	// Use CreateOrUpdate to handle the RouteAgent resource
 	_, err := util.CreateOrUpdate(context.TODO(), h.routeAgentResourceInterface(), routeAgent,
 		func(existing *submarinerv1.RouteAgent) (*submarinerv1.RouteAgent, error) {
+			existing.OwnerReferences = routeAgent.OwnerReferences
 			existing.Status = routeAgent.Status
 
 			return existing, nil
@@ -252,16 +255,24 @@ func (h *controller) syncRouteAgentStatus() {
 }
 
 func (h *controller) generateRouteAgentObject() *submarinerv1.RouteAgent {
-	return &submarinerv1.RouteAgent{
+	ra := &submarinerv1.RouteAgent{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: h.localNodeName,
+			Name:      h.config.LocalNodeName,
+			Namespace: h.config.Namespace,
 		},
 		Status: submarinerv1.RouteAgentStatus{
-			Version:         h.version,
+			Version:         h.config.Version,
 			StatusFailure:   "",
 			RemoteEndpoints: []submarinerv1.RemoteEndpoint{},
 		},
 	}
+
+	err := controllerutil.SetOwnerReference(h.config.RouteAgentOwner, ra, scheme.Scheme)
+	if err != nil {
+		logger.Errorf(err, "Error setting owner reference")
+	}
+
+	return ra
 }
 
 func (h *controller) routeAgentResourceInterface() resource.Interface[*submarinerv1.RouteAgent] {

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/pinger/fake"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubeScheme "k8s.io/client-go/kubernetes/scheme"
@@ -47,6 +49,7 @@ const (
 	healthCheckIP1  = "1.1.1.1"
 	healthCheckIP2  = "2.2.2.2"
 	localNodeName   = "nodeName"
+	ownerName       = "owner-name"
 )
 
 var _ = Describe("RouteAgent syncing", func() {
@@ -110,6 +113,22 @@ var _ = Describe("RouteAgent syncing", func() {
 				g.Expect(ra.Status.RemoteEndpoints).To(HaveLen(1))
 				g.Expect(ra.Status.RemoteEndpoints[0].Spec.GetHealthCheckIP(k8snet.IPv4)).To(Equal(healthCheckIP2))
 			})
+		})
+	})
+
+	When("the RouteAgent resource exists on startup without the OwnerReference", func() {
+		BeforeEach(func() {
+			_, err := t.routeAgents.Create(context.TODO(), &submarinerv1.RouteAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      localNodeName,
+					Namespace: namespace,
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should add the OwnerReference", func() {
+			t.awaitRouteAgent(nil)
 		})
 	})
 })
@@ -325,7 +344,7 @@ var _ = Describe("Stop", func() {
 		t.pingerMap[healthCheckIP1].AwaitStop()
 
 		Eventually(func(g Gomega) {
-			_, err := t.client.Get(context.TODO(), localNodeName, metav1.GetOptions{})
+			_, err := t.routeAgents.Get(context.TODO(), localNodeName, metav1.GetOptions{})
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		}).Within(5 * time.Second).Should(Succeed())
 
@@ -339,7 +358,8 @@ type testDriver struct {
 	pingerMap            map[string]*fake.Pinger
 	handler              event.Handler
 	endpoints            dynamic.ResourceInterface
-	client               submarinerv1client.RouteAgentInterface
+	routeAgents          submarinerv1client.RouteAgentInterface
+	submClient           *fakeClient.Clientset
 	healthcheckerEnabled bool
 }
 
@@ -352,12 +372,12 @@ func newTestDriver() *testDriver {
 		t.supportedIPFamilies = []k8snet.IPFamily{k8snet.IPv4}
 		t.healthcheckerEnabled = true
 
-		clientset := fakeClient.NewSimpleClientset()
+		t.submClient = fakeClient.NewSimpleClientset()
 
 		dynamicClient := dynamicfake.NewSimpleDynamicClient(kubeScheme.Scheme)
 
 		t.endpoints = dynamicClient.Resource(submarinerv1.SchemeGroupVersion.WithResource("endpoints")).Namespace(namespace)
-		t.client = clientset.SubmarinerV1().RouteAgents(namespace)
+		t.routeAgents = t.submClient.SubmarinerV1().RouteAgents(namespace)
 		t.pingerMap = map[string]*fake.Pinger{
 			healthCheckIP1: fake.NewPinger(healthCheckIP1),
 			healthCheckIP2: fake.NewPinger(healthCheckIP2),
@@ -380,9 +400,19 @@ func newTestDriver() *testDriver {
 			},
 			HealthCheckerEnabled:     t.healthcheckerEnabled,
 			RouteAgentUpdateInterval: 100 * time.Millisecond,
+			LocalNodeName:            localNodeName,
+			Version:                  "v1",
+			Namespace:                namespace,
+			RouteAgentOwner: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ownerName,
+					Namespace: namespace,
+					UID:       uuid.NewUUID(),
+				},
+			},
 		}
 
-		t.handler = healthchecker.New(config, t.client, "v1", localNodeName)
+		t.handler = healthchecker.New(config, t.submClient.SubmarinerV1())
 
 		t.Start(t.handler)
 	})
@@ -439,8 +469,12 @@ func (t *testDriver) Start(handler event.Handler) {
 
 func (t *testDriver) awaitRouteAgent(verify func(*submarinerv1.RouteAgent, Gomega)) {
 	Eventually(func(g Gomega) {
-		ra, err := t.client.Get(context.TODO(), localNodeName, metav1.GetOptions{})
+		ra, err := t.routeAgents.Get(context.TODO(), localNodeName, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred(), "Error retrieving RouteAgent")
+
+		g.Expect(ra.OwnerReferences).To(HaveLen(1))
+		g.Expect(ra.OwnerReferences[0].Name).To(Equal(ownerName))
+		g.Expect(ra.OwnerReferences[0].Kind).To(Equal("Pod"))
 
 		if verify != nil {
 			verify(ra, g)

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -135,6 +136,9 @@ func main() {
 	localNode, err := node.GetLocalNode(ctx, k8sClientSet)
 	logger.FatalOnError(err, "Error getting information on the local node")
 
+	pod, err := k8sClientSet.CoreV1().Pods(submSpec.Namespace).Get(ctx, os.Getenv("POD_NAME"), metav1.GetOptions{})
+	logger.FatalOnError(err, "Error getting local Pod %q", os.Getenv("POD_NAME"))
+
 	var handlers []event.Handler //nolint:prealloc // Ignore
 
 	for _, family := range cidr.ExtractIPFamilies(env.ClusterCidr) {
@@ -157,7 +161,11 @@ func main() {
 			},
 			HealthCheckerEnabled:     submSpec.HealthCheckEnabled,
 			RouteAgentUpdateInterval: 60 * time.Second,
-		}, smClientset.SubmarinerV1().RouteAgents(submSpec.Namespace), versions.Submariner(), localNode.Name))
+			RouteAgentOwner:          pod,
+			LocalNodeName:            localNode.Name,
+			Version:                  versions.Submariner(),
+			Namespace:                submSpec.Namespace,
+		}, smClientset.SubmarinerV1()))
 
 	registry, err := event.NewRegistry(ctx, "routeagent_driver", np, handlers...)
 

--- a/test/e2e/redundancy/route_agent_restart.go
+++ b/test/e2e/redundancy/route_agent_restart.go
@@ -19,15 +19,21 @@ limitations under the License.
 package redundancy
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	subDataplane "github.com/submariner-io/submariner/test/e2e/dataplane"
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 	"github.com/submariner-io/submariner/test/e2e/labels"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8snet "k8s.io/utils/net"
 )
 
@@ -83,6 +89,8 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool, supportedF
 	routeAgentPod := f.AwaitRouteAgentPodOnNode(framework.ClusterA, node.Name, "")
 	framework.By(fmt.Sprintf("Found route agent pod %q on node %q", routeAgentPod.Name, node.Name))
 
+	assertRouteAgentResource(framework.ClusterA, node.Name, routeAgentPod.Name)
+
 	framework.By(fmt.Sprintf("Deleting route agent pod %q", routeAgentPod.Name))
 	f.DeletePod(framework.ClusterA, routeAgentPod.Name, framework.TestContext.SubmarinerNamespace)
 
@@ -116,4 +124,25 @@ func testRouteAgentRestart(f *subFramework.Framework, onGateway bool, supportedF
 			IPFamily:              ipFamily,
 		}, subFramework.GetGlobalnetEgressParams(subFramework.ClusterSelector))
 	}
+}
+
+func assertRouteAgentResource(cluster framework.ClusterIndex, name, ownerName string) {
+	raClient := framework.DynClients[cluster].Resource(submarinerv1.SchemeGroupVersion.WithResource("routeagents")).Namespace(
+		framework.TestContext.SubmarinerNamespace)
+
+	routeAgent := framework.AwaitUntil(fmt.Sprintf("await RouteAgent %q", name),
+		func() (*unstructured.Unstructured, error) {
+			ra, err := raClient.Get(context.TODO(), name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return nil, nil //nolint:nilnil // OK
+			}
+
+			return ra, err
+		},
+		func(ra *unstructured.Unstructured) (bool, string, error) {
+			return ra != nil, "RouteAgent not found yet", nil
+		})
+
+	Expect(routeAgent.GetOwnerReferences()).To(HaveLen(1))
+	Expect(routeAgent.GetOwnerReferences()[0].Name).To(Equal(ownerName))
 }


### PR DESCRIPTION
...so it's garbage collected when the pod is deleted.

Fixes https://github.com/submariner-io/submariner/issues/3660
