### PR TITLE
Automated backport of #3679: Handle equal CreationTimestamps for Endpoint removal events

### DIFF
--- a/pkg/event/controller/controller.go
+++ b/pkg/event/controller/controller.go
@@ -33,7 +33,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/event"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
@@ -78,13 +77,13 @@ type Controller struct {
 }
 
 type handlerController struct {
-	syncMutex               sync.Mutex
-	handlerState            handlerStateImpl
-	handler                 event.Handler
-	nodeHandler             event.NodeHandler
-	hostname                string
-	clusterID               string
-	remoteEndpointTimeStamp map[string]v1.Time
+	syncMutex          sync.Mutex
+	handlerState       handlerStateImpl
+	handler            event.Handler
+	nodeHandler        event.NodeHandler
+	hostname           string
+	clusterID          string
+	lastRemoteEndpoint map[string]*subv1.Endpoint
 }
 
 // If the handler cannot recover from a failure, even after retrying for maximum requeue attempts,
@@ -173,10 +172,10 @@ func (c *Controller) setupHandlerController(handler event.Handler, clusterID, ho
 	syncerConfig syncer.ResourceSyncerConfig,
 ) error {
 	hCtrl := &handlerController{
-		handler:                 handler,
-		hostname:                hostname,
-		clusterID:               clusterID,
-		remoteEndpointTimeStamp: map[string]v1.Time{},
+		handler:            handler,
+		hostname:           hostname,
+		clusterID:          clusterID,
+		lastRemoteEndpoint: map[string]*subv1.Endpoint{},
 	}
 
 	handler.SetState(&hCtrl.handlerState)

--- a/pkg/event/controller/controller_test.go
+++ b/pkg/event/controller/controller_test.go
@@ -153,26 +153,11 @@ var _ = Describe("Event controller", func() {
 	})
 
 	When("a remote Endpoint is deleted after a newer Endpoint from the same cluster", func() {
-		It("should notify the handler of the stale removed Endpoint", func() {
-			now := time.Now()
-			staleEndpoint := t.CreateEndpoint(&submV1.Endpoint{
-				ObjectMeta: v1meta.ObjectMeta{Name: "stale", CreationTimestamp: v1meta.NewTime(now)},
-				Spec:       submV1.EndpointSpec{ClusterID: "east"},
-			})
-			t.awaitEvent(testing.EvRemoteEndpointCreated, staleEndpoint)
+		t.testStaleRemovedEndpoint(2 * time.Second)
+	})
 
-			latestEndpoint := t.CreateEndpoint(&submV1.Endpoint{
-				ObjectMeta: v1meta.ObjectMeta{Name: "latest", CreationTimestamp: v1meta.NewTime(now.Add(2 * time.Second))},
-				Spec:       submV1.EndpointSpec{ClusterID: "east"},
-			})
-			t.awaitEvent(testing.EvRemoteEndpointCreated, latestEndpoint)
-			Expect(t.handler.remoteEndpoints.Load()).To(HaveLen(2))
-
-			t.DeleteEndpoint(staleEndpoint.GetName())
-			t.awaitEvent(testing.EvStaleRemoteEndpointRemoved, staleEndpoint)
-			t.ensureNoEvents()
-			Expect(t.handler.remoteEndpoints.Load()).To(Equal([]submV1.Endpoint{*latestEndpoint}))
-		})
+	When("a remote Endpoint with thw same CreationTimestamp as the last Endpoint from the same cluster is deleted", func() {
+		t.testStaleRemovedEndpoint(0)
 	})
 })
 
@@ -280,6 +265,32 @@ func (t *testDriver) testRemoteEndpoints() {
 	t.awaitEvent(testing.EvRemoteEndpointRemoved, endpoint1)
 	Expect(t.handler.remoteEndpoints.Load()).To(BeEmpty())
 	t.ensureNoEvents()
+}
+
+func (t *testDriver) testStaleRemovedEndpoint(tsDiff time.Duration) {
+	It("should notify the handler of the stale removed Endpoint", func() {
+		now := time.Now()
+		staleEndpoint := t.CreateEndpoint(&submV1.Endpoint{
+			ObjectMeta: v1meta.ObjectMeta{Name: "stale", CreationTimestamp: v1meta.NewTime(now)},
+			Spec:       submV1.EndpointSpec{ClusterID: "east"},
+		})
+		t.awaitEvent(testing.EvRemoteEndpointCreated, staleEndpoint)
+
+		latestEndpoint := t.CreateEndpoint(&submV1.Endpoint{
+			ObjectMeta: v1meta.ObjectMeta{Name: "latest", CreationTimestamp: v1meta.NewTime(now.Add(tsDiff))},
+			Spec:       submV1.EndpointSpec{ClusterID: "east"},
+		})
+		t.awaitEvent(testing.EvRemoteEndpointCreated, latestEndpoint)
+		Expect(t.handler.remoteEndpoints.Load()).To(HaveLen(2))
+
+		t.DeleteEndpoint(staleEndpoint.GetName())
+		t.awaitEvent(testing.EvStaleRemoteEndpointRemoved, staleEndpoint)
+		t.ensureNoEvents()
+		Expect(t.handler.remoteEndpoints.Load()).To(Equal([]submV1.Endpoint{*latestEndpoint}))
+
+		t.DeleteEndpoint(latestEndpoint.GetName())
+		t.awaitEvent(testing.EvRemoteEndpointRemoved, latestEndpoint)
+	})
 }
 
 type TestHandler struct {

--- a/pkg/event/controller/endpoint_created.go
+++ b/pkg/event/controller/endpoint_created.go
@@ -71,16 +71,16 @@ func (c *handlerController) handleCreatedLocalEndpoint(endpoint *smv1.Endpoint) 
 }
 
 func (c *handlerController) handleCreatedRemoteEndpoint(endpoint *smv1.Endpoint) error {
-	lastProcessedTime, ok := c.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
+	lastClusterEndpoint, ok := c.lastRemoteEndpoint[endpoint.Spec.ClusterID]
 
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
-		logger.Infof("Handler %q: Ignoring new remote %#v since a later endpoint was already processed",
-			c.handler.GetName(), endpoint)
+	if ok && lastClusterEndpoint.CreationTimestamp.After(endpoint.CreationTimestamp.Time) {
+		logger.Infof("Handler %q: Ignoring new remote %#v since a later endpoint %q was already processed",
+			c.handler.GetName(), endpoint, lastClusterEndpoint.Spec.CableName)
 		return nil
 	}
 
 	c.handlerState.remoteEndpoints.Store(endpoint.Name, endpoint)
-	c.remoteEndpointTimeStamp[endpoint.Spec.ClusterID] = endpoint.CreationTimestamp
+	c.lastRemoteEndpoint[endpoint.Spec.ClusterID] = endpoint
 
 	return c.handler.RemoteEndpointCreated(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -69,13 +69,15 @@ func (c *handlerController) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) 
 func (c *handlerController) handleRemovedRemoteEndpoint(endpoint *smv1.Endpoint) error {
 	c.handlerState.remoteEndpoints.Delete(endpoint.Name)
 
-	lastProcessedTime, ok := c.remoteEndpointTimeStamp[endpoint.Spec.ClusterID]
-
-	if ok && lastProcessedTime.After(endpoint.CreationTimestamp.Time) {
+	// It's possible due to timing of notifications across the broker that we could observe a remove event for an
+	// older Endpoint for a cluster after the create event for the new Endpoint, in which case we'll notify of a
+	// stale removed Endpoint.
+	lastClusterEndpoint, ok := c.lastRemoteEndpoint[endpoint.Spec.ClusterID]
+	if ok && lastClusterEndpoint.UID != endpoint.UID {
 		return c.handler.StaleRemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 	}
 
-	delete(c.remoteEndpointTimeStamp, endpoint.Spec.ClusterID)
+	delete(c.lastRemoteEndpoint, endpoint.Spec.ClusterID)
 
 	return c.handler.RemoteEndpointRemoved(endpoint) //nolint:wrapcheck  // Let the caller wrap it
 }

--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -111,7 +111,9 @@ func (c *ControllerSupport) CreateLocalHostEndpoint() *submV1.Endpoint {
 }
 
 func (c *ControllerSupport) CreateEndpoint(endpoint *submV1.Endpoint) *submV1.Endpoint {
+	endpoint.UID = uuid.NewUUID()
 	Expect(scheme.Scheme.Convert(test.CreateResource(c.endpoints, endpoint), endpoint, nil)).To(Succeed())
+
 	return endpoint
 }
 

--- a/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
@@ -49,12 +49,12 @@ var _ = Describe("IPPool Handler", func() {
 			// Ensure it handles existing IPPools.
 			Expect(t.handler.RemoteEndpointCreated(remoteEP1)).To(Succeed())
 
+			t.DeleteEndpoint(remoteEP1.Name)
+			t.awaitNoIPPools(subnets1...)
+
 			subnets2 := []string{"192.0.4.0/24"}
 			remoteEP2 := t.CreateEndpoint(testing.NewEndpoint("remote-cluster1", "host", subnets2...))
 			t.awaitIPPools(subnets2...)
-
-			t.DeleteEndpoint(remoteEP1.Name)
-			t.awaitNoIPPools(subnets1...)
 
 			t.DeleteEndpoint(localEP.Name)
 

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -90,35 +90,40 @@ func (h *controller) Stop() error {
 }
 
 func (h *controller) RemoteEndpointCreated(endpoint *submarinerv1.Endpoint) error {
-	return h.RemoteEndpointUpdated(endpoint)
+	return h.onRemoteEndpint(endpoint, "created")
 }
 
 func (h *controller) RemoteEndpointUpdated(endpoint *submarinerv1.Endpoint) error {
+	return h.onRemoteEndpint(endpoint, "updated")
+}
+
+func (h *controller) onRemoteEndpint(endpoint *submarinerv1.Endpoint, op string) error {
 	if !h.config.HealthCheckerEnabled || h.State().IsOnGateway() {
 		return nil
 	}
 
-	h.processEndpointCreatedOrUpdated(endpoint)
+	h.processEndpointCreatedOrUpdated(endpoint, op)
 
 	return nil
 }
 
-func (h *controller) processEndpointCreatedOrUpdated(endpoint *submarinerv1.Endpoint) {
-	logger.Infof("Processing Endpoint: %#v", endpoint)
-
+func (h *controller) processEndpointCreatedOrUpdated(endpoint *submarinerv1.Endpoint, op string) {
+	logger.Infof("Processing %s Endpoint: %s", op, resource.ToJSON(endpoint))
 	h.pingerController.EndpointCreatedOrUpdated(&endpoint.Spec)
 }
 
 func (h *controller) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
 	logger.Infof("Processing removed Endpoint %q", endpoint.Spec.CableName)
-
 	h.pingerController.EndpointRemoved(&endpoint.Spec)
 
 	return nil
 }
 
 func (h *controller) StaleRemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
-	return h.RemoteEndpointRemoved(endpoint)
+	logger.Infof("Processing stale removed Endpoint: %s", resource.ToJSON(endpoint))
+	h.pingerController.EndpointRemoved(&endpoint.Spec)
+
+	return nil
 }
 
 func (h *controller) Init(_ context.Context) error {
@@ -138,7 +143,7 @@ func (h *controller) TransitionToNonGateway() error {
 		remoteEndpoints := h.State().GetRemoteEndpoints()
 
 		for i := range remoteEndpoints {
-			h.processEndpointCreatedOrUpdated(&remoteEndpoints[i])
+			h.processEndpointCreatedOrUpdated(&remoteEndpoints[i], "existing")
 		}
 	}
 

--- a/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
+++ b/pkg/routeagent_driver/handlers/mtu/mtuhandler.go
@@ -207,6 +207,8 @@ func (h *mtuHandler) LocalEndpointRemoved(endpoint *submV1.Endpoint) error {
 }
 
 func (h *mtuHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
+	logger.Infof("Processing created Endpoint %q", endpoint.Spec.CableName)
+
 	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
 	for _, subnet := range subnets {
 		err := h.remoteIPSet.AddEntry(subnet, true)
@@ -219,6 +221,8 @@ func (h *mtuHandler) RemoteEndpointCreated(endpoint *submV1.Endpoint) error {
 }
 
 func (h *mtuHandler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
+	logger.Infof("Processing removed Endpoint %q", endpoint.Spec.CableName)
+
 	subnets := cidr.ExtractSubnets(h.ipFamily, endpoint.Spec.Subnets)
 	for _, subnet := range subnets {
 		logError(h.remoteIPSet.DelEntry(subnet), "Error deleting the subnet %q from the remote IPSet", subnet)


### PR DESCRIPTION
Backport of #3679 on release-0.21.

#3679: Handle equal CreationTimestamps for Endpoint removal events

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.