### PR TITLE
Exclude globalnet, ovn job from the E2E full matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,9 @@ jobs:
         exclude:
           - cable-driver: wireguard
             extra-toggles: ovn
+          - globalnet: globalnet
+            extra-toggles: ovn
+            cable-driver:
         include:
           - extra-toggles: dual-stack
           - extra-toggles: dual-stack, globalnet


### PR DESCRIPTION
This has been failing for a while and, since it works with nftables which is now the default, we have no plans to address it.

