### PR TITLE
Automated backport of #3620: Add force-udp-encaps coverage in tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,7 @@ jobs:
           - extra-toggles: nftables
           - extra-toggles: nftables, ovn
           - extra-toggles: nftables, globalnet
+          - extra-toggles: dual-stack, ovn, force-udp-encaps
           - extra-toggles: dual-stack, ovn
           # Oldest Kubernetes version thought to work with SubM.
           # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:


### PR DESCRIPTION
Backport of #3620 on release-0.21.

#3620: Add force-udp-encaps coverage in tests

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on: https://github.com/submariner-io/shipyard/pull/2189