### PR TITLE
Automated backport of #3716: Add iptables cleanup for nftables migration

### DIFF
--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -38,8 +38,11 @@ import (
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
 	submarinerClientset "github.com/submariner-io/submariner/pkg/client/clientset/versioned"
+	"github.com/submariner-io/submariner/pkg/globalnet/constants"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
+	"github.com/submariner-io/submariner/pkg/packetfilter"
 	pfconfigure "github.com/submariner-io/submariner/pkg/packetfilter/configure"
+	"github.com/submariner-io/submariner/pkg/packetfilter/iptables"
 	"github.com/submariner-io/submariner/pkg/versions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -167,6 +170,8 @@ func main() {
 	err = gatewayMonitor.Start()
 	logger.FatalOnError(err, "Error starting the gatewayMonitor")
 
+	cleanupLegacyIptables()
+
 	<-ctx.Done()
 	gatewayMonitor.Stop()
 
@@ -178,4 +183,58 @@ func init() {
 	flag.StringVar(&masterURL, "master", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.BoolVar(&showVersion, "version", showVersion, "Show version")
+}
+
+// =============================================================================
+// TEMPORARY: Legacy iptables cleanup for migration to nftables
+// This entire section can be removed once migration is complete
+// =============================================================================
+
+func cleanupLegacyIptables() {
+	if pfconfigure.GetDriverType() == pfconfigure.IPTables {
+		return
+	}
+
+	// Globalnet only supports IPv4
+	pIPtables, err := iptables.New(k8snet.IPv4)
+	if err != nil {
+		logger.Errorf(err, "Failed to create IPv%v iptables driver for cleanup", k8snet.IPv4)
+		return
+	}
+
+	_ = pIPtables.ClearChain(packetfilter.TableTypeNAT, constants.SmGlobalnetIngressChain)
+
+	if err := pIPtables.DeleteIPHookChain(&packetfilter.ChainIPHook{
+		Name:     constants.SmGlobalnetIngressChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPrerouting,
+		Priority: packetfilter.ChainPriorityFirst,
+	}); err != nil {
+		logger.V(log.DEBUG).Infof("Failed to delete IPv%v iptables IP hook chain %q: %v", k8snet.IPv4, constants.SmGlobalnetIngressChain, err)
+	} else {
+		logger.Infof("Cleaned up IPv%v iptables IP hook chain %q", k8snet.IPv4, constants.SmGlobalnetIngressChain)
+	}
+
+	regularChains := []struct {
+		Table packetfilter.TableType
+		Chain string
+	}{
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChainForCluster},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChainForHeadlessSvcPods},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChainForHeadlessSvcEPs},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChainForNamespace},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChainForPods},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetMarkChain},
+		{Table: packetfilter.TableTypeNAT, Chain: constants.SmGlobalnetEgressChain},
+	}
+
+	for _, item := range regularChains {
+		_ = pIPtables.ClearChain(item.Table, item.Chain)
+
+		if err := pIPtables.DeleteChain(item.Table, item.Chain); err != nil {
+			logger.V(log.DEBUG).Infof("Failed to delete IPv%v iptables chain %q: %v", k8snet.IPv4, item.Chain, err)
+		} else {
+			logger.Infof("Cleaned up IPv%v iptables chain %q", k8snet.IPv4, item.Chain)
+		}
+	}
 }

--- a/pkg/packetfilter/configure/configure.go
+++ b/pkg/packetfilter/configure/configure.go
@@ -27,6 +27,13 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type DriverType int
+
+const (
+	IPTables DriverType = iota
+	NfTables
+)
+
 const UseNftablesKey = "use-nftables"
 
 var logger = log.Logger{Logger: logf.Log.WithName("Packetfilter")}
@@ -41,4 +48,12 @@ func DriverFromGlobalConfig() {
 		logger.Info("Using iptables packet filter driver")
 		packetfilter.SetNewDriverFn(iptables.New)
 	}
+}
+
+func GetDriverType() DriverType {
+	if global.Get(UseNftablesKey, true) {
+		return NfTables
+	}
+
+	return IPTables
 }

--- a/pkg/packetfilter/configure/configure_suite_test.go
+++ b/pkg/packetfilter/configure/configure_suite_test.go
@@ -33,14 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type DriverType int
-
-const (
-	IPTables DriverType = iota
-	NfTables
-)
-
-const defaultDriver = NfTables
+const defaultDriver = configure.NfTables
 
 var _ = Describe("DriverFromGlobalConfig", func() {
 	var cm *corev1.ConfigMap
@@ -66,7 +59,7 @@ var _ = Describe("DriverFromGlobalConfig", func() {
 
 			It("should set the nftables driver", func() {
 				configure.DriverFromGlobalConfig()
-				verifyDriverFn(NfTables)
+				verifyDriverFn(configure.NfTables)
 			})
 		})
 
@@ -77,7 +70,7 @@ var _ = Describe("DriverFromGlobalConfig", func() {
 
 			It("should set the iptables driver", func() {
 				configure.DriverFromGlobalConfig()
-				verifyDriverFn(IPTables)
+				verifyDriverFn(configure.IPTables)
 			})
 		})
 	})
@@ -90,12 +83,12 @@ var _ = Describe("DriverFromGlobalConfig", func() {
 	})
 })
 
-func verifyDriverFn(dType DriverType) {
+func verifyDriverFn(dType configure.DriverType) {
 	fnValue := func(v interface{}) string {
 		return fmt.Sprintf("%v", v)
 	}
 
-	if dType == NfTables {
+	if dType == configure.NfTables {
 		Expect(fnValue(packetfilter.GetNewDriverFn())).To(Equal(fnValue(nftables.New)))
 	} else {
 		Expect(fnValue(packetfilter.GetNewDriverFn())).To(Equal(fnValue(iptables.New)))

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -47,8 +47,10 @@ import (
 	"github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	pfconfigure "github.com/submariner-io/submariner/pkg/packetfilter/configure"
+	"github.com/submariner-io/submariner/pkg/packetfilter/iptables"
 	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cabledriver"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/calico"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
@@ -211,6 +213,8 @@ func main() {
 	err = ctl.Start(stopCh)
 	logger.FatalOnError(err, "Error starting controller")
 
+	cleanupLegacyIptables(env.ClusterCidr)
+
 	<-stopCh
 	ctl.Stop()
 
@@ -260,6 +264,100 @@ func removeInvalidSockets() {
 				logger.Errorf(err, "Failed to delete invalid socket %s", dir)
 			} else {
 				logger.Infof("Deleted invalid socket %s", dir)
+			}
+		}
+	}
+}
+
+// =============================================================================
+// TEMPORARY: iptables cleanup for migration to nftables
+// This entire section can be removed once migration is complete
+// =============================================================================
+
+func cleanupLegacyIptables(clusterCidr []string) {
+	if pfconfigure.GetDriverType() == pfconfigure.IPTables {
+		return
+	}
+
+	ipHookChains := []struct {
+		Table packetfilter.TableType
+		Chain *packetfilter.ChainIPHook
+	}{
+		{
+			Table: packetfilter.TableTypeNAT,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     constants.SmPostRoutingChain,
+				Type:     packetfilter.ChainTypeNAT,
+				Hook:     packetfilter.ChainHookPostrouting,
+				Priority: packetfilter.ChainPriorityFirst,
+			},
+		},
+		{
+			Table: packetfilter.TableTypeFilter,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     constants.SmInputChain,
+				Type:     packetfilter.ChainTypeFilter,
+				Hook:     packetfilter.ChainHookInput,
+				Priority: packetfilter.ChainPriorityLast,
+				JumpRule: &packetfilter.Rule{
+					Proto:       packetfilter.RuleProtoUDP,
+					Action:      packetfilter.RuleActionJump,
+					TargetChain: constants.SmInputChain,
+				},
+			},
+		},
+		{
+			Table: packetfilter.TableTypeNAT,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     constants.SmSelfSnatChain,
+				Type:     packetfilter.ChainTypeNAT,
+				Hook:     packetfilter.ChainHookPostrouting,
+				Priority: packetfilter.ChainPriorityMiddle,
+			},
+		},
+		{
+			Table: packetfilter.TableTypeFilter,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     constants.SmForwardChain,
+				Type:     packetfilter.ChainTypeFilter,
+				Hook:     packetfilter.ChainHookForward,
+				Priority: packetfilter.ChainPriorityFirst,
+			},
+		},
+		{
+			Table: packetfilter.TableTypeFilter,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     ovn.ForwardingSubmarinerMSSClampChain,
+				Type:     packetfilter.ChainTypeFilter,
+				Hook:     packetfilter.ChainHookForward,
+				Priority: packetfilter.ChainPriorityFirst,
+			},
+		},
+		{
+			Table: packetfilter.TableTypeRoute,
+			Chain: &packetfilter.ChainIPHook{
+				Name:     constants.SmPostRoutingMssChain,
+				Type:     packetfilter.ChainTypeRoute,
+				Hook:     packetfilter.ChainHookPostrouting,
+				Priority: packetfilter.ChainPriorityFirst,
+			},
+		},
+	}
+
+	for _, family := range cidr.ExtractIPFamilies(clusterCidr) {
+		pIPtables, err := iptables.New(family)
+		if err != nil {
+			logger.Errorf(err, "Failed to create IPv%v iptables driver for cleanup", family)
+			continue
+		}
+
+		for _, item := range ipHookChains {
+			_ = pIPtables.ClearChain(item.Table, item.Chain.Name)
+
+			if err := pIPtables.DeleteIPHookChain(item.Chain); err != nil {
+				logger.V(log.DEBUG).Infof("Failed to delete IPv%v iptables IP hook chain %q: %v", family, item.Chain.Name, err)
+			} else {
+				logger.Infof("Cleaned up IPv%v iptables IP hook chain %q", family, item.Chain.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Backport of #3716 on release-0.22.

#3716: Add iptables cleanup for nftables migration

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.