### PR TITLE
Automated backport of #3588: Clear the forwarding chains on transition to non-gateway

### DIFF
--- a/pkg/netlink/fake/netlink.go
+++ b/pkg/netlink/fake/netlink.go
@@ -306,7 +306,7 @@ func (n *basicType) RouteDel(route *netlink.Route) error {
 	routes := n.routes[route.LinkIndex]
 
 	for i := range routes {
-		if reflect.DeepEqual(routes[i].Dst, route.Dst) {
+		if routes[i].Table == route.Table && (reflect.DeepEqual(routes[i].Gw, route.Gw) || reflect.DeepEqual(routes[i].Dst, route.Dst)) {
 			n.routes[route.LinkIndex] = goslices.Delete(routes, i, i+1)
 			break
 		}

--- a/pkg/packetfilter/fake/packetfilter.go
+++ b/pkg/packetfilter/fake/packetfilter.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
@@ -219,15 +220,15 @@ func (i *PacketFilter) delete(table packetfilter.TableType, chain, ruleSpec stri
 }
 
 func (i *PacketFilter) deleteChain(table uint32, chain string) error {
+	defer GinkgoRecover()
+
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
 	key := chainKey(table, chain)
 
 	rules := i.chainRules[key]
-	if len(rules) > 0 {
-		return fmt.Errorf("cannot delete chain %q for table %q - %d rules remain", chain, table, len(rules))
-	}
+	Expect(rules).To(BeEmpty(), "cannot delete chain %q for table %q - %d rules remain", chain, table, len(rules))
 
 	delete(i.chainRules, key)
 

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -21,6 +21,7 @@ package ovn
 import (
 	"context"
 	"encoding/json"
+	goerrors "errors"
 	"os"
 	"strconv"
 
@@ -205,21 +206,12 @@ func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
 }
 
 func (ovn *Handler) cleanupForwardingIptables() error {
-	if err := ovn.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
-		Name:     ForwardingSubmarinerMSSClampChain,
-		Type:     packetfilter.ChainTypeFilter,
-		Hook:     packetfilter.ChainHookForward,
-		Priority: packetfilter.ChainPriorityFirst,
-	}); err != nil {
-		return errors.Wrapf(err, "error clearing chain %q", ForwardingSubmarinerMSSClampChain)
-	}
-
-	return errors.Wrapf(ovn.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
-		Name:     ForwardingSubmarinerFWDChain,
-		Type:     packetfilter.ChainTypeFilter,
-		Hook:     packetfilter.ChainHookForward,
-		Priority: packetfilter.ChainPriorityFirst,
-	}), "error clearing chain %q", ForwardingSubmarinerFWDChain)
+	return goerrors.Join(
+		errors.Wrapf(ovn.pFilter.ClearChain(packetfilter.TableTypeFilter, ForwardingSubmarinerMSSClampChain),
+			"error clearing chain %q", ForwardingSubmarinerMSSClampChain),
+		errors.Wrapf(ovn.pFilter.ClearChain(packetfilter.TableTypeFilter, ForwardingSubmarinerFWDChain),
+			"error clearing chain %q", ForwardingSubmarinerFWDChain),
+	)
 }
 
 func (ovn *Handler) getRouteToOVNDataPlane() (*netlink.Route, error) {

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -229,12 +229,7 @@ func (ovn *Handler) getRouteToOVNDataPlane() (*netlink.Route, error) {
 func (ovn *Handler) initIPtablesChains() error {
 	logger.V(log.DEBUG).Infof("Install/ensure %q/%s IPHook chain exists", constants.SmPostRoutingChain, "NAT")
 
-	if err := ovn.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
-		Name:     constants.SmPostRoutingChain,
-		Type:     packetfilter.ChainTypeNAT,
-		Hook:     packetfilter.ChainHookPostrouting,
-		Priority: packetfilter.ChainPriorityFirst,
-	}); err != nil {
+	if err := ovn.pFilter.CreateIPHookChainIfNotExists(newPostRoutingChain()); err != nil {
 		return errors.Wrapf(err, "error installing %q IPHook chain", constants.SmPostRoutingChain)
 	}
 
@@ -246,14 +241,9 @@ func (ovn *Handler) initIPtablesChains() error {
 }
 
 func (ovn *Handler) ensureForwardChains() error {
-	for _, chain := range []string{ForwardingSubmarinerFWDChain, ForwardingSubmarinerMSSClampChain} {
-		if err := ovn.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
-			Name:     chain,
-			Type:     packetfilter.ChainTypeFilter,
-			Hook:     packetfilter.ChainHookForward,
-			Priority: packetfilter.ChainPriorityFirst,
-		}); err != nil {
-			return errors.Wrapf(err, "error installing forwarding IPHook chain %q", chain)
+	for _, chain := range []*packetfilter.ChainIPHook{newSubmarinerFWDChain(), newSubmarinerMSSClampChain()} {
+		if err := ovn.pFilter.CreateIPHookChainIfNotExists(chain); err != nil {
+			return errors.Wrapf(err, "error creating forwarding IPHook chain %q", chain.Name)
 		}
 	}
 
@@ -331,5 +321,32 @@ func (ovn *Handler) nodeResourceInterface() resource.Interface[*corev1.Node] {
 	return &resource.InterfaceFuncs[*corev1.Node]{
 		GetFunc:    ovn.K8sClient.CoreV1().Nodes().Get,
 		UpdateFunc: ovn.K8sClient.CoreV1().Nodes().Update,
+	}
+}
+
+func newPostRoutingChain() *packetfilter.ChainIPHook {
+	return &packetfilter.ChainIPHook{
+		Name:     constants.SmPostRoutingChain,
+		Type:     packetfilter.ChainTypeNAT,
+		Hook:     packetfilter.ChainHookPostrouting,
+		Priority: packetfilter.ChainPriorityFirst,
+	}
+}
+
+func newSubmarinerFWDChain() *packetfilter.ChainIPHook {
+	return &packetfilter.ChainIPHook{
+		Name:     ForwardingSubmarinerFWDChain,
+		Type:     packetfilter.ChainTypeFilter,
+		Hook:     packetfilter.ChainHookForward,
+		Priority: packetfilter.ChainPriorityFirst,
+	}
+}
+
+func newSubmarinerMSSClampChain() *packetfilter.ChainIPHook {
+	return &packetfilter.ChainIPHook{
+		Name:     ForwardingSubmarinerMSSClampChain,
+		Type:     packetfilter.ChainTypeFilter,
+		Hook:     packetfilter.ChainHookForward,
+		Priority: packetfilter.ChainPriorityFirst,
 	}
 }

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -344,10 +344,14 @@ func (t *handlerTestDriver) testGatewayTransitions(ipFamilySubnets, nonIPFamilyS
 			for _, s := range ipFamilySubnets {
 				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, t.clusterCIDR)
 				t.netLink.AwaitRule(constants.RouteAgentInterClusterNetworkTableID, s, t.serviceCIDR)
+				t.pFilter.AwaitRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain, ContainSubstring(s))
+				t.pFilter.AwaitRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerMSSClampChain, ContainSubstring(s))
 			}
 
 			for _, s := range nonIPFamilySubnets {
 				t.netLink.EnsureNoRule(constants.RouteAgentInterClusterNetworkTableID, s, t.clusterCIDR)
+				t.pFilter.EnsureNoRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain, ContainSubstring(s))
+				t.pFilter.EnsureNoRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerMSSClampChain, ContainSubstring(s))
 			}
 
 			t.awaitOVNKNodeAnnotationContaining(ipFamilySubnets...)
@@ -361,6 +365,8 @@ func (t *handlerTestDriver) testGatewayTransitions(ipFamilySubnets, nonIPFamilyS
 			for _, s := range ipFamilySubnets {
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, t.clusterCIDR)
 				t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, s, t.serviceCIDR)
+				t.pFilter.AwaitNoRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain, ContainSubstring(s))
+				t.pFilter.AwaitNoRule(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerMSSClampChain, ContainSubstring(s))
 			}
 
 			t.awaitOVNKNodeAnnotationContaining()

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -175,26 +175,41 @@ var _ = Describe("Handler", func() {
 	})
 
 	Context("on Uninstall", func() {
-		It("should delete the table rules", func() {
+		It("should delete the table rules and chains", func() {
 			Expect(t.pFilter.ChainExists(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain)).To(BeTrue())
 			Expect(t.pFilter.ChainExists(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerMSSClampChain)).To(BeTrue())
+			Expect(t.pFilter.ChainExists(packetfilter.TableTypeNAT, constants.SmPostRoutingChain)).To(BeTrue())
 
-			_ = t.netLink.RuleAdd(&netlink.Rule{
+			Expect(t.netLink.RuleAdd(&netlink.Rule{
 				Table:  constants.RouteAgentHostNetworkTableID,
 				Family: netlink.FAMILY_V4,
-			})
+			})).To(Succeed())
 
-			_ = t.netLink.RuleAdd(&netlink.Rule{
+			Expect(t.netLink.RuleAdd(&netlink.Rule{
 				Table:  constants.RouteAgentInterClusterNetworkTableID,
 				Family: netlink.FAMILY_V4,
-			})
+			})).To(Succeed())
+
+			Expect(t.pFilter.Append(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain, &packetfilter.Rule{
+				DestCIDR: "1.2.3.4/16",
+				Action:   packetfilter.RuleActionAccept,
+			})).To(Succeed())
+
+			Expect(t.pFilter.Append(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain, &packetfilter.Rule{
+				DestCIDR:  "1.2.3.4/16",
+				Action:    packetfilter.RuleActionMss,
+				ClampType: packetfilter.ToValue,
+				MssValue:  "5",
+			})).To(Succeed())
 
 			Expect(t.handler.Uninstall()).To(Succeed())
 
 			t.netLink.AwaitNoRule(constants.RouteAgentHostNetworkTableID, "", "")
 			t.netLink.AwaitNoRule(constants.RouteAgentInterClusterNetworkTableID, "", "")
 
+			Expect(t.pFilter.ChainExists(packetfilter.TableTypeNAT, constants.SmPostRoutingChain)).To(BeFalse())
 			Expect(t.pFilter.ChainExists(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerFWDChain)).To(BeFalse())
+			Expect(t.pFilter.ChainExists(packetfilter.TableTypeFilter, ovn.ForwardingSubmarinerMSSClampChain)).To(BeFalse())
 		})
 	})
 })

--- a/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
+++ b/pkg/routeagent_driver/handlers/ovn/route_config_syncer.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -147,12 +146,7 @@ func (ovn *Handler) handleInterfaceAddressChange() error {
 
 		logger.V(log.DEBUG).Infof("Install/ensure %q/%s IPHook chain exists", constants.SmPostRoutingChain, "NAT")
 
-		if err := ovn.pFilter.CreateIPHookChainIfNotExists(&packetfilter.ChainIPHook{
-			Name:     constants.SmPostRoutingChain,
-			Type:     packetfilter.ChainTypeNAT,
-			Hook:     packetfilter.ChainHookPostrouting,
-			Priority: packetfilter.ChainPriorityFirst,
-		}); err != nil {
+		if err := ovn.pFilter.CreateIPHookChainIfNotExists(newPostRoutingChain()); err != nil {
 			return errors.Wrap(err, "error installing IPHook chain")
 		}
 

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -60,33 +60,9 @@ func (ovn *Handler) Uninstall() error {
 			constants.RouteAgentHostNetworkTableID)
 	}
 
-	if err := ovn.pFilter.ClearChain(packetfilter.TableTypeFilter, ForwardingSubmarinerFWDChain); err != nil {
-		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", ForwardingSubmarinerFWDChain, "Filter")
-	}
-
-	if err := ovn.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
-		Name:     ForwardingSubmarinerFWDChain,
-		Type:     packetfilter.ChainTypeFilter,
-		Hook:     packetfilter.ChainHookForward,
-		Priority: packetfilter.ChainPriorityFirst,
-	}); err != nil {
-		logger.Errorf(err, "DeleteIPHookChain %s returned error",
-			ForwardingSubmarinerFWDChain)
-	}
-
-	if err := ovn.pFilter.ClearChain(packetfilter.TableTypeNAT, constants.SmPostRoutingChain); err != nil {
-		logger.Errorf(err, "Error flushing packetfilter chain %q of %q table", constants.SmPostRoutingChain, "NAT")
-	}
-
-	if err := ovn.pFilter.DeleteIPHookChain(&packetfilter.ChainIPHook{
-		Name:     constants.SmPostRoutingChain,
-		Type:     packetfilter.ChainTypeNAT,
-		Hook:     packetfilter.ChainHookPostrouting,
-		Priority: packetfilter.ChainPriorityFirst,
-	}); err != nil {
-		logger.Errorf(err, "DeleteIPHookChain %s returned error",
-			constants.SmPostRoutingChain)
-	}
+	ovn.deleteIPHookChain(packetfilter.TableTypeFilter, newSubmarinerFWDChain())
+	ovn.deleteIPHookChain(packetfilter.TableTypeFilter, newSubmarinerMSSClampChain())
+	ovn.deleteIPHookChain(packetfilter.TableTypeNAT, newPostRoutingChain())
 
 	err = util.Update[*corev1.Node](context.TODO(), ovn.nodeResourceInterface(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeutil.GetLocalNodeName()},
@@ -99,6 +75,16 @@ func (ovn *Handler) Uninstall() error {
 	}
 
 	return nil
+}
+
+func (ovn *Handler) deleteIPHookChain(table packetfilter.TableType, chain *packetfilter.ChainIPHook) {
+	if err := ovn.pFilter.ClearChain(table, chain.Name); err != nil {
+		logger.Errorf(err, "Error clearing IP hook chain %q from %q table", chain.Name, table)
+	}
+
+	if err := ovn.pFilter.DeleteIPHookChain(chain); err != nil {
+		logger.Errorf(err, "Error deleting IP hook chain %q from %q table", chain.Name, table)
+	}
 }
 
 func (ovn *Handler) cleanupRoutes() error {


### PR DESCRIPTION
Backport of #3588 on release-0.21.

#3588: Clear the forwarding chains on transition to non-gateway

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.