### PR TITLE
Adjust to golangci-lint v2.7.2

### DIFF
--- a/pkg/natdiscovery/request_handle.go
+++ b/pkg/natdiscovery/request_handle.go
@@ -44,7 +44,7 @@ func (nd *natDiscovery) handleRequestFromAddress(req *proto.SubmarinerNATDiscove
 		},
 		Receiver: req.GetSender(),
 		ReceivedSrc: &proto.IPPortPair{
-			Port: int32(addr.Port),
+			Port: int32(addr.Port), //nolint:gosec // Tgnore integer overflow conversion int -> int32
 			IP:   addr.IP.String(),
 		},
 	}


### PR DESCRIPTION
Revert the prior `nolint:gosec` removals due to v2.7.1.

Depends on https://github.com/submariner-io/shipyard/pull/2231
