### PR TITLE
Fix panic in NAT discovery unit test

### DIFF
--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -151,9 +151,11 @@ func (c *FakeServerConnection) inputFrom(b []byte, addr *net.UDPAddr) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.udpReadChannel <- UDPReadInfo{
-		b:    b,
-		addr: addr,
+	if !c.closed.Load() {
+		c.udpReadChannel <- UDPReadInfo{
+			b:    b,
+			addr: addr,
+		}
 	}
 }
 


### PR DESCRIPTION
```
panic: send on closed channel

goroutine 718 [running]:
.../submariner/pkg/natdiscovery_test.(*FakeServerConnection).inputFrom(),
  .../submariner/pkg/natdiscovery/natdiscovery_suite_test.go:154
```

It seems remnants can still be running async after test cleanup closes the channel so guard against that.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed a race condition in network discovery tests by preventing UDP read events from being queued after the server connection closes, eliminating potential deadlocks and writes to closed channels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->