### PR TITLE
Fix CVE workflow stale image/artifact handling

### DIFF
--- a/.agents/workflows/cve-fix.md
+++ b/.agents/workflows/cve-fix.md
@@ -38,11 +38,15 @@ One commit per package (may fix multiple CVEs), one PR total.
 ##### 2. Scan
 
 ```bash
+# Ensure fresh build image and clean workspace
+docker pull quay.io/submariner/shipyard-dapper-base:release-0.X
+make clean
+
 make BUILD_UPX=false build
 grype . --config .grype.yaml -o table
 ```
 
-BUILD_UPX=false enables stdlib CVE detection. Skip stdlib CVEs (NAME=stdlib) - handle in step 9.
+BUILD_UPX=false enables stdlib CVE detection. For stdlib CVEs (NAME=stdlib), see Step 9.
 
 Ignore warning "no explicit name and version provided".
 
@@ -185,7 +189,7 @@ Repeat steps 3-8 for each remaining dependency CVE.
 
 If no CVEs remain, skip to step 10.
 
-**Stdlib CVEs:** Require Shipyard Go upgrade - run CVE workflow there.
+**Stdlib CVEs:** Caused by the dapper-base image's Go version. Step 2's `docker pull` ensures you have the latest image; if CVEs persist, run the CVE workflow in Shipyard to bump the Go version.
 
 If fix requires breaking changes (Go version, K8s major version, incompatible APIs), consider:
 - CVE severity (Low/Medium vs High/Critical)


### PR DESCRIPTION
Stale Docker images and local binaries caused false positive CVEs.

- Pull fresh dapper-base image before building
- Clean workspace to remove stale artifacts
- Fix stdlib CVE guidance to direct users to Shipyard

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CVE fix workflow guidance, including image refresh procedures and stdlib CVE handling instructions in the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->