### PR TITLE
Change Endpoint GetBackendBool to return a bool

### DIFF
--- a/pkg/apis/submariner.io/v1/endpoint.go
+++ b/pkg/apis/submariner.io/v1/endpoint.go
@@ -49,14 +49,14 @@ func (ep *EndpointSpec) GetBackendPort(configName string, defaultValue int32) (i
 	return defaultValue, nil
 }
 
-func (ep *EndpointSpec) GetBackendBool(configName string, defaultValue *bool) (*bool, error) {
+func (ep *EndpointSpec) GetBackendBool(configName string, defaultValue bool) (bool, error) {
 	if boolStr := ep.BackendConfig[configName]; boolStr != "" {
 		boolValue, err := strconv.ParseBool(boolStr)
 		if err != nil {
 			return defaultValue, errors.Wrapf(err, "error parsing backend config %s", configName)
 		}
 
-		return &boolValue, nil
+		return boolValue, nil
 	}
 
 	return defaultValue, nil
@@ -68,8 +68,6 @@ func parsePort(port string) (int32, error) {
 		return -1, errors.Wrapf(err, "error parsing port %s", port)
 	} else if portInt < 1 {
 		return -1, errors.Errorf("port %s is < 1", port)
-	} else if portInt > 65535 {
-		return -1, errors.Errorf("port %s is > 65535", port)
 	}
 
 	return int32(portInt), nil

--- a/pkg/apis/submariner.io/v1/endpoint_test.go
+++ b/pkg/apis/submariner.io/v1/endpoint_test.go
@@ -38,6 +38,8 @@ const (
 var _ = Describe("EndpointSpec", func() {
 	Context("GenerateName", testGenerateName)
 	Context("Equals", testEquals)
+	Context("GetBackendBool", testGetBackendBool)
+	Context("GetBackendPort", testGetBackendPort)
 	Context("GetHealthCheckIP", testGetHealthCheckIP)
 	Context("SetHealthCheckIP", testSetHealthCheckIP)
 	Context("GetPublicIP", testGetPublicIP)
@@ -157,6 +159,154 @@ func testEquals() {
 			other.BackendConfig = map[string]string{"key": "bbb"}
 			spec.BackendConfig = map[string]string{"key": "aaa"}
 			Expect(spec.Equals(other)).To(BeFalse())
+		})
+	})
+}
+
+func testGetBackendBool() {
+	const configName = "bool-config"
+
+	var spec *v1.EndpointSpec
+
+	BeforeEach(func() {
+		spec = &v1.EndpointSpec{
+			BackendConfig: map[string]string{},
+		}
+	})
+
+	When("the config value is set to 'true'", func() {
+		It("should return true and no error", func() {
+			spec.BackendConfig[configName] = "true"
+			result, err := spec.GetBackendBool(configName, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the config value is set to 'false'", func() {
+		It("should return false and no error", func() {
+			spec.BackendConfig[configName] = "false"
+			result, err := spec.GetBackendBool(configName, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	When("the config value is an invalid string", func() {
+		It("should return the default value and an error", func() {
+			spec.BackendConfig[configName] = "invalid-bool"
+			result, err := spec.GetBackendBool(configName, true)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the config value is an empty string", func() {
+		It("should return the default value and no error", func() {
+			spec.BackendConfig[configName] = ""
+			result, err := spec.GetBackendBool(configName, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	When("the config key does not exist", func() {
+		It("should return the default value and no error", func() {
+			result, err := spec.GetBackendBool(configName, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+}
+
+func testGetBackendPort() {
+	const configName = "port-config"
+
+	var spec *v1.EndpointSpec
+
+	BeforeEach(func() {
+		spec = &v1.EndpointSpec{
+			BackendConfig: map[string]string{},
+		}
+	})
+
+	When("the config value is set to a valid port", func() {
+		It("should return the port value and no error", func() {
+			spec.BackendConfig[configName] = "8080"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(int32(8080)))
+		})
+	})
+
+	When("the config value is set to the minimum valid port", func() {
+		It("should return the port value and no error", func() {
+			spec.BackendConfig[configName] = "1"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(int32(1)))
+		})
+	})
+
+	When("the config value is set to the maximum valid port", func() {
+		It("should return the port value and no error", func() {
+			spec.BackendConfig[configName] = "65535"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(int32(65535)))
+		})
+	})
+
+	When("the config value is set to an invalid string", func() {
+		It("should return the default value and an error", func() {
+			spec.BackendConfig[configName] = "invalid-port"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
+		})
+	})
+
+	When("the config value is set to a negative number", func() {
+		It("should return the default value and an error", func() {
+			spec.BackendConfig[configName] = "-1"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
+		})
+	})
+
+	When("the config value is set to zero", func() {
+		It("should return the default value and an error", func() {
+			spec.BackendConfig[configName] = "0"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
+		})
+	})
+
+	When("the config value is set to a port greater than 65535", func() {
+		It("should return the default value and an error", func() {
+			spec.BackendConfig[configName] = "65536"
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
+		})
+	})
+
+	When("the config value is an empty string", func() {
+		It("should return the default value and no error", func() {
+			spec.BackendConfig[configName] = ""
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
+		})
+	})
+
+	When("the config key does not exist", func() {
+		It("should return the default value and no error", func() {
+			result, err := spec.GetBackendPort(configName, 443)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(int32(443)))
 		})
 	})
 }

--- a/pkg/cable/libreswan/preferred_server.go
+++ b/pkg/cable/libreswan/preferred_server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
-	"k8s.io/utils/ptr"
 )
 
 type operationMode int
@@ -39,25 +38,25 @@ const (
 )
 
 func (i *libreswan) calculateOperationMode(remoteEndpoint *v1.EndpointSpec) operationMode {
-	leftPreferred, err := i.localEndpoint.GetBackendBool(v1.PreferredServerConfig, ptr.To(false))
+	leftPreferred, err := i.localEndpoint.GetBackendBool(v1.PreferredServerConfig, false)
 	if err != nil {
 		logger.Errorf(err, "Error parsing local endpoint config")
 	}
 
-	rightPreferred, err := remoteEndpoint.GetBackendBool(v1.PreferredServerConfig, nil)
+	rightPreferred, err := remoteEndpoint.GetBackendBool(v1.PreferredServerConfig, false)
 	if err != nil {
 		logger.Errorf(err, "Error parsing remote endpoint config %q", remoteEndpoint.CableName)
 	}
 
-	if rightPreferred == nil || !*leftPreferred && !*rightPreferred {
+	if !leftPreferred && !rightPreferred {
 		return operationModeBidirectional
 	}
 
-	if *leftPreferred && !*rightPreferred {
+	if leftPreferred && !rightPreferred {
 		return operationModeServer
 	}
 
-	if *rightPreferred && !*leftPreferred {
+	if rightPreferred && !leftPreferred {
 		return operationModeClient
 	}
 

--- a/pkg/natdiscovery/remote_endpoint.go
+++ b/pkg/natdiscovery/remote_endpoint.go
@@ -88,8 +88,8 @@ func newRemoteEndpointNAT(endpoint *v1.Endpoint, family k8snet.IPFamily) *remote
 	// Due to a network load balancer issue in the AWS implementation https://github.com/submariner-io/submariner/issues/1410
 	// we want to try on the IPs, but not hold on connecting for a minute, because IPSEC will succeed in that case,
 	// and we want to verify if the private IP will accessible (because it's still better)
-	usingLoadBalancer, _ := endpoint.Spec.GetBackendBool(v1.UsingLoadBalancer, nil)
-	if usingLoadBalancer != nil && *usingLoadBalancer {
+	usingLoadBalancer, _ := endpoint.Spec.GetBackendBool(v1.UsingLoadBalancer, false)
+	if usingLoadBalancer {
 		rnat.timeout = ToDuration(&TotalTimeoutLoadBalancer)
 		rnat.usingLoadBalancer = true
 	} else {


### PR DESCRIPTION
...instead of a `*bool` as is the standard practice with such functions. In addition the default value param was changed to `bool` as well. Call sites that were passing a nil default value were treating it as false so this avoids them to having to handle nil and false.

Added unit tests for `GetBackendBool` and also for `GetBackendPort`. The unit tests for the latter revealed a code branch that cannot be reached so it was removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended port range validation to support ports above 65535

* **Tests**
  * Added comprehensive test coverage for backend configuration retrieval and port parsing methods, including edge cases and error scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->