### PR TITLE
Add s390x EUS support for gateway

### DIFF
--- a/.rpm-lockfiles/gateway/rpms.in.yaml
+++ b/.rpm-lockfiles/gateway/rpms.in.yaml
@@ -13,3 +13,4 @@ packages:
 arches:
   - x86_64
   - aarch64
+  - s390x

--- a/.rpm-lockfiles/gateway/rpms.lock.yaml
+++ b/.rpm-lockfiles/gateway/rpms.lock.yaml
@@ -18,73 +18,161 @@ arches:
     name: libreswan
     evr: 4.15-8.el9
     sourcerpm: libreswan-4.15-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nspr-4.35.0-17.el9_2.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 136412
-    checksum: sha256:d6bf6ce947ef0fc91a4d0e3d3d0bff464d6e9483a3df353df16996dd2504bcb3
+    size: 132948
+    checksum: sha256:17124daa5425a70b9573ff2ac479043d42174f9197f656c549307d31843c75c1
     name: nspr
-    evr: 4.35.0-17.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-3.101.0-10.el9_2.aarch64.rpm
+    evr: 4.36.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 715233
-    checksum: sha256:82382945fd9b359d78eee74fa631774ed9867f0e51031afe90c167eb3904a02e
+    size: 716093
+    checksum: sha256:b604959ea1defcc76f55b2fd7a2299300dec998108b0c1cb80be0efa845e8572
     name: nss
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-softokn-3.101.0-10.el9_2.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 395776
-    checksum: sha256:d300da461a1a1d791d8d8358415fdfcbd06fce516eeb3a6d24f2ed31682faa70
+    size: 399692
+    checksum: sha256:35197e3cac43476bf14b17b89c95be12209af7fa193ae3807ec73ed88a0f4d5a
     name: nss-softokn
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-softokn-freebl-3.101.0-10.el9_2.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 310319
-    checksum: sha256:9eedc117413f39248290d35b07c89f915432fd872e1204c63643cef3c7bc463c
+    size: 424604
+    checksum: sha256:131a636b10bdb8f94f7918e461ec18d37d81e7f5bf97b307c60c482db4d31034
     name: nss-softokn-freebl
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-sysinit-3.101.0-10.el9_2.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 21018
-    checksum: sha256:5408f22abccf0ae737bb0ed9263422b47287352c0edc3f4eba7b10465f8dc125
+    size: 18002
+    checksum: sha256:89d455cb36e1b3b059eabc502f94c21161219f0570668068efba70d5df2c0719
     name: nss-sysinit
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-tools-3.101.0-10.el9_2.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-tools-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 453636
-    checksum: sha256:c2f46a3967812c7e513e4aba51b3b93111c2a90215f1fc650878fa9980392a52
+    size: 453637
+    checksum: sha256:db2bbb98756cd5be41c9922aa11e1e9e7b4caf9f4b19a644d8bf26f9247d39c0
     name: nss-tools
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-util-3.101.0-10.el9_2.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 90707
-    checksum: sha256:ae2c232b98ebe609c404fcfaf6c75dfbb034fc12391e3913466dc410c107560f
+    size: 88331
+    checksum: sha256:f15db365cf300f60b6ae9e0730c01015bd70d217ea656161daa63f1a75d4ea1e
     name: nss-util
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/u/unbound-libs-1.16.2-19.el9_6.1.aarch64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/u/unbound-libs-1.16.2-21.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 543541
-    checksum: sha256:58dc5268cf6477cb643a44446277abec96692ff7d3ce321dfeca606214f90b78
+    size: 543055
+    checksum: sha256:2b69126cf75800a45577a0e2228eef4f1819825ce8a9037d3695fdcbb4b9acd1
     name: unbound-libs
-    evr: 1.16.2-19.el9_6.1
-    sourcerpm: unbound-1.16.2-19.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/k/kmod-28-10.el9.aarch64.rpm
+    evr: 1.16.2-21.el9
+    sourcerpm: unbound-1.16.2-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/k/kmod-28-11.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 130824
-    checksum: sha256:02835d70e5283383d02367e1bb3431a74033bbd1be5e3961e572623e1cbca4ca
+    size: 125869
+    checksum: sha256:ed0cf7e6f05e0646f968e862c6b6764c5eac8378f918a33e1b78bcde7a994aa3
     name: kmod
-    evr: 28-10.el9
-    sourcerpm: kmod-28-10.el9.src.rpm
+    evr: 28-11.el9
+    sourcerpm: kmod-28-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 38582
     checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: s390x
+  packages:
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/l/ldns-1.7.1-11.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 163422
+    checksum: sha256:3caf1cb1cf17b4a056466b5ab7af9cf0a0c31d6df3ff93f44dc51b16e8f55065
+    name: ldns
+    evr: 1.7.1-11.el9
+    sourcerpm: ldns-1.7.1-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/l/libreswan-4.12-3.el9_4.1.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 1379365
+    checksum: sha256:f8b12a183f9acc7411a0fb92499dc016a1dc0c5010e600917ebd8b2dce9f1271
+    name: libreswan
+    evr: 4.12-3.el9_4.1
+    sourcerpm: libreswan-4.12-3.el9_4.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 135799
+    checksum: sha256:54fbd8f7a41548d165c2b3d6140e3175d3d48f8ee79301d9757cab0a8788d2d2
+    name: nspr
+    evr: 4.36.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 694219
+    checksum: sha256:963396fd7816a9c1b92ef17695046c35a626f556251397aa3351a386c3f6b137
+    name: nss
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 391378
+    checksum: sha256:1d3639c8fd1a8d9916ebe8c1f68bdd63c0b54d3c1eef9d844a44346659acb594
+    name: nss-softokn
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 417708
+    checksum: sha256:fc2c460ce088b06dae6f82998754868899c404c80b0cd574b7e935c0f303a5ed
+    name: nss-softokn-freebl
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 18087
+    checksum: sha256:69f2bb25e414bca1d2eac2786c3a915fc0ff50f8e3dd7dba7bb3fd06d4bd17d3
+    name: nss-sysinit
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-tools-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 449584
+    checksum: sha256:a3dd0701f9bbf8784b68125b37459845dfff743d4c9f301841366d099819195e
+    name: nss-tools
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 90586
+    checksum: sha256:3c3d6cca2c14c25144b46fa25e0ab7186db29612cb7117304174bbde18b347b2
+    name: nss-util
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/u/unbound-libs-1.16.2-8.el9_4.2.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 534461
+    checksum: sha256:f8b99dd4765ee20686c72ed8c733409ba884994fb10f33877150a91ced6a289b
+    name: unbound-libs
+    evr: 1.16.2-8.el9_4.2
+    sourcerpm: unbound-1.16.2-8.el9_4.2.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/k/kmod-28-9.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 131796
+    checksum: sha256:b32d495767e9e88bd935d6cdbab69cebe4a99baea544c38189554fca959d8453
+    name: kmod
+    evr: 28-9.el9
+    sourcerpm: kmod-28-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 38450
+    checksum: sha256:0ba1d0bcbc80c2dc53fdac3eecf2606aab133ca22ba7cf857d720c78cb120782
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
@@ -106,69 +194,69 @@ arches:
     name: libreswan
     evr: 4.15-8.el9
     sourcerpm: libreswan-4.15-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nspr-4.35.0-17.el9_2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nspr-4.36.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 140607
-    checksum: sha256:2e0acde0bc7ae98792638c1aae305461486c9891ecc02817362bc0e76ae505b4
+    size: 136524
+    checksum: sha256:dd9a598390e8adfebdcec7adbc5aa140d6584ede4d581d5fec328d2e4a5107db
     name: nspr
-    evr: 4.35.0-17.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-3.101.0-10.el9_2.x86_64.rpm
+    evr: 4.36.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 736821
-    checksum: sha256:c642ba6fc4cf83466640f05b98ca75968db524e1f4418a2e7b30a7512aed6808
+    size: 740527
+    checksum: sha256:6eefe50251cf43934ea5c949a0f23e0da20d81262394e7824328e0f21aabbe88
     name: nss
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-softokn-3.101.0-10.el9_2.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 402822
-    checksum: sha256:b633b9b499984d9e02d7ffdcf575bacf54f7075173466fbba42c4a5818eae6c8
+    size: 409821
+    checksum: sha256:ac09b91c717cf003714b62cb033bea51770c887fdc70426f625a677e50b0813f
     name: nss-softokn
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-softokn-freebl-3.101.0-10.el9_2.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 320699
-    checksum: sha256:a664810fcd953ce4c940ff6bf3693dd1dc484c1dc8ff24ca98580864fc06c367
+    size: 423244
+    checksum: sha256:1eb3fb60d885f3a1071dcb335e1ee34c156bbc50c797f42772d61412a91db8f5
     name: nss-softokn-freebl
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-sysinit-3.101.0-10.el9_2.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 21285
-    checksum: sha256:16c68e2a826f0c4d27b90310c99cf1dac1d81301f7d72f24dc8a39c27a9e9925
+    size: 18225
+    checksum: sha256:5b5314ce6088f161b2a404b566c6d5016811b6c12e90c7bf70d3fd281168d659
     name: nss-sysinit
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-tools-3.101.0-10.el9_2.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-tools-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 459918
-    checksum: sha256:3e939e4436eafbb9b55cd18ab476a97a73cacffe5893f85da78716587ee4f9c8
+    size: 461236
+    checksum: sha256:aa385d1e49bcf623632c60b4935914e32bffe9328287096e2cedd0514d443b4e
     name: nss-tools
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-util-3.101.0-10.el9_2.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nss-util-3.112.0-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 94111
-    checksum: sha256:1138da0bc3c4e0ead78842dc3180f1d5a60bc3824223cd1bca38eaf0c026dd9e
+    size: 91543
+    checksum: sha256:3904f1eab4e56789d8d818d0ca4a76c49d1ef5de947ccdabaf64f9d748ad05df
     name: nss-util
-    evr: 3.101.0-10.el9_2
-    sourcerpm: nss-3.101.0-10.el9_2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.16.2-19.el9_6.1.x86_64.rpm
+    evr: 3.112.0-4.el9_4
+    sourcerpm: nss-3.112.0-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.16.2-21.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 564481
-    checksum: sha256:a0588ea4d96ab5c7820d8a4e0067289c6e8fd04b8001a3bd0f87d5916722725c
+    size: 564369
+    checksum: sha256:744c97335bacd9050d4f1727e939459c8e073964562e7f36590313ceb18f930f
     name: unbound-libs
-    evr: 1.16.2-19.el9_6.1
-    sourcerpm: unbound-1.16.2-19.el9_6.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-10.el9.x86_64.rpm
+    evr: 1.16.2-21.el9
+    sourcerpm: unbound-1.16.2-21.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kmod-28-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 132888
-    checksum: sha256:e9ccad17d4c6c30524ec5c2aab8d8d351f2776ab564baccdbd2df9b54e28baea
+    size: 127775
+    checksum: sha256:f85ac587f3c6abab55c30986b5f4af790c3fa2f2a413057db8e9250c79825b5d
     name: kmod
-    evr: 28-10.el9
-    sourcerpm: kmod-28-10.el9.src.rpm
+    evr: 28-11.el9
+    sourcerpm: kmod-28-11.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38224

--- a/.rpm-lockfiles/gateway/submariner-rhel-9.repo
+++ b/.rpm-lockfiles/gateway/submariner-rhel-9.repo
@@ -15,10 +15,33 @@ gpgcheck = 1
 sslverify = 0
 sslclientcert = /etc/pki/entitlement/*.pem
 sslclientkey = /etc/pki/entitlement/*-key.pem
+skip_if_unavailable = 1
 
 [rhel-9-for-$basearch-appstream-rpms]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
 baseurl = https://cdn.redhat.com/content/dist/rhel9/9/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 0
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem
+skip_if_unavailable = 1
+
+# s390x requires EUS repos (standard RHEL 9 repos lack s390x in self-serve subscriptions)
+[rhel-9-for-s390x-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for s390x - BaseOS EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 0
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem
+
+[rhel-9-for-s390x-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for s390x - AppStream EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1

--- a/.tekton/submariner-gateway-0-20-pull-request.yaml
+++ b/.tekton/submariner-gateway-0-20-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/s390x
   - name: dockerfile
     value: package/Dockerfile.submariner-gateway.konflux
   - name: prefetch-input

--- a/.tekton/submariner-gateway-0-20-push.yaml
+++ b/.tekton/submariner-gateway-0-20-push.yaml
@@ -28,6 +28,7 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/s390x
   - name: dockerfile
     value: package/Dockerfile.submariner-gateway.konflux
   - name: prefetch-input


### PR DESCRIPTION
Standard RHEL 9 repos return 403 for s390x with self-serve subscriptions. EUS (Extended Update Support) repos are accessible and contain all required packages.

Changes:
- Add skip_if_unavailable=1 to standard repos (allows graceful fallback)
- Add s390x EUS BaseOS and AppStream repo entries
- Add s390x to rpms.in.yaml arches and regenerate lockfile
- Add linux/s390x to Tekton pipeline build-platforms

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added s390x architecture support for gateway deployments

* **Chores**
  * Updated package versions and metadata for improved stability
  * Added Extended Update Support (EUS) repositories for s390x
  * Updated build pipelines to include s390x architecture

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->