### PR TITLE
Use the correct encapsulation for Libreswan < 5.0 (forward port to release-0.22)

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -52,7 +52,7 @@ const (
 	whackTimeout     = 5 * time.Second
 	dpdDelay         = 30 // seconds
 	encryptArg       = "--encrypt"
-	forceencapsArg   = "--encapsulation=yes"
+	forceencapsArg   = "--encaps=yes"
 	nameArg          = "--name"
 	hostArg          = "--host"
 	clientArg        = "--client"

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -52,7 +52,7 @@ const (
 	whackTimeout     = 5 * time.Second
 	dpdDelay         = 30 // seconds
 	encryptArg       = "--encrypt"
-	forceencapsArg   = "--encaps=yes"
+	forceencapsArg   = "--encaps="
 	nameArg          = "--name"
 	hostArg          = "--host"
 	clientArg        = "--client"
@@ -492,7 +492,9 @@ func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpoi
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],
@@ -540,7 +542,9 @@ func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo 
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],
@@ -581,7 +585,9 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],


### PR DESCRIPTION
See #3699 and individual commits for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN encapsulation flag handling to correctly support both explicit and automatic encapsulation modes based on connection type and network conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->