### PR TITLE
Use the correct encapsulation for Libreswan < 5.0 (forward port to devel)

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -52,7 +52,7 @@ const (
 	whackTimeout     = 5 * time.Second
 	dpdDelay         = 30 // seconds
 	encryptArg       = "--encrypt"
-	forceencapsArg   = "--encaps=yes"
+	forceencapsArg   = "--encaps="
 	nameArg          = "--name"
 	hostArg          = "--host"
 	clientArg        = "--client"
@@ -491,7 +491,9 @@ func (i *libreswan) bidirectionalConnectToEndpoint(connectionName string, endpoi
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],
@@ -539,7 +541,9 @@ func (i *libreswan) serverConnectToEndpoint(connectionName string, endpointInfo 
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],
@@ -580,7 +584,9 @@ func (i *libreswan) clientConnectToEndpoint(connectionName string, endpointInfo 
 
 	args := []string{"--psk", encryptArg}
 	if endpointInfo.UseNAT || i.forceUDPEncapsulation {
-		args = append(args, forceencapsArg)
+		args = append(args, forceencapsArg+"yes")
+	} else {
+		args = append(args, forceencapsArg+"auto")
 	}
 
 	args = append(args, nameArg, connectionName, ipFamilyArgs[endpointInfo.UseFamily],

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -52,7 +52,7 @@ const (
 	whackTimeout     = 5 * time.Second
 	dpdDelay         = 30 // seconds
 	encryptArg       = "--encrypt"
-	forceencapsArg   = "--encapsulation=yes"
+	forceencapsArg   = "--encaps=yes"
 	nameArg          = "--name"
 	hostArg          = "--host"
 	clientArg        = "--client"


### PR DESCRIPTION
See #3699 and individual commits for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced encapsulation configuration handling for NAT and UDP scenarios across connection types, ensuring proper parameter initialization for all connection endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->