### PR TITLE
ipset: ensure entry is defined

### DIFF
--- a/pkg/ipset/ipset_test.go
+++ b/pkg/ipset/ipset_test.go
@@ -215,106 +215,85 @@ var _ = Describe("AddIPEntry", func() {
 var _ = Describe("AddEntry", func() {
 	t := newTestDriver()
 
-	var entry *ipset.Entry
-
-	testSuccess := func(args func() []any) {
+	testSuccess := func(entry *ipset.Entry, args ...any) {
 		It("should invoke the correct command", func() {
 			err := t.ipSet.AddEntry(entry, testSet, false)
 			Expect(err).To(Succeed())
-			t.cmdExecutor.AwaitCommand(IPSetPathMatcher, append([]any{"add", testSet}, args()...)...)
+			t.cmdExecutor.AwaitCommand(IPSetPathMatcher, append([]any{"add", testSet}, args...)...)
 		})
 	}
 
 	Context("with set type HashIPPort", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType:  ipset.HashIPPort,
-				IP:       entryIP,
-				Port:     123,
-				Protocol: ipset.ProtocolTCP,
-			}
-		})
+		entry := &ipset.Entry{
+			SetType:  ipset.HashIPPort,
+			IP:       entryIP,
+			Port:     123,
+			Protocol: ipset.ProtocolTCP,
+		}
 
-		testSuccess(func() []any {
-			return []any{entry.IP + "," + string(entry.Protocol) + ":123"}
-		})
+		testSuccess(entry, entry.IP+","+string(entry.Protocol)+":123")
 	})
 
 	Context("with set type HashIPPortIP", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType:  ipset.HashIPPortIP,
-				IP:       entryIP,
-				Port:     123,
-				Protocol: ipset.ProtocolTCP,
-				IP2:      "192.168.1.2",
-			}
-		})
+		entry := &ipset.Entry{
+			SetType:  ipset.HashIPPortIP,
+			IP:       entryIP,
+			Port:     123,
+			Protocol: ipset.ProtocolTCP,
+			IP2:      "192.168.1.2",
+		}
 
-		testSuccess(func() []any {
-			return []any{entry.IP + "," + string(entry.Protocol) + ":123," + entry.IP2}
-		})
+		testSuccess(entry, entry.IP+","+string(entry.Protocol)+":123,"+entry.IP2)
 	})
 
 	Context("with set type HashNet", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType: ipset.HashNet,
-				Net:     "10.0.1.0/24",
-			}
-		})
+		entry := &ipset.Entry{
+			SetType: ipset.HashNet,
+			Net:     "10.0.1.0/24",
+		}
 
-		testSuccess(func() []any {
-			return []any{entry.Net}
-		})
+		testSuccess(entry, entry.Net)
 	})
 
 	Context("with set type HashNetPort", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType:  ipset.HashNetPort,
-				Protocol: ipset.ProtocolUDP,
-				Port:     123,
-				Net:      "10.0.1.0/24",
-			}
-		})
+		entry := &ipset.Entry{
+			SetType:  ipset.HashNetPort,
+			Protocol: ipset.ProtocolUDP,
+			Port:     123,
+			Net:      "10.0.1.0/24",
+		}
 
-		testSuccess(func() []any {
-			return []any{entry.Net + "," + string(entry.Protocol) + ":123"}
-		})
+		testSuccess(entry, entry.Net+","+string(entry.Protocol)+":123")
 	})
 
 	Context("with set type HashIPPortNet", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType:  ipset.HashIPPortNet,
-				IP:       entryIP,
-				Protocol: ipset.ProtocolUDP,
-				Port:     123,
-				Net:      "10.0.1.0/24",
-			}
-		})
+		entry := &ipset.Entry{
+			SetType:  ipset.HashIPPortNet,
+			IP:       entryIP,
+			Protocol: ipset.ProtocolUDP,
+			Port:     123,
+			Net:      "10.0.1.0/24",
+		}
 
-		testSuccess(func() []any {
-			return []any{entry.IP + "," + string(entry.Protocol) + ":123," + entry.Net}
-		})
+		testSuccess(entry, entry.IP+","+string(entry.Protocol)+":123,"+entry.Net)
 	})
 
 	Context("with set type BitmapPort", func() {
-		BeforeEach(func() {
-			entry = &ipset.Entry{
-				SetType: ipset.BitmapPort,
-				Port:    123,
-			}
-		})
+		entry := &ipset.Entry{
+			SetType: ipset.BitmapPort,
+			Port:    123,
+		}
 
-		testSuccess(func() []any {
-			return []any{"123"}
-		})
+		testSuccess(entry, "123")
 	})
 
 	When("the command fails", func() {
 		It("should return an error", func() {
+			entry := &ipset.Entry{
+				SetType: ipset.BitmapPort,
+				Port:    123,
+			}
+
 			t.cmdExecutor.SetupCommandOutputWithError("", errors.New("exit status 1"), IPSetPathMatcher, "add")
 			err := t.ipSet.AddEntry(entry, testSet, false)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
The last test relies on entry being set from a previous test; this fails if the tests are run in parallel. This changes the test construction so that entry is private to each test block, and simplifies testSuccess since the argument construction never varies.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored test helpers to accept explicit inputs instead of relying on shared setup.
  * Test data is now constructed inline within each test case, improving clarity and reducing cross-test coupling.
  * Failure-case inputs made explicit to avoid unintended reuse of prior state.
  * Overall organization improved while preserving coverage and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->