### PR TITLE
Pin Konflux Dockerfile version labels to v0.22.1

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -70,7 +70,7 @@ ENTRYPOINT ["/usr/local/bin/submariner.sh"]
 
 LABEL com.redhat.component="submariner-gateway-container" \
       name="rhacm2/submariner-gateway-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Submariner Gateway" \
       description="The Submariner Gateway facilitates secure connections between clusters." \
       distribution-scope="public" \

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -57,7 +57,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-globalnet.sh"]
 
 LABEL com.redhat.component="submariner-globalnet-container" \
       name="rhacm2/submariner-globalnet-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Submariner Globalnet" \
       description="The Submariner Globalnet component provides connectivity for overlapping CIDRs in different clusters." \
       distribution-scope="public" \

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -67,7 +67,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-route-agent.sh"]
 
 LABEL com.redhat.component="submariner-route-agent-container" \
       name="rhacm2/submariner-route-agent-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Submariner Route Agent" \
       description="The Submariner Route Agent programs network routes on each node to facilitate cross-cluster communication." \
       distribution-scope="public" \


### PR DESCRIPTION
Enables dynamic tagging in Konflux releases for 0.22.1 Z-stream.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to v0.22.1 across container image definitions for the Submariner gateway, GlobalNet, and route-agent components. This is a patch release that updates image metadata labels only (no behavioral or functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->