### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -67,6 +67,7 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
+
 	syncer.GatewayUpdateInterval = 200 * time.Millisecond
 	syncer.GatewayStaleTimeout = 1 * time.Second
 })

--- a/pkg/natdiscovery/request_handle_test.go
+++ b/pkg/natdiscovery/request_handle_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Request handling", func() {
 	When("receiving a request with a known sender endpoint", func() {
 		It("should respond with OK", func() {
 			localND.instance.AddEndpoint(&remoteEndpoint, k8snet.IPv4)
+
 			response := requestResponseFromRemoteToLocal(remoteND.ipv4Connection.addr)
 			Expect(response[0].GetResponse()).To(Equal(natproto.ResponseType_OK))
 			Expect(response[1].GetResponse()).To(Equal(natproto.ResponseType_NAT_DETECTED))
@@ -82,6 +83,7 @@ var _ = Describe("Request handling", func() {
 			It("should respond with NAT_DETECTED and SrcIpNatDetected", func() {
 				remoteND.ipv4Connection.addr.IP = net.ParseIP(testRemotePublicIP)
 				localND.instance.AddEndpoint(&remoteEndpoint, k8snet.IPv4)
+
 				response := requestResponseFromRemoteToLocal(remoteND.ipv4Connection.addr)
 				Expect(response[0].GetResponse()).To(Equal(natproto.ResponseType_NAT_DETECTED))
 				Expect(response[0].GetSrcIpNatDetected()).To(BeTrue())
@@ -93,6 +95,7 @@ var _ = Describe("Request handling", func() {
 			It("should respond with NAT_DETECTED and SrcPortNatDetected", func() {
 				remoteND.ipv4Connection.addr.Port = int(testRemoteNATPort + 1)
 				localND.instance.AddEndpoint(&remoteEndpoint, k8snet.IPv4)
+
 				response := requestResponseFromRemoteToLocal(remoteND.ipv4Connection.addr)
 				Expect(response[0].GetResponse()).To(Equal(natproto.ResponseType_NAT_DETECTED))
 				Expect(response[0].GetSrcIpNatDetected()).To(BeFalse())
@@ -104,6 +107,7 @@ var _ = Describe("Request handling", func() {
 	When("receiving a request with an unknown receiver endpoint ID", func() {
 		It("should respond with UNKNOWN_DST_ENDPOINT", func() {
 			localND.instance.AddEndpoint(&remoteEndpoint, k8snet.IPv4)
+
 			localEndpoint.Spec.CableName = "invalid"
 			response := requestResponseFromRemoteToLocal(remoteND.ipv4Connection.addr)
 			Expect(response[0].GetResponse()).To(Equal(natproto.ResponseType_UNKNOWN_DST_ENDPOINT))
@@ -113,6 +117,7 @@ var _ = Describe("Request handling", func() {
 	When("receiving a request with an unknown receiver cluster ID", func() {
 		It("should respond with UNKNOWN_DST_CLUSTER", func() {
 			localND.instance.AddEndpoint(&remoteEndpoint, k8snet.IPv4)
+
 			localEndpoint.Spec.ClusterID = "invalid"
 			response := requestResponseFromRemoteToLocal(remoteND.ipv4Connection.addr)
 			Expect(response[0].GetResponse()).To(Equal(natproto.ResponseType_UNKNOWN_DST_CLUSTER))

--- a/pkg/netlink/netlink_internal_test.go
+++ b/pkg/netlink/netlink_internal_test.go
@@ -42,6 +42,7 @@ var _ = Describe("retryOnInterrupted", func() {
 			if callCount < 4 {
 				return "", netlink.ErrDumpInterrupted
 			}
+
 			return "success after retries", nil
 		})
 		Expect(err).To(Succeed())

--- a/pkg/pinger/controller_test.go
+++ b/pkg/pinger/controller_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Controller", func() {
 
 				p, ok := pingerMap[pingerCfg.IP]
 				Expect(ok).To(BeTrue())
+
 				return p
 			},
 		})

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker_test.go
@@ -243,6 +243,7 @@ var _ = Describe("RemoteEndpoint latency info", func() {
 
 			t.awaitRouteAgent(func(ra *submarinerv1.RouteAgent, g Gomega) {
 				epMap := map[string]*submarinerv1.RemoteEndpoint{}
+
 				for i := range ra.Status.RemoteEndpoints {
 					g.Expect(ra.Status.RemoteEndpoints[i].Spec.HealthCheckIPs).To(HaveLen(1))
 					epMap[ra.Status.RemoteEndpoints[i].Spec.HealthCheckIPs[0]] = &ra.Status.RemoteEndpoints[i]

--- a/pkg/vxlan/vxlan_test.go
+++ b/pkg/vxlan/vxlan_test.go
@@ -188,6 +188,7 @@ var _ = Describe("Interface", func() {
 		t.netLink.AwaitDstRoutes(0, 100, destCIDR1, destCIDR2)
 
 		Expect(vxlanInterface.AddRoutes(net.ParseIP("240.17.2.3"), net.ParseIP("120.17.2.3"), 100, *ipNet1, *ipNet2)).To(Succeed())
+
 		list, err := t.netLink.RouteList(&netlink.GenericLink{}, k8snet.IPFamilyUnknown)
 		Expect(err).To(Succeed())
 		Expect(list).To(HaveLen(2))

--- a/test/e2e/cluster/add_remove_cluster.go
+++ b/test/e2e/cluster/add_remove_cluster.go
@@ -37,6 +37,7 @@ var _ = PDescribe("[expansion] Test expanding/shrinking an existing cluster flee
 		clusterCName := framework.TestContext.ClusterIDs[framework.ClusterC]
 
 		framework.By(fmt.Sprintf("Verifying no GW nodes are present on cluster %q", clusterCName))
+
 		gatewayNode := framework.FindGatewayNodes(framework.ClusterC)
 		Expect(gatewayNode).To(BeEmpty(), fmt.Sprintf("Expected no gateway node on %q", framework.ClusterC))
 

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -83,6 +83,7 @@ var _ = Describe("Gateway status reporting", Label(labels.Dataplane), func() {
 					if apierrors.IsNotFound(err) {
 						return nil, nil //nolint:nilnil // Returning nil value is intentional
 					}
+
 					return resGw, err
 				},
 				func(result *submarinerv1.Gateway) (bool, string, error) {

--- a/test/e2e/dataplane/tcp_gn_pod_connectivity.go
+++ b/test/e2e/dataplane/tcp_gn_pod_connectivity.go
@@ -102,6 +102,7 @@ var _ = Describe("Basic TCP connectivity tests across overlapping clusters witho
 							f.Namespace), service, func(existing *v1.Service) (*v1.Service, error) {
 							existing.Spec.Ports[0].Port = lpConfig.Port
 							existing.Spec.Ports[0].TargetPort = intstr.FromInt32(lpConfig.Port)
+
 							return existing, nil
 						})
 						Expect(err).To(Succeed())


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced formatting and organization across multiple test suites for improved readability and maintainability.
  * Refined test execution logic to ensure proper return handling in retry and update operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->