### PR TITLE
Fix stale bot cache issue by adding actions:write permission

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
     steps:
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d
         with:


### PR DESCRIPTION
## Summary

This PR fixes a caching issue in the stale workflow where issues are being perpetually skipped with the message "skipped due being processed during the previous run".

## Problem

The stale workflow was lacking the `actions:write` permission needed to delete/update the cache between runs. Without this permission:
- The stale action creates a cache of processed issues
- It cannot delete or update this cache in subsequent runs (403 error)
- Issues get stuck in a "perpetually processing" state

## Solution

Add `actions:write` to the job permissions in `.github/workflows/stale.yml`.

## References

- Issue: https://github.com/actions/stale/issues/1131
- Related PR in actions/stale: https://github.com/actions/stale/pull/1237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved automation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->