### PR TITLE
Adjust to golangci-lint 2.10.1

### DIFF
--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -708,7 +708,7 @@ func testPluto() {
 	When("the control socket file doesn't exist", func() {
 		BeforeEach(func() {
 			Expect(t.plutoCtlFile.Close()).To(Succeed())
-			Expect(os.Remove(t.plutoCtlFile.Name())).To(Succeed())
+			Expect(os.Remove(t.plutoCtlFile.Name())).To(Succeed()) //nolint:gosec // Test file created by test setup
 		})
 
 		It("should succeed when the file is eventually created", func() {

--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -196,7 +196,7 @@ func publicAPI(family k8snet.IPFamily, _ kubernetes.Interface, _, value string) 
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err == nil {
-		response, err = http.DefaultClient.Do(req)
+		response, err = http.DefaultClient.Do(req) //nolint:gosec // URL from trusted gateway configuration
 	}
 
 	if err != nil {

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -107,12 +107,12 @@ func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (s
 	diskFilePath := path.Join(storageDirectory, parsedURL.Path)
 	dir := path.Join(storageDirectory, pathContainerObject)
 
-	err = os.MkdirAll(dir, 0o700)
+	err = os.MkdirAll(dir, 0o700) //nolint:gosec // Directory created in temp directory with validated inputs
 	if err != nil {
 		return "", errors.Wrapf(err, "error creating %s directory to store %s", dir, diskFilePath)
 	}
 
-	err = os.WriteFile(diskFilePath, data, 0o400)
+	err = os.WriteFile(diskFilePath, data, 0o400) //nolint:gosec // File written to temp directory with validated inputs
 	if err != nil {
 		return "", errors.Wrapf(err, "error writing cluster file to  %q", diskFilePath)
 	}


### PR DESCRIPTION
See commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added lint suppression directives to suppress security linter warnings across codebase. No functional changes or behavioral modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->