### PR TITLE
Fix route agent to watch RouteAgentComponent config

### DIFF
--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -128,7 +128,7 @@ func main() {
 
 	global.Init(globalConfigMap, configMap)
 
-	configmap.WatchAndSignalOnChange(ctx, k8sClientSet, env.Namespace, syscall.SIGINT, configmap.Global, names.GatewayComponent)
+	configmap.WatchAndSignalOnChange(ctx, k8sClientSet, env.Namespace, syscall.SIGINT, configmap.Global, names.RouteAgentComponent)
 
 	pfconfigure.DriverFromGlobalConfig()
 


### PR DESCRIPTION
The route agent was incorrectly watching `GatewayComponent` configuration changes. This updates it to watch the correct `RouteAgentComponent` configuration for its own config updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected signal monitoring to target the appropriate component for graceful shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->