### PR TITLE
Automated backport of #3851: Fix route agent to watch RouteAgentComponent config

### DIFF
--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -128,7 +128,7 @@ func main() {
 
 	global.Init(globalConfigMap, configMap)
 
-	configmap.WatchAndSignalOnChange(ctx, k8sClientSet, env.Namespace, syscall.SIGINT, configmap.Global, names.GatewayComponent)
+	configmap.WatchAndSignalOnChange(ctx, k8sClientSet, env.Namespace, syscall.SIGINT, configmap.Global, names.RouteAgentComponent)
 
 	pfconfigure.DriverFromGlobalConfig()
 


### PR DESCRIPTION
Backport of #3851 on release-0.22.

#3851: Fix route agent to watch RouteAgentComponent config

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component monitoring to ensure the system correctly detects and responds to routing configuration changes, improving the reliability of dynamic configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->