### PR TITLE
Add timeout to prevent blocking on test event channel

### DIFF
--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/event"
@@ -106,9 +107,12 @@ func (t *TestHandlerBase) addEvent(eventName string, param any) error {
 		Handler:   t.Name,
 	}
 
-	t.Events <- ev
-
-	return nil
+	select {
+	case t.Events <- ev:
+		return nil
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("timeout sending event %q to channel", eventName)
+	}
 }
 
 func (t *TestHandlerBase) Init(_ context.Context) error {


### PR DESCRIPTION
The `addEvent` function in _pkg/event/testing/testing.go_ previously performed blocking sends to the event channel, which could cause test hangs if the channel buffer filled up. This could occur during error injection tests or when tests fail to consume events.

Add a 5-second timeout using a select statement. If the channel is full, the function now returns an error instead of blocking indefinitely, providing better diagnostics for test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event testing utilities now include a 5-second timeout mechanism to prevent indefinite test hangs and provide improved error feedback when events are not processed promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->