### PR TITLE
Add cleanup function to clusterfiles.Get

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/connection.go
+++ b/pkg/routeagent_driver/handlers/ovn/connection.go
@@ -167,26 +167,29 @@ func (c *ConnectionHandler) createLibovsdbClient(ctx context.Context, dbModel mo
 	return client, nil
 }
 
-func getFile(ctx context.Context, k8sClientset clientset.Interface, url string) (string, error) {
-	file, err := clusterfiles.Get(ctx, k8sClientset, url)
-	return file, errors.Wrapf(err, "error getting config file for %q", url)
+func getFile(ctx context.Context, k8sClientset clientset.Interface, url string) (string, func(), error) {
+	file, cleanup, err := clusterfiles.Get(ctx, k8sClientset, url)
+	return file, cleanup, errors.Wrapf(err, "error getting config file for %q", url)
 }
 
 func getTLSConfig(ctx context.Context, k8sClientset clientset.Interface) (*tls.Config, error) {
-	certFile, err := getFile(ctx, k8sClientset, getOVNCertPath())
+	certFile, cleanupCert, err := getFile(ctx, k8sClientset, getOVNCertPath())
 	if err != nil {
 		return nil, err
 	}
+	defer cleanupCert()
 
-	pkFile, err := getFile(ctx, k8sClientset, getOVNPrivKeyPath())
+	pkFile, cleanupPk, err := getFile(ctx, k8sClientset, getOVNPrivKeyPath())
 	if err != nil {
 		return nil, err
 	}
+	defer cleanupPk()
 
-	caFile, err := getFile(ctx, k8sClientset, getOVNCaBundlePath())
+	caFile, cleanupCa, err := getFile(ctx, k8sClientset, getOVNCaBundlePath())
 	if err != nil {
 		return nil, err
 	}
+	defer cleanupCa()
 
 	tlsConfig, err := getOVNTLSConfig(pkFile, certFile, caFile)
 	if err != nil {

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -34,16 +34,28 @@ import (
 
 var logger = log.Logger{Logger: logf.Log.WithName("ClusterFiles")}
 
+var noopCleanup = func() {}
+
 // Get retrieves a config from a secret, configmap or file within the k8s cluster
 // using an url schema that supports configmap://<namespace>/<configmap-name>/<data-file>
 // secret://<namespace>/<secret-name>/<data-file> and file:///<path> returning
-// a local path to the file.
-func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string) (string, error) {
+// a local path to the file and a cleanup function. The cleanup function should be called
+// when the file is no longer needed to remove temporary files. For file:// URLs, the
+// cleanup function is a no-op since the file is not temporary.
+func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string) (string, func(), error) {
 	logger.V(log.DEBUG).Infof("Reading cluster_file: %s", urlAddress)
 
 	parsedURL, err := url.Parse(urlAddress)
 	if err != nil {
-		return "", errors.Wrapf(err, "error parsing cluster file URL %q", urlAddress)
+		return "", noopCleanup, errors.Wrapf(err, "error parsing cluster file URL %q", urlAddress)
+	}
+
+	if parsedURL.Scheme == "file" {
+		if parsedURL.Host != "" || parsedURL.Path == "" {
+			return "", noopCleanup, errors.Errorf("cluster file URL %q is not well formed", urlAddress)
+		}
+
+		return parsedURL.Path, noopCleanup, nil
 	}
 
 	namespace := parsedURL.Host
@@ -51,32 +63,29 @@ func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string)
 	pathContainerObject = strings.Trim(pathContainerObject, "/")
 
 	if pathContainerObject == "" || pathFile == "" {
-		return "", errors.Errorf("cluster file URL %q is not well formed", urlAddress)
+		return "", noopCleanup, errors.Errorf("cluster file URL %q is not well formed", urlAddress)
 	}
 
 	var data []byte
 
 	switch parsedURL.Scheme {
-	case "file":
-		return parsedURL.Path, nil
-
 	case "secret":
 		secret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
-			return "", errors.Wrapf(err, "error reading secret %q from namespace %q", pathContainerObject, namespace)
+			return "", noopCleanup, errors.Wrapf(err, "error reading secret %q from namespace %q", pathContainerObject, namespace)
 		}
 
 		var ok bool
 
 		data, ok = secret.Data[pathFile]
 		if !ok {
-			return "", errors.Errorf("cluster file data %q not found in secret %s", pathFile, secret.Name)
+			return "", noopCleanup, errors.Errorf("cluster file data %q not found in secret %s", pathFile, secret.Name)
 		}
 
 	case "configmap":
 		configMap, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
-			return "", errors.Wrapf(err, "error reading configmap %q from namespace %q", pathContainerObject, namespace)
+			return "", noopCleanup, errors.Wrapf(err, "error reading configmap %q from namespace %q", pathContainerObject, namespace)
 		}
 
 		var ok bool
@@ -85,23 +94,32 @@ func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string)
 		if !ok {
 			dataStr, ok := configMap.Data[pathFile]
 			if !ok {
-				return "", errors.Errorf("cluster file data %q not found in %#v", pathFile, configMap)
+				return "", noopCleanup, errors.Errorf("cluster file data %q not found in configmap %q in namespace %q",
+					pathFile, configMap.Name, configMap.Namespace)
 			}
 
 			data = []byte(dataStr)
 		}
 
 	default:
-		return "", errors.Errorf("the scheme %q in cluster file URL %q is not supported ", parsedURL.Scheme, urlAddress)
+		return "", noopCleanup, errors.Errorf("the scheme %q in cluster file URL %q is not supported ", parsedURL.Scheme, urlAddress)
 	}
 
 	return storeToDisk(pathContainerObject, parsedURL, data)
 }
 
-func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (string, error) {
+func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (string, func(), error) {
 	storageDirectory, err := os.MkdirTemp("", "cluster_files")
 	if err != nil {
-		return "", errors.Wrap(err, "error creating cluster_files directory")
+		return "", noopCleanup, errors.Wrap(err, "error creating cluster_files directory")
+	}
+
+	cleanup := func() {
+		if err := os.RemoveAll(storageDirectory); err != nil {
+			logger.Warningf("Failed to cleanup temporary directory %s: %v", storageDirectory, err)
+		} else {
+			logger.V(log.DEBUG).Infof("Cleaned up temporary directory: %s", storageDirectory)
+		}
 	}
 
 	diskFilePath := path.Join(storageDirectory, parsedURL.Path)
@@ -109,13 +127,15 @@ func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (s
 
 	err = os.MkdirAll(dir, 0o700)
 	if err != nil {
-		return "", errors.Wrapf(err, "error creating %s directory to store %s", dir, diskFilePath)
+		cleanup()
+		return "", noopCleanup, errors.Wrapf(err, "error creating %s directory to store %s", dir, diskFilePath)
 	}
 
 	err = os.WriteFile(diskFilePath, data, 0o400) //nolint:gosec // File written to temp directory with validated inputs
 	if err != nil {
-		return "", errors.Wrapf(err, "error writing cluster file to  %q", diskFilePath)
+		cleanup()
+		return "", noopCleanup, errors.Wrapf(err, "error writing cluster file to  %q", diskFilePath)
 	}
 
-	return diskFilePath, nil
+	return diskFilePath, cleanup, nil
 }

--- a/pkg/util/clusterfiles/cluster_files_test.go
+++ b/pkg/util/clusterfiles/cluster_files_test.go
@@ -73,40 +73,48 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("The scheme is unknown", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(ctx, client, "randomschema://ns1/my-secret-noo/data1")
+			_, _, err := clusterfiles.Get(ctx, client, "randomschema://ns1/my-secret-noo/data1")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("a file source does not exist", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret-noo/data1")
+			_, _, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret-noo/data1")
 			Expect(err).To(HaveOccurred())
-			_, err = clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-noo/data1")
+			_, _, err = clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-noo/data1")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the content inside the file does not exist", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1-does-not-exist")
+			_, _, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1-does-not-exist")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the URL is malformed", func() {
 		It("should return an error", func() {
-			_, err := clusterfiles.Get(ctx, client, "secret://ns1/")
+			_, _, err := clusterfiles.Get(ctx, client, "secret://ns1/")
 			Expect(err).To(HaveOccurred())
-			_, err = clusterfiles.Get(ctx, client, "secret://ns1/secret-with-no-content-detail")
+			_, _, err = clusterfiles.Get(ctx, client, "secret://ns1/secret-with-no-content-detail")
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	When("the source secret exist", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1")
+			file, cleanup, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1")
 			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cleanup()
+
+				_, statErr := os.Stat(file)
+				Expect(os.IsNotExist(statErr)).To(BeTrue())
+			})
+
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
@@ -115,8 +123,16 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source configmap exist", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap/data1")
+			file, cleanup, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap/data1")
 			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cleanup()
+
+				_, statErr := os.Stat(file)
+				Expect(os.IsNotExist(statErr)).To(BeTrue())
+			})
+
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
@@ -125,8 +141,16 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source configmap exist and has binary data", func() {
 		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-binary/data1")
+			file, cleanup, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-binary/data1")
 			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				cleanup()
+
+				_, statErr := os.Stat(file)
+				Expect(os.IsNotExist(statErr)).To(BeTrue())
+			})
+
 			fileContent, err := os.ReadFile(file)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fileContent).To(Equal(theData))
@@ -135,9 +159,10 @@ var _ = Describe("Cluster Files Get", func() {
 
 	When("the source is a file", func() {
 		It("should return the original path for the file:/// scheme", func() {
-			file, err := clusterfiles.Get(ctx, nil, "file:///dir/file")
+			file, cleanup, err := clusterfiles.Get(ctx, nil, "file:///dir/file")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(file).To(Equal("/dir/file"))
+			cleanup() // Should be a no-op for file:// scheme
 		})
 	})
 })


### PR DESCRIPTION
The `Get` function now returns a cleanup function that removes temporary directories created for `secret://` and `configmap://` URLs. For `file://`URLs, the cleanup function is a no-op since no temporary files are created.

This prevents disk space leaks from accumulating temporary directories, especially in tests and when pods restart frequently.

Also handle `file://` URLs before path validation to fix rejection of single-component paths like `file:///hosts`. The validation that splits the path into container and object is only needed for `secret://` and `configmap://` schemes.

Additionally, reject malformed `file://` URLs with a host component (e.g., `file://tmp/cert`). The documented format is `file:///<path>` with three slashes, which produces an empty Host. URLs with two slashes are parsed as having a host, leading to incorrect paths.

Also fix `ConfigMap` error message to avoid logging sensitive data. The `%#v` format verb would dump the entire `ConfigMap` structure including `Data` and `BinaryData` fields. Use only the name and namespace instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files and certificate artifacts are now reliably cleaned up after retrieval, preventing resource leaks.

* **Breaking Change**
  * Retrieval API now returns an additional cleanup callback; callers must invoke or defer it to release temporary resources (local-file cases provide a no-op cleanup).

* **Tests**
  * Tests updated to exercise and verify cleanup behavior and ensure temporary resources are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->