### PR TITLE
Replace context.TODO() with proper context in public IP watcher

### DIFF
--- a/pkg/endpoint/public_ip_watcher.go
+++ b/pkg/endpoint/public_ip_watcher.go
@@ -54,15 +54,15 @@ func NewPublicIPWatcher(config *PublicIPWatcherConfig) *PublicIPWatcher {
 	return controller
 }
 
-func (p *PublicIPWatcher) Run(stopCh <-chan struct{}) {
+func (p *PublicIPWatcher) Run(ctx context.Context) {
 	logger.Info("Starting the public IP watcher.")
 
 	go func() {
-		wait.Until(p.syncPublicIP, p.config.Interval, stopCh)
+		wait.UntilWithContext(ctx, p.syncPublicIP, p.config.Interval)
 	}()
 }
 
-func (p *PublicIPWatcher) syncPublicIP() {
+func (p *PublicIPWatcher) syncPublicIP(ctx context.Context) {
 	var publicIPs []string
 	localEndpointSpec := p.config.LocalEndpoint.Spec()
 
@@ -81,15 +81,15 @@ func (p *PublicIPWatcher) syncPublicIP() {
 	if len(publicIPs) > 0 {
 		logger.Infof("Public IPs changed for the Gateway, updating the local endpoint with public IPs %q", publicIPs)
 
-		if err := p.updateLocalEndpoint(publicIPs); err != nil {
+		if err := p.updateLocalEndpoint(ctx, publicIPs); err != nil {
 			logger.Error(err, "Error updating the public IP for local endpoint")
 			return
 		}
 	}
 }
 
-func (p *PublicIPWatcher) updateLocalEndpoint(publicIPs []string) error {
-	err := p.config.LocalEndpoint.Update(context.TODO(), func(existing *submv1.EndpointSpec) {
+func (p *PublicIPWatcher) updateLocalEndpoint(ctx context.Context, publicIPs []string) error {
+	err := p.config.LocalEndpoint.Update(ctx, func(existing *submv1.EndpointSpec) {
 		for _, publicIP := range publicIPs {
 			existing.SetPublicIP(publicIP)
 		}

--- a/pkg/endpoint/public_ip_watcher_test.go
+++ b/pkg/endpoint/public_ip_watcher_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -105,7 +106,7 @@ func newPublicIPWatcherTestDriver() *publicIPWatcherTestDriver {
 			LocalEndpoint: t.localEndpoint,
 		})
 
-		ipWatcher.Run(t.stopCh)
+		ipWatcher.Run(wait.ContextForChannel(t.stopCh))
 	})
 
 	AfterEach(func() {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -320,7 +320,7 @@ func (g *gatewayType) onStartedLeading(ctx context.Context) {
 	}
 
 	if g.publicIPWatcher != nil {
-		go g.publicIPWatcher.Run(ctx.Done())
+		go g.publicIPWatcher.Run(ctx)
 	}
 }
 


### PR DESCRIPTION
Change the `PublicIPWatcher` `Run` method to take a `context.Context` parameter instead of a stop channel, and propagate it through `syncPublicIP()` to `updateLocalEndpoint()`. This ensures proper cancellation when the watcher is stopped and eliminates the use of `context.TODO()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cancellation and shutdown handling for the public IP watcher by fully propagating contexts so endpoint updates stop promptly and cleanup is more reliable.
* **Tests**
  * Updated tests to drive watcher shutdown via context, aligning test behavior with the new cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->