### PR TITLE
Fix intermittent failure in kubeproxy endpoint test

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_test.go
@@ -80,27 +80,30 @@ func testEndpoints() {
 		JustBeforeEach(func() {
 			t.CreateEndpoint(t.localEndpoint)
 			t.awaitVxlanLink()
-			t.DeleteEndpoint(t.localEndpoint.Name)
 		})
 
 		Context("and its host name matches that associated with the existing VxLAN interface", func() {
 			It("should remove the existing VxLAN interface", func() {
+				t.DeleteEndpoint(t.localEndpoint.Name)
 				t.netLink.AwaitNoLink(kubeproxy.GetVxLANInterfaceName(k8snet.IPv4))
 			})
 		})
 
 		Context("and its host name does not match that associated with the existing VxLAN interface", func() {
-			BeforeEach(func() {
-				t.localEndpoint.Spec.Hostname = localNodeName2
-			})
-
 			It("should not remove the existing VxLAN interface", func() {
-				t.awaitVxlanLink()
+				t.localEndpoint.Spec.Hostname = localNodeName2
+				t.UpdateEndpoint(t.localEndpoint)
+				t.DeleteEndpoint(t.localEndpoint.Name)
+
+				Consistently(func(_ Gomega) {
+					t.awaitVxlanLink()
+				}).Should(Succeed())
 			})
 		})
 
 		Context("and is subsequently recreated", func() {
 			It("should recreate the VxLAN interface", func() {
+				t.DeleteEndpoint(t.localEndpoint.Name)
 				t.netLink.AwaitNoLink(kubeproxy.GetVxLANInterfaceName(k8snet.IPv4))
 
 				t.CreateEndpoint(t.localEndpoint)


### PR DESCRIPTION
The test "_when a local Endpoint is deleted and its host name does not match that associated with the existing VxLAN interface_" was flaky because it set the local Endpoint `Hostname` in `BeforeEach` before the Endpoint was created, causing the Endpoint to be created with "localNodeName2".

The test then deleted this Endpoint in `JustBeforeEach` and expected the VxLAN interface to remain, since the deleted `Hostname` should not have matched the original Endpoint. However, the erroneous test setup caused them to be the same resulting in the VxLAN interface being removed. But the test didn't fail every time due to a race condition: if `t.awaitVxlanLink()` executed before the delete was processed, the test passed. If the delete executed first and removed the VxLAN interface, the test failed.

Fix by moving the `Hostname` change to the test case itself, using `UpdateEndpoint` to change the `Hostname` after creation, and then deleting it. Also use `Consistently` to verify the VxLAN interface remains stable.

Additionally, move `DeleteEndpoint` from `JustBeforeEach` into the individual test cases where it's actually needed, making the test flow clearer: create → verify → (optionally update) → delete → verify removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test timing and sequencing for endpoint deletion and VxLAN interface removal scenarios.
  * Added stability verification checks to ensure consistent interface behavior during endpoint lifecycle testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->