### PR TITLE
Fix intermittent failure in healthchecker endpoint test

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
@@ -94,6 +95,10 @@ var _ = Describe("Controller", func() {
 		healthChecker, err = healthchecker.New(config)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(healthChecker.Start(stopCh)).To(Succeed())
+
+		// Wait for the watcher to actually start watching before creating endpoints to avoid a
+		// race condition in the fake client causing it to drop events.
+		testutil.AwaitWatchAction(&dynamicClient.Fake, "endpoints")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
The test "_when a remote Endpoint is created should start a Pinger and return the correct LatencyInfo_" was flaky because it created endpoints immediately after calling `healthChecker.Start()`, which starts the watcher asynchronously. This created a race condition where endpoints could be created before the watcher had registered its watch with the fake client, causing endpoint creation events to be dropped.

The test would then timeout waiting for the pinger to start, since the `EndpointCreatedOrUpdated` handler was never invoked.

Fix by using `testutil.AwaitWatchAction()` to ensure the watcher has actually started watching before creating endpoints. This eliminates the race condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of health checker tests by introducing additional synchronization mechanisms. These changes prevent race conditions in concurrent test operations, resulting in more reliable and consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->