### PR TITLE
Return OVN connection data directly

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/connection.go
+++ b/pkg/routeagent_driver/handlers/ovn/connection.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/cenkalti/backoff/v4"
@@ -75,20 +74,17 @@ func (c *ConnectionHandler) initClients(ctx context.Context, newOVSDBClient NewO
 	return nil
 }
 
-func getOVNTLSConfig(pkFile, certFile, caFile string) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(certFile, pkFile)
+func getOVNTLSConfig(pkData, certData, caData []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(certData, pkData)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failure loading ovn certificates")
 	}
 
 	rootCAs := x509.NewCertPool()
 
-	data, err := os.ReadFile(caFile)
-	if err != nil {
-		return nil, errors.Wrap(err, "failure loading OVNDB ca bundle")
+	if !rootCAs.AppendCertsFromPEM(caData) {
+		return nil, errors.New("failed to parse any certificates from the provided CA data")
 	}
-
-	rootCAs.AppendCertsFromPEM(data)
 
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
@@ -167,28 +163,23 @@ func (c *ConnectionHandler) createLibovsdbClient(ctx context.Context, dbModel mo
 	return client, nil
 }
 
-func getFile(ctx context.Context, k8sClientset clientset.Interface, url string) (string, error) {
-	file, err := clusterfiles.Get(ctx, k8sClientset, url)
-	return file, errors.Wrapf(err, "error getting config file for %q", url)
-}
-
 func getTLSConfig(ctx context.Context, k8sClientset clientset.Interface) (*tls.Config, error) {
-	certFile, err := getFile(ctx, k8sClientset, getOVNCertPath())
+	certData, err := clusterfiles.Get(ctx, k8sClientset, getOVNCertPath())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error retrieving certificate data from %q", getOVNCertPath())
 	}
 
-	pkFile, err := getFile(ctx, k8sClientset, getOVNPrivKeyPath())
+	pkData, err := clusterfiles.Get(ctx, k8sClientset, getOVNPrivKeyPath())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error retrieving private key data from %q", getOVNPrivKeyPath())
 	}
 
-	caFile, err := getFile(ctx, k8sClientset, getOVNCaBundlePath())
+	caData, err := clusterfiles.Get(ctx, k8sClientset, getOVNCaBundlePath())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error retrieving CA data from %q", getOVNCaBundlePath())
 	}
 
-	tlsConfig, err := getOVNTLSConfig(pkFile, certFile, caFile)
+	tlsConfig, err := getOVNTLSConfig(pkData, certData, caData)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting OVN TLS config")
 	}

--- a/pkg/util/clusterfiles/cluster_files.go
+++ b/pkg/util/clusterfiles/cluster_files.go
@@ -36,14 +36,13 @@ var logger = log.Logger{Logger: logf.Log.WithName("ClusterFiles")}
 
 // Get retrieves a config from a secret, configmap or file within the k8s cluster
 // using an url schema that supports configmap://<namespace>/<configmap-name>/<data-file>
-// secret://<namespace>/<secret-name>/<data-file> and file:///<path> returning
-// a local path to the file.
-func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string) (string, error) {
+// secret://<namespace>/<secret-name>/<data-file> and file:///<path>.
+func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string) ([]byte, error) {
 	logger.V(log.DEBUG).Infof("Reading cluster_file: %s", urlAddress)
 
 	parsedURL, err := url.Parse(urlAddress)
 	if err != nil {
-		return "", errors.Wrapf(err, "error parsing cluster file URL %q", urlAddress)
+		return nil, errors.Wrapf(err, "error parsing cluster file URL %q", urlAddress)
 	}
 
 	namespace := parsedURL.Host
@@ -51,71 +50,54 @@ func Get(ctx context.Context, k8sClient kubernetes.Interface, urlAddress string)
 	pathContainerObject = strings.Trim(pathContainerObject, "/")
 
 	if pathContainerObject == "" || pathFile == "" {
-		return "", errors.Errorf("cluster file URL %q is not well formed", urlAddress)
+		return nil, errors.Errorf("cluster file URL %q is not well formed", urlAddress)
 	}
-
-	var data []byte
 
 	switch parsedURL.Scheme {
 	case "file":
-		return parsedURL.Path, nil
+		if parsedURL.Host != "" {
+			return nil, errors.Errorf("cluster file %q is not well formed (file: URIs shouldn't specify a host)", urlAddress)
+		}
+
+		data, err := os.ReadFile(parsedURL.Path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading file %q", parsedURL.Path)
+		}
+
+		return data, nil
 
 	case "secret":
 		secret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
-			return "", errors.Wrapf(err, "error reading secret %q from namespace %q", pathContainerObject, namespace)
+			return nil, errors.Wrapf(err, "error reading secret %q from namespace %q", pathContainerObject, namespace)
 		}
 
-		var ok bool
-
-		data, ok = secret.Data[pathFile]
+		data, ok := secret.Data[pathFile]
 		if !ok {
-			return "", errors.Errorf("cluster file data %q not found in secret %s", pathFile, secret.Name)
+			return nil, errors.Errorf("cluster file data %q not found in secret %s", pathFile, secret.Name)
 		}
+
+		return data, nil
 
 	case "configmap":
 		configMap, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, pathContainerObject, metav1.GetOptions{})
 		if err != nil {
-			return "", errors.Wrapf(err, "error reading configmap %q from namespace %q", pathContainerObject, namespace)
+			return nil, errors.Wrapf(err, "error reading configmap %q from namespace %q", pathContainerObject, namespace)
 		}
 
-		var ok bool
-
-		data, ok = configMap.BinaryData[pathFile]
+		data, ok := configMap.BinaryData[pathFile]
 		if !ok {
 			dataStr, ok := configMap.Data[pathFile]
 			if !ok {
-				return "", errors.Errorf("cluster file data %q not found in %#v", pathFile, configMap)
+				return nil, errors.Errorf("cluster file data %q not found in %#v", pathFile, configMap)
 			}
 
 			data = []byte(dataStr)
 		}
 
+		return data, nil
+
 	default:
-		return "", errors.Errorf("the scheme %q in cluster file URL %q is not supported ", parsedURL.Scheme, urlAddress)
+		return nil, errors.Errorf("the scheme %q in cluster file URL %q is not supported ", parsedURL.Scheme, urlAddress)
 	}
-
-	return storeToDisk(pathContainerObject, parsedURL, data)
-}
-
-func storeToDisk(pathContainerObject string, parsedURL *url.URL, data []byte) (string, error) {
-	storageDirectory, err := os.MkdirTemp("", "cluster_files")
-	if err != nil {
-		return "", errors.Wrap(err, "error creating cluster_files directory")
-	}
-
-	diskFilePath := path.Join(storageDirectory, parsedURL.Path)
-	dir := path.Join(storageDirectory, pathContainerObject)
-
-	err = os.MkdirAll(dir, 0o700)
-	if err != nil {
-		return "", errors.Wrapf(err, "error creating %s directory to store %s", dir, diskFilePath)
-	}
-
-	err = os.WriteFile(diskFilePath, data, 0o400) //nolint:gosec // File written to temp directory with validated inputs
-	if err != nil {
-		return "", errors.Wrapf(err, "error writing cluster file to  %q", diskFilePath)
-	}
-
-	return diskFilePath, nil
 }

--- a/pkg/util/clusterfiles/cluster_files_test.go
+++ b/pkg/util/clusterfiles/cluster_files_test.go
@@ -103,41 +103,54 @@ var _ = Describe("Cluster Files Get", func() {
 		})
 	})
 
-	When("the source secret exist", func() {
-		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1")
+	When("the source secret exists", func() {
+		It("should return the data", func() {
+			secretContent, err := clusterfiles.Get(ctx, client, "secret://ns1/my-secret/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := os.ReadFile(file)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fileContent).To(Equal(theData))
+			Expect(secretContent).To(Equal(theData))
 		})
 	})
 
-	When("the source configmap exist", func() {
-		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap/data1")
+	When("the source configmap exists", func() {
+		It("should return the data", func() {
+			configMapContent, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := os.ReadFile(file)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fileContent).To(Equal(theData))
+			Expect(configMapContent).To(Equal(theData))
 		})
 	})
 
-	When("the source configmap exist and has binary data", func() {
-		It("should return the data in a tmp file", func() {
-			file, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-binary/data1")
+	When("the source configmap exists and has binary data", func() {
+		It("should return the data", func() {
+			configMapContent, err := clusterfiles.Get(ctx, client, "configmap://ns1/my-configmap-binary/data1")
 			Expect(err).NotTo(HaveOccurred())
-			fileContent, err := os.ReadFile(file)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fileContent).To(Equal(theData))
+			Expect(configMapContent).To(Equal(theData))
 		})
 	})
 
 	When("the source is a file", func() {
-		It("should return the original path for the file:/// scheme", func() {
-			file, err := clusterfiles.Get(ctx, nil, "file:///dir/file")
+		It("should fail on file: URIs with hosts", func() {
+			_, err := clusterfiles.Get(ctx, nil, "file://host/file")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return the file's content", func() {
+			filename := func() string {
+				file, err := os.CreateTemp("", "testdata")
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(file.Close()).NotTo(HaveOccurred()) }()
+
+				_, err = file.Write(theData)
+				Expect(err).NotTo(HaveOccurred())
+
+				return file.Name()
+			}()
+
+			defer func() { Expect(os.Remove(filename)).NotTo(HaveOccurred()) }()
+
+			fileContent, err := clusterfiles.Get(ctx, nil, "file://"+filename)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(file).To(Equal("/dir/file"))
+			Expect(fileContent).To(Equal(theData))
 		})
 	})
 })


### PR DESCRIPTION
Instead of storing data in temporary files (which then need to be cleaned up), return the relevant data directly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched TLS/certificate handling to in-memory byte data and removed local disk I/O for cluster files. CA bytes are appended to the trust pool. File URI handling now validates hosts and returns clearer errors. Cluster file retrieval returns raw bytes instead of file paths.

* **Tests**
  * Updated tests to assert returned byte content directly for secret, configmap, and file schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->