### PR TITLE
Fix intermittent failures with tests due to fake client

### DIFF
--- a/pkg/event/testing/controller_support.go
+++ b/pkg/event/testing/controller_support.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/event/controller"
@@ -86,6 +87,8 @@ func (c *ControllerSupport) Start(handlers ...event.Handler) {
 
 	Expect(err).To(Succeed())
 	Expect(eventController.Start(stopCh)).To(Succeed())
+
+	testutil.AwaitWatchAction(&(config.Client.(*dynamicfake.FakeDynamicClient)).Fake, "endpoints")
 
 	DeferCleanup(func() {
 		close(stopCh)

--- a/pkg/globalnet/controllers/cluster_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/cluster_egressip_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/chains"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
@@ -393,6 +394,8 @@ func (t *clusterGlobalEgressIPControllerTestDriver) start() {
 
 	Expect(err).To(Succeed())
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "clusterglobalegressips")
 }
 
 func (t *clusterGlobalEgressIPControllerTestDriver) awaitPacketFilterRules(ips ...string) {

--- a/pkg/globalnet/controllers/gateway_controller_test.go
+++ b/pkg/globalnet/controllers/gateway_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/chains"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
@@ -192,6 +193,8 @@ func (t *gatewayControllerTestDriver) start() {
 	}()
 
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "gatewaies")
 }
 
 func (t *gatewayControllerTestDriver) awaitPacketFilterRules(globalIP string) {

--- a/pkg/globalnet/controllers/global_egressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_egressip_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/chains"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
@@ -623,6 +624,8 @@ func (t *globalEgressIPControllerTestDriver) start() {
 
 	Expect(err).To(Succeed())
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "globalegressips")
 }
 
 func (t *globalEgressIPControllerTestDriver) awaitPacketFilterRules(chain string, ips ...string) string {

--- a/pkg/globalnet/controllers/global_ingressip_controller_test.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/chains"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
@@ -571,6 +572,8 @@ func (t *globalIngressIPControllerTestDriver) start() syncer.Interface {
 	t.controller = controller
 
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "globalingressips")
 
 	return controller.GetSyncer()
 }

--- a/pkg/globalnet/controllers/service_controller_test.go
+++ b/pkg/globalnet/controllers/service_controller_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	corev1 "k8s.io/api/core/v1"
@@ -205,4 +206,6 @@ func (t *serviceControllerTestDriver) start() {
 
 	Expect(err).To(Succeed())
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "services")
 }

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/controllers"
 	"github.com/submariner-io/submariner/pkg/globalnet/metrics"
@@ -516,6 +517,8 @@ func (t *serviceExportControllerTestDriver) start() (*syncer.ResourceSyncerConfi
 
 	Expect(err).To(Succeed())
 	Expect(t.controller.Start()).To(Succeed())
+
+	testutil.AwaitWatchAction(&t.dynClient.Fake, "serviceexports")
 
 	return config, podControllers, controller.GetSyncer()
 }


### PR DESCRIPTION
There is a race condition in the fake dynamic client on startup where creation events may be dropped if objects are created concurrently with informer startup. This is eliminated by using `testutil.AwaitWatchAction()` to ensure the watch has been registered before creating objects. Modify the event controller test support and globalnet tests to call `testutil.AwaitWatchAction()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test startup synchronization across multiple controller tests to wait for resource watch establishment before proceeding, increasing reliability and reducing flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->