### PR TITLE
Fix verify-packages.sh to dynamically read repo filenames

### DIFF
--- a/.rpm-lockfiles/verify-packages.sh
+++ b/.rpm-lockfiles/verify-packages.sh
@@ -52,7 +52,12 @@ if [[ -n "$BRANCH" ]]; then
     for comp in gateway route-agent globalnet; do
         mkdir -p "$LOCKFILES_DIR/$comp"
         git show "$GIT_REF:.rpm-lockfiles/$comp/rpms.in.yaml" > "$LOCKFILES_DIR/$comp/rpms.in.yaml" 2>/dev/null || continue
-        git show "$GIT_REF:.rpm-lockfiles/$comp/submariner-rhel-10.repo" > "$LOCKFILES_DIR/$comp/submariner-rhel-10.repo" 2>/dev/null || true
+
+        # Extract repo filename from rpms.in.yaml
+        repo_file=$(grep -A1 "repofiles:" "$LOCKFILES_DIR/$comp/rpms.in.yaml" | grep "^ *-" | sed 's/.*- //' | head -1)
+        if [[ -n "$repo_file" ]]; then
+            git show "$GIT_REF:.rpm-lockfiles/$comp/$repo_file" > "$LOCKFILES_DIR/$comp/$repo_file"
+        fi
     done
     echo "Verifying packages for $BRANCH"
 else

--- a/.rpm-lockfiles/verify-packages.sh
+++ b/.rpm-lockfiles/verify-packages.sh
@@ -53,8 +53,7 @@ if [[ -n "$BRANCH" ]]; then
         mkdir -p "$LOCKFILES_DIR/$comp"
         git show "$GIT_REF:.rpm-lockfiles/$comp/rpms.in.yaml" > "$LOCKFILES_DIR/$comp/rpms.in.yaml" 2>/dev/null || continue
 
-        # Extract repo filename from rpms.in.yaml
-        repo_file=$(grep -A1 "repofiles:" "$LOCKFILES_DIR/$comp/rpms.in.yaml" | grep "^ *-" | sed 's/.*- //' | head -1)
+        repo_file=$(yq '.contentOrigin.repofiles[0] // ""' "$LOCKFILES_DIR/$comp/rpms.in.yaml")
         if [[ -n "$repo_file" ]]; then
             git show "$GIT_REF:.rpm-lockfiles/$comp/$repo_file" > "$LOCKFILES_DIR/$comp/$repo_file"
         fi
@@ -67,6 +66,7 @@ fi
 
 # Check prerequisites
 command -v podman &>/dev/null || { echo "Requires: podman"; exit 1; }
+command -v yq &>/dev/null || { echo "Requires: yq"; exit 1; }
 
 # Get current cert ID
 CERT_ID=$(basename "$(find /etc/pki/entitlement -maxdepth 1 -name '*.pem' ! -name '*-key.pem' 2>/dev/null | head -1)" .pem)


### PR DESCRIPTION
The script was hardcoded to fetch "submariner-rhel-10.repo" from git, which silently failed (|| true) when verifying older branches that use submariner-rhel-9.repo. This caused the script to verify packages against the wrong RHEL version.

Changes:
- Extract repo filename from rpms.in.yaml for each component
- Remove || true to fail fast when repo file is missing
- Makes the script version-agnostic (works with RHEL 9 and 10)

Verified:
- release-0.22 (RHEL 9) correctly shows rhel-9 repos
- release-0.23 (RHEL 10) correctly shows rhel-10 repos

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package verification to dynamically determine and fetch repository files per component based on configuration rather than a fixed default.
  * Added a preflight check to ensure the required CLI tool is available before running verification, improving reliability and clearer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->