### PR TITLE
Automated backport of #3893: Fix intermittent failure in healthchecker endpoint test

### DIFF
--- a/pkg/cableengine/healthchecker/healthchecker_test.go
+++ b/pkg/cableengine/healthchecker/healthchecker_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	testutil "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
@@ -94,6 +95,10 @@ var _ = Describe("Controller", func() {
 		healthChecker, err = healthchecker.New(config)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(healthChecker.Start(stopCh)).To(Succeed())
+
+		// Wait for the watcher to actually start watching before creating endpoints to avoid a
+		// race condition in the fake client causing it to drop events.
+		testutil.AwaitWatchAction(&dynamicClient.Fake, "endpoints")
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Backport of #3893 on release-0.23.

#3893: Fix intermittent failure in healthchecker endpoint test

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding synchronization to prevent race conditions in health checker testing.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->