### PR TITLE
Automated backport of #3892: Fix intermittent failure in kubeproxy endpoint test

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/endpoint_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/endpoint_test.go
@@ -80,27 +80,30 @@ func testEndpoints() {
 		JustBeforeEach(func() {
 			t.CreateEndpoint(t.localEndpoint)
 			t.awaitVxlanLink()
-			t.DeleteEndpoint(t.localEndpoint.Name)
 		})
 
 		Context("and its host name matches that associated with the existing VxLAN interface", func() {
 			It("should remove the existing VxLAN interface", func() {
+				t.DeleteEndpoint(t.localEndpoint.Name)
 				t.netLink.AwaitNoLink(kubeproxy.GetVxLANInterfaceName(k8snet.IPv4))
 			})
 		})
 
 		Context("and its host name does not match that associated with the existing VxLAN interface", func() {
-			BeforeEach(func() {
-				t.localEndpoint.Spec.Hostname = localNodeName2
-			})
-
 			It("should not remove the existing VxLAN interface", func() {
-				t.awaitVxlanLink()
+				t.localEndpoint.Spec.Hostname = localNodeName2
+				t.UpdateEndpoint(t.localEndpoint)
+				t.DeleteEndpoint(t.localEndpoint.Name)
+
+				Consistently(func(_ Gomega) {
+					t.awaitVxlanLink()
+				}).Should(Succeed())
 			})
 		})
 
 		Context("and is subsequently recreated", func() {
 			It("should recreate the VxLAN interface", func() {
+				t.DeleteEndpoint(t.localEndpoint.Name)
 				t.netLink.AwaitNoLink(kubeproxy.GetVxLANInterfaceName(k8snet.IPv4))
 
 				t.CreateEndpoint(t.localEndpoint)


### PR DESCRIPTION
Backport of #3892 on release-0.23.

#3892: Fix intermittent failure in kubeproxy endpoint test

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for endpoint deletion and VxLAN interface lifecycle management. Improved test scenarios to verify proper cleanup and recreation of network interfaces when hostnames match and don't match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->