### PR TITLE
Fix potential stale active gateway scenarios

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -231,6 +231,16 @@ func (g *gatewayType) Run(ctx context.Context) error {
 
 	waitGroup.Wait()
 
+	// Always set passive status on graceful shutdown after all components have stopped.
+	// Use a timeout context to avoid blocking shutdown indefinitely.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	//nolint:contextcheck // Ignore "Non-inherited new context" - can't use ctx b/c it's already cancelled.
+	if err := g.gatewayPod.SetHALabels(timeoutCtx, subv1.HAStatusPassive); err != nil {
+		logger.Warningf("Error updating pod label to passive on shutdown: %s", err)
+	}
+
 	logger.Info("Gateway engine stopped")
 
 	return nil

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -21,7 +21,6 @@ package gateway
 import (
 	"context"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -29,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/certificate"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -47,7 +45,6 @@ import (
 	"github.com/submariner-io/submariner/pkg/types"
 	"github.com/submariner-io/submariner/pkg/versions"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
@@ -354,31 +351,8 @@ func (g *gatewayType) onStoppedLeading(ctx context.Context) {
 }
 
 func (g *gatewayType) updateGatewayHAStatus(ctx context.Context, status subv1.HAStatus) {
-	logger.Infof("Updating Gateway pod HA status to %q", status)
-
-	var lastErrMsg string
-
-	err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
-		err := g.gatewayPod.SetHALabels(ctx, status)
-		if resource.IsTransientErr(err) {
-			errMsg := err.Error()
-			if !reflect.DeepEqual(errMsg, lastErrMsg) {
-				lastErrMsg = errMsg
-
-				logger.Warningf("Error updating Gateway pod HA status to %q: %v - retrying...", status, err)
-			}
-
-			return false, nil
-		}
-
-		return err == nil, errors.Wrapf(err, "error updating Gateway pod HA status to %q", status)
-	})
-	if !errors.Is(err, context.Canceled) {
-		if err == nil {
-			logger.Infof("Successfully updated Gateway pod HA status to %q", status)
-		} else {
-			logger.Errorf(err, "")
-		}
+	if err := g.gatewayPod.SetHALabels(ctx, status); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Errorf(err, "Failed to update Gateway pod HA status to %q", status)
 	}
 }
 

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -51,7 +51,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -181,21 +180,6 @@ var _ = Describe("Run", func() {
 			})
 
 			fakeDriver.AwaitDisconnectFromEndpoint(&endpoint.Spec, k8snet.IPv4)
-		})
-
-		Context("and update Gateway HA status fails with a non-transient error", func() {
-			It("should not block re-election", func() {
-				By("Setting leases resource updates to fail")
-
-				fake.FailOnAction(&t.kubeClient.Fake, "pods", "patch", apierrors.NewNotFound(schema.GroupResource{}, ""), true)
-
-				t.leaderElection.FailLease(t.config.RenewDeadline)
-
-				By("Setting leases resource updates to succeed")
-
-				t.leaderElection.SucceedLease()
-				t.leaderElection.AwaitLeaseRenewed()
-			})
 		})
 	})
 
@@ -370,9 +354,12 @@ func newTestDriver() *testDriver {
 				Expect(err).To(ContainErrorSubstring(t.expectedRunErr))
 
 				if !t.config.Spec.Uninstall {
-					t.awaitHAStatus(submarinerv1.HAStatusPassive)
 					t.awaitGatewayStatusError(t.expectedRunErr.Error())
 				}
+			}
+
+			if !t.config.Spec.Uninstall {
+				t.awaitHAStatus(submarinerv1.HAStatusPassive)
 			}
 		})
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -22,19 +22,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/resource"
 	submV1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-type GatewayPodInterface interface {
-	SetHALabels(status submV1.HAStatus) error
-}
 
 type GatewayPod struct {
 	namespace string
@@ -66,7 +65,7 @@ func NewGatewayPod(ctx context.Context, k8sClient kubernetes.Interface) (*Gatewa
 	}
 
 	if err := gp.SetHALabels(ctx, submV1.HAStatusPassive); err != nil {
-		logger.Warningf("Error updating pod label: %s", err)
+		return nil, errors.Wrap(err, "error setting initial passive HA status")
 	}
 
 	return gp, nil
@@ -75,13 +74,35 @@ func NewGatewayPod(ctx context.Context, k8sClient kubernetes.Interface) (*Gatewa
 const patchFormat = `{"metadata": {"labels": {"gateway.submariner.io/node": "%s", "gateway.submariner.io/status": "%s"}}}`
 
 func (gp *GatewayPod) SetHALabels(ctx context.Context, status submV1.HAStatus) error {
+	logger.Infof("Updating Gateway pod HA status to %q", status)
+
 	podsInterface := gp.clientset.CoreV1().Pods(gp.namespace)
 	patch := fmt.Sprintf(patchFormat, gp.node, status)
 
-	_, err := podsInterface.Patch(ctx, gp.name, types.MergePatchType, []byte(patch), v1.PatchOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "Error patching own pod %q in namespace %q with %s", gp.name, gp.namespace, patch)
+	var lastErrMsg string
+
+	err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
+		_, err := podsInterface.Patch(ctx, gp.name, types.MergePatchType, []byte(patch), v1.PatchOptions{})
+		if err != nil {
+			if resource.IsTransientErr(err) {
+				errMsg := err.Error()
+				if errMsg != lastErrMsg {
+					lastErrMsg = errMsg
+
+					logger.Warningf("Error updating Gateway pod HA status to %q: %v - retrying...", status, err)
+				}
+
+				return false, nil
+			}
+
+			return false, errors.Wrapf(err, "error patching own pod %q in namespace %q with %s", gp.name, gp.namespace, patch)
+		}
+
+		return true, nil
+	})
+	if err == nil {
+		logger.Infof("Successfully updated Gateway pod HA status to %q", status)
 	}
 
-	return nil
+	return err //nolint:wrapcheck // No need to wrap
 }


### PR DESCRIPTION
It was observed in a real environment where two gateway pods had their `gateway.submariner.io/status` labels set to true even though only one of them was actually as evidenced by the `Gateway` CRs.

Code inspection revealed two potential issues that could lead to this scenario that were addressed in separate commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved HA status handling: shutdown now attempts to set gateways to passive within a short timeout, and pod status updates automatically retry transient failures for greater reliability.

* **Tests**
  * Adjusted HA-status test ordering to match updated shutdown and error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->