### PR TITLE
Handle stale active gateway pods in the gateway syncer

### DIFF
--- a/pkg/cableengine/syncer/syncer.go
+++ b/pkg/cableengine/syncer/syncer.go
@@ -20,7 +20,9 @@ package syncer
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -36,15 +38,20 @@ import (
 	"github.com/submariner-io/submariner/pkg/cableengine/healthchecker"
 	v1typed "github.com/submariner-io/submariner/pkg/client/clientset/versioned/typed/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/pinger"
+	gwpod "github.com/submariner-io/submariner/pkg/pod"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type GatewaySyncer struct {
 	mutex       sync.Mutex
-	client      v1typed.GatewayInterface
+	gateways    v1typed.GatewayInterface
+	pods        corev1typed.PodInterface
 	engine      cableengine.Engine
 	version     string
 	statusError error
@@ -71,11 +78,12 @@ func init() {
 }
 
 // NewGatewaySyncer creates a new Engine for the local cluster.
-func NewGatewaySyncer(engine cableengine.Engine, client v1typed.GatewayInterface,
+func NewGatewaySyncer(engine cableengine.Engine, gateways v1typed.GatewayInterface, pods corev1typed.PodInterface,
 	version string, healthCheck healthchecker.Interface,
 ) *GatewaySyncer {
 	return &GatewaySyncer{
-		client:      client,
+		gateways:    gateways,
+		pods:        pods,
 		engine:      engine,
 		version:     version,
 		healthCheck: healthCheck,
@@ -83,17 +91,32 @@ func NewGatewaySyncer(engine cableengine.Engine, client v1typed.GatewayInterface
 }
 
 func (gs *GatewaySyncer) Run(stopCh <-chan struct{}) {
-	wait.Until(gs.syncGatewayStatus, GatewayUpdateInterval, stopCh)
+	wait.UntilWithContext(wait.ContextForChannel(stopCh), func(ctx context.Context) {
+		name := gs.syncGatewayStatus(ctx)
+
+		if gs.engine.GetHAStatus() == v1.HAStatusActive {
+			err := gs.cleanupStaleGatewayEntries(ctx, name)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("error cleaning up stale gateway entries: %w", err))
+			}
+
+			err = gs.cleanupStaleGatewayPods(ctx)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("error cleaning up stale gateway pods: %w", err))
+			}
+		}
+	}, GatewayUpdateInterval)
+
 	gs.CleanupGatewayEntry(context.Background())
 
 	logger.Info("CableEngine syncer stopped")
 }
 
-func (gs *GatewaySyncer) syncGatewayStatus() {
+func (gs *GatewaySyncer) syncGatewayStatus(ctx context.Context) string {
 	gs.mutex.Lock()
 	defer gs.mutex.Unlock()
 
-	gs.syncGatewayStatusSafe(context.Background())
+	return gs.syncGatewayStatusSafe(ctx)
 }
 
 func (gs *GatewaySyncer) SetGatewayStatusError(ctx context.Context, err error) {
@@ -106,14 +129,14 @@ func (gs *GatewaySyncer) SetGatewayStatusError(ctx context.Context, err error) {
 
 func (gs *GatewaySyncer) gatewayResourceInterface() resource.Interface[*v1.Gateway] {
 	return &resource.InterfaceFuncs[*v1.Gateway]{
-		GetFunc:    gs.client.Get,
-		CreateFunc: gs.client.Create,
-		UpdateFunc: gs.client.Update,
-		DeleteFunc: gs.client.Delete,
+		GetFunc:    gs.gateways.Get,
+		CreateFunc: gs.gateways.Create,
+		UpdateFunc: gs.gateways.Update,
+		DeleteFunc: gs.gateways.Delete,
 	}
 }
 
-func (gs *GatewaySyncer) syncGatewayStatusSafe(ctx context.Context) {
+func (gs *GatewaySyncer) syncGatewayStatusSafe(ctx context.Context) string {
 	logger.V(log.TRACE).Info("Running Gateway status sync")
 	gatewaySyncIterations.Inc()
 
@@ -133,7 +156,7 @@ func (gs *GatewaySyncer) syncGatewayStatusSafe(ctx context.Context) {
 		})
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error creating/updating Gateway: %w", err))
-		return
+		return gatewayObj.Name
 	}
 
 	if result == util.OperationResultCreated {
@@ -144,16 +167,11 @@ func (gs *GatewaySyncer) syncGatewayStatusSafe(ctx context.Context) {
 		logger.V(log.TRACE).Info("Gateway already exists but doesn't need updating")
 	}
 
-	if gatewayObj.Status.HAStatus == v1.HAStatusActive {
-		err := gs.cleanupStaleGatewayEntries(ctx, gatewayObj.Name)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("error cleaning up stale gateway entries: %w", err))
-		}
-	}
+	return gatewayObj.Name
 }
 
 func (gs *GatewaySyncer) cleanupStaleGatewayEntries(ctx context.Context, localGatewayName string) error {
-	gateways, err := gs.client.List(ctx, metav1.ListOptions{})
+	gateways, err := gs.gateways.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error listing Gateways")
 	}
@@ -171,7 +189,7 @@ func (gs *GatewaySyncer) cleanupStaleGatewayEntries(ctx context.Context, localGa
 		}
 
 		if stale {
-			err := gs.client.Delete(ctx, gw.Name, metav1.DeleteOptions{})
+			err := gs.gateways.Delete(ctx, gw.Name, metav1.DeleteOptions{})
 			if err != nil {
 				// In this case we don't want to stop the cleanup loop and just log it.
 				utilruntime.HandleError(fmt.Errorf("error deleting stale Gateway %+v: %w", gw, err))
@@ -199,6 +217,41 @@ func isGatewayStale(gateway *v1.Gateway) (bool, error) {
 	now := time.Now().UTC().Unix()
 
 	return now >= timestampInt+int64(GatewayStaleTimeout.Seconds()), nil
+}
+
+var gatewayStatusActiveSelector = labels.SelectorFromSet(map[string]string{gwpod.GatewayStatusLabel: string(v1.HAStatusActive)}).String()
+
+func (gs *GatewaySyncer) cleanupStaleGatewayPods(ctx context.Context) error {
+	localGatewayPodName := os.Getenv("POD_NAME")
+
+	pods, err := gs.pods.List(ctx, metav1.ListOptions{
+		LabelSelector: gatewayStatusActiveSelector,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error listing Gateway pods")
+	}
+
+	var errs []error
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Name == localGatewayPodName {
+			continue
+		}
+
+		logger.Infof("Found stale active gateway pod %q - setting to passive", pod.Name)
+
+		err = util.Update(ctx, &resource.InterfaceFuncs[*corev1.Pod]{
+			GetFunc:    gs.pods.Get,
+			UpdateFunc: gs.pods.Update,
+		}, pod, func(existing *corev1.Pod) (*corev1.Pod, error) {
+			existing.Labels[gwpod.GatewayStatusLabel] = string(v1.HAStatusPassive)
+			return existing, nil
+		})
+		errs = append(errs, err)
+	}
+
+	return goerrors.Join(errs...)
 }
 
 func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
@@ -278,13 +331,13 @@ func (gs *GatewaySyncer) generateGatewayObject() *v1.Gateway {
 // CleanupGatewayEntry removes this Gateway entry from the k8s API, it does not
 // propagate error up because it's a termination function that we also provide externally.
 func (gs *GatewaySyncer) CleanupGatewayEntry(ctx context.Context) {
-	hostName := gs.engine.GetLocalEndpoint().Spec.Hostname
+	gatewayName := resource.EnsureValidName(gs.engine.GetLocalEndpoint().Spec.Hostname)
 
-	err := gs.client.Delete(ctx, hostName, metav1.DeleteOptions{})
+	err := gs.gateways.Delete(ctx, gatewayName, metav1.DeleteOptions{})
 	if err != nil {
-		logger.Errorf(err, "Error while trying to delete own Gateway %q", hostName)
+		logger.Errorf(err, "Error while trying to delete own Gateway %q", gatewayName)
 		return
 	}
 
-	logger.Infof("The Gateway entry for %q has been deleted", hostName)
+	logger.Infof("The Gateway resource %q has been deleted", gatewayName)
 }

--- a/pkg/cableengine/syncer/syncer_test.go
+++ b/pkg/cableengine/syncer/syncer_test.go
@@ -20,6 +20,7 @@ package syncer_test
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -45,19 +46,24 @@ import (
 	submarinerInformers "github.com/submariner-io/submariner/pkg/client/informers/externalversions"
 	"github.com/submariner-io/submariner/pkg/pinger"
 	"github.com/submariner-io/submariner/pkg/pinger/fake"
+	gwpod "github.com/submariner-io/submariner/pkg/pod"
 	"github.com/submariner-io/submariner/pkg/types"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	fakeClient "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	kubeScheme "k8s.io/client-go/kubernetes/scheme"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	k8snet "k8s.io/utils/net"
 )
 
 const (
-	namespace = "submariner"
+	namespace           = "submariner"
+	localGatewayPodName = "local-gateway-pod"
 )
 
 func init() {
@@ -75,24 +81,13 @@ var _ = BeforeSuite(func() {
 var _ = Describe("", func() {
 	Context("Gateway syncing", testGatewaySyncing)
 	Context("Stale Gateway cleanup", testStaleGatewayCleanup)
+	Context("Stale Gateway pod HA status cleanup", testStaleGatewayPodCleanup)
 	Context("Gateway sync errors", testGatewaySyncErrors)
 	Context("Gateway latency info", testGatewayLatencyInfo)
 })
 
 func testGatewaySyncing() {
-	var t *testDriver
-
-	BeforeEach(func() {
-		t = newTestDriver()
-	})
-
-	JustBeforeEach(func() {
-		t.run()
-	})
-
-	AfterEach(func() {
-		t.stop()
-	})
+	t := newTestDriver()
 
 	testPeriodicTimestampUpdate := func() {
 		It("should periodically update the Gateway resource timestamp", func() {
@@ -216,13 +211,13 @@ func testGatewaySyncing() {
 }
 
 func testStaleGatewayCleanup() {
-	var t *testDriver
+	t := newTestDriver()
+
 	var staleGateway *submarinerv1.Gateway
 
 	expectedErr := errors.New("fake error")
 
 	BeforeEach(func() {
-		t = newTestDriver()
 		staleGateway = &submarinerv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "raiders",
@@ -237,18 +232,12 @@ func testStaleGatewayCleanup() {
 	})
 
 	JustBeforeEach(func() {
-		t.run()
-
 		t.awaitGatewayUpdated(t.expectedGateway)
 
 		_, err := t.gateways.Create(context.TODO(), staleGateway, metav1.CreateOptions{})
 		Expect(err).To(Succeed())
 
 		t.awaitGatewayUpdated(staleGateway)
-	})
-
-	AfterEach(func() {
-		t.stop()
 	})
 
 	When("the Gateway's update timestamp expires", func() {
@@ -310,22 +299,54 @@ func testStaleGatewayCleanup() {
 	})
 }
 
+func testStaleGatewayPodCleanup() {
+	const otherGatewayPodName = "other-gateway-pod"
+
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		t.expectedGateway.Status.HAStatus = submarinerv1.HAStatusActive
+		t.engine.HAStatus = t.expectedGateway.Status.HAStatus
+	})
+
+	It("should not update the local Pod HA status", func() {
+		Consistently(func(g Gomega) {
+			pod, err := t.pods.Get(context.TODO(), localGatewayPodName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Labels).To(HaveKeyWithValue(gwpod.GatewayStatusLabel, string(submarinerv1.HAStatusActive)))
+		}).Within(time.Millisecond * 500).To(Succeed())
+	})
+
+	When("another Gateway pod's HA status is active", func() {
+		JustBeforeEach(func() {
+			_, err := t.pods.Create(context.TODO(), &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      otherGatewayPodName,
+					Namespace: namespace,
+					Labels:    map[string]string{gwpod.GatewayStatusLabel: string(submarinerv1.HAStatusActive)},
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should update it to passive", func() {
+			Eventually(func(g Gomega) {
+				pod, err := t.pods.Get(context.TODO(), otherGatewayPodName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pod.Labels).To(HaveKeyWithValue(gwpod.GatewayStatusLabel, string(submarinerv1.HAStatusPassive)))
+			}).Within(3 * time.Second).To(Succeed())
+		})
+	})
+}
+
 func testGatewaySyncErrors() {
-	var t *testDriver
+	t := newTestDriver()
+
 	var expectedErr error
 
 	BeforeEach(func() {
-		t = newTestDriver()
 		expectedErr = errors.New("fake error")
 		t.expectedDeletedAfter = nil
-	})
-
-	JustBeforeEach(func() {
-		t.run()
-	})
-
-	AfterEach(func() {
-		t.stop()
 	})
 
 	When("Gateway create fails", func() {
@@ -377,19 +398,7 @@ func testGatewaySyncErrors() {
 }
 
 func testGatewayLatencyInfo() {
-	var t *testDriver
-
-	BeforeEach(func() {
-		t = newTestDriver()
-	})
-
-	JustBeforeEach(func() {
-		t.run()
-	})
-
-	AfterEach(func() {
-		t.stop()
-	})
+	t := newTestDriver()
 
 	When("the health checker provides latency info", func() {
 		It("should correctly update the Gateway Status information", func() {
@@ -478,6 +487,7 @@ type testDriver struct {
 	client               *fakeClientset.Clientset
 	gateways             submarinerClientsetv1.GatewayInterface
 	gatewayReactor       *fakeReactor.FailingReactor
+	pods                 corev1typed.PodInterface
 	syncer               *syncer.GatewaySyncer
 	healthChecker        healthchecker.Interface
 	pinger               *fake.Pinger
@@ -493,120 +503,135 @@ type testDriver struct {
 }
 
 func newTestDriver() *testDriver {
-	client := fakeClientset.NewSimpleClientset()
+	t := &testDriver{}
 
-	t := &testDriver{
-		engine:             fakeEngine.New(),
-		client:             client,
-		gateways:           client.SubmarinerV1().Gateways(namespace),
-		gatewayReactor:     fakeReactor.NewFailingReactorForResource(&client.Fake, "gateways"),
-		gatewayUpdated:     make(chan *submarinerv1.Gateway, 10),
-		gatewayDeleted:     make(chan *submarinerv1.Gateway, 10),
-		stopSyncer:         make(chan struct{}),
-		stopInformer:       make(chan struct{}),
-		savedErrorHandlers: utilruntime.ErrorHandlers,
-		handledError:       make(chan error, 10),
-	}
+	BeforeEach(func() {
+		t.engine = fakeEngine.New()
+		t.client = fakeClientset.NewSimpleClientset()
+		t.gateways = t.client.SubmarinerV1().Gateways(namespace)
+		t.gatewayReactor = fakeReactor.NewFailingReactorForResource(&t.client.Fake, "gateways")
+		t.gatewayUpdated = make(chan *submarinerv1.Gateway, 10)
+		t.gatewayDeleted = make(chan *submarinerv1.Gateway, 10)
+		t.stopSyncer = make(chan struct{})
+		t.stopInformer = make(chan struct{})
+		t.savedErrorHandlers = utilruntime.ErrorHandlers
+		t.handledError = make(chan error, 10)
 
-	t.engine.LocalEndPoint = &types.SubmarinerEndpoint{Spec: submarinerv1.EndpointSpec{
-		ClusterID:  "east",
-		CableName:  "submariner-cable-east-192-68-1-2",
-		Hostname:   "redsox",
-		PrivateIPs: []string{"192.6.1.3"},
-		Backend:    "libreswan",
-	}}
+		k8sClient := k8sfake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      localGatewayPodName,
+				Namespace: namespace,
+				Labels:    map[string]string{gwpod.GatewayStatusLabel: string(submarinerv1.HAStatusActive)},
+			},
+		})
 
-	t.expectedGateway = &submarinerv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: t.engine.LocalEndPoint.Spec.Hostname,
-		},
-		Status: submarinerv1.GatewayStatus{
-			Version:       "1",
-			HAStatus:      t.engine.GetHAStatus(),
-			LocalEndpoint: t.engine.LocalEndPoint.Spec,
-			Connections:   t.engine.Connections,
-		},
-	}
+		t.pods = k8sClient.CoreV1().Pods(namespace)
 
-	t.expectedDeletedAfter = t.expectedGateway
+		t.engine.LocalEndPoint = &types.SubmarinerEndpoint{Spec: submarinerv1.EndpointSpec{
+			ClusterID:  "east",
+			CableName:  "submariner-cable-east-192-68-1-2",
+			Hostname:   "redsox",
+			PrivateIPs: []string{"192.6.1.3"},
+			Backend:    "libreswan",
+		}}
+
+		t.expectedGateway = &submarinerv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: t.engine.LocalEndPoint.Spec.Hostname,
+			},
+			Status: submarinerv1.GatewayStatus{
+				Version:       "1",
+				HAStatus:      t.engine.GetHAStatus(),
+				LocalEndpoint: t.engine.LocalEndPoint.Spec,
+				Connections:   t.engine.Connections,
+			},
+		}
+
+		t.expectedDeletedAfter = t.expectedGateway
+
+		os.Setenv("POD_NAME", localGatewayPodName)
+	})
+
+	JustBeforeEach(func() {
+		//nolint:reassign // Modifying ErrorHandlers *is* the API
+		utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers, func(_ context.Context, err error, _ string, _ ...any) {
+			t.handledError <- err
+		})
+
+		scheme := runtime.NewScheme()
+		Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())
+
+		dynamicClient := fakeClient.NewSimpleDynamicClient(scheme)
+		restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{})
+
+		t.pinger = fake.NewPinger("10.130.2.2")
+
+		var err error
+
+		t.healthChecker, err = healthchecker.New(&healthchecker.Config{
+			ControllerConfig: pinger.ControllerConfig{
+				SupportedIPFamilies: []k8snet.IPFamily{k8snet.IPv4},
+				NewPinger: func(pingerCfg pinger.Config) pinger.Interface {
+					defer GinkgoRecover()
+					Expect(pingerCfg.IP).To(Equal(t.pinger.GetIP()))
+
+					return t.pinger
+				},
+			},
+			WatcherConfig: watcher.Config{
+				RestMapper: restMapper,
+				Client:     dynamicClient,
+				Scheme:     scheme,
+			},
+			EndpointNamespace: namespace,
+			ClusterID:         t.engine.LocalEndPoint.Spec.ClusterID,
+		})
+		Expect(err).To(Succeed())
+
+		t.endpoints = dynamicClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{})).Namespace(namespace)
+
+		t.syncer = syncer.NewGatewaySyncer(t.engine, t.gateways, t.pods, t.expectedGateway.Status.Version, t.healthChecker)
+
+		informerFactory := submarinerInformers.NewSharedInformerFactory(t.client, 0)
+		informer := informerFactory.Submariner().V1().Gateways().Informer()
+
+		_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				t.gatewayUpdated <- obj.(*submarinerv1.Gateway)
+			},
+			UpdateFunc: func(_, newObj any) {
+				t.gatewayUpdated <- newObj.(*submarinerv1.Gateway)
+			},
+			DeleteFunc: func(obj any) {
+				t.gatewayDeleted <- obj.(*submarinerv1.Gateway)
+			},
+		})
+		Expect(err).To(Succeed())
+
+		go informer.Run(t.stopInformer)
+		Expect(cache.WaitForCacheSync(t.stopInformer, informer.HasSynced)).To(BeTrue())
+
+		go t.syncer.Run(t.stopSyncer)
+
+		Expect(t.healthChecker.Start(t.stopSyncer)).To(Succeed())
+	})
+
+	JustAfterEach(func() {
+		os.Unsetenv("POD_NAME")
+
+		close(t.stopSyncer)
+
+		if t.healthChecker != nil && t.expectedDeletedAfter != nil {
+			t.awaitGatewayDeleted(t.expectedDeletedAfter)
+		}
+
+		close(t.stopInformer)
+
+		//nolint:reassign // Modifying ErrorHandlers *is* the API
+		utilruntime.ErrorHandlers = t.savedErrorHandlers
+	})
 
 	return t
-}
-
-func (t *testDriver) run() {
-	//nolint:reassign // Modifying ErrorHandlers *is* the API
-	utilruntime.ErrorHandlers = append(utilruntime.ErrorHandlers, func(_ context.Context, err error, _ string, _ ...any) {
-		t.handledError <- err
-	})
-
-	scheme := runtime.NewScheme()
-	Expect(submarinerv1.AddToScheme(scheme)).To(Succeed())
-
-	dynamicClient := fakeClient.NewSimpleDynamicClient(scheme)
-	restMapper := test.GetRESTMapperFor(&submarinerv1.Endpoint{})
-
-	t.pinger = fake.NewPinger("10.130.2.2")
-
-	var err error
-
-	t.healthChecker, err = healthchecker.New(&healthchecker.Config{
-		ControllerConfig: pinger.ControllerConfig{
-			SupportedIPFamilies: []k8snet.IPFamily{k8snet.IPv4},
-			NewPinger: func(pingerCfg pinger.Config) pinger.Interface {
-				defer GinkgoRecover()
-				Expect(pingerCfg.IP).To(Equal(t.pinger.GetIP()))
-
-				return t.pinger
-			},
-		},
-		WatcherConfig: watcher.Config{
-			RestMapper: restMapper,
-			Client:     dynamicClient,
-			Scheme:     scheme,
-		},
-		EndpointNamespace: namespace,
-		ClusterID:         t.engine.LocalEndPoint.Spec.ClusterID,
-	})
-	Expect(err).To(Succeed())
-
-	t.endpoints = dynamicClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{})).Namespace(namespace)
-
-	t.syncer = syncer.NewGatewaySyncer(t.engine, t.gateways, t.expectedGateway.Status.Version, t.healthChecker)
-
-	informerFactory := submarinerInformers.NewSharedInformerFactory(t.client, 0)
-	informer := informerFactory.Submariner().V1().Gateways().Informer()
-
-	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			t.gatewayUpdated <- obj.(*submarinerv1.Gateway)
-		},
-		UpdateFunc: func(_, newObj any) {
-			t.gatewayUpdated <- newObj.(*submarinerv1.Gateway)
-		},
-		DeleteFunc: func(obj any) {
-			t.gatewayDeleted <- obj.(*submarinerv1.Gateway)
-		},
-	})
-	Expect(err).To(Succeed())
-
-	go informer.Run(t.stopInformer)
-	Expect(cache.WaitForCacheSync(t.stopInformer, informer.HasSynced)).To(BeTrue())
-
-	go t.syncer.Run(t.stopSyncer)
-
-	Expect(t.healthChecker.Start(t.stopSyncer)).To(Succeed())
-}
-
-func (t *testDriver) stop() {
-	close(t.stopSyncer)
-
-	if t.healthChecker != nil && t.expectedDeletedAfter != nil {
-		t.awaitGatewayDeleted(t.expectedDeletedAfter)
-	}
-
-	close(t.stopInformer)
-	//nolint:reassign // Modifying ErrorHandlers *is* the API
-	utilruntime.ErrorHandlers = t.savedErrorHandlers
 }
 
 func (t *testDriver) awaitGatewayUpdated(expected *submarinerv1.Gateway) {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -171,6 +171,7 @@ func New(ctx context.Context, config *Config) (Interface, error) {
 	g.cableEngineSyncer = syncer.NewGatewaySyncer(
 		g.cableEngine,
 		g.SubmarinerClient.SubmarinerV1().Gateways(g.Spec.Namespace),
+		g.KubeClient.CoreV1().Pods(g.Spec.Namespace),
 		versions.Submariner(), g.cableHealthChecker)
 
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
When the active gateway transitions to passive or is restarted, its pod may incorrectly retain the active HA status label in some edge case scenarios. This can lead to multiple pods believing they are active.

As added protection to prevent this case, this commit updates the gateway syncer to clean up stale gateway pod HA status labels when the local gateway is active. It lists all pods with active HA status and updates any non-local pods to passive status.

Additionally, the cleanup logic for stale gateway entries has been refactored out of `syncGatewayStatus` as we only want it to run via the periodic check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced management of gateway pods in high-availability configurations
  * More reliable cleanup of stale gateway pods to prevent resource accumulation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->