### PR TITLE
Automated backport of #3881: Fix deletion of non-Submariner OVN routes during

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/fake/ovsdb_client.go
+++ b/pkg/routeagent_driver/handlers/ovn/fake/ovsdb_client.go
@@ -189,11 +189,39 @@ func (c *OVSDBClient) AwaitNoModel(m any) {
 	}).Should(BeFalse(), "OVSBD model exists: %s", resource.ToJSON(m))
 }
 
+func (c *OVSDBClient) EnsureModel(m any) {
+	Consistently(func(g Gomega) {
+		found, existing := c.hasModel(m)
+		g.Expect(found).To(BeTrue(), "OVSDB model not found: %s. Actual models: %v", resource.ToJSON(m), existing)
+	}).Should(Succeed())
+}
+
 func (c *OVSDBClient) EnsureNoModel(m any) {
 	Consistently(func() bool {
 		found, _ := c.hasModel(m)
 		return found
 	}).Should(BeFalse(), "OVSBD model exists: %s", resource.ToJSON(m))
+}
+
+func (c *OVSDBClient) GetModel(m any) any {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for _, o := range c.models[reflect.TypeOf(m)] {
+		switch t := m.(type) {
+		case *nbdb.LogicalRouterPolicy:
+			if strings.Contains(o.(*nbdb.LogicalRouterPolicy).Match, t.Match) &&
+				reflect.DeepEqual(o.(*nbdb.LogicalRouterPolicy).Nexthop, t.Nexthop) {
+				return o
+			}
+		case *nbdb.LogicalRouterStaticRoute:
+			if o.(*nbdb.LogicalRouterStaticRoute).IPPrefix == t.IPPrefix {
+				return o
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *OVSDBClient) EnsureNoModelsOfType(m any) {

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -461,6 +461,140 @@ func (t *handlerTestDriver) testGatewayRoute(ipFamilySubnets []string, nonIPFami
 			})
 		})
 	})
+
+	When("a non-Submariner route exists with the same nexthop", func() {
+		It("should not delete the non-Submariner route during reconciliation", func() {
+			client := t.dynClient.Resource(submarinerv1.SchemeGroupVersion.WithResource("gatewayroutes")).Namespace(testing.Namespace)
+
+			// Create a route that simulates an OVN-K managed route (no submariner external_id)
+			// This uses the same nexthop as Submariner but has a different prefix (local cluster subnet)
+			ovnkRoute := &nbdb.LogicalRouterStaticRoute{
+				IPPrefix:    t.clusterCIDR,
+				Nexthop:     t.OVNK8sMgmntIntCIDR[t.ipFamily].IP.String(),
+				ExternalIDs: map[string]string{},
+			}
+
+			_, err := t.ovsdbClient.Create(ovnkRoute)
+			Expect(err).To(Succeed())
+
+			// Create a GatewayRoute which will trigger reconciliation
+			gwRoute := &submarinerv1.GatewayRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway-route-preserve",
+				},
+				RoutePolicySpec: submarinerv1.RoutePolicySpec{
+					NextHops:    []string{ovnkRoute.Nexthop},
+					RemoteCIDRs: ipFamilySubnets,
+				},
+			}
+
+			test.CreateResource(client, gwRoute)
+
+			// Wait for Submariner routes to be reconciled.
+			for _, cidr := range gwRoute.RoutePolicySpec.RemoteCIDRs {
+				t.ovsdbClient.AwaitModel(&nbdb.LogicalRouterStaticRoute{
+					IPPrefix: cidr,
+				})
+			}
+
+			// Verify the OVN-K route still exists and is untagged
+			t.ovsdbClient.EnsureModel(&nbdb.LogicalRouterStaticRoute{
+				IPPrefix: ovnkRoute.IPPrefix,
+			})
+			retrievedRoute := t.ovsdbClient.GetModel(&nbdb.LogicalRouterStaticRoute{
+				IPPrefix: ovnkRoute.IPPrefix,
+			}).(*nbdb.LogicalRouterStaticRoute)
+			Expect(retrievedRoute.ExternalIDs).ToNot(HaveKey(ovn.SubmarinerExternalIDKey),
+				"OVN-K route should not be tagged with submariner")
+
+			Expect(client.Delete(context.Background(), gwRoute.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			// Check the OVN-K route still exists and remains untagged after removing the gateway
+			t.ovsdbClient.EnsureModel(&nbdb.LogicalRouterStaticRoute{
+				IPPrefix: ovnkRoute.IPPrefix,
+			})
+			retrievedRoute = t.ovsdbClient.GetModel(&nbdb.LogicalRouterStaticRoute{
+				IPPrefix: ovnkRoute.IPPrefix,
+			}).(*nbdb.LogicalRouterStaticRoute)
+			Expect(retrievedRoute.ExternalIDs).ToNot(HaveKey(ovn.SubmarinerExternalIDKey),
+				"OVN-K route should not be tagged with submariner after cleanup")
+		})
+	})
+
+	When("a non-Submariner policy exists with the same priority", func() {
+		It("should not delete the non-Submariner policy during reconciliation", func() {
+			client := t.dynClient.Resource(submarinerv1.SchemeGroupVersion.WithResource("gatewayroutes")).Namespace(testing.Namespace)
+
+			// Determine priority and match field based on IP family
+			priority := 20000
+			ipMatchField := "ip4.dst"
+
+			if t.ipFamily == k8snet.IPv6 {
+				priority = 20100
+				ipMatchField = "ip6.dst"
+			}
+
+			// Create a policy that simulates an OVN-K managed policy (no submariner external_id)
+			// This uses the same priority as Submariner but has a different match
+			ovnkPolicy := &nbdb.LogicalRouterPolicy{
+				Priority:    priority,
+				Match:       ipMatchField + " == " + t.clusterCIDR,
+				Action:      "reroute",
+				Nexthop:     ptr.To(t.OVNK8sMgmntIntCIDR[t.ipFamily].IP.String()),
+				ExternalIDs: map[string]string{}, // No submariner tag
+			}
+
+			_, err := t.ovsdbClient.Create(ovnkPolicy)
+			Expect(err).To(Succeed())
+
+			// Create a GatewayRoute which will trigger reconciliation
+			gwRoute := &submarinerv1.GatewayRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gateway-route-preserve-policy",
+				},
+				RoutePolicySpec: submarinerv1.RoutePolicySpec{
+					NextHops:    []string{*ovnkPolicy.Nexthop},
+					RemoteCIDRs: ipFamilySubnets,
+				},
+			}
+
+			test.CreateResource(client, gwRoute)
+
+			// Wait for Submariner policies to be reconciled
+			for _, cidr := range gwRoute.RoutePolicySpec.RemoteCIDRs {
+				t.ovsdbClient.AwaitModel(&nbdb.LogicalRouterPolicy{
+					Match:   ipMatchField + " == " + cidr,
+					Nexthop: ovnkPolicy.Nexthop,
+				})
+			}
+
+			// Verify the OVN-K policy still exists and is untagged
+			t.ovsdbClient.EnsureModel(&nbdb.LogicalRouterPolicy{
+				Match:   ovnkPolicy.Match,
+				Nexthop: ovnkPolicy.Nexthop,
+			})
+			retrievedPolicy := t.ovsdbClient.GetModel(&nbdb.LogicalRouterPolicy{
+				Match:   ovnkPolicy.Match,
+				Nexthop: ovnkPolicy.Nexthop,
+			}).(*nbdb.LogicalRouterPolicy)
+			Expect(retrievedPolicy.ExternalIDs).ToNot(HaveKey(ovn.SubmarinerExternalIDKey),
+				"OVN-K policy should not be tagged with submariner")
+
+			Expect(client.Delete(context.Background(), gwRoute.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			// Check the OVN-K policy still exists and remains untagged after removing the gateway
+			t.ovsdbClient.EnsureModel(&nbdb.LogicalRouterPolicy{
+				Match:   ovnkPolicy.Match,
+				Nexthop: ovnkPolicy.Nexthop,
+			})
+			retrievedPolicy = t.ovsdbClient.GetModel(&nbdb.LogicalRouterPolicy{
+				Match:   ovnkPolicy.Match,
+				Nexthop: ovnkPolicy.Nexthop,
+			}).(*nbdb.LogicalRouterPolicy)
+			Expect(retrievedPolicy.ExternalIDs).ToNot(HaveKey(ovn.SubmarinerExternalIDKey),
+				"OVN-K policy should not be tagged with submariner after cleanup")
+		})
+	})
 }
 
 func (t *handlerTestDriver) testNonGatewayRoutes(ipFamilyNextHop string, ipFamilyCIDRs1, ipFamilyCIDRs2 []string, nonIPFamilyNextHop string,

--- a/pkg/routeagent_driver/handlers/ovn/ovn_logical_routes.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_logical_routes.go
@@ -32,15 +32,21 @@ import (
 )
 
 const (
-	OVNClusterRouter       = "ovn_cluster_router"
-	ovnRoutePoliciesPrioV4 = 20000
-	ovnRoutePoliciesPrioV6 = 20100
+	OVNClusterRouter        = "ovn_cluster_router"
+	ovnRoutePoliciesPrioV4  = 20000
+	ovnRoutePoliciesPrioV6  = 20100
+	SubmarinerExternalIDKey = "submariner"
 )
 
 func (c *ConnectionHandler) reconcileOvnLogicalRouterStaticRoutes(remoteSubnets sets.Set[string],
 	nextHop string,
 ) error {
 	staleLRSRPred := func(item *nbdb.LogicalRouterStaticRoute) bool {
+		// Only manage routes that Submariner created, ignore rest of the system's routes.
+		if _, ok := item.ExternalIDs[SubmarinerExternalIDKey]; !ok {
+			return false
+		}
+
 		// Legacy routes will have same prefix but different nextHop
 		return (item.Nexthop == nextHop && !remoteSubnets.Has(item.IPPrefix)) ||
 			(item.Nexthop != nextHop && remoteSubnets.Has(item.IPPrefix))
@@ -75,7 +81,7 @@ func buildLRSRsFromSubnets(subnetsToAdd []string, nextHop string) []*nbdb.Logica
 			Nexthop:  nextHop,
 			IPPrefix: subnet,
 			ExternalIDs: map[string]string{
-				"submariner": versions.Submariner(),
+				SubmarinerExternalIDKey: versions.Submariner(),
 			},
 		}
 	}
@@ -92,6 +98,11 @@ func (c *ConnectionHandler) reconcileSubOvnLogicalRouterPolicies(remoteSubnets s
 	expectedLRPs := buildLRPsFromSubnets(c.ipFamily, remoteSubnets.UnsortedList(), nextHop, priority)
 
 	lrpStalePredicate := func(item *nbdb.LogicalRouterPolicy) bool {
+		// Only manage policies that Submariner created, ignore rest of the system's policies.
+		if _, ok := item.ExternalIDs[SubmarinerExternalIDKey]; !ok {
+			return false
+		}
+
 		if item.Priority != priority {
 			return false
 		}
@@ -149,7 +160,7 @@ func buildLRPsFromSubnets(family k8snet.IPFamily, subnetsToAdd []string, nextHop
 			Match:    match,
 			Nexthop:  ptr.To(nextHop),
 			ExternalIDs: map[string]string{
-				"submariner": versions.Submariner(),
+				SubmarinerExternalIDKey: versions.Submariner(),
 			},
 		})
 	}


### PR DESCRIPTION
Backport of #3881 on release-0.22.

#3881: Fix deletion of non-Submariner OVN routes during

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routes and policies created by other system components are now properly preserved and not inadvertently removed during reconciliation.

* **Tests**
  * Added test cases validating correct handling of externally-managed gateway routes during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->