### PR TITLE
Add comprehensive unit test coverage for the GetLocalIP function

### DIFF
--- a/pkg/endpoint/local_endpoint_suite_test.go
+++ b/pkg/endpoint/local_endpoint_suite_test.go
@@ -19,10 +19,12 @@ limitations under the License.
 package endpoint_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -36,6 +38,11 @@ func init() {
 
 var _ = BeforeSuite(func() {
 	kzerolog.InitK8sLogging()
+
+	log.Exit = func(code int) {
+		defer GinkgoRecover()
+		Fail(fmt.Sprintf("Exited with code %d", code))
+	}
 })
 
 func TestEndpoint(t *testing.T) {

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -48,9 +48,10 @@ const testNodeName = "this-node"
 
 var _ = Describe("GetLocalSpec", func() {
 	var (
-		submSpec *types.SubmarinerSpecification
-		client   kubernetes.Interface
-		node     *v1.Node
+		submSpec     *types.SubmarinerSpecification
+		client       kubernetes.Interface
+		node         *v1.Node
+		originalDial = endpoint.Dial
 	)
 
 	const (
@@ -127,9 +128,8 @@ var _ = Describe("GetLocalSpec", func() {
 			Gw:        net.ParseIP("2001:0:0:0::"),
 		})).To(Succeed())
 
-		defaultDial := endpoint.Dial
 		DeferCleanup(func() {
-			endpoint.Dial = defaultDial
+			endpoint.Dial = originalDial
 		})
 
 		endpoint.Dial = func(_, _ string) (net.Conn, error) {

--- a/pkg/endpoint/local_ip.go
+++ b/pkg/endpoint/local_ip.go
@@ -23,6 +23,7 @@ import (
 	"net"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/submariner/pkg/cni"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	k8snet "k8s.io/utils/net"
 )
@@ -74,14 +75,16 @@ func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
 			return localAddr.IP.String()
 		}
 
-		logger.Warningf("IP %q returned from Dial isn't usable - trying to find another IP from the same interface", localAddr.IP)
+		logger.Infof("IP %q returned from Dial isn't usable - trying to find another IP from the same interface", localAddr.IP)
 
 		// Try to find a valid global-scope IP from the same interface
 		ifaceIP, err := getValidGlobalIPv6FromSameInterface(localAddr.IP)
-		if err == nil {
+		if err != nil {
+			logger.Errorf(err, "Error retrieving valid IPv6 address for %q", localAddr.IP)
+		} else if ifaceIP != "" {
 			return ifaceIP
 		} else {
-			logger.Warningf("Failed to retrieve valid IPv6 address for %q: %v", localAddr.IP, err)
+			logger.Infof("No acceptable IPv6 found on same interface as %q, trying route-based discovery", localAddr.IP)
 		}
 	}
 
@@ -102,66 +105,29 @@ func isAcceptableIPv6(ip net.IP) bool {
 }
 
 func getValidGlobalIPv6FromSameInterface(ip net.IP) (string, error) {
-	interfaces, err := net.Interfaces()
+	hostInterfaces, err := cni.HostInterfaces()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to list interfaces")
 	}
-	var (
-		ownedIfaceName  string
-		ownedIfaceAddrs []net.Addr
-	)
 
-	for _, iface := range interfaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			logger.Warningf("Failed to list the address from the interface %v", iface.Name)
+	var ownedIfaceName string
+
+	for i := range hostInterfaces {
+		actualIP, _, err := net.ParseCIDR(hostInterfaces[i].Addr)
+		if err != nil || k8snet.IPFamilyOf(actualIP) != k8snet.IPv6 {
 			continue
 		}
 
-		// Confirm this interface owns the original (non-global) IP
-		ownsIP := false
-
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok || ipNet.IP.To4() != nil {
-				continue
-			}
-
-			if ipNet.Contains(ip) {
-				ownsIP = true
-				break
-			}
+		if ownedIfaceName == "" && actualIP.Equal(ip) {
+			ownedIfaceName = hostInterfaces[i].Name
 		}
 
-		if ownsIP {
-			ownedIfaceName = iface.Name
-			ownedIfaceAddrs = addrs
-
-			break
+		if ownedIfaceName != "" && ownedIfaceName == hostInterfaces[i].Name && isAcceptableIPv6(actualIP) {
+			return actualIP.String(), nil
 		}
 	}
 
-	if len(ownedIfaceAddrs) == 0 {
-		return "", fmt.Errorf("no interface for IP %q was found", ip)
-	}
-	// Scan for a valid global IPv6 on the same interface
-	for _, addr := range ownedIfaceAddrs {
-		ipNet, ok := addr.(*net.IPNet)
-		if !ok {
-			continue
-		}
-
-		// Skip IPv4 addresses
-		if ipNet.IP.To4() != nil {
-			continue
-		}
-
-		if isAcceptableIPv6(ipNet.IP) {
-			return ipNet.IP.String(), nil
-		}
-	}
-
-	return "", fmt.Errorf("no valid global IPv6 found on interface %q for IP %q", ownedIfaceName, ip)
+	return "", nil
 }
 
 func GetLocalIP(family k8snet.IPFamily) string {

--- a/pkg/endpoint/local_ip_test.go
+++ b/pkg/endpoint/local_ip_test.go
@@ -1,0 +1,198 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint_test
+
+import (
+	"errors"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/submariner/pkg/cni"
+	"github.com/submariner-io/submariner/pkg/endpoint"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
+)
+
+var _ = Describe("GetLocalIP", func() {
+	const (
+		ipv4DialIP           = "100.10.1.0"
+		ipv4RouteIP          = "200.10.1.0"
+		ipv6RouteIP          = "2002:0:0:1234::"
+		ipv6LinkLocalUnicast = "fe80::10"
+	)
+
+	var (
+		ipv6DialIP string
+		netLink    *fakeNetlink.NetLink
+	)
+
+	BeforeEach(func() {
+		ipv6DialIP = ""
+
+		netLink = fakeNetlink.New()
+		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
+			return netLink
+		}
+
+		defaultDial := endpoint.Dial
+		DeferCleanup(func() {
+			endpoint.Dial = defaultDial
+		})
+
+		endpoint.Dial = func(network, _ string) (net.Conn, error) {
+			if network == "udp4" {
+				return &fakeConn{ip: net.ParseIP(ipv4DialIP)}, nil
+			} else if network == "udp6" {
+				return &fakeConn{ip: net.ParseIP(ipv6DialIP)}, nil
+			}
+
+			return nil, errors.New("invalid network: " + network)
+		}
+	})
+
+	Context("IPv4", func() {
+		When("Dial succeeds", func() {
+			It("should return the IP", func() {
+				Expect(endpoint.GetLocalIP(k8snet.IPv4)).To(Equal(ipv4DialIP))
+			})
+		})
+
+		When("Dial fails", func() {
+			BeforeEach(func() {
+				endpoint.Dial = func(_, _ string) (net.Conn, error) {
+					return nil, errors.New("mock error")
+				}
+
+				Expect(netLink.RouteAdd(&netlink.Route{
+					LinkIndex: 1,
+					Src:       net.ParseIP(ipv4RouteIP),
+					Gw:        net.ParseIP("1.2.0.0"),
+				})).To(Succeed())
+			})
+
+			It("should return a route local IP", func() {
+				Expect(endpoint.GetLocalIP(k8snet.IPv4)).To(Equal(ipv4RouteIP))
+			})
+		})
+	})
+
+	Context("IPv6", func() {
+		BeforeEach(func() {
+			ipv6DialIP = "2001:0:0:4321::"
+
+			cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+				return []cni.HostInterface{}, nil
+			}
+		})
+
+		When("Dial succeeds", func() {
+			Context("and the IP is usable", func() {
+				It("should return the IP", func() {
+					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6DialIP))
+				})
+			})
+
+			Context("and the IP isn't usable and no other IP on the same interface exists", func() {
+				It("should return a route local IP", func() {
+					Expect(netLink.RouteAdd(&netlink.Route{
+						LinkIndex: 2,
+						Src:       net.ParseIP("fd69::2"),
+						Gw:        net.ParseIP("2001:0:0:0::"),
+					})).To(Succeed())
+
+					Expect(netLink.RouteAdd(&netlink.Route{
+						LinkIndex: 2,
+						Src:       net.ParseIP(ipv6RouteIP),
+						Gw:        net.ParseIP("2001:0:0:0::"),
+					})).To(Succeed())
+
+					ipv6DialIP = net.IPv6loopback.String()
+					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+
+					ipv6DialIP = ipv6LinkLocalUnicast // link-local unicast address
+					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+
+					cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+						return []cni.HostInterface{
+							{
+								Name: "v6-owns",
+								Addr: "fe80::14b:b63:c7e1:1558/64",
+							},
+						}, nil
+					}
+
+					ipv6DialIP = ipv6LinkLocalUnicast
+					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+				})
+			})
+
+			Context("and the IP isn't usable and another IP on the same interface exists", func() {
+				It("should return another usable IPv6 from the same interface", func() {
+					cni.HostInterfaces = func() ([]cni.HostInterface, error) {
+						return []cni.HostInterface{
+							{
+								Name: "not-a-cidr",
+								Addr: "not-a-cidr",
+							},
+							{
+								Name: "v4",
+								Addr: "10.34.1.0/24",
+							},
+							{
+								Name: "v6-not-owns",
+								Addr: "ff00::1/8",
+							},
+							{
+								Name: "v6-other",
+								Addr: "2001::14b:b63:c7e1:123/64",
+							},
+							{
+								Name: "v6-owns",
+								Addr: "fe80::14b:b63:c7e1:1558/64",
+							},
+							{
+								Name: "v6-owns",
+								Addr: "fc00::14b:b63:c7e1:aaa/8",
+							},
+						}, nil
+					}
+
+					ipv6DialIP = "fe80::14b:b63:c7e1:1558"
+					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal("fc00::14b:b63:c7e1:aaa"))
+				})
+			})
+		})
+	})
+})
+
+type fakeConn struct {
+	net.TCPConn
+	ip net.IP
+}
+
+func (f *fakeConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: f.ip}
+}
+
+func (f *fakeConn) Close() error {
+	return nil
+}


### PR DESCRIPTION
...including tests for both IPv4 and IPv6 address resolution through dial and route fallback mechanisms.

Refactored `getValidGlobalIPv6FromSameInterface` to use `cni.HostInterfaces` instead of `net.Interfaces` for consistency and improved testability.

Other improvements:
  - Return empty string for "not found" cases vs error for actual failures
  - Change intermediate fallback log messages from Warning to Info level
  - Add `originalDial` variable to the `GetLocalSpec` tests prevent pollution between tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 global address detection by using host-provided interface metadata, yielding better same-interface address selection and more reliable fallbacks.
  * Reduced noisy error logging when address discovery fails—fallbacks now return empty results and log at an informational level instead of surfacing original errors.

* **Tests**
  * Added comprehensive IPv4/IPv6 tests for dial success/failure, route fallbacks, and interface-based address selection.
  * Strengthened test setup/cleanup to reliably restore modified globals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->