### PR TITLE
Refactor HostInterface to use net.IP instead of string

### DIFF
--- a/pkg/cable/vxlan/vxlan_test.go
+++ b/pkg/cable/vxlan/vxlan_test.go
@@ -269,11 +269,11 @@ func newTestDriver() *testDriver {
 			return []cni.HostInterface{
 				{
 					Name: "veth0",
-					Addr: cniIPAddress + "/24",
+					Addr: net.ParseIP(cniIPAddress),
 				},
 				{
 					Name: "veth0",
-					Addr: cniIPv6Address + "/64",
+					Addr: net.ParseIP(cniIPv6Address),
 				},
 			}, nil
 		}

--- a/pkg/cni/cni_iface.go
+++ b/pkg/cni/cni_iface.go
@@ -35,7 +35,7 @@ type Interface struct {
 
 type HostInterface struct {
 	Name string
-	Addr string
+	Addr net.IP
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("CNI")}
@@ -55,7 +55,12 @@ var HostInterfaces = func() ([]HostInterface, error) {
 		}
 
 		for _, a := range addrs {
-			hostInterfaces = append(hostInterfaces, HostInterface{Name: netInterfaces[i].Name, Addr: a.String()})
+			ipNet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			hostInterfaces = append(hostInterfaces, HostInterface{Name: netInterfaces[i].Name, Addr: ipNet.IP})
 		}
 	}
 
@@ -77,21 +82,16 @@ func Discover(clusterCIDRs []string, family k8snet.IPFamily) (*Interface, error)
 		utilruntime.Must(errors.Wrapf(err, "unable to ParseCIDR %q", clusterCIDR))
 
 		for i := range hostInterfaces {
-			ipAddr, _, err := net.ParseCIDR(hostInterfaces[i].Addr)
-			if err != nil {
-				logger.Errorf(err, "Unable to parse CIDR %q for host interface %q", hostInterfaces[i].Addr, hostInterfaces[i].Name)
-				continue
-			}
+			ipAddr := hostInterfaces[i].Addr
 
 			if k8snet.IPFamilyOf(ipAddr) != family {
 				continue
 			}
 
 			logger.V(log.DEBUG).Infof("Host interface %q has address %q", hostInterfaces[i].Name, ipAddr)
-			address := net.ParseIP(ipAddr.String())
 
 			// Verify that interface has an address from cluster CIDR
-			if clusterNetwork.Contains(address) {
+			if clusterNetwork.Contains(ipAddr) {
 				logger.V(log.DEBUG).Infof("Found CNI Interface %q that has IP %q from ClusterCIDR %q",
 					hostInterfaces[i].Name, ipAddr, clusterCIDR)
 

--- a/pkg/cni/cni_iface_test.go
+++ b/pkg/cni/cni_iface_test.go
@@ -20,6 +20,7 @@ package cni_test
 
 import (
 	"errors"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,17 +40,17 @@ const (
 var (
 	v4HostInterface1 = cni.HostInterface{
 		Name: "v4-iface1",
-		Addr: ipV4CIDR1,
+		Addr: net.ParseIP(ipV4Addr1),
 	}
 
 	v4HostInterface2 = cni.HostInterface{
 		Name: "v4-iface2",
-		Addr: ipV4CIDR2,
+		Addr: net.ParseIP(ipV4Addr2),
 	}
 
 	v6HostInterface = cni.HostInterface{
 		Name: "v6-iface",
-		Addr: ipV6CIDR,
+		Addr: net.ParseIP(ipV6Addr),
 	}
 )
 
@@ -99,20 +100,6 @@ var _ = Describe("Discover", func() {
 
 			_, err := cni.Discover([]string{ipV4CIDR2}, k8snet.IPv4)
 			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	When("the address for a host interface is not a CIDR", func() {
-		It("should ignore it", func() {
-			setupHostInterfaces(cni.HostInterface{
-				Name: "no-cidr",
-				Addr: "1.1.1.1",
-			}, v4HostInterface1)
-
-			cniInterface, err := cni.Discover([]string{ipV4CIDR1}, k8snet.IPv4)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cniInterface.Name).To(Equal(v4HostInterface1.Name))
-			Expect(cniInterface.IPAddress).To(Equal(ipV4Addr1))
 		})
 	})
 

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -96,11 +96,11 @@ var _ = Describe("GetLocalSpec", func() {
 			return []cni.HostInterface{
 				{
 					Name: "veth0",
-					Addr: ipv4CIDR,
+					Addr: net.ParseIP(cniInterfaceIPv4),
 				},
 				{
 					Name: "veth1",
-					Addr: ipv6CIDR,
+					Addr: net.ParseIP(cniInterfaceIPv6),
 				},
 			}, nil
 		}

--- a/pkg/endpoint/local_ip.go
+++ b/pkg/endpoint/local_ip.go
@@ -113,8 +113,9 @@ func getValidGlobalIPv6FromSameInterface(ip net.IP) (string, error) {
 	var ownedIfaceName string
 
 	for i := range hostInterfaces {
-		actualIP, _, err := net.ParseCIDR(hostInterfaces[i].Addr)
-		if err != nil || k8snet.IPFamilyOf(actualIP) != k8snet.IPv6 {
+		actualIP := hostInterfaces[i].Addr
+
+		if k8snet.IPFamilyOf(actualIP) != k8snet.IPv6 {
 			continue
 		}
 

--- a/pkg/endpoint/local_ip_test.go
+++ b/pkg/endpoint/local_ip_test.go
@@ -135,7 +135,7 @@ var _ = Describe("GetLocalIP", func() {
 						return []cni.HostInterface{
 							{
 								Name: "v6-owns",
-								Addr: "fe80::14b:b63:c7e1:1558/64",
+								Addr: net.ParseIP("fe80::14b:b63:c7e1:1558"),
 							},
 						}, nil
 					}
@@ -150,28 +150,24 @@ var _ = Describe("GetLocalIP", func() {
 					cni.HostInterfaces = func() ([]cni.HostInterface, error) {
 						return []cni.HostInterface{
 							{
-								Name: "not-a-cidr",
-								Addr: "not-a-cidr",
-							},
-							{
 								Name: "v4",
-								Addr: "10.34.1.0/24",
+								Addr: net.ParseIP("10.34.1.0"),
 							},
 							{
 								Name: "v6-not-owns",
-								Addr: "ff00::1/8",
+								Addr: net.ParseIP("ff00::1"),
 							},
 							{
 								Name: "v6-other",
-								Addr: "2001::14b:b63:c7e1:123/64",
+								Addr: net.ParseIP("2001::14b:b63:c7e1:123"),
 							},
 							{
 								Name: "v6-owns",
-								Addr: "fe80::14b:b63:c7e1:1558/64",
+								Addr: net.ParseIP("fe80::14b:b63:c7e1:1558"),
 							},
 							{
 								Name: "v6-owns",
-								Addr: "fc00::14b:b63:c7e1:aaa/8",
+								Addr: net.ParseIP("fc00::14b:b63:c7e1:aaa"),
 							},
 						}, nil
 					}

--- a/pkg/globalnet/controllers/controllers_suite_test.go
+++ b/pkg/globalnet/controllers/controllers_suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	cni.HostInterfaces = func() ([]cni.HostInterface, error) {
 		return []cni.HostInterface{{
 			Name: "veth0",
-			Addr: cniInterfaceIP + "/24",
+			Addr: net.ParseIP(cniInterfaceIP),
 		}}, nil
 	}
 

--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -89,7 +89,7 @@ var _ = Describe("", func() {
 		cni.HostInterfaces = func() ([]cni.HostInterface, error) {
 			return []cni.HostInterface{{
 				Name: "veth0",
-				Addr: localClusterCIDRs[0],
+				Addr: net.ParseIP("10.1.0.0"),
 			}}, nil
 		}
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
@@ -116,11 +116,11 @@ func newTestDriver() *testDriver {
 			return []cni.HostInterface{
 				{
 					Name: "veth0",
-					Addr: localClusterIPv4CIDR,
+					Addr: net.ParseIP(cniIP4Address),
 				},
 				{
 					Name: "veth1",
-					Addr: localClusterIPv6CIDR,
+					Addr: net.ParseIP(cniIP6Address),
 				},
 			}, nil
 		}


### PR DESCRIPTION
Change the `HostInterface.Addr` field from string to `net.IP` since callers only use the IP and not the subnet mask. This also eliminates redundant CIDR parsing across multiple callers and improves type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Host interface addresses now use native IP values, resulting in more consistent and reliable network-address handling across the product.

* **Tests**
  * Test fixtures updated to reflect the new address representation, improving test consistency and reducing parsing-related noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->