### PR TITLE
Return errors from GetLocalIPForDestination instead of fatal exit

### DIFF
--- a/pkg/endpoint/local_endpoint.go
+++ b/pkg/endpoint/local_endpoint.go
@@ -135,6 +135,7 @@ func (l *Local) Create(ctx context.Context) error {
 	return err
 }
 
+//nolint:gocyclo // Function complexity from multiple IP families and optional features - refactoring would reduce readability
 func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, k8sClient kubernetes.Interface,
 	airGappedDeployment bool,
 ) (*submv1.EndpointSpec, error) {
@@ -180,7 +181,12 @@ func GetLocalSpec(ctx context.Context, submSpec *types.SubmarinerSpecification, 
 	}
 
 	for _, family := range submSpec.GetIPFamilies() {
-		endpointSpec.SetPrivateIP(GetLocalIP(family))
+		privateIP, err := GetLocalIP(family)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error getting local IP for family %v", family)
+		}
+
+		endpointSpec.SetPrivateIP(privateIP)
 	}
 
 	var replacedIP string

--- a/pkg/endpoint/local_endpoint_test.go
+++ b/pkg/endpoint/local_endpoint_test.go
@@ -163,9 +163,11 @@ var _ = Describe("GetLocalSpec", func() {
 
 		It("should set the IPv4 private IP", func() {
 			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(spec.GetPrivateIP(k8snet.IPv4)).To(Equal(endpoint.GetLocalIP(k8snet.IPv4)))
+			expectedIP, err := endpoint.GetLocalIP(k8snet.IPv4)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.GetPrivateIP(k8snet.IPv4)).To(Equal(expectedIP))
 		})
 	})
 
@@ -202,10 +204,13 @@ var _ = Describe("GetLocalSpec", func() {
 
 		It("should set IPv6 private IP", func() {
 			spec, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedIP, err := endpoint.GetLocalIP(k8snet.IPv6)
+			Expect(err).NotTo(HaveOccurred())
 
 			ipv6PrivateAddr := spec.GetPrivateIP(k8snet.IPv6)
-			Expect(ipv6PrivateAddr).To(Equal(endpoint.GetLocalIP(k8snet.IPv6)))
+			Expect(ipv6PrivateAddr).To(Equal(expectedIP))
 
 			Expect(spec.CableName).To(ContainSubstring(strings.ReplaceAll(ipv6PrivateAddr, ":", "-")))
 		})
@@ -319,6 +324,17 @@ var _ = Describe("GetLocalSpec", func() {
 				_, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, true)
 				Expect(err).To(HaveOccurred())
 			})
+		})
+	})
+
+	When("obtaining a public IP fails", func() {
+		BeforeEach(func() {
+			node.Labels[backendConfigPrefix+testPublicIPLabel] = "ipv4:"
+		})
+
+		It("should return an error", func() {
+			_, err := endpoint.GetLocalSpec(context.TODO(), submSpec, client, false)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/endpoint/local_ip.go
+++ b/pkg/endpoint/local_ip.go
@@ -19,7 +19,6 @@ limitations under the License.
 package endpoint
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/pkg/errors"
@@ -65,14 +64,14 @@ func getLocalIPFromRoutes(family k8snet.IPFamily) (string, error) {
 	return "", errors.Errorf("couldn't find route for family %v", family)
 }
 
-func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
+func GetLocalIPForDestination(dst string, family k8snet.IPFamily) (string, error) {
 	conn, err := Dial("udp"+string(family), net.JoinHostPort(dst, "53"))
 	if err == nil {
 		defer conn.Close()
 
 		localAddr := conn.LocalAddr().(*net.UDPAddr)
 		if family == k8snet.IPv4 || isAcceptableIPv6(localAddr.IP) {
-			return localAddr.IP.String()
+			return localAddr.IP.String(), nil
 		}
 
 		logger.Infof("IP %q returned from Dial isn't usable - trying to find another IP from the same interface", localAddr.IP)
@@ -82,7 +81,7 @@ func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
 		if err != nil {
 			logger.Errorf(err, "Error retrieving valid IPv6 address for %q", localAddr.IP)
 		} else if ifaceIP != "" {
-			return ifaceIP
+			return ifaceIP, nil
 		} else {
 			logger.Infof("No acceptable IPv6 found on same interface as %q, trying route-based discovery", localAddr.IP)
 		}
@@ -90,9 +89,8 @@ func GetLocalIPForDestination(dst string, family k8snet.IPFamily) string {
 
 	// connection failed try fallback method
 	localIP, err := getLocalIPFromRoutes(family)
-	logger.FatalOnError(err, fmt.Sprintf("Error getting local IPv%v", family))
 
-	return localIP
+	return localIP, errors.Wrapf(err, "error getting local IPv%v", family)
 }
 
 func isAcceptableIPv6(ip net.IP) bool {
@@ -131,6 +129,6 @@ func getValidGlobalIPv6FromSameInterface(ip net.IP) (string, error) {
 	return "", nil
 }
 
-func GetLocalIP(family k8snet.IPFamily) string {
+func GetLocalIP(family k8snet.IPFamily) (string, error) {
 	return GetLocalIPForDestination(familyToDestIP[family], family)
 }

--- a/pkg/endpoint/local_ip_test.go
+++ b/pkg/endpoint/local_ip_test.go
@@ -72,7 +72,9 @@ var _ = Describe("GetLocalIP", func() {
 	Context("IPv4", func() {
 		When("Dial succeeds", func() {
 			It("should return the IP", func() {
-				Expect(endpoint.GetLocalIP(k8snet.IPv4)).To(Equal(ipv4DialIP))
+				ip, err := endpoint.GetLocalIP(k8snet.IPv4)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ip).To(Equal(ipv4DialIP))
 			})
 		})
 
@@ -81,16 +83,30 @@ var _ = Describe("GetLocalIP", func() {
 				endpoint.Dial = func(_, _ string) (net.Conn, error) {
 					return nil, errors.New("mock error")
 				}
-
-				Expect(netLink.RouteAdd(&netlink.Route{
-					LinkIndex: 1,
-					Src:       net.ParseIP(ipv4RouteIP),
-					Gw:        net.ParseIP("1.2.0.0"),
-				})).To(Succeed())
 			})
 
-			It("should return a route local IP", func() {
-				Expect(endpoint.GetLocalIP(k8snet.IPv4)).To(Equal(ipv4RouteIP))
+			Context("and route lookup succeeds", func() {
+				BeforeEach(func() {
+					Expect(netLink.RouteAdd(&netlink.Route{
+						LinkIndex: 1,
+						Src:       net.ParseIP(ipv4RouteIP),
+						Gw:        net.ParseIP("1.2.0.0"),
+					})).To(Succeed())
+				})
+
+				It("should return a route local IP", func() {
+					ip, err := endpoint.GetLocalIP(k8snet.IPv4)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal(ipv4RouteIP))
+				})
+			})
+
+			Context("and route lookup also fails", func() {
+				It("should return an error", func() {
+					// No routes added, so route lookup will fail
+					_, err := endpoint.GetLocalIP(k8snet.IPv4)
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 	})
@@ -107,7 +123,9 @@ var _ = Describe("GetLocalIP", func() {
 		When("Dial succeeds", func() {
 			Context("and the IP is usable", func() {
 				It("should return the IP", func() {
-					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6DialIP))
+					ip, err := endpoint.GetLocalIP(k8snet.IPv6)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal(ipv6DialIP))
 				})
 			})
 
@@ -126,10 +144,14 @@ var _ = Describe("GetLocalIP", func() {
 					})).To(Succeed())
 
 					ipv6DialIP = net.IPv6loopback.String()
-					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+					ip, err := endpoint.GetLocalIP(k8snet.IPv6)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal(ipv6RouteIP))
 
 					ipv6DialIP = ipv6LinkLocalUnicast // link-local unicast address
-					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+					ip, err = endpoint.GetLocalIP(k8snet.IPv6)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal(ipv6RouteIP))
 
 					cni.HostInterfaces = func() ([]cni.HostInterface, error) {
 						return []cni.HostInterface{
@@ -141,7 +163,9 @@ var _ = Describe("GetLocalIP", func() {
 					}
 
 					ipv6DialIP = ipv6LinkLocalUnicast
-					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal(ipv6RouteIP))
+					ip, err = endpoint.GetLocalIP(k8snet.IPv6)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal(ipv6RouteIP))
 				})
 			})
 
@@ -173,7 +197,9 @@ var _ = Describe("GetLocalIP", func() {
 					}
 
 					ipv6DialIP = "fe80::14b:b63:c7e1:1558"
-					Expect(endpoint.GetLocalIP(k8snet.IPv6)).To(Equal("fc00::14b:b63:c7e1:aaa"))
+					ip, err := endpoint.GetLocalIP(k8snet.IPv6)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ip).To(Equal("fc00::14b:b63:c7e1:aaa"))
 				})
 			})
 		})

--- a/pkg/natdiscovery/natdiscovery.go
+++ b/pkg/natdiscovery/natdiscovery.go
@@ -44,7 +44,7 @@ type Interface interface {
 
 type (
 	udpWriteFunction         func(b []byte, addr *net.UDPAddr) (int, error)
-	FindSrcIPFunction        func(destinationIP string, family k8snet.IPFamily) string
+	FindSrcIPFunction        func(destinationIP string, family k8snet.IPFamily) (string, error)
 	CreateServerConnectionFn func(port int32, family k8snet.IPFamily) (ServerConnection, error)
 )
 

--- a/pkg/natdiscovery/natdiscovery_suite_test.go
+++ b/pkg/natdiscovery/natdiscovery_suite_test.go
@@ -224,19 +224,19 @@ func newNATDiscovery(endpoint *submarinerv1.Endpoint, addr, addrv6 *net.UDPAddr)
 
 			return nil, errors.New("unsupported IP family")
 		},
-		FindSourceIP: func(_ string, family k8snet.IPFamily) string {
+		FindSourceIP: func(_ string, family k8snet.IPFamily) (string, error) {
 			defer GinkgoRecover()
 			Expect(family).ToNot(Equal(k8snet.IPFamilyUnknown))
 
 			if family == k8snet.IPv4 {
-				return srcIP
+				return srcIP, nil
 			}
 
 			if family == k8snet.IPv6 {
-				return srcIPv6
+				return srcIPv6, nil
 			}
 
-			return ""
+			return "", errors.New("unsupported IP family")
 		},
 		RunLoop: func(_ <-chan struct{}, doCheck func()) {
 			natDiscoveryInfo.checkDiscovery = doCheck

--- a/pkg/natdiscovery/request_send.go
+++ b/pkg/natdiscovery/request_send.go
@@ -64,7 +64,10 @@ func (nd *natDiscovery) sendCheckRequestToTargetIP(remoteNAT *remoteEndpointNAT,
 		return err
 	}
 
-	sourceIP := nd.FindSourceIP(targetIP, remoteNAT.family)
+	sourceIP, err := nd.FindSourceIP(targetIP, remoteNAT.family)
+	if err != nil {
+		return errors.Wrapf(err, "error finding source IP for target %s", targetIP)
+	}
 
 	localEndpointSpec := nd.LocalEndpoint.Spec()
 


### PR DESCRIPTION
`GetLocalIPForDestination` previously called `logger.FatalOnError` when route-based IP discovery failed, causing the entire process to exit. This prevented proper error handling by callers and made testing difficult.

`GetLocalIPForDestination` and `GetLocalIP` now return (string ,error). This allows callers to handle failures gracefully. For GetLocalSpec, it propagates the error which results in gracefully exiting the process. For NAT discovery, errors are logged and handled per-target allowing partial success if one of public/private IP discovery works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced IP discovery error handling to properly report and propagate failures when determining local or source IP addresses during network endpoint configuration and NAT discovery, improving error diagnostics and preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->