### PR TITLE
Propagate leader election context to startControllers

### DIFF
--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -290,8 +290,8 @@ func (g *gatewayMonitor) startLeaderElection() {
 		RetryPeriod:     g.RetryPeriod,
 		ReleaseOnCancel: true,
 		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(_ context.Context) {
-				err := g.startControllers(context.Background()) //nolint:contextcheck // Intentional to not pass context
+			OnStartedLeading: func(ctx context.Context) {
+				err := g.startControllers(ctx)
 				if err != nil {
 					logger.Error(err, "Error starting the controllers - stopping leader election")
 					leaderElectionInfo.stop()


### PR DESCRIPTION
Pass the leader election context from `OnStartedLeading` callback to `startControllers` instead of using `context.Background()`. This allows blocking startup operations (like `RemoveStaleInternalServices` and initial reconciliation API calls) to be cancelled if leadership is lost during controller startup.

The controllers' long-running lifecycle remains managed by their `stopCh` channel, so this change only affects request-scoped operations during the startup sequence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context handling in gateway monitor leadership election to properly propagate cancellation and timeout signals during controller startup, ensuring more reliable service lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->