### PR TITLE
Add localEndpoint parameter to TransitionToNonGateway

### DIFF
--- a/pkg/event/controller/controller_test.go
+++ b/pkg/event/controller/controller_test.go
@@ -225,7 +225,7 @@ func (t *testDriver) testLocalEndpoint() {
 	t.DeleteEndpoint(endpoint.GetName())
 
 	t.awaitEvent(testing.EvLocalEndpointRemoved, endpoint)
-	t.awaitEvent(testing.EvTransitionToNonGateway, nil)
+	t.awaitEvent(testing.EvTransitionToNonGateway, endpoint)
 	t.ensureNoEvents()
 }
 

--- a/pkg/event/controller/endpoint_removed.go
+++ b/pkg/event/controller/endpoint_removed.go
@@ -57,7 +57,7 @@ func (c *handlerController) handleRemovedLocalEndpoint(endpoint *smv1.Endpoint) 
 	if err == nil && c.handlerState.wasOnGateway && !c.handlerState.IsOnGateway() {
 		logger.Infof("Handler %q: Transitioned to non-gateway node %q", c.handler.GetName(), endpoint.Spec.Hostname)
 
-		err = c.handler.TransitionToNonGateway()
+		err = c.handler.TransitionToNonGateway(endpoint)
 	}
 
 	if err == nil {

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -45,7 +45,7 @@ func (c *DefaultHandlerState) GetRemoteEndpoints() []submV1.Endpoint {
 
 type EndpointHandler interface {
 	// TransitionToNonGateway is called once for each transition of the local node from Gateway to a non-Gateway.
-	TransitionToNonGateway() error
+	TransitionToNonGateway(localEndpoint *submV1.Endpoint) error
 
 	// TransitionToGateway is called once for each transition of the local node from non-Gateway to a Gateway.
 	TransitionToGateway() error
@@ -136,7 +136,7 @@ func (ev *HandlerBase) Uninstall(_ context.Context) error {
 	return nil
 }
 
-func (ev *HandlerBase) TransitionToNonGateway() error {
+func (ev *HandlerBase) TransitionToNonGateway(_ *submV1.Endpoint) error {
 	return nil
 }
 

--- a/pkg/event/logger/handler.go
+++ b/pkg/event/logger/handler.go
@@ -44,7 +44,7 @@ func (l *Handler) GetNetworkPlugins() []string {
 	return []string{event.AnyNetworkPlugin}
 }
 
-func (l *Handler) TransitionToNonGateway() error {
+func (l *Handler) TransitionToNonGateway(_ *submV1.Endpoint) error {
 	logger.V(log.DEBUG).Info("The current node is no longer a Gateway")
 	return nil
 }

--- a/pkg/event/registry_test.go
+++ b/pkg/event/registry_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Event Handler", func() {
 		Expect(h.RemoteEndpointUpdated(&submv1.Endpoint{})).To(Succeed())
 		Expect(h.RemoteEndpointRemoved(&submv1.Endpoint{})).To(Succeed())
 		Expect(h.TransitionToGateway()).To(Succeed())
-		Expect(h.TransitionToNonGateway()).To(Succeed())
+		Expect(h.TransitionToNonGateway(&submv1.Endpoint{})).To(Succeed())
 	})
 
 	Specify("NodeHandlerBase should stub all Node methods", func() {

--- a/pkg/event/testing/testing.go
+++ b/pkg/event/testing/testing.go
@@ -154,8 +154,8 @@ func (t *TestHandlerBase) Uninstall(_ context.Context) error {
 	return t.addEvent(EvUninstall, nil)
 }
 
-func (t *TestHandlerBase) TransitionToNonGateway() error {
-	return t.addEvent(EvTransitionToNonGateway, nil)
+func (t *TestHandlerBase) TransitionToNonGateway(endpoint *v1.Endpoint) error {
+	return t.addEvent(EvTransitionToNonGateway, endpoint)
 }
 
 func (t *TestHandlerBase) TransitionToGateway() error {

--- a/pkg/globalnet/controllers/gateway_monitor.go
+++ b/pkg/globalnet/controllers/gateway_monitor.go
@@ -208,7 +208,7 @@ func (g *gatewayMonitor) TransitionToGateway() error {
 	return nil
 }
 
-func (g *gatewayMonitor) TransitionToNonGateway() error {
+func (g *gatewayMonitor) TransitionToNonGateway(_ *v1.Endpoint) error {
 	g.stopControllers(context.Background(), true)
 	return nil
 }

--- a/pkg/routeagent_driver/cabledriver/cabledriver_suite_test.go
+++ b/pkg/routeagent_driver/cabledriver/cabledriver_suite_test.go
@@ -1,0 +1,40 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cabledriver_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+)
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+func TestCableDriver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cable Driver Suite")
+}

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler.go
@@ -32,7 +32,6 @@ import (
 
 type vxlanCleanup struct {
 	event.HandlerBase
-	lastRemovedEndpoint *submv1.Endpoint
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("CableDriver")}
@@ -49,15 +48,12 @@ func (h *vxlanCleanup) GetName() string {
 	return "VXLAN cleanup handler"
 }
 
-func (h *vxlanCleanup) TransitionToNonGateway() error {
-	lastEndpoint := h.lastRemovedEndpoint
-	h.lastRemovedEndpoint = nil
-
+func (h *vxlanCleanup) TransitionToNonGateway(localEndpoint *submv1.Endpoint) error {
 	// During libreswan to vxlan cable driver update, new vxlan interface is created before old endpoint is deleted.
 	// Skip cleanup if removed endpoint wasn't vxlan to avoid deleting the newly created vxlan interface.
-	if lastEndpoint != nil && lastEndpoint.Spec.Backend != vxlan.CableDriverName {
+	if localEndpoint.Spec.Backend != vxlan.CableDriverName {
 		logger.Infof("Skipping VXLAN cleanup - removed endpoint cable driver was %q, not vxlan",
-			lastEndpoint.Spec.Backend)
+			localEndpoint.Spec.Backend)
 
 		return nil
 	}
@@ -68,10 +64,4 @@ func (h *vxlanCleanup) TransitionToNonGateway() error {
 	errv4 := netlink.DeleteIfaceAndAssociatedRoutes(vxlan.GetVxlanInterfaceName(k8snet.IPv4), vxlan.TableID, k8snet.IPv4)
 
 	return errors.Join(errv6, errv4)
-}
-
-func (h *vxlanCleanup) LocalEndpointRemoved(endpoint *submv1.Endpoint) error {
-	h.lastRemovedEndpoint = endpoint
-
-	return nil
 }

--- a/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler_test.go
+++ b/pkg/routeagent_driver/cabledriver/vxlan_tunnel_cleanup_handler_test.go
@@ -1,0 +1,149 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cabledriver_test
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable/vxlan"
+	"github.com/submariner-io/submariner/pkg/event"
+	eventtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/cabledriver"
+	"github.com/vishvananda/netlink"
+	k8snet "k8s.io/utils/net"
+)
+
+var _ = Describe("VXLAN Cleanup Handler", func() {
+	t := newTestDriver()
+
+	Specify("should have a non-empty name", func() {
+		Expect(t.handler.GetName()).NotTo(BeEmpty())
+	})
+
+	Specify("should support any network plugin", func() {
+		plugins := t.handler.GetNetworkPlugins()
+		Expect(plugins).To(Equal([]string{event.AnyNetworkPlugin}))
+	})
+
+	When("transitioning to a non-gateway node", func() {
+		BeforeEach(func() {
+			vxlanLinkV4 := &netlink.Vxlan{
+				LinkAttrs: netlink.LinkAttrs{
+					Name:  vxlan.GetVxlanInterfaceName(k8snet.IPv4),
+					Index: 10,
+				},
+			}
+			Expect(t.netLink.LinkAdd(vxlanLinkV4)).To(Succeed())
+
+			Expect(t.netLink.RouteAdd(&netlink.Route{
+				LinkIndex: vxlanLinkV4.Index,
+				Dst: &net.IPNet{
+					IP:   net.ParseIP("10.0.0.0"),
+					Mask: net.CIDRMask(16, 32),
+				},
+				Table: vxlan.TableID,
+			})).To(Succeed())
+
+			vxlanLinkV6 := &netlink.Vxlan{
+				LinkAttrs: netlink.LinkAttrs{
+					Name:  vxlan.GetVxlanInterfaceName(k8snet.IPv6),
+					Index: 11,
+				},
+			}
+			Expect(t.netLink.LinkAdd(vxlanLinkV6)).To(Succeed())
+
+			Expect(t.netLink.RouteAdd(&netlink.Route{
+				LinkIndex: vxlanLinkV6.Index,
+				Dst: &net.IPNet{
+					IP:   net.ParseIP("fd12:3456:789a:2::"),
+					Mask: net.CIDRMask(64, 128),
+				},
+				Table: vxlan.TableID,
+			})).To(Succeed())
+		})
+
+		Context("and the local endpoint uses the VXLAN cable driver", func() {
+			It("should delete the VXLAN interfaces", func() {
+				endpoint := t.createLocalEndpointWithBackend(vxlan.CableDriverName)
+				t.DeleteEndpoint(endpoint.Name)
+
+				Eventually(func(g Gomega) {
+					_, err := t.netLink.LinkByName(vxlan.GetVxlanInterfaceName(k8snet.IPv4))
+					g.Expect(netlinkAPI.IsLinkNotFoundError(err)).To(BeTrue())
+
+					_, err = t.netLink.LinkByName(vxlan.GetVxlanInterfaceName(k8snet.IPv6))
+					g.Expect(netlinkAPI.IsLinkNotFoundError(err)).To(BeTrue())
+				}).Should(Succeed())
+			})
+		})
+
+		Context("and the local endpoint uses a different cable driver", func() {
+			It("should not delete the VXLAN interfaces", func() {
+				endpoint := t.createLocalEndpointWithBackend("libreswan")
+				t.DeleteEndpoint(endpoint.Name)
+
+				Consistently(func(g Gomega) {
+					_, err := t.netLink.LinkByName(vxlan.GetVxlanInterfaceName(k8snet.IPv4))
+					g.Expect(err).NotTo(HaveOccurred())
+
+					_, err = t.netLink.LinkByName(vxlan.GetVxlanInterfaceName(k8snet.IPv6))
+					g.Expect(err).NotTo(HaveOccurred())
+				}).Should(Succeed())
+			})
+		})
+	})
+})
+
+type testDriver struct {
+	*eventtesting.ControllerSupport
+	handler event.Handler
+	netLink *fakeNetlink.NetLink
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{
+		ControllerSupport: eventtesting.NewControllerSupport(),
+	}
+
+	BeforeEach(func() {
+		t.netLink = fakeNetlink.New()
+		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
+			return t.netLink
+		}
+	})
+
+	JustBeforeEach(func() {
+		t.handler = cabledriver.NewVXLANCleanup()
+		t.ControllerSupport.Start(t.handler)
+	})
+
+	return t
+}
+
+func (t *testDriver) createLocalEndpointWithBackend(backend string) *submv1.Endpoint {
+	endpoint := eventtesting.NewEndpoint(eventtesting.LocalClusterID, t.Hostname)
+	endpoint.Spec.Backend = backend
+
+	return t.CreateEndpoint(endpoint)
+}

--- a/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
+++ b/pkg/routeagent_driver/cabledriver/xfrm_cleanup_handler.go
@@ -21,6 +21,7 @@ package cabledriver
 import (
 	"errors"
 
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/event"
 	"github.com/submariner-io/submariner/pkg/netlink"
 	k8snet "k8s.io/utils/net"
@@ -42,7 +43,7 @@ func (h *xrfmCleanup) GetNetworkPlugins() []string {
 	return []string{event.AnyNetworkPlugin}
 }
 
-func (h *xrfmCleanup) TransitionToNonGateway() error {
+func (h *xrfmCleanup) TransitionToNonGateway(_ *submarinerv1.Endpoint) error {
 	logger.Info("Transitioned to non-Gateway, cleaning up the IPsec xfrm rules")
 
 	errv6 := netlink.DeleteXfrmRules(k8snet.IPv6)

--- a/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
+++ b/pkg/routeagent_driver/handlers/healthchecker/healthchecker.go
@@ -137,7 +137,7 @@ func (h *controller) Init(_ context.Context) error {
 }
 
 // TransitionToNonGateway is called once for each transition of the local node from Gateway to a non-Gateway.
-func (h *controller) TransitionToNonGateway() error {
+func (h *controller) TransitionToNonGateway(_ *submarinerv1.Endpoint) error {
 	if h.config.HealthCheckerEnabled {
 		remoteEndpoints := h.State().GetRemoteEndpoints()
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -20,11 +20,12 @@ package kubeproxy
 
 import (
 	"github.com/submariner-io/admiral/pkg/log"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
 )
 
-func (kp *SyncHandler) TransitionToNonGateway() error {
+func (kp *SyncHandler) TransitionToNonGateway(_ *submarinerv1.Endpoint) error {
 	logger.V(log.DEBUG).Info("The current node is no longer a Gateway")
 
 	kp.cleanVxSubmarinerRoutes()

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -260,7 +260,7 @@ func (ovn *Handler) RemoteEndpointRemoved(endpoint *submV1.Endpoint) error {
 	return goerrors.Join(errs...)
 }
 
-func (ovn *Handler) TransitionToNonGateway() error {
+func (ovn *Handler) TransitionToNonGateway(_ *submV1.Endpoint) error {
 	return goerrors.Join(
 		errors.Wrap(ovn.processEndpointSubnets(false, ovn.State().GetRemoteEndpoints()...),
 			"error processing Endpoints on non-gateway transition"),


### PR DESCRIPTION
Update `TransitionToNonGateway` signature to accept the local endpoint being removed, providing handlers access to endpoint metadata during gateway-to-non-gateway transitions.
    
The motivation for this is to simplify the `vxlanCleanup` handler which needs access to the previous local `Endpoint` that triggered the change. Previously, it cached the endpoint on `LocalEndpointRemoved`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the cable driver VXLAN cleanup handler to validate endpoint-deletion behavior and network interface cleanup.

* **Refactor**
  * Gateway transition handlers now receive endpoint context, improving propagation of endpoint information across networking components and enhancing cleanup accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->