### PR TITLE
Remove redundant assertions after AwaitActiveGatewayPod

### DIFF
--- a/test/e2e/compliance/fips.go
+++ b/test/e2e/compliance/fips.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	subFramework "github.com/submariner-io/submariner/test/e2e/framework"
 	"github.com/submariner-io/submariner/test/e2e/labels"
@@ -60,7 +59,6 @@ func testFIPSGatewayStatus(ctx context.Context, f *subFramework.Framework) {
 	framework.By(fmt.Sprintf("Locate active gateway pod on cluster %q", fipsClusterName))
 
 	gwPod := f.AwaitActiveGatewayPod(ctx, fipsCluster, nil)
-	Expect(gwPod).ToNot(BeNil(), "Did not find an active gateway pod")
 
 	f.TestGatewayNodeFIPSMode(ctx, fipsCluster, gwPod.Name)
 }

--- a/test/e2e/dataplane/gateway_status.go
+++ b/test/e2e/dataplane/gateway_status.go
@@ -54,7 +54,6 @@ var _ = Describe("Gateway status reporting", Label(labels.Dataplane), func() {
 			otherCluster := framework.TestContext.ClusterIDs[otherClusterIndex]
 
 			gatewayPod := f.AwaitActiveGatewayPod(ctx, otherClusterIndex, nil)
-			Expect(gatewayPod).ToNot(BeNil(), "Did not find an active gateway pod for cluster %q", otherCluster)
 
 			healthCheckEnabled := false
 

--- a/test/e2e/redundancy/gateway_failover.go
+++ b/test/e2e/redundancy/gateway_failover.go
@@ -197,7 +197,6 @@ func testGatewayFailOverScenario(ctx context.Context, f *subFramework.Framework,
 	framework.By(fmt.Sprintf("Found two gateway nodes on %q", clusterAName))
 
 	initialGWPod := f.AwaitActiveGatewayPod(ctx, framework.ClusterIndex(primaryCluster), nil)
-	Expect(initialGWPod).ToNot(BeNil(), "Did not find an active gateway pod")
 
 	framework.By(fmt.Sprintf("Ensure active gateway node %q has established connections", initialGWPod.Name))
 
@@ -213,9 +212,8 @@ func testGatewayFailOverScenario(ctx context.Context, f *subFramework.Framework,
 
 	newGWPod := f.AwaitActiveGatewayPod(ctx, framework.ClusterIndex(primaryCluster), func(pod *v1.Pod) bool {
 		return pod.Spec.NodeName != initialGWPod.Spec.NodeName
-	})
+	}, "Did not find a new active gateway pod running on a different node")
 
-	Expect(newGWPod).ToNot(BeNil(), "Did not find a new active gateway pod running on a different node")
 	framework.By(fmt.Sprintf("Found new submariner gateway pod %q", newGWPod.Name))
 
 	// Verify a new Endpoint instance is created by the new gateway instance. This is a bit whitebox but it's a sanity check

--- a/test/e2e/redundancy/leader_election.go
+++ b/test/e2e/redundancy/leader_election.go
@@ -66,7 +66,6 @@ func testLeaderElectionFailover(ctx context.Context, f *subFramework.Framework, 
 	clusterName := framework.TestContext.ClusterIDs[cluster]
 
 	gatewayPod := f.AwaitActiveGatewayPod(ctx, cluster, nil)
-	Expect(gatewayPod).ToNot(BeNil(), "Did not find an active gateway pod")
 
 	restartCount := gatewayPod.Status.ContainerStatuses[0].RestartCount
 


### PR DESCRIPTION
The `AwaitActiveGatewayPod` function now handles nil pod assertions internally, making external assertions redundant.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test assertions by removing redundant nil-checks, allowing downstream operations to handle validation failures more naturally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->