### PR TITLE
Fix submarinerManagedLabel cleanup in restore for Calico handler

### DIFF
--- a/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
+++ b/pkg/routeagent_driver/handlers/calico/calico_suite_test.go
@@ -63,7 +63,7 @@ func newTestDriver() *testDriver {
 				CalicoNetwork: &tigerav1.CalicoNetworkSpec{
 					IPPools: []tigerav1.IPPool{
 						{
-							Encapsulation: tigerav1.EncapsulationIPIPCrossSubnet,
+							Encapsulation: tigerav1.EncapsulationNone,
 						},
 					},
 				},
@@ -93,16 +93,6 @@ func TestCalico(t *testing.T) {
 }
 
 func (t *testDriver) Start(ctx context.Context, handler event.Handler) {
-	_, err := t.calicoClient.ProjectcalicoV3().IPPools().Create(ctx, &calicoapi.IPPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: calico.DefaultV4IPPoolName,
-		},
-		Spec: calicoapi.IPPoolSpec{
-			IPIPMode: calicoapi.IPIPModeNever,
-		},
-	}, metav1.CreateOptions{})
-	Expect(err).To(Succeed())
-
 	t.handler = handler
 	t.ControllerSupport.Start(ctx, handler)
 }
@@ -145,17 +135,14 @@ func (t *testDriver) awaitNoIPPools(subnets ...string) {
 	}).ShouldNot(ContainElements(toAny(subnets)...))
 }
 
-func (t *testDriver) getDefaultIPPoolIPIPMode() string {
-	p, err := t.calicoClient.ProjectcalicoV3().IPPools().Get(context.Background(), calico.DefaultV4IPPoolName, metav1.GetOptions{})
-	Expect(err).To(Succeed())
-
-	return string(p.Spec.IPIPMode)
+func (t *testDriver) getDefaultInstallation(ctx context.Context) *tigerav1.Installation {
+	return test.GetResource(ctx, t.dynClient.Resource(calico.InstallationsGVR), &tigerav1.Installation{ObjectMeta: metav1.ObjectMeta{
+		Name: calico.DefaultInstallationName,
+	}})
 }
 
 func (t *testDriver) getDefaultInstallationEncapsulation(ctx context.Context) string {
-	installation := test.GetResource(ctx, t.dynClient.Resource(calico.InstallationsGVR), &tigerav1.Installation{ObjectMeta: metav1.ObjectMeta{
-		Name: calico.DefaultInstallationName,
-	}})
+	installation := t.getDefaultInstallation(ctx)
 	Expect(installation.Spec.CalicoNetwork).NotTo(BeNil())
 	Expect(installation.Spec.CalicoNetwork.IPPools).NotTo(BeEmpty())
 

--- a/pkg/routeagent_driver/handlers/calico/ippool_handler.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler.go
@@ -53,9 +53,8 @@ const (
 	SubmarinerIPPool            = "submariner.io/ippool"
 	GwLBSvcName                 = "submariner-gateway"
 	GwLBSvcROKSAnnotation       = "service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type"
-	DefaultV4IPPoolName         = "default-ipv4-ippool"
-	submarinerManagedLabel      = "submariner-managed"
-	submarinerPrevEncapsulation = "submariner-prev-encapsulation"
+	SubmarinerManagedLabel      = "submariner-managed"
+	SubmarinerPrevEncapsulation = "submariner-prev-encapsulation"
 	DefaultInstallationName     = "default"
 )
 
@@ -286,8 +285,8 @@ func (h *calicoIPPoolHandler) updateROKSCalicoCfg(ctx context.Context) error {
 				installation.Annotations = map[string]string{}
 			}
 
-			installation.Annotations[submarinerPrevEncapsulation] = ipPools[0].Encapsulation.String()
-			installation.Annotations[submarinerManagedLabel] = "true"
+			installation.Annotations[SubmarinerPrevEncapsulation] = ipPools[0].Encapsulation.String()
+			installation.Annotations[SubmarinerManagedLabel] = "true"
 
 			ipPools[0].Encapsulation = tigerav1.EncapsulationIPIP
 
@@ -308,7 +307,7 @@ func (h *calicoIPPoolHandler) restoreROKSCalicoCfg(ctx context.Context) error {
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, installation)
 			utilruntime.Must(err)
 
-			prevEncapsulation := installation.Annotations[submarinerPrevEncapsulation]
+			prevEncapsulation := installation.Annotations[SubmarinerPrevEncapsulation]
 			if prevEncapsulation == "" {
 				return existing, nil // no need to update
 			}
@@ -318,8 +317,8 @@ func (h *calicoIPPoolHandler) restoreROKSCalicoCfg(ctx context.Context) error {
 				ipPools[0].Encapsulation = tigerav1.EncapsulationType(prevEncapsulation)
 			}
 
-			delete(installation.Labels, submarinerManagedLabel)
-			delete(installation.Annotations, submarinerPrevEncapsulation)
+			delete(installation.Annotations, SubmarinerManagedLabel)
+			delete(installation.Annotations, SubmarinerPrevEncapsulation)
 
 			return resource.MustToUnstructured(installation), nil
 		})

--- a/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
+++ b/pkg/routeagent_driver/handlers/calico/ippool_handler_test.go
@@ -65,18 +65,18 @@ var _ = Describe("IPPool Handler", func() {
 
 	When("the platform is not ROKS", func() {
 		Context("because the Submariner GW load balancer is not deployed", func() {
-			It("should not update the default IPPool's IPIPMode", func() {
-				Expect(t.getDefaultIPPoolIPIPMode()).Should(Equal(string(calicoapi.IPIPModeNever)))
+			It("should not update the default Installation's Encapsulation", func(ctx context.Context) {
+				Expect(t.getDefaultInstallationEncapsulation(ctx)).Should(Equal(tigerav1.EncapsulationNone.String()))
 			})
 		})
 
 		Context("because the Submariner GW load balancer does not have the ROKS annotation", func() {
 			BeforeEach(func(ctx context.Context) {
-				t.createSubmarinerGwLBService(ctx, map[string]string{calico.GwLBSvcROKSAnnotation: "foo"})
+				t.createSubmarinerGwLBService(ctx, map[string]string{})
 			})
 
-			It("should not update the default IPPool's IPIPMode", func() {
-				Expect(t.getDefaultIPPoolIPIPMode()).Should(Equal(string(calicoapi.IPIPModeNever)))
+			It("should not update the default Installation's Encapsulation", func(ctx context.Context) {
+				Expect(t.getDefaultInstallationEncapsulation(ctx)).Should(Equal(tigerav1.EncapsulationNone.String()))
 			})
 		})
 	})
@@ -89,12 +89,15 @@ var _ = Describe("IPPool Handler", func() {
 		It("should update the default Installation's Encapsulation to IPIP", func(ctx context.Context) {
 			Expect(t.getDefaultInstallationEncapsulation(ctx)).Should(Equal(tigerav1.EncapsulationIPIP.String()))
 		})
+
+		It("should set the Submariner annotations on the default Installation", func(ctx context.Context) {
+			Expect(t.getDefaultInstallation(ctx).Annotations).To(
+				And(HaveKey(calico.SubmarinerManagedLabel), HaveKey(calico.SubmarinerPrevEncapsulation)))
+		})
 	})
 
 	Context("on Uninstall", func() {
 		BeforeEach(func(ctx context.Context) {
-			t.createSubmarinerGwLBService(ctx, map[string]string{})
-
 			_, err := t.calicoClient.ProjectcalicoV3().IPPools().Create(ctx, &calicoapi.IPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "pool1",
@@ -124,8 +127,19 @@ var _ = Describe("IPPool Handler", func() {
 			Expect(list.Items).To(BeEmpty())
 		})
 
-		It("should reset the default Installation's Encapsulation", func(ctx context.Context) {
-			Expect(t.getDefaultInstallationEncapsulation(ctx)).Should(Equal(tigerav1.EncapsulationIPIPCrossSubnet.String()))
+		Context("and the platform is ROKS", func() {
+			BeforeEach(func(ctx context.Context) {
+				t.createSubmarinerGwLBService(ctx, map[string]string{calico.GwLBSvcROKSAnnotation: "foo"})
+			})
+
+			It("should reset the default Installation's Encapsulation", func(ctx context.Context) {
+				Expect(t.getDefaultInstallationEncapsulation(ctx)).Should(Equal(tigerav1.EncapsulationNone.String()))
+			})
+
+			It("should remove the Submariner annotations on the default Installation", func(ctx context.Context) {
+				Expect(t.getDefaultInstallation(ctx).Annotations).NotTo(
+					Or(HaveKey(calico.SubmarinerManagedLabel), HaveKey(calico.SubmarinerPrevEncapsulation)))
+			})
 		})
 	})
 })


### PR DESCRIPTION
The `submarinerManagedLabel` was written to `installation.Annotations` but restore removed it from `installation.Labels`, leaving the annotation behind. Now correctly delete from `Annotations`.

Added test coverage for verifying annotations are properly set and removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched encapsulation checks to use the Tigera operator Installation API, ensuring default encapsulation is treated as "None" and improving reliability during install/uninstall flows.
  * ROKS restore/uninstall now correctly updates and removes Submariner-related annotations from the cluster installation to avoid stale config.

* **Refactor**
  * Annotation identifiers made public for clearer integration across components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner/pull/3973)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->