### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -78,6 +78,5 @@ LABEL com.redhat.component="submariner-gateway-container" \
       io.openshift.tags="submariner, submariner-gateway, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.13::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -65,6 +65,5 @@ LABEL com.redhat.component="submariner-globalnet-container" \
       io.openshift.tags="submariner, submariner-globalnet, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.13::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -75,6 +75,5 @@ LABEL com.redhat.component="submariner-route-agent-container" \
       io.openshift.tags="submariner, submariner-route-agent, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.13::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Git commit metadata label from container images for Submariner Gateway, Globalnet, and Route Agent components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->