### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -82,6 +82,5 @@ LABEL com.redhat.component="submariner-gateway-container" \
       url="https://github.com/submariner-io/submariner" \
       vendor="Red Hat, Inc." \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.15::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -69,6 +69,5 @@ LABEL com.redhat.component="submariner-globalnet-container" \
       url="https://github.com/submariner-io/submariner" \
       vendor="Red Hat, Inc." \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.15::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -79,6 +79,5 @@ LABEL com.redhat.component="submariner-route-agent-container" \
       url="https://github.com/submariner-io/submariner" \
       vendor="Red Hat, Inc." \
       com.github.url="https://github.com/submariner-io/submariner" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.15::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container image metadata configuration by removing a redundant label from Submariner gateway, globalnet, and route agent container images. This cleanup improves consistency across image specifications without impacting runtime behavior or user-facing functionality, supporting better maintainability and standardization of containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->