### PR TITLE
Ignore x/crypto CVEs in release-0.20

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,13 @@ ignore:
   - vulnerability: CVE-2021-22570
     package:
       name: google.golang.org/protobuf
+
+  # Update requires Go 1.24.0, incompatible with release-0.20's Go 1.23.0. Medium severity doesn't justify breaking changes.
+  - vulnerability: GHSA-j5w8-q4qc-rx2x
+    package:
+      name: golang.org/x/crypto
+
+  # Update requires Go 1.24.0, incompatible with release-0.20's Go 1.23.0. Medium severity doesn't justify breaking changes.
+  - vulnerability: GHSA-f6x5-jh6r-wrfv
+    package:
+      name: golang.org/x/crypto


### PR DESCRIPTION
Requires Go 1.23→1.24 minor upgrade, medium severity doesn't justify breaking stable branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to ignore two specific advisories affecting the golang.org/x/crypto package. Notes clarify the available fixes require Go 1.24 and are not compatible with release-0.20 (Go 1.23). This alignment reduces noisy alerts for releases that do not support the newer Go version while preserving attention to advisories that can be addressed in supported future releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner/pull/4035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->