### PR TITLE
Update version labels to v0.21.3

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -70,7 +70,7 @@ ENTRYPOINT ["/usr/local/bin/submariner.sh"]
 
 LABEL com.redhat.component="submariner-gateway-container" \
       name="rhacm2/submariner-gateway-rhel9" \
-      version="v0.21.2" \
+      version="v0.21.3" \
       summary="Submariner Gateway" \
       description="The Submariner Gateway facilitates secure connections between clusters." \
       io.k8s.display-name="Submariner Gateway" \

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -57,7 +57,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-globalnet.sh"]
 
 LABEL com.redhat.component="submariner-globalnet-container" \
       name="rhacm2/submariner-globalnet-rhel9" \
-      version="v0.21.2" \
+      version="v0.21.3" \
       summary="Submariner Globalnet" \
       description="The Submariner Globalnet component provides connectivity for overlapping CIDRs in different clusters." \
       io.k8s.display-name="Submariner Globalnet" \

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -67,7 +67,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-route-agent.sh"]
 
 LABEL com.redhat.component="submariner-route-agent-container" \
       name="rhacm2/submariner-route-agent-rhel9" \
-      version="v0.21.2" \
+      version="v0.21.3" \
       summary="Submariner Route Agent" \
       description="The Submariner Route Agent programs network routes on each node to facilitate cross-cluster communication." \
       io.k8s.display-name="Submariner Route Agent" \


### PR DESCRIPTION
Update Dockerfile version labels from v0.21.2 to v0.21.3 for correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions to v0.21.3 for Submariner gateway, globalnet, and route-agent components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner/pull/4043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->