### PR TITLE
Remove periodic job that updates submariner dependencies

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -8,41 +8,6 @@ on:
 permissions: {}
 
 jobs:
-  internal-integration:
-    name: Internal Integration
-    if: github.repository_owner == 'submariner-io'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Update internal submariner-io/* dependencies to latest
-        run: |
-          for dep in $(awk '!/module/ && /github.com.submariner-io/ { print $1 }' go.mod)
-            do go get ${dep}@devel
-          done
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-        with:
-          title: Update submariner-io/* dependencies to latest
-          body: |
-            This checks the current status of this repository against the latest version of all the Submariner projects it depends on.
-            If something fails, the failure should be investigated and at least tracked as an issue blocking the next release.
-            Since some CI only runs periodically, if on-PR CI passes it's still good to merge this update for full integration coverage.
-          commit-message: |
-            Update submariner-io/* dependencies to latest
-
-            This upgrades all our dependencies on other Submariner projects to their
-            latest development snapshots, ensuring the code in the projects remains
-            coherent and that tests of development images verify the latest code.
-          signoff: true
-          author: GitHub <noreply@github.com>
-          labels: automated, dependencies
-
   markdown-link-check-periodic:
     name: Markdown Links (all files)
     if: github.repository_owner == 'submariner-io'


### PR DESCRIPTION
The job runs every week and creates or updates a PR with summary "_Update submariner-io/* dependencies to latest_". This PR may have had benefit in the past but is pretty much ignored now and is noise. Plus we don't have such a job in any other submariner repo so it's inconsistent in that manner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic dependency update checks from the periodic workflow. The scheduled workflow now exclusively runs periodic markdown link validation to detect broken links across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->