### PR TITLE
Switch to depends-on/depends-on-action for PR dependencies

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,27 +2,15 @@
 name: PR Dependencies
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
   pull_request_target:
     types:
       - opened
       - edited
-      - closed
       - reopened
       - synchronize
-  schedule:
-    - cron: '0 0/6 * * *'  # every 6 hours
 
 permissions:
-  issues: write
   pull-requests: write
-  statuses: write
 
 jobs:
   check:
@@ -30,15 +18,7 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@950226e7ca8fc43dc209a7febf67c655af3bdb43
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: depends-on/depends-on-action@0.16.0
         with:
-          # The label to use to mark dependent issues
-          label: dependent
-
-          # Enable checking for dependencies in issues.
-          check_issues: on
-
-          # A comma-separated list of keywords to mark dependency.
-          keywords: depends on, Depends on
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-unmerged-pr: true

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
-      - uses: depends-on/depends-on-action@0.16.0
+      - uses: depends-on/depends-on-action@e7915c70317af4efc4e6c4a4eb1e9260e215270c  # v0.16.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           check-unmerged-pr: true


### PR DESCRIPTION
Replace unmaintained dependent-issues with depends-on-action

The old action (z0al/dependent-issues) is archived and will stop working when GitHub removes Node.js 20 support on September 16, 2026.

The new action (depends-on/depends-on-action) is actively maintained - it currently uses Node.js 20 but there's an open PR to upgrade..

Differences with dependent-issues:
- Syntax change: Use "Depends-On: #123" instead of "depends on #123"
- Issues no longer supported (PRs only)
- Removed schedule trigger (not applicable with new action)

Fixes: #2836

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal pull-request dependency workflow: now runs only on pull request events, uses reduced permissions, and streamlines dependency checks.
  * Improved detection of dependent and unmerged pull requests to provide more accurate dependency status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->