### PR TITLE
Disable pprof endpoints by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,15 @@ func main() {
 	logger.Infof("Proxy env variables: HTTP_PROXY: %v, HTTPS_PROXY: %v, NO_PROXY: %v",
 		proxyEnv.HTTPProxy, proxyEnv.HTTPSProxy, proxyEnv.NoProxy)
 
-	defer http.StartServer(http.Metrics|http.Profile, submSpec.MetricsPort)()
+	endpoints := http.Metrics // Always enable metrics for Prometheus
+
+	if submSpec.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", submSpec.MetricsPort)
+
+		endpoints |= http.Profile
+	}
+
+	defer http.StartServer(endpoints, submSpec.MetricsPort)()
 
 	var err error
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -88,7 +88,8 @@ type Specification struct {
 	ClusterID   string
 	Namespace   string
 	GlobalCIDR  []string
-	MetricsPort int `default:"32781"`
+	MetricsPort int  `default:"32781"`
+	Debug       bool `default:"false"`
 	Uninstall   bool
 }
 

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -119,7 +119,15 @@ func main() {
 
 	logger.Info("Starting submariner-globalnet", spec)
 
-	defer http.StartServer(http.Metrics|http.Profile, spec.MetricsPort)()
+	endpoints := http.Metrics // Always enable metrics
+
+	if spec.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", spec.MetricsPort)
+
+		endpoints |= http.Profile
+	}
+
+	defer http.StartServer(endpoints, spec.MetricsPort)()
 
 	err = mcsv1b1.Install(scheme.Scheme)
 	logger.FatalOnError(err, "Error adding Multicluster v1beta1 to the scheme")

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -24,7 +24,8 @@ type Specification struct {
 	ClusterCidr          []string
 	ServiceCidr          []string
 	GlobalCidr           []string
-	ProfilePort          int `default:"32782"`
+	ProfilePort          int  `default:"32782"`
+	Debug                bool `default:"false"`
 	Uninstall            bool
 	IntraRoutingDisabled bool
 }

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -200,7 +200,12 @@ func main() {
 		return
 	}
 
-	defer http.StartServer(http.Profile, env.ProfilePort)()
+	if env.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", env.ProfilePort)
+		defer http.StartServer(http.Profile, env.ProfilePort)()
+	} else {
+		logger.Infof("Profiling endpoints disabled (production mode)")
+	}
 
 	ctl, err := controller.New(&controller.Config{
 		Registry:   registry,


### PR DESCRIPTION
The pprof debugging endpoints were unconditionally exposed on all Submariner components running with hostNetwork: true, making them accessible on all host network interfaces without authentication.

Make pprof endpoints conditional on SUBMARINER_DEBUG environment variable (disabled by default) for all components.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug configuration toggle to control whether profiling endpoints are exposed, enabled only in debug mode (disabled by default).
  * When debug mode is enabled, profiling endpoints start and a warning is logged including the relevant metrics port.
  * Metrics endpoints remain enabled at all times for monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->