### PR TITLE
Update version labels to v0.20.3

### DIFF
--- a/package/Dockerfile.submariner-gateway.konflux
+++ b/package/Dockerfile.submariner-gateway.konflux
@@ -70,7 +70,7 @@ ENTRYPOINT ["/usr/local/bin/submariner.sh"]
 
 LABEL com.redhat.component="submariner-gateway-container" \
       name="rhacm2/submariner-gateway-rhel9" \
-      version="v0.20.2" \
+      version="v0.20.3" \
       summary="Submariner Gateway" \
       description="The Submariner Gateway facilitates secure connections between clusters." \
       io.k8s.display-name="Submariner Gateway" \

--- a/package/Dockerfile.submariner-globalnet.konflux
+++ b/package/Dockerfile.submariner-globalnet.konflux
@@ -57,7 +57,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-globalnet.sh"]
 
 LABEL com.redhat.component="submariner-globalnet-container" \
       name="rhacm2/submariner-globalnet-rhel9" \
-      version="v0.20.2" \
+      version="v0.20.3" \
       summary="Submariner Globalnet" \
       description="The Submariner Globalnet component provides connectivity for overlapping CIDRs in different clusters." \
       io.k8s.display-name="Submariner Globalnet" \

--- a/package/Dockerfile.submariner-route-agent.konflux
+++ b/package/Dockerfile.submariner-route-agent.konflux
@@ -67,7 +67,7 @@ ENTRYPOINT ["/usr/local/bin/submariner-route-agent.sh"]
 
 LABEL com.redhat.component="submariner-route-agent-container" \
       name="rhacm2/submariner-route-agent-rhel9" \
-      version="v0.20.2" \
+      version="v0.20.3" \
       summary="Submariner Route Agent" \
       description="The Submariner Route Agent programs network routes on each node to facilitate cross-cluster communication." \
       io.k8s.display-name="Submariner Route Agent" \


### PR DESCRIPTION
Enables correct Konflux image tagging via {{ labels.version }}.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version metadata to `v0.20.3` for the gateway, globalnet, and route agent images.
  * No runtime behavior, build steps, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->