### PR TITLE
Automated backport of #4073: Security: Disable pprof endpoints by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,15 @@ func main() {
 	logger.Infof("Proxy env variables: HTTP_PROXY: %v, HTTPS_PROXY: %v, NO_PROXY: %v",
 		proxyEnv.HTTPProxy, proxyEnv.HTTPSProxy, proxyEnv.NoProxy)
 
-	defer http.StartServer(http.Metrics|http.Profile, submSpec.MetricsPort)()
+	endpoints := http.Metrics // Always enable metrics for Prometheus
+
+	if submSpec.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", submSpec.MetricsPort)
+
+		endpoints |= http.Profile
+	}
+
+	defer http.StartServer(endpoints, submSpec.MetricsPort)()
 
 	var err error
 

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -88,7 +88,8 @@ type Specification struct {
 	ClusterID   string
 	Namespace   string
 	GlobalCIDR  []string
-	MetricsPort int `default:"32781"`
+	MetricsPort int  `default:"32781"`
+	Debug       bool `default:"false"`
 	Uninstall   bool
 }
 

--- a/pkg/globalnet/main.go
+++ b/pkg/globalnet/main.go
@@ -119,7 +119,15 @@ func main() {
 
 	logger.Info("Starting submariner-globalnet", spec)
 
-	defer http.StartServer(http.Metrics|http.Profile, spec.MetricsPort)()
+	endpoints := http.Metrics // Always enable metrics
+
+	if spec.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", spec.MetricsPort)
+
+		endpoints |= http.Profile
+	}
+
+	defer http.StartServer(endpoints, spec.MetricsPort)()
 
 	err = mcsv1a1.Install(scheme.Scheme)
 	logger.FatalOnError(err, "Error adding Multicluster v1alpha1 to the scheme")

--- a/pkg/routeagent_driver/environment/env.go
+++ b/pkg/routeagent_driver/environment/env.go
@@ -24,7 +24,8 @@ type Specification struct {
 	ClusterCidr          []string
 	ServiceCidr          []string
 	GlobalCidr           []string
-	ProfilePort          int `default:"32782"`
+	ProfilePort          int  `default:"32782"`
+	Debug                bool `default:"false"`
 	Uninstall            bool
 	IntraRoutingDisabled bool
 }

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -199,7 +199,12 @@ func main() {
 		return
 	}
 
-	defer http.StartServer(http.Profile, env.ProfilePort)()
+	if env.Debug {
+		logger.Warningf("SECURITY WARNING: Profiling endpoints enabled (debug mode). Port: %d", env.ProfilePort)
+		defer http.StartServer(http.Profile, env.ProfilePort)()
+	} else {
+		logger.Infof("Profiling endpoints disabled (production mode)")
+	}
 
 	ctl, err := controller.New(&controller.Config{
 		Registry:   registry,


### PR DESCRIPTION
Backport of #4073 on release-0.23.

#4073: Security: Disable pprof endpoints by default

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a debug mode setting for network components.
  * Metrics endpoints remain enabled by default, while profiling endpoints can now be turned on only in debug mode.

* **Security**
  * Profiling access is no longer exposed by default.
  * When debug mode is enabled, a warning is logged with the relevant port information.

* **Bug Fixes**
  * Updated server startup behavior so profiling is disabled in production-style runs unless explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->