### PR TITLE
Remove unused Token field from SubmarinerSpecification

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,7 +42,6 @@ type SubmarinerSpecification struct {
 	ClusterID                     string
 	Namespace                     string
 	PublicIP                      string
-	Token                         string
 	Debug                         bool
 	NATEnabled                    bool
 	HealthCheckEnabled            bool `default:"true"`


### PR DESCRIPTION
The Token field was previously used by the phpapi broker backend, which was removed in commit 4398494c (June 2020). Since then, the field has been populated from environment variables but never read or used anywhere in the codebase.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed token information from a public specification, reducing exposure of sensitive data while keeping the remaining settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->