### PR TITLE
Add input validation for Libreswan endpoint configuration

### DIFF
--- a/pkg/cable/libreswan/certificate_auth_mode.go
+++ b/pkg/cable/libreswan/certificate_auth_mode.go
@@ -32,6 +32,12 @@ func (i *libreswan) connectToEndpointCertMode(endpointInfo *natdiscovery.NATEndp
 	endpoint := &endpointInfo.Endpoint
 	leftID := ClientCertName
 	left := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
+
+	// Validate endpoint inputs to prevent config injection
+	if err := validateEndpointInputs(&endpoint.Spec, left, endpointInfo.UseIP); err != nil {
+		return "", err
+	}
+
 	right := endpointInfo.UseIP
 
 	leftSubnets := i.localEndpoint.ExtractSubnetsExcludingIP(endpointInfo.UseIP)

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -83,7 +84,50 @@ var (
 	FatalError            = func(err error, msg string) {
 		logger.FatalOnError(err, msg)
 	}
+
+	// cableNamePattern matches safe characters for connection names (alphanumeric, dash, underscore, dot).
+	cableNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 )
+
+// validateCableName ensures the cable name doesn't contain injection characters.
+func validateCableName(cableName string) error {
+	if cableName == "" {
+		return errors.New("cable name is empty")
+	}
+
+	if !cableNamePattern.MatchString(cableName) {
+		return fmt.Errorf("cable name %q contains invalid characters", cableName)
+	}
+
+	return nil
+}
+
+// validateEndpointInputs validates endpoint configuration to prevent injection attacks.
+func validateEndpointInputs(endpoint *subv1.EndpointSpec, localIP, remoteIP string) error {
+	// Validate cable name
+	if err := validateCableName(endpoint.CableName); err != nil {
+		return err
+	}
+
+	// Validate all subnets
+	for _, subnet := range endpoint.Subnets {
+		if _, _, err := net.ParseCIDR(subnet); err != nil {
+			return errors.Wrapf(err, "invalid CIDR %q", subnet)
+		}
+	}
+
+	// Validate remote IP address
+	if net.ParseIP(remoteIP) == nil {
+		return fmt.Errorf("invalid IP address %q", remoteIP)
+	}
+
+	// Validate local IP address
+	if net.ParseIP(localIP) == nil {
+		return fmt.Errorf("invalid IP address %q", localIP)
+	}
+
+	return nil
+}
 
 func init() {
 	cable.AddDriver(cableDriverName, NewLibreswan)
@@ -437,6 +481,12 @@ func (i *libreswan) connectToEndpointPSKMode(endpointInfo *natdiscovery.NATEndpo
 
 	// We'll panic if endpointInfo is nil, this is intentional
 	endpoint := &endpointInfo.Endpoint
+
+	// Validate endpoint inputs to prevent config injection
+	localIP := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
+	if err := validateEndpointInputs(&endpoint.Spec, localIP, endpointInfo.UseIP); err != nil {
+		return "", err
+	}
 
 	rightNATTPort, err := endpoint.Spec.GetBackendPort(subv1.UDPPortConfig, i.defaultNATTPort)
 	if err != nil {


### PR DESCRIPTION
Add validation for cable_name and subnet fields to ensure they contain only safe 
characters before using them in IPsec configuration. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for endpoint names, subnets, and IP addresses before connection setup.
  * Invalid inputs now fail fast with clear errors, helping prevent malformed connection configurations.
  * Improved safeguards to reduce the risk of malformed or injected VPN configuration during connection creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->