### PR TITLE
Fix VXLAN loopback drops from shared MAC

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -52,17 +52,22 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 		return errors.Wrapf(err, "failed to derive the vxlan vtepIP for %s", ipAddr)
 	}
 
+	hwAddr := vxlan.HardwareAddrFromIP(ipAddr)
+
 	if ifaceType == VxInterfaceGateway {
 		attrs := &vxlan.Attributes{
-			Name:     kp.vxlanIface,
-			VxlanID:  100,
-			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU(),
+			Name:         kp.vxlanIface,
+			VxlanID:      100,
+			VtepPort:     port.IntraClusterVxLAN,
+			Mtu:          kp.defaultHostIface.MTU(),
+			SrcAddr:      ipAddr,
+			HardwareAddr: hwAddr,
 		}
 
-		// For IPv6 VxLAN interface SrcAddr should be set with local IP
-		if kp.ipFamily == k8snet.IPv6 {
+		// For IPv6, prefer the gateway VTEP/local endpoint IP when available.
+		if kp.ipFamily == k8snet.IPv6 && kp.vxlanGwIP != nil {
 			attrs.SrcAddr = *kp.vxlanGwIP
+			attrs.HardwareAddr = vxlan.HardwareAddrFromIP(attrs.SrcAddr)
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)
@@ -86,11 +91,13 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 	} else if ifaceType == VxInterfaceWorker {
 		// non-Gateway/Worker Node
 		attrs := &vxlan.Attributes{
-			Name:     kp.vxlanIface,
-			VxlanID:  100,
-			Group:    gatewayNodeIP,
-			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU(),
+			Name:         kp.vxlanIface,
+			VxlanID:      100,
+			Group:        gatewayNodeIP,
+			VtepPort:     port.IntraClusterVxLAN,
+			Mtu:          kp.defaultHostIface.MTU(),
+			SrcAddr:      ipAddr,
+			HardwareAddr: hwAddr,
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)

--- a/pkg/vxlan/vxlan.go
+++ b/pkg/vxlan/vxlan.go
@@ -19,6 +19,8 @@ limitations under the License.
 package vxlan
 
 import (
+	"bytes"
+	"hash/fnv"
 	"io/fs"
 	"net"
 	"syscall"
@@ -33,12 +35,13 @@ import (
 )
 
 type Attributes struct {
-	Name     string
-	VxlanID  int
-	Group    net.IP
-	SrcAddr  net.IP
-	VtepPort int
-	Mtu      int
+	Name         string
+	VxlanID      int
+	Group        net.IP
+	SrcAddr      net.IP
+	VtepPort     int
+	Mtu          int
+	HardwareAddr net.HardwareAddr
 }
 
 type Interface struct {
@@ -62,12 +65,35 @@ func NewInterface(attrs *Attributes, netLink netlinkAPI.Interface) (*Interface, 
 	}, nil
 }
 
+// HardwareAddrFromIP returns a locally-administered unicast MAC derived from the
+// given IP. This avoids Linux VXLAN loopback drops when gateway and worker
+// vx-submariner interfaces would otherwise share the same kernel-assigned MAC
+// (see https://github.com/submariner-io/submariner/issues/4024).
+func HardwareAddrFromIP(ip net.IP) net.HardwareAddr {
+	if ip4 := ip.To4(); ip4 != nil {
+		return net.HardwareAddr{0x02, 0x00, ip4[0], ip4[1], ip4[2], ip4[3]}
+	}
+
+	if ip6 := ip.To16(); ip6 != nil {
+		h := fnv.New64a()
+		_, _ = h.Write(ip6)
+		sum := h.Sum64()
+
+		// Truncation to bytes is intentional for a 40-bit MAC payload.
+		//nolint:gosec // G115: truncate hash to MAC bytes
+		return net.HardwareAddr{0x02, byte(sum >> 32), byte(sum >> 24), byte(sum >> 16), byte(sum >> 8), byte(sum)}
+	}
+
+	return nil
+}
+
 func createLinkDevice(attrs *Attributes, netLink netlinkAPI.Interface) (*netlink.Vxlan, error) {
 	link := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:  attrs.Name,
-			MTU:   attrs.Mtu - MTUOverhead,
-			Flags: net.FlagUp,
+			Name:         attrs.Name,
+			MTU:          attrs.Mtu - MTUOverhead,
+			Flags:        net.FlagUp,
+			HardwareAddr: attrs.HardwareAddr,
 		},
 		VxlanId: attrs.VxlanID,
 		SrcAddr: attrs.SrcAddr,
@@ -129,6 +155,13 @@ func isVxlanConfigTheSame(newLink, currentLink netlink.Link) bool {
 
 	if required.Port != existing.Port {
 		logger.Warningf("Vxlan Port (%d) of existing interface does not match with required Port (%d)", existing.Port, required.Port)
+		return false
+	}
+
+	if len(required.HardwareAddr) > 0 && !bytes.Equal(required.HardwareAddr, existing.HardwareAddr) {
+		logger.Warningf("Vxlan HardwareAddr (%v) of existing interface does not match with required HardwareAddr (%v)",
+			existing.HardwareAddr, required.HardwareAddr)
+
 		return false
 	}
 

--- a/pkg/vxlan/vxlan_test.go
+++ b/pkg/vxlan/vxlan_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package vxlan_test
 
 import (
+	"crypto/rand"
 	"net"
 	"testing"
 
@@ -93,8 +94,97 @@ var _ = Describe("NewInterface", func() {
 				t.assertLink(&newAttrs)
 			})
 		})
+
+		Context("and the HardwareAddr differs", func() {
+			It("should re-create it", func() {
+				newAttrs.HardwareAddr = net.HardwareAddr{0x02, 0x00, 0x01, 0x02, 0x03, 0x04}
+				_ = t.newInterface(&newAttrs)
+				t.assertLink(&newAttrs)
+			})
+		})
 	})
 })
+
+var _ = Describe("HardwareAddrFromIP", func() {
+	It("should return nil for an invalid IP", func() {
+		Expect(vxlan.HardwareAddrFromIP(nil)).To(BeNil())
+		Expect(vxlan.HardwareAddrFromIP(net.IP{})).To(BeNil())
+	})
+
+	DescribeTableSubtree("for random addresses",
+		func(randomIP func() net.IP) {
+			It("should be stable, locally-administered, unicast, and unique", func() {
+				const samples = 32
+
+				ips := make([]net.IP, 0, samples)
+				seenIP := map[string]bool{}
+
+				for len(ips) < samples {
+					ip := randomIP()
+					if seenIP[ip.String()] {
+						continue
+					}
+
+					seenIP[ip.String()] = true
+					ips = append(ips, ip)
+				}
+
+				seenMAC := map[string]bool{}
+
+				for _, ip := range ips {
+					mac := vxlan.HardwareAddrFromIP(ip)
+					Expect(mac).ToNot(BeNil())
+					Expect(mac).To(HaveLen(6))
+
+					// Stable for a given input.
+					Expect(vxlan.HardwareAddrFromIP(ip)).To(Equal(mac))
+
+					// Locally administered (U/L bit) and unicast (I/G bit clear).
+					Expect(mac[0] & 0x02).NotTo(BeZero())
+					Expect(mac[0] & 0x01).To(BeZero())
+
+					Expect(seenMAC).NotTo(HaveKey(mac.String()))
+					seenMAC[mac.String()] = true
+				}
+			})
+		},
+		Entry("IPv4", randomIPv4),
+		Entry("IPv6", randomIPv6),
+	)
+
+	It("should derive different MACs when IPv6 addresses share a suffix but differ in prefix", func() {
+		suffix := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+
+		ip1 := make(net.IP, net.IPv6len)
+		ip1[0] = 0x20
+		copy(ip1[11:], suffix)
+
+		ip2 := make(net.IP, net.IPv6len)
+		ip2[0] = 0xfd
+		copy(ip2[11:], suffix)
+
+		mac1 := vxlan.HardwareAddrFromIP(ip1)
+		mac2 := vxlan.HardwareAddrFromIP(ip2)
+
+		Expect(mac1).ToNot(Equal(mac2))
+	})
+})
+
+func randomIPv4() net.IP {
+	b := make([]byte, 4)
+	_, err := rand.Read(b)
+	Expect(err).NotTo(HaveOccurred())
+
+	return net.IP(b)
+}
+
+func randomIPv6() net.IP {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	Expect(err).NotTo(HaveOccurred())
+
+	return net.IP(b)
+}
 
 var _ = Describe("GetVtepIPAddressFrom", func() {
 	It("should return the correct IP", func() {
@@ -236,4 +326,8 @@ func (t *testDriver) assertLink(attrs *vxlan.Attributes) {
 	Expect(link.Group).To(Equal(attrs.Group))
 	Expect(link.Port).To(Equal(attrs.VtepPort))
 	Expect(link.MTU).To(Equal(attrs.Mtu - vxlan.MTUOverhead))
+
+	if len(attrs.HardwareAddr) > 0 {
+		Expect(link.HardwareAddr).To(Equal(attrs.HardwareAddr))
+	}
 }


### PR DESCRIPTION
## What this PR does / why we need it

In multi-node clusters we hit silent packet loss on the intra-cluster VXLAN path
toward the gateway: workers encapsulate and send, but the gateway never receives
usable traffic on `vx-submariner`. Cross-cluster connectivity from non-gateway
nodes then fails or becomes flaky even though the cable between clusters looks fine.

Root cause (tracked in #4024): `vx-submariner` interfaces on the gateway and
worker nodes can end up with the **same MAC**. When the Linux VXLAN driver sees
an underlay packet whose source MAC equals the local interface MAC, it treats
the frame as loopback and **silently drops** it. There is no error in userspace —
only missing RX counters and broken worker → gateway VXLAN.

This PR makes each VTEP identity unique and explicit:

- Derive a locally-administered unicast MAC from the node IP (`HardwareAddrFromIP`)
- Set `SrcAddr` from the node IP so VTEPs no longer share one address/MAC pair

After this, worker → gateway VXLAN RX increments again and non-gateway nodes can
participate in the intra-cluster overlay. A follow-up PR then hardens the gateway
ingress path itself (unicast FDB/routes instead of zero-MAC flood).

## Fixes

- Fixes https://github.com/submariner-io/submariner/issues/4024

## Checklist

- [ ] Unit tests added/updated
- [ ] Stacked follow-up: GW ingress unicast path PR (optional next)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * VXLAN interfaces now set and reconcile a locally administered MAC address derived from configured IP details.
  * Gateway and non-gateway VXLAN configuration now includes updated source endpoint and MAC-related parameters for both IPv4 and IPv6.
  * VXLAN reconciliation now detects hardware (MAC) changes and automatically recreates the interface when needed.
* **Tests**
  * Added coverage for MAC derivation from IPv4/IPv6 inputs (including invalid-input handling).
  * Extended assertions to validate MAC only when expected and to confirm interface re-creation on MAC updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->