### PR TITLE
Fix GW ingress path via unicast VXLAN

### DIFF
--- a/pkg/routeagent_driver/handlers/kubeproxy/dual_stack_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/dual_stack_test.go
@@ -73,8 +73,9 @@ func testDualStack() {
 				}
 			})
 
-			It("should only add an FDB entry on the VxLAN interface for the target IP family address", func() {
-				t.netLink.AwaitNeighbors(t.getVxLanInterfaceIndex(), nodeAddresses[t.ipFamily])
+			It("should only add underlay FDB and VTEP neighbor entries for the target IP family address", func() {
+				nodeIP := nodeAddresses[t.ipFamily]
+				t.netLink.AwaitNeighbors(t.getVxLanInterfaceIndex(), nodeIP, expectedNodeVTEP(nodeIP, t.ipFamily))
 			})
 		})
 	}

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition.go
@@ -28,6 +28,7 @@ import (
 func (kp *SyncHandler) TransitionToNonGateway(_ *submarinerv1.Endpoint) error {
 	logger.V(log.DEBUG).Info("The current node is no longer a Gateway")
 
+	kp.clearAllRemoteNodesOnGateway()
 	kp.cleanVxSubmarinerRoutes()
 	// If the active Gateway transitions to a new node, we flush the HostNetwork routing table.
 	kp.updateRoutingRulesForHostNetworkSupport(nil, Flush)
@@ -63,6 +64,9 @@ func (kp *SyncHandler) TransitionToGateway() error {
 
 	// Add routes to the new endpoint on the GatewayNode.
 	kp.updateRoutingRulesForHostNetworkSupport(kp.remoteSubnets.UnsortedList(), Add)
+
+	// Ensure node podCIDR ingress routes/FDB/neighbors are present (e.g. after iface recreate).
+	kp.syncAllRemoteNodesOnGateway()
 
 	return nil
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/gw_transition_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/gw_transition_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	k8snet "k8s.io/utils/net"
 )
 
 func testGatewayTransition() {
@@ -66,8 +67,10 @@ func testGatewayTransition() {
 				t.CreateNode(ctx, newNode(nodeIPv4Address2))
 			})
 
-			It("should add an FDB entry on the VxLAN interface for each address", func() {
-				t.netLink.AwaitNeighbors(vxLanInterfaceIndex, nodeIPv4Address1, nodeIPv4Address2)
+			It("should add underlay FDB and VTEP neighbor entries for each address", func() {
+				t.netLink.AwaitNeighbors(vxLanInterfaceIndex,
+					nodeIPv4Address1, expectedNodeVTEP(nodeIPv4Address1, k8snet.IPv4),
+					nodeIPv4Address2, expectedNodeVTEP(nodeIPv4Address2, k8snet.IPv4))
 			})
 		})
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kp_packetfilter.go
@@ -50,6 +50,7 @@ type SyncHandler struct {
 	remoteSubnets          set.Set[string]
 	remoteSubnetGw         map[string]net.IP
 	remoteVTEPs            set.Set[string]
+	remoteNodePodCIDRs     map[string][]string
 	routeCacheGWNode       set.Set[string]
 	pFilter                packetfilter.Interface
 	netLink                netlink.Interface
@@ -85,17 +86,18 @@ func NewSyncHandler(ipFamily k8snet.IPFamily, localClusterCidr, localServiceCidr
 	}
 
 	return &SyncHandler{
-		ipFamily:         ipFamily,
-		localClusterCidr: cidr.ExtractSubnets(ipFamily, localClusterCidr),
-		localServiceCidr: cidr.ExtractSubnets(ipFamily, localServiceCidr),
-		remoteSubnets:    set.New[string](),
-		remoteSubnetGw:   map[string]net.IP{},
-		remoteVTEPs:      set.New[string](),
-		routeCacheGWNode: set.New[string](),
-		netLink:          netlink.New(),
-		pFilter:          pFilter,
-		vtepPrefixCIDR:   vtepPrefixCIDR,
-		vxlanIface:       GetVxLANInterfaceName(ipFamily),
+		ipFamily:           ipFamily,
+		localClusterCidr:   cidr.ExtractSubnets(ipFamily, localClusterCidr),
+		localServiceCidr:   cidr.ExtractSubnets(ipFamily, localServiceCidr),
+		remoteSubnets:      set.New[string](),
+		remoteSubnetGw:     map[string]net.IP{},
+		remoteVTEPs:        set.New[string](),
+		remoteNodePodCIDRs: map[string][]string{},
+		routeCacheGWNode:   set.New[string](),
+		netLink:            netlink.New(),
+		pFilter:            pFilter,
+		vtepPrefixCIDR:     vtepPrefixCIDR,
+		vxlanIface:         GetVxLANInterfaceName(ipFamily),
 	}
 }
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
@@ -271,6 +271,18 @@ func newNodeWithPodCIDR(addr, podCIDR string) *corev1.Node {
 	return node
 }
 
+func expectedNodeVTEP(nodeIP string, family k8snet.IPFamily) string {
+	prefix := kubeproxy.VxLANVTepNetworkPrefixCIDR
+	if family == k8snet.IPv6 {
+		prefix = kubeproxy.VxLANVTepNetworkPrefixCIDRIPv6
+	}
+
+	vtepIP, err := vxlan.GetVtepIPAddressFrom(nodeIP, prefix, family)
+	Expect(err).NotTo(HaveOccurred())
+
+	return vtepIP.String()
+}
+
 func toVxlan(link netlink.Link) *netlink.Vxlan {
 	vxLan, ok := link.(*netlink.Vxlan)
 	Expect(ok).To(BeTrue(), "Unexpected Link type: %T", link)

--- a/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/kubeproxy_suite_test.go
@@ -242,7 +242,11 @@ func newRemoteEndpoint() *submarinerv1.Endpoint {
 }
 
 func newNode(addr string) *corev1.Node {
-	return &corev1.Node{
+	return newNodeWithPodCIDR(addr, "")
+}
+
+func newNodeWithPodCIDR(addr, podCIDR string) *corev1.Node {
+	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(uuid.NewUUID()),
 		},
@@ -258,6 +262,13 @@ func newNode(addr string) *corev1.Node {
 			},
 		},
 	}
+
+	if podCIDR != "" {
+		node.Spec.PodCIDR = podCIDR
+		node.Spec.PodCIDRs = []string{podCIDR}
+	}
+
+	return node
 }
 
 func toVxlan(link netlink.Link) *netlink.Vxlan {

--- a/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/node_handler.go
@@ -20,62 +20,212 @@ package kubeproxy
 
 import (
 	"net"
+	"slices"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/vxlan"
 	k8sV1 "k8s.io/api/core/v1"
 	k8snet "k8s.io/utils/net"
 )
 
 func (kp *SyncHandler) NodeCreated(node *k8sV1.Node) error {
-	logger.V(log.DEBUG).Infof("A Node with name %q and addresses %#v has been added to the cluster",
-		node.Name, node.Status.Addresses)
+	return kp.syncRemoteNode(node, Add)
+}
 
-	for i, addr := range node.Status.Addresses {
-		if addr.Type == k8sV1.NodeInternalIP && k8snet.IPFamilyOfString(node.Status.Addresses[i].Address) == kp.ipFamily {
-			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address, Add)
-			break
-		}
-	}
-
-	return nil
+func (kp *SyncHandler) NodeUpdated(node *k8sV1.Node) error {
+	return kp.syncRemoteNode(node, Add)
 }
 
 func (kp *SyncHandler) NodeRemoved(node *k8sV1.Node) error {
-	logger.V(log.DEBUG).Infof("A Node with name %q has been removed", node.Name)
+	return kp.syncRemoteNode(node, Delete)
+}
 
-	for i, addr := range node.Status.Addresses {
-		if addr.Type == k8sV1.NodeInternalIP {
-			kp.populateRemoteVtepIps(node.Status.Addresses[i].Address, Delete)
-			break
+func (kp *SyncHandler) syncRemoteNode(node *k8sV1.Node, operation Operation) error {
+	logger.V(log.DEBUG).Infof("Syncing node %q (operation=%v), addresses %#v, podCIDR=%q",
+		node.Name, operation, node.Status.Addresses, node.Spec.PodCIDR)
+
+	internalIP := kp.nodeInternalIP(node)
+	if internalIP == "" {
+		return nil
+	}
+
+	localIP, err := kp.getHostIfaceIPAddress()
+	if err == nil && localIP.Equal(net.ParseIP(internalIP)) {
+		logger.V(log.DEBUG).Infof("Skipping local node IP %s", internalIP)
+		return nil
+	}
+
+	podCIDRs := kp.nodePodCIDRs(node)
+
+	return kp.populateRemoteNode(internalIP, podCIDRs, operation)
+}
+
+func (kp *SyncHandler) nodeInternalIP(node *k8sV1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == k8sV1.NodeInternalIP && k8snet.IPFamilyOfString(addr.Address) == kp.ipFamily {
+			return addr.Address
 		}
+	}
+
+	return ""
+}
+
+func (kp *SyncHandler) nodePodCIDRs(node *k8sV1.Node) []string {
+	var cidrs []string
+
+	// Prefer PodCIDRs when set — its first entry normally duplicates PodCIDR.
+	if len(node.Spec.PodCIDRs) > 0 {
+		for _, podCIDR := range node.Spec.PodCIDRs {
+			if k8snet.IPFamilyOfCIDRString(podCIDR) == kp.ipFamily {
+				cidrs = append(cidrs, podCIDR)
+			}
+		}
+
+		return cidrs
+	}
+
+	if node.Spec.PodCIDR != "" && k8snet.IPFamilyOfCIDRString(node.Spec.PodCIDR) == kp.ipFamily {
+		cidrs = append(cidrs, node.Spec.PodCIDR)
+	}
+
+	return cidrs
+}
+
+func (kp *SyncHandler) populateRemoteNode(internalIP string, podCIDRs []string, operation Operation) error {
+	if operation == Add {
+		if existing, ok := kp.remoteNodePodCIDRs[internalIP]; ok && slices.Equal(existing, podCIDRs) {
+			return nil
+		}
+
+		kp.remoteVTEPs.Insert(internalIP)
+		kp.remoteNodePodCIDRs[internalIP] = podCIDRs
+	} else if operation == Delete {
+		kp.remoteVTEPs.Delete(internalIP)
+		delete(kp.remoteNodePodCIDRs, internalIP)
+	}
+
+	if !kp.State().IsOnGateway() || kp.vxlanDevice == nil {
+		logger.V(log.DEBUG).Infof("populateRemoteNode %s cached only (gateway=%t device=%v)",
+			internalIP, kp.State().IsOnGateway(), kp.vxlanDevice != nil)
+
+		return nil
+	}
+
+	return kp.programRemoteNodeOnGateway(internalIP, podCIDRs, operation)
+}
+
+func (kp *SyncHandler) programRemoteNodeOnGateway(internalIP string, podCIDRs []string, operation Operation) error {
+	underlayIP := net.ParseIP(internalIP)
+	if underlayIP == nil {
+		return errors.Errorf("invalid node internal IP %q", internalIP)
+	}
+
+	hwAddr := vxlan.HardwareAddrFromIP(underlayIP)
+	if hwAddr == nil {
+		return errors.Errorf("unable to derive MAC for node IP %q", internalIP)
+	}
+
+	hwAddrStr := hwAddr.String()
+
+	vtepIP, err := vxlan.GetVtepIPAddressFrom(internalIP, kp.vtepPrefixCIDR, kp.ipFamily)
+	if err != nil {
+		return errors.Wrapf(err, "failed to derive VTEP IP for %s", internalIP)
+	}
+
+	logger.V(log.DEBUG).Infof("Programming gateway datapath for node %s (vtep=%s mac=%s podCIDRs=%v op=%v)",
+		internalIP, vtepIP, hwAddrStr, podCIDRs, operation)
+
+	switch operation {
+	case Add:
+		// Remove legacy flood FDB entries that cause reply duplication.
+		_ = kp.vxlanDevice.DelFDB(underlayIP, "00:00:00:00:00:00")
+
+		if err := kp.vxlanDevice.AddFDB(underlayIP, hwAddrStr); err != nil {
+			return errors.Wrapf(err, "failed to add unicast FDB for %s", internalIP)
+		}
+
+		if err := kp.vxlanDevice.AddNeighbor(vtepIP, hwAddrStr); err != nil {
+			return errors.Wrapf(err, "failed to add VTEP neighbor for %s", vtepIP)
+		}
+
+		return kp.updateIngressRoutesForNode(vtepIP, podCIDRs, Add)
+	case Delete:
+		if err := kp.updateIngressRoutesForNode(vtepIP, podCIDRs, Delete); err != nil {
+			logger.Errorf(err, "Failed to delete ingress routes for node %s", internalIP)
+		}
+
+		if err := kp.vxlanDevice.DelNeighbor(vtepIP, hwAddrStr); err != nil {
+			logger.Errorf(err, "Failed to delete VTEP neighbor for %s", vtepIP)
+		}
+
+		if err := kp.vxlanDevice.DelFDB(underlayIP, hwAddrStr); err != nil {
+			logger.Errorf(err, "Failed to delete FDB for %s", internalIP)
+		}
+
+		_ = kp.vxlanDevice.DelFDB(underlayIP, "00:00:00:00:00:00")
+
+		return nil
+	case Flush:
+		return nil
 	}
 
 	return nil
 }
 
-func (kp *SyncHandler) populateRemoteVtepIps(vtepIP string, operation Operation) {
-	// The remoteVTEP info is cached on all the routeAgent nodes and is used when there is a Gateway transition.
-	if operation == Add && !kp.remoteVTEPs.Has(vtepIP) {
-		kp.remoteVTEPs.Insert(vtepIP)
-	} else if operation == Delete {
-		kp.remoteVTEPs.Delete(vtepIP)
+func (kp *SyncHandler) updateIngressRoutesForNode(vtepIP net.IP, podCIDRs []string, operation Operation) error {
+	if len(podCIDRs) == 0 {
+		return nil
 	}
 
-	isOnGateway := kp.State().IsOnGateway()
+	destCIDRs := make([]net.IPNet, 0, len(podCIDRs))
 
-	logger.V(log.DEBUG).Infof("populateRemoteVtepIps is called with vtepIP %s, isGatewayNode %t", vtepIP, isOnGateway)
+	for _, podCIDR := range podCIDRs {
+		_, ipNet, err := net.ParseCIDR(podCIDR)
+		if err != nil {
+			logger.Errorf(err, "Invalid pod CIDR %q", podCIDR)
+			continue
+		}
 
-	if isOnGateway && kp.vxlanDevice != nil {
-		switch operation {
-		case Add:
-			if err := kp.vxlanDevice.AddFDB(net.ParseIP(vtepIP), "00:00:00:00:00:00"); err != nil {
-				logger.Errorf(err, "Failed to add FDB entry on the Gateway Node vxlan iface")
-			}
-		case Delete:
-			if err := kp.vxlanDevice.DelFDB(net.ParseIP(vtepIP), "00:00:00:00:00:00"); err != nil {
-				logger.Errorf(err, "Failed to delete FDB entry on the Gateway Node vxlan iface")
-			}
-		case Flush:
+		destCIDRs = append(destCIDRs, *ipNet)
+	}
+
+	if len(destCIDRs) == 0 {
+		return nil
+	}
+
+	switch operation {
+	case Add:
+		return errors.Wrap(kp.vxlanDevice.AddRoutes(vtepIP, nil, 0, destCIDRs...), "failed to add ingress routes")
+	case Delete:
+		return errors.Wrap(kp.vxlanDevice.DelRoutes(0, destCIDRs...), "failed to delete ingress routes")
+	case Flush:
+		return nil
+	}
+
+	return nil
+}
+
+func (kp *SyncHandler) syncAllRemoteNodesOnGateway() {
+	if kp.vxlanDevice == nil {
+		return
+	}
+
+	for internalIP, podCIDRs := range kp.remoteNodePodCIDRs {
+		if err := kp.programRemoteNodeOnGateway(internalIP, podCIDRs, Add); err != nil {
+			logger.Errorf(err, "Failed to program gateway datapath for remote node %s", internalIP)
+		}
+	}
+}
+
+func (kp *SyncHandler) clearAllRemoteNodesOnGateway() {
+	if kp.vxlanDevice == nil {
+		return
+	}
+
+	for internalIP, podCIDRs := range kp.remoteNodePodCIDRs {
+		if err := kp.programRemoteNodeOnGateway(internalIP, podCIDRs, Delete); err != nil {
+			logger.Errorf(err, "Failed to clear gateway datapath for remote node %s", internalIP)
 		}
 	}
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -52,11 +52,11 @@ func testNodes() {
 			t.CreateNode(ctx, node)
 		})
 
-		It("should add/remove an FDB entry on the VxLAN interface for each Node address", func(ctx context.Context) {
-			t.netLink.AwaitNeighbors(vxLanInterfaceIndex, nodeIPv4Address1)
+		It("should add/remove underlay FDB and VTEP neighbor entries for each Node address", func(ctx context.Context) {
+			t.netLink.AwaitNeighbors(vxLanInterfaceIndex, nodeIPv4Address1, expectedNodeVTEP(nodeIPv4Address1, k8snet.IPv4))
 
 			t.DeleteNode(ctx, node.Name)
-			t.netLink.AwaitNoNeighbors(vxLanInterfaceIndex, nodeIPv4Address1)
+			t.netLink.AwaitNoNeighbors(vxLanInterfaceIndex, nodeIPv4Address1, expectedNodeVTEP(nodeIPv4Address1, k8snet.IPv4))
 		})
 
 		It("should add/remove an ingress route for the Node pod CIDR via its VTEP", func(ctx context.Context) {

--- a/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/sync_handler_test.go
@@ -43,7 +43,7 @@ func testNodes() {
 	var node *corev1.Node
 
 	BeforeEach(func() {
-		node = newNode(nodeIPv4Address1)
+		node = newNodeWithPodCIDR(nodeIPv4Address1, "10.244.1.0/24")
 	})
 
 	When("a Node is created and then deleted on a gateway node", func() {
@@ -57,6 +57,14 @@ func testNodes() {
 
 			t.DeleteNode(ctx, node.Name)
 			t.netLink.AwaitNoNeighbors(vxLanInterfaceIndex, nodeIPv4Address1)
+		})
+
+		It("should add/remove an ingress route for the Node pod CIDR via its VTEP", func(ctx context.Context) {
+			vxlanLink := t.awaitVxlanLink()
+			t.netLink.AwaitDstRoutes(vxlanLink.Attrs().Index, 0, "10.244.1.0/24")
+
+			t.DeleteNode(ctx, node.Name)
+			t.netLink.AwaitNoDstRoutes(vxlanLink.Attrs().Index, 0, "10.244.1.0/24")
 		})
 	})
 

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -75,12 +75,8 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 			return errors.Wrap(err, "failed to create vxlan interface on Gateway Node")
 		}
 
-		for _, fdbAddress := range kp.remoteVTEPs.UnsortedList() {
-			err = kp.vxlanDevice.AddFDB(net.ParseIP(fdbAddress), "00:00:00:00:00:00")
-			if err != nil {
-				return errors.Wrap(err, "failed to add FDB entry on the Gateway Node vxlan iface")
-			}
-		}
+		// Remote-node FDB/neigh/routes are programmed by TransitionToGateway via
+		// syncAllRemoteNodesOnGateway after the interface exists.
 
 		err = kp.netLink.EnsureLooseModeIsConfigured(kp.vxlanIface, kp.ipFamily)
 		if err != nil {

--- a/pkg/vxlan/vxlan.go
+++ b/pkg/vxlan/vxlan.go
@@ -286,6 +286,64 @@ func (i *Interface) DelFDB(ipAddress net.IP, hwAddr string) error {
 	return nil
 }
 
+// AddNeighbor installs a permanent L3 neighbor entry so VTEP IPs resolve
+// without ARP (avoids relying on zero-MAC FDB flood for discovery).
+func (i *Interface) AddNeighbor(ipAddress net.IP, hwAddr string) error {
+	macAddr, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return errors.Wrapf(err, "invalid MAC Address %q", hwAddr)
+	}
+
+	neigh := &netlink.Neigh{
+		LinkIndex:    i.link.Index,
+		Family:       ipFamilyOf(ipAddress),
+		State:        netlink.NUD_PERMANENT,
+		IP:           ipAddress,
+		HardwareAddr: macAddr,
+	}
+
+	err = i.netLink.NeighAppend(neigh)
+	if err != nil {
+		return errors.Wrapf(err, "unable to add the neighbor entry %v", neigh)
+	}
+
+	logger.V(log.DEBUG).Infof("Successfully added the neighbor entry %v", neigh)
+
+	return nil
+}
+
+func (i *Interface) DelNeighbor(ipAddress net.IP, hwAddr string) error {
+	macAddr, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return errors.Wrapf(err, "invalid MAC Address %q", hwAddr)
+	}
+
+	neigh := &netlink.Neigh{
+		LinkIndex:    i.link.Index,
+		Family:       ipFamilyOf(ipAddress),
+		State:        netlink.NUD_PERMANENT,
+		IP:           ipAddress,
+		HardwareAddr: macAddr,
+	}
+
+	err = i.netLink.NeighDel(neigh)
+	if err != nil {
+		return errors.Wrapf(err, "unable to delete the neighbor entry %v", neigh)
+	}
+
+	logger.V(log.DEBUG).Infof("Successfully deleted the neighbor entry %v", neigh)
+
+	return nil
+}
+
+func ipFamilyOf(ip net.IP) int {
+	if ip.To4() != nil {
+		return unix.AF_INET
+	}
+
+	return unix.AF_INET6
+}
+
 func (i *Interface) AddRoutes(gwIP, srcIP net.IP, tableID int, destCIDRs ...net.IPNet) error {
 	for j := range destCIDRs {
 		route := &netlink.Route{


### PR DESCRIPTION
## What this PR does / why we need it

This PR is the datapath follow-up to the unique-MAC fix in #04.
After fixing shared-MAC loopback drops, we still observed cases where traffic involving
non-gateway workers and the active gateway was unreliable or asymmetric under VXLAN.
In practice, this showed up as unstable reply paths and inconsistent delivery for
cross-cluster flows that should traverse the active gateway.

Root cause: the gateway datapath still depended on legacy zero-MAC flood behavior in
the VXLAN FDB, and did not always have deterministic per-node ingress programming for
remote worker Pod CIDRs. Flood-based learning can produce ambiguous forwarding behavior
and reply duplication under churn.

This PR makes the gateway path explicit and deterministic:

- Program per-node pod CIDR routes via VTEP on the active gateway
- Install unicast FDB + permanent neighbor entries per node/VTEP
- Remove legacy all-zero flood FDB entries that can cause reply duplication

In short: instead of relying on flood/discovery behavior, the active gateway now forwards
to known VTEPs via explicit unicast entries and routes.

## Depends on

- **Depends on** https://github.com/submariner-io/submariner/issues/4024 fix (`fix/vxlan-unique-mac`) — open as stacked PR with base = that branch until merged.

## Related issues

- Depends on / stacked after the [#4024](https://github.com/submariner-io/submariner/issues/4024) unique-MAC fix
- Related to (historical / incomplete) https://github.com/submariner-io/submariner/issues/1336 — GW→worker encapsulation via VTEP + drop zero-MAC FDB was proposed for AKS/CIVO and went stale

## Checklist

- [ ] Tests updated
- [ ] Rebase onto `devel` after unique-MAC PR merges

## Cross-links (this series)

- **Stacked on / depends on** https://github.com/submariner-io/submariner/pull/4098 (unique-MAC fix). Until that merges, this PR includes both commits — please review the top commit as the incremental change.
- After https://github.com/submariner-io/submariner/pull/4098 merges, this will be rebased onto `devel`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable VXLAN hardware (MAC) addressing derived from IP, plus expanded neighbor management for both IPv4 and IPv6.
  * Program pod CIDR ingress/destination routing per node via the node’s VTEP on gateway and worker, with improved handling during gateway resyncs.
  * Unified remote-node handling for node create/update/remove through a shared synchronization workflow.
* **Bug Fixes**
  * Improved gateway transitions by clearing stale remote-node gateway state before reconciling and repopulating gateway datapath entries immediately after gateway setup.
* **Tests**
  * Extended coverage for VXLAN hardware/MAC behavior, link recreation on MAC mismatch, pod CIDR route programming, and route deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->