### PR TITLE
Add Amazon VPC CNI route-agent handler

### DIFF
--- a/pkg/cni/plugins.go
+++ b/pkg/cni/plugins.go
@@ -28,8 +28,10 @@ const (
 	OpenShiftSDN  = "OpenShiftSDN"
 	OVNKubernetes = "OVNKubernetes"
 	WeaveNet      = "weave-net"
+	// AmazonVPCCNI is the AWS VPC CNI used by EKS.
+	AmazonVPCCNI = "amazon-vpc-cni"
 )
 
 func GetNetworkPlugins() []string {
-	return []string{Generic, Calico, CanalFlannel, Flannel, KindNet, OpenShiftSDN, OVNKubernetes, WeaveNet}
+	return []string{Generic, Calico, CanalFlannel, Flannel, KindNet, OpenShiftSDN, OVNKubernetes, WeaveNet, AmazonVPCCNI}
 }

--- a/pkg/routeagent_driver/handlers/awsvpc/handler.go
+++ b/pkg/routeagent_driver/handlers/awsvpc/handler.go
@@ -1,0 +1,491 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package awsvpc provides Route Agent handling for Amazon VPC CNI (EKS).
+//
+// Enablement matches other CNI handlers: the operator/subctl sets
+// SUBMARINER_NETWORKPLUGIN=amazon-vpc-cni, and this handler is registered only
+// for that plugin name (see GetNetworkPlugins).
+//
+// It addresses two dataplane gaps:
+//  1. Active-gateway return path: program podIP/32 in the main table via the
+//     hosting node's VTEP on vx-submariner so replies from the cable are not sent
+//     into the VPC underlay (where Security Groups typically drop foreign pod
+//     CIDRs). Node InternalIP/32 routes go into a dedicated PBR table (not main)
+//     selected for traffic from the cable interface / remote CIDRs — putting node
+//     IPs in main breaks VXLAN underlay (FDB dst = node IP).
+//  2. Worker egress with AWS CNI PBR: replicate remote-cluster routes (and the
+//     VTEP CIDR) into custom routing tables created for secondary ENIs
+//     (see https://github.com/submariner-io/submariner/issues/3697).
+//
+// Ops fallback: allow the remote cluster's pod/service CIDRs in node Security
+// Groups so VPC return can work without VTEP routes (similar to the GKE firewall
+// workaround). Prefer these routes for the correct Submariner datapath.
+package awsvpc
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cni"
+	"github.com/submariner-io/submariner/pkg/event"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	k8snet "k8s.io/utils/net"
+	"k8s.io/utils/set"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	vxlanIfaceName     = kubeproxy.VxLANIface
+	vtepPrefixCIDR     = kubeproxy.VxLANVTepNetworkPrefixCIDR
+	reconcilePeriod    = time.Minute
+	routeProtocol      = 4 // matches kubeproxy inter-cluster routes
+	mainRoutingTableID = 254
+
+	// awsVPCNodeIngressTableID holds node InternalIP/32 via VTEP routes used only
+	// for cable ingress / remote-CIDR return traffic (see syncNodeIngressPolicyLocked).
+	awsVPCNodeIngressTableID = 152
+)
+
+var logger = log.Logger{Logger: logf.Log.WithName("AWSVPC")}
+
+// Handler programs Amazon VPC CNI–specific routes on top of the kubeproxy VXLAN datapath.
+type Handler struct {
+	event.HandlerBase
+	event.NodeHandlerBase
+
+	clientset kubernetes.Interface
+	netLink   netlinkAPI.Interface
+	podLister corelisters.PodLister
+
+	ipFamily k8snet.IPFamily
+	nodeName string
+	enabled  bool
+	stopCh   chan struct{}
+	mutex    sync.Mutex
+
+	// nodeName -> IPv4 InternalIP
+	nodeIPs map[string]string
+	// pod namespace/name -> last known IPv4 (survives delete tombstones with empty Status)
+	podIPs map[string]string
+	// pod dstIP/32 -> VTEP (main table; only while on gateway)
+	ingressRoutes map[string]string
+	// node InternalIP/32 -> VTEP (table awsVPCNodeIngressTableID; only while on gateway)
+	nodeIngressRoutes map[string]string
+	// cable device name from local endpoint (e.g. "submariner" for AmneziaWG)
+	cableIfaceName string
+	// per remote endpoint (UID or ns/name) -> IPv4 subnets
+	remoteEndpointCIDRs map[string]set.Set[string]
+	// union of remoteEndpointCIDRs; used for CNI PBR / ingress policy
+	remoteCIDRs set.Set[string]
+}
+
+// NewHandler returns an event handler for Amazon VPC CNI. ipFamily is reserved for
+// future dual-stack; only IPv4 VPC CNI is handled today.
+func NewHandler(clientset kubernetes.Interface, ipFamily k8snet.IPFamily) event.Handler {
+	return &Handler{
+		clientset:           clientset,
+		netLink:             netlinkAPI.New(),
+		ipFamily:            ipFamily,
+		nodeIPs:             map[string]string{},
+		podIPs:              map[string]string{},
+		ingressRoutes:       map[string]string{},
+		nodeIngressRoutes:   map[string]string{},
+		remoteEndpointCIDRs: map[string]set.Set[string]{},
+		remoteCIDRs:         set.New[string](),
+		stopCh:              make(chan struct{}),
+	}
+}
+
+func (h *Handler) GetName() string {
+	return "AmazonVPC-CNI"
+}
+
+func (h *Handler) GetNetworkPlugins() []string {
+	return []string{cni.AmazonVPCCNI}
+}
+
+func (h *Handler) Init(ctx context.Context) error {
+	if h.ipFamily != k8snet.IPv4 {
+		logger.Info("Amazon VPC CNI handler supports IPv4 only; skipping")
+		return nil
+	}
+
+	h.nodeName = os.Getenv("NODE_NAME")
+	if h.nodeName == "" {
+		var err error
+
+		h.nodeName, err = os.Hostname()
+		if err != nil {
+			return errors.Wrap(err, "unable to determine node name")
+		}
+	}
+
+	h.enabled = true
+	logger.Infof("Amazon VPC CNI handler enabled on node %q", h.nodeName)
+
+	factory := informers.NewSharedInformerFactory(h.clientset, 0)
+	pods := factory.Core().V1().Pods()
+	podInformer := pods.Informer()
+	h.podLister = pods.Lister()
+
+	_, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			h.onPod(obj.(*corev1.Pod), false)
+		},
+		UpdateFunc: func(_, newObj any) {
+			h.onPod(newObj.(*corev1.Pod), false)
+		},
+		DeleteFunc: func(obj any) {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					return
+				}
+
+				pod, ok = tombstone.Obj.(*corev1.Pod)
+				if !ok {
+					return
+				}
+			}
+
+			h.onPod(pod, true)
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "error adding pod event handler")
+	}
+
+	factory.Start(h.stopCh)
+
+	if !cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced) {
+		return errors.New("timed out waiting for pod informer sync")
+	}
+
+	go wait.Until(h.reconcile, reconcilePeriod, h.stopCh)
+
+	return nil
+}
+
+func (h *Handler) Stop(_ context.Context) error {
+	select {
+	case <-h.stopCh:
+	default:
+		close(h.stopCh)
+	}
+
+	return nil
+}
+
+func (h *Handler) Uninstall(_ context.Context) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.clearIngressRoutesLocked()
+	h.clearCNITableRoutesLocked()
+
+	return nil
+}
+
+func (h *Handler) LocalEndpointCreated(endpoint *submarinerv1.Endpoint) error {
+	return h.syncCableIface(endpoint)
+}
+
+func (h *Handler) LocalEndpointUpdated(endpoint *submarinerv1.Endpoint) error {
+	return h.syncCableIface(endpoint)
+}
+
+func (h *Handler) LocalEndpointRemoved(_ *submarinerv1.Endpoint) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.cableIfaceName = ""
+	if h.State().IsOnGateway() {
+		h.syncNodeIngressPolicyLocked()
+	}
+
+	return nil
+}
+
+func (h *Handler) syncCableIface(endpoint *submarinerv1.Endpoint) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.cableIfaceName = endpoint.Spec.BackendConfig[cable.InterfaceNameConfig]
+	if h.State().IsOnGateway() {
+		h.syncNodeIngressPolicyLocked()
+	}
+
+	return nil
+}
+
+func (h *Handler) TransitionToGateway() error {
+	if !h.enabled {
+		return nil
+	}
+
+	logger.Info("Became gateway; programming Amazon VPC CNI ingress routes")
+
+	ctx := context.Background()
+
+	if err := h.seedNodeIPs(ctx); err != nil {
+		logger.Errorf(err, "Failed to list nodes while becoming gateway")
+	}
+
+	h.mutex.Lock()
+	h.programAllNodeIngressRoutesLocked()
+	h.syncNodeIngressPolicyLocked()
+	h.mutex.Unlock()
+
+	if err := h.programAllPodIngressRoutes(); err != nil {
+		logger.Errorf(err, "Failed to list pods while becoming gateway")
+	}
+
+	h.reconcileIngressRoutes()
+
+	return nil
+}
+
+func (h *Handler) TransitionToNonGateway(_ *submarinerv1.Endpoint) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	logger.Info("No longer gateway; clearing Amazon VPC CNI ingress routes")
+	h.clearIngressRoutesLocked()
+
+	return nil
+}
+
+func (h *Handler) NodeCreated(node *corev1.Node) error {
+	return h.syncNode(node, false)
+}
+
+func (h *Handler) NodeUpdated(node *corev1.Node) error {
+	return h.syncNode(node, false)
+}
+
+func (h *Handler) NodeRemoved(node *corev1.Node) error {
+	return h.syncNode(node, true)
+}
+
+func (h *Handler) RemoteEndpointCreated(endpoint *submarinerv1.Endpoint) error {
+	return h.syncRemoteEndpoint(endpoint, false)
+}
+
+func (h *Handler) RemoteEndpointUpdated(endpoint *submarinerv1.Endpoint) error {
+	return h.syncRemoteEndpoint(endpoint, false)
+}
+
+func (h *Handler) RemoteEndpointRemoved(endpoint *submarinerv1.Endpoint) error {
+	return h.syncRemoteEndpoint(endpoint, true)
+}
+
+func (h *Handler) syncNode(node *corev1.Node, removed bool) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if removed {
+		if ip := h.nodeIPs[node.Name]; ip != "" {
+			h.removeNodeIngressRouteLocked(ip + "/32")
+		}
+
+		delete(h.nodeIPs, node.Name)
+
+		return nil
+	}
+
+	ip := nodeIPv4(node)
+	if ip == "" {
+		return nil
+	}
+
+	prev := h.nodeIPs[node.Name]
+	h.nodeIPs[node.Name] = ip
+
+	if !h.State().IsOnGateway() {
+		return nil
+	}
+
+	if prev != "" && prev != ip {
+		h.removeNodeIngressRouteLocked(prev + "/32")
+	}
+
+	h.ensureNodeIngressRouteLocked(node.Name, ip)
+
+	return nil
+}
+
+func (h *Handler) syncRemoteEndpoint(endpoint *submarinerv1.Endpoint, removed bool) error {
+	if !h.enabled {
+		return nil
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	key := remoteEndpointKey(endpoint)
+
+	if removed {
+		delete(h.remoteEndpointCIDRs, key)
+	} else {
+		cidrs := set.New[string]()
+
+		for _, subnet := range endpoint.Spec.Subnets {
+			if k8snet.IPFamilyOfCIDRString(subnet) == k8snet.IPv4 {
+				cidrs.Insert(subnet)
+			}
+		}
+
+		h.remoteEndpointCIDRs[key] = cidrs
+	}
+
+	h.rebuildRemoteCIDRsLocked()
+	h.syncCNITableRoutesLocked()
+
+	if h.State().IsOnGateway() {
+		h.syncNodeIngressPolicyLocked()
+	}
+
+	return nil
+}
+
+func (h *Handler) rebuildRemoteCIDRsLocked() {
+	h.remoteCIDRs = set.New[string]()
+
+	for _, cidrs := range h.remoteEndpointCIDRs {
+		h.remoteCIDRs.Insert(cidrs.UnsortedList()...)
+	}
+}
+
+func remoteEndpointKey(endpoint *submarinerv1.Endpoint) string {
+	if endpoint.UID != "" {
+		return string(endpoint.UID)
+	}
+
+	return endpoint.Namespace + "/" + endpoint.Name
+}
+
+func (h *Handler) reconcile() {
+	if !h.enabled {
+		return
+	}
+
+	// Re-apply from informer/node cache so routes missed while vx-submariner was
+	// not ready (TransitionToGateway race) are programmed once the link exists.
+	if h.State().IsOnGateway() {
+		h.mutex.Lock()
+		h.programAllNodeIngressRoutesLocked()
+		h.mutex.Unlock()
+
+		if err := h.programAllPodIngressRoutes(); err != nil {
+			logger.Errorf(err, "Failed to list pods during reconcile")
+		}
+	}
+
+	h.reconcileIngressRoutes()
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.syncCNITableRoutesLocked()
+
+	if h.State().IsOnGateway() {
+		h.syncNodeIngressPolicyLocked()
+	}
+}
+
+func (h *Handler) seedNodeIPs(ctx context.Context) error {
+	nodes, err := h.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "list nodes")
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	for i := range nodes.Items {
+		if ip := nodeIPv4(&nodes.Items[i]); ip != "" {
+			h.nodeIPs[nodes.Items[i].Name] = ip
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) programAllPodIngressRoutes() error {
+	if h.podLister == nil {
+		return nil
+	}
+
+	pods, err := h.podLister.List(labels.Everything())
+	if err != nil {
+		return errors.Wrap(err, "list pods from informer cache")
+	}
+
+	for _, pod := range pods {
+		h.onPod(pod, false)
+	}
+
+	return nil
+}
+
+func nodeIPv4(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP && k8snet.IPFamilyOfString(addr.Address) == k8snet.IPv4 {
+			return addr.Address
+		}
+	}
+
+	return ""
+}

--- a/pkg/routeagent_driver/handlers/awsvpc/handler_test.go
+++ b/pkg/routeagent_driver/handlers/awsvpc/handler_test.go
@@ -1,0 +1,202 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsvpc_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
+	"github.com/submariner-io/submariner/pkg/cni"
+	"github.com/submariner-io/submariner/pkg/event"
+	evtesting "github.com/submariner-io/submariner/pkg/event/testing"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	fakeNetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/awsvpc"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
+	"github.com/vishvananda/netlink"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8snet "k8s.io/utils/net"
+)
+
+const (
+	gatewayNodeName = "gateway-node"
+	workerNodeName  = "worker-a"
+	workerNodeIP    = "10.151.71.78"
+	workerVTEP      = "240.151.71.78"
+	podIP           = "10.151.70.157"
+	vxlanIndex      = 99
+)
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
+
+func TestAWSVPC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS VPC CNI Handler Suite")
+}
+
+var _ = Describe("Amazon VPC CNI handler", func() {
+	t := newTestDriver()
+
+	Specify("GetNetworkPlugins should return only amazon-vpc-cni", func() {
+		Expect(t.handler.GetNetworkPlugins()).To(Equal([]string{cni.AmazonVPCCNI}))
+	})
+
+	It("should program a pod /32 via the worker VTEP on the gateway", func(ctx context.Context) {
+		t.addNode(gatewayNodeName, "10.151.4.10")
+		t.addNode(workerNodeName, workerNodeIP)
+		t.addPod("p1", workerNodeName, podIP)
+
+		t.Start(ctx)
+		t.CreateLocalHostEndpoint(ctx)
+
+		t.netLink.AwaitDstRoutes(vxlanIndex, 0, podIP+"/32")
+
+		routes, err := t.netLink.RouteList(t.vxlanLink, k8snet.IPv4)
+		Expect(err).NotTo(HaveOccurred())
+
+		found := false
+
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == podIP+"/32" {
+				Expect(routes[i].Gw.String()).To(Equal(workerVTEP))
+
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
+
+	It("should program a node InternalIP /32 via VTEP in the PBR table, not main", func(ctx context.Context) {
+		t.addNode(gatewayNodeName, "10.151.4.10")
+		t.addNode(workerNodeName, workerNodeIP)
+
+		t.Start(ctx)
+		t.CreateLocalHostEndpoint(ctx)
+
+		t.netLink.AwaitDstRoutes(vxlanIndex, 152, workerNodeIP+"/32")
+		t.netLink.AwaitNoDstRoutes(vxlanIndex, 0, workerNodeIP+"/32")
+
+		routes, err := t.netLink.RouteList(t.vxlanLink, k8snet.IPv4)
+		Expect(err).NotTo(HaveOccurred())
+
+		found := false
+
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == workerNodeIP+"/32" {
+				Expect(routes[i].Gw.String()).To(Equal(workerVTEP))
+				Expect(routes[i].Table).To(Equal(152))
+
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
+
+	It("should ignore pods on the local gateway node", func(ctx context.Context) {
+		t.addNode(gatewayNodeName, "10.151.4.10")
+		t.addPod("local-pod", gatewayNodeName, "10.151.70.1")
+
+		t.Start(ctx)
+		t.CreateLocalHostEndpoint(ctx)
+
+		t.netLink.AwaitNoDstRoutes(vxlanIndex, 0, "10.151.70.1/32")
+		// Local gateway node IP must not get a VTEP route either.
+		t.netLink.AwaitNoDstRoutes(vxlanIndex, 0, "10.151.4.10/32")
+	})
+})
+
+type testDriver struct {
+	*evtesting.ControllerSupport
+	handler   event.Handler
+	clientset *fake.Clientset
+	netLink   *fakeNetlink.NetLink
+	vxlanLink *netlink.Vxlan
+}
+
+func newTestDriver() *testDriver {
+	t := &testDriver{
+		ControllerSupport: evtesting.NewControllerSupport(),
+	}
+
+	BeforeEach(func() {
+		Expect(os.Setenv("NODE_NAME", gatewayNodeName)).To(Succeed())
+
+		t.clientset = fake.NewSimpleClientset()
+		t.netLink = fakeNetlink.New()
+		t.netLink.SetLinkIndex(kubeproxy.VxLANIface, vxlanIndex)
+
+		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
+			return t.netLink
+		}
+
+		t.vxlanLink = &netlink.Vxlan{
+			LinkAttrs: netlink.LinkAttrs{Name: kubeproxy.VxLANIface, Index: vxlanIndex},
+		}
+		Expect(t.netLink.LinkAdd(t.vxlanLink)).To(Succeed())
+
+		t.handler = awsvpc.NewHandler(t.clientset, k8snet.IPv4)
+	})
+
+	AfterEach(func() {
+		_ = t.handler.Stop(context.TODO())
+		_ = os.Unsetenv("NODE_NAME")
+		netlinkAPI.NewFunc = nil
+	})
+
+	return t
+}
+
+func (t *testDriver) Start(ctx context.Context) {
+	t.ControllerSupport.Start(ctx, t.handler)
+}
+
+func (t *testDriver) addNode(name, ip string) {
+	_, err := t.clientset.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: ip}},
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (t *testDriver) addPod(name, nodeName, ip string) {
+	_, err := t.clientset.CoreV1().Pods("default").Create(context.TODO(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIP:  ip,
+			PodIPs: []corev1.PodIP{{IP: ip}},
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/routeagent_driver/handlers/awsvpc/ingress.go
+++ b/pkg/routeagent_driver/handlers/awsvpc/ingress.go
@@ -1,0 +1,477 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsvpc
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
+	"github.com/submariner-io/submariner/pkg/vxlan"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	corev1 "k8s.io/api/core/v1"
+	k8snet "k8s.io/utils/net"
+	"k8s.io/utils/set"
+)
+
+func (h *Handler) onPod(pod *corev1.Pod, deleted bool) {
+	if !h.enabled || !h.State().IsOnGateway() {
+		return
+	}
+
+	if pod.Spec.NodeName == "" || pod.Spec.NodeName == h.nodeName {
+		return
+	}
+
+	// hostNetwork pods use the node InternalIP; covered by node ingress routes.
+	if pod.Spec.HostNetwork {
+		return
+	}
+
+	key := podKey(pod)
+
+	if deleted {
+		ip := h.takeTrackedPodIP(key)
+		if ip == "" {
+			ip = podIPv4(pod)
+		}
+
+		if ip != "" {
+			h.removeIngressRouteByIPString(ip)
+		}
+
+		return
+	}
+
+	podIP := podIPv4(pod)
+	if podIP == "" {
+		return
+	}
+
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		h.clearTrackedPodIP(key)
+		h.removeIngressRouteByIPString(podIP)
+
+		return
+	}
+
+	if pod.Status.Phase != corev1.PodRunning && pod.Status.PodIP == "" {
+		return
+	}
+
+	h.trackPodIP(key, podIP)
+	h.ensurePodIngressRoute(pod.Spec.NodeName, podIP)
+}
+
+func podKey(pod *corev1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
+}
+
+func (h *Handler) trackPodIP(key, ip string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if prev, ok := h.podIPs[key]; ok && prev != "" && prev != ip {
+		h.removePodIngressRouteLocked(prev + "/32")
+	}
+
+	h.podIPs[key] = ip
+}
+
+func (h *Handler) takeTrackedPodIP(key string) string {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	ip := h.podIPs[key]
+	delete(h.podIPs, key)
+
+	return ip
+}
+
+func (h *Handler) clearTrackedPodIP(key string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	delete(h.podIPs, key)
+}
+
+func (h *Handler) reconcileIngressRoutes() {
+	if !h.State().IsOnGateway() {
+		return
+	}
+
+	// Re-apply tracked routes (e.g. after vx-submariner recreate).
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	for dstCIDR, vtep := range h.ingressRoutes {
+		if err := h.addHostRouteLocked(dstCIDR, vtep, 0); err != nil {
+			logger.Errorf(err, "Failed to re-apply pod ingress route %s via %s", dstCIDR, vtep)
+		}
+	}
+
+	for dstCIDR, vtep := range h.nodeIngressRoutes {
+		// Ensure leftovers in main (from older builds) are removed.
+		_ = h.delHostRouteLocked(dstCIDR, 0)
+
+		if err := h.addHostRouteLocked(dstCIDR, vtep, awsVPCNodeIngressTableID); err != nil {
+			logger.Errorf(err, "Failed to re-apply node ingress route %s via %s", dstCIDR, vtep)
+		}
+	}
+
+	h.syncNodeIngressPolicyLocked()
+}
+
+// ensurePodIngressRoute programs dstIP/32 via the node's VTEP in the main table.
+func (h *Handler) ensurePodIngressRoute(nodeName, dstIP string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.ensurePodIngressRouteLocked(nodeName, dstIP)
+}
+
+func (h *Handler) ensurePodIngressRouteLocked(nodeName, dstIP string) {
+	vtepStr, ok := h.vtepForNodeLocked(nodeName, dstIP)
+	if !ok {
+		return
+	}
+
+	dstCIDR := dstIP + "/32"
+
+	if existing, ok := h.ingressRoutes[dstCIDR]; ok && existing == vtepStr {
+		return
+	}
+
+	if err := h.addHostRouteLocked(dstCIDR, vtepStr, 0); err != nil {
+		logger.Errorf(err, "Failed to add pod ingress route %s via %s", dstCIDR, vtepStr)
+		return
+	}
+
+	h.ingressRoutes[dstCIDR] = vtepStr
+	logger.Infof("Programmed AWS VPC CNI pod ingress route %s via %s (node %s)", dstCIDR, vtepStr, nodeName)
+}
+
+func (h *Handler) ensureNodeIngressRouteLocked(nodeName, dstIP string) {
+	vtepStr, ok := h.vtepForNodeLocked(nodeName, dstIP)
+	if !ok {
+		return
+	}
+
+	dstCIDR := dstIP + "/32"
+
+	if existing, ok := h.nodeIngressRoutes[dstCIDR]; ok && existing == vtepStr {
+		return
+	}
+
+	// Node IPs must not live in main — VXLAN FDB uses them as underlay destinations.
+	_ = h.delHostRouteLocked(dstCIDR, 0)
+
+	if err := h.addHostRouteLocked(dstCIDR, vtepStr, awsVPCNodeIngressTableID); err != nil {
+		logger.Errorf(err, "Failed to add node ingress route %s via %s", dstCIDR, vtepStr)
+		return
+	}
+
+	h.nodeIngressRoutes[dstCIDR] = vtepStr
+	logger.Infof("Programmed AWS VPC CNI node ingress route %s via %s table %d (node %s)",
+		dstCIDR, vtepStr, awsVPCNodeIngressTableID, nodeName)
+}
+
+func (h *Handler) vtepForNodeLocked(nodeName, dstIP string) (string, bool) {
+	if nodeName == h.nodeName {
+		return "", false
+	}
+
+	nodeIP, ok := h.nodeIPs[nodeName]
+	if !ok || nodeIP == "" {
+		logger.V(log.DEBUG).Infof("No InternalIP yet for node %q (dst %s); will retry", nodeName, dstIP)
+		return "", false
+	}
+
+	vtepIP, err := vxlan.GetVtepIPAddressFrom(nodeIP, vtepPrefixCIDR, k8snet.IPv4)
+	if err != nil {
+		logger.Errorf(err, "Failed to derive VTEP for node %s (%s)", nodeName, nodeIP)
+		return "", false
+	}
+
+	return vtepIP.String(), true
+}
+
+func (h *Handler) programAllNodeIngressRoutesLocked() {
+	for nodeName, nodeIP := range h.nodeIPs {
+		h.ensureNodeIngressRouteLocked(nodeName, nodeIP)
+	}
+}
+
+func (h *Handler) removeIngressRouteByIPString(dstIP string) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.removePodIngressRouteLocked(dstIP + "/32")
+}
+
+func (h *Handler) removePodIngressRouteLocked(dstCIDR string) {
+	if _, ok := h.ingressRoutes[dstCIDR]; !ok {
+		return
+	}
+
+	if err := h.delHostRouteLocked(dstCIDR, 0); err != nil {
+		logger.Errorf(err, "Failed to delete pod ingress route %s", dstCIDR)
+	}
+
+	delete(h.ingressRoutes, dstCIDR)
+	logger.Infof("Removed AWS VPC CNI pod ingress route %s", dstCIDR)
+}
+
+func (h *Handler) removeNodeIngressRouteLocked(dstCIDR string) {
+	if _, ok := h.nodeIngressRoutes[dstCIDR]; !ok {
+		return
+	}
+
+	if err := h.delHostRouteLocked(dstCIDR, awsVPCNodeIngressTableID); err != nil {
+		logger.Errorf(err, "Failed to delete node ingress route %s", dstCIDR)
+	}
+
+	_ = h.delHostRouteLocked(dstCIDR, 0)
+
+	delete(h.nodeIngressRoutes, dstCIDR)
+	logger.Infof("Removed AWS VPC CNI node ingress route %s", dstCIDR)
+}
+
+func (h *Handler) clearIngressRoutesLocked() {
+	for dstCIDR := range h.ingressRoutes {
+		if err := h.delHostRouteLocked(dstCIDR, 0); err != nil {
+			logger.Errorf(err, "Failed to delete pod ingress route %s", dstCIDR)
+		}
+	}
+
+	for dstCIDR := range h.nodeIngressRoutes {
+		if err := h.delHostRouteLocked(dstCIDR, awsVPCNodeIngressTableID); err != nil {
+			logger.Errorf(err, "Failed to delete node ingress route %s", dstCIDR)
+		}
+
+		_ = h.delHostRouteLocked(dstCIDR, 0)
+	}
+
+	h.ingressRoutes = map[string]string{}
+	h.nodeIngressRoutes = map[string]string{}
+	h.podIPs = map[string]string{}
+	h.clearNodeIngressPolicyLocked()
+}
+
+// syncNodeIngressPolicyLocked installs PBR so node /32 VTEP routes are used for
+// return traffic from the cable without hijacking VXLAN underlay lookups in main.
+func (h *Handler) syncNodeIngressPolicyLocked() {
+	if !h.State().IsOnGateway() {
+		h.clearNodeIngressPolicyLocked()
+		return
+	}
+
+	desiredSrc := h.remoteCIDRs.Clone()
+
+	existing, err := h.netLink.RuleList(k8snet.IPv4)
+	if err != nil {
+		logger.Errorf(err, "Failed to list ip rules for node ingress policy")
+		return
+	}
+
+	haveCableRule := h.reconcileNodeIngressRulesLocked(existing, desiredSrc)
+	h.ensureNodeIngressSrcRulesLocked(desiredSrc)
+
+	if h.cableIfaceName != "" && !haveCableRule {
+		rule := netlinkAPI.NewTableRule(awsVPCNodeIngressTableID, k8snet.IPv4)
+		rule.IifName = h.cableIfaceName
+
+		if err := h.netLink.RuleAddIfNotPresent(rule); err != nil {
+			logger.Errorf(err, "Failed to add node ingress rule iif %s", h.cableIfaceName)
+		} else {
+			logger.Infof("Added AWS VPC CNI node ingress rule iif %s lookup %d",
+				h.cableIfaceName, awsVPCNodeIngressTableID)
+		}
+	}
+}
+
+// reconcileNodeIngressRulesLocked drops stale table rules and returns whether the
+// cable iif rule is already present. desiredSrc is updated in place for CIDRs that
+// already have a matching src rule.
+func (h *Handler) reconcileNodeIngressRulesLocked(
+	existing []netlink.Rule, desiredSrc set.Set[string],
+) bool {
+	haveCableRule := false
+
+	for i := range existing {
+		rule := existing[i]
+		if rule.Table != awsVPCNodeIngressTableID {
+			continue
+		}
+
+		if rule.IifName != "" {
+			if h.cableIfaceName != "" && rule.IifName == h.cableIfaceName {
+				haveCableRule = true
+				continue
+			}
+
+			_ = h.netLink.RuleDelIfPresent(&rule)
+
+			continue
+		}
+
+		if rule.Src == nil {
+			_ = h.netLink.RuleDelIfPresent(&rule)
+			continue
+		}
+
+		src := rule.Src.String()
+		if desiredSrc.Has(src) {
+			desiredSrc.Delete(src)
+			continue
+		}
+
+		_ = h.netLink.RuleDelIfPresent(&rule)
+	}
+
+	return haveCableRule
+}
+
+func (h *Handler) ensureNodeIngressSrcRulesLocked(desiredSrc set.Set[string]) {
+	for _, cidrStr := range desiredSrc.UnsortedList() {
+		_, src, err := net.ParseCIDR(cidrStr)
+		if err != nil {
+			continue
+		}
+
+		rule := netlinkAPI.NewTableRule(awsVPCNodeIngressTableID, k8snet.IPv4)
+		rule.Src = src
+
+		if err := h.netLink.RuleAddIfNotPresent(rule); err != nil {
+			logger.Errorf(err, "Failed to add node ingress rule from %s", cidrStr)
+		} else {
+			logger.Infof("Added AWS VPC CNI node ingress rule from %s lookup %d", cidrStr, awsVPCNodeIngressTableID)
+		}
+	}
+}
+
+func (h *Handler) clearNodeIngressPolicyLocked() {
+	rules, err := h.netLink.RuleList(k8snet.IPv4)
+	if err != nil {
+		logger.Errorf(err, "Failed to list ip rules while clearing node ingress policy")
+		return
+	}
+
+	for i := range rules {
+		if rules[i].Table != awsVPCNodeIngressTableID {
+			continue
+		}
+
+		if err := h.netLink.RuleDelIfPresent(&rules[i]); err != nil {
+			logger.Errorf(err, "Failed to delete node ingress rule %#v", rules[i])
+		}
+	}
+}
+
+func (h *Handler) addHostRouteLocked(dstCIDR, via string, table int) error {
+	link, err := h.netLink.LinkByName(vxlanIfaceName)
+	if err != nil {
+		return errors.Wrapf(err, "link %s not found", vxlanIfaceName)
+	}
+
+	_, dst, err := net.ParseCIDR(dstCIDR)
+	if err != nil {
+		return errors.Wrapf(err, "parse dest %s", dstCIDR)
+	}
+
+	gw := net.ParseIP(via)
+	if gw == nil {
+		return errors.Errorf("invalid gateway IP %q", via)
+	}
+
+	route := &netlink.Route{
+		Dst:       dst,
+		Gw:        gw,
+		LinkIndex: link.Attrs().Index,
+		Scope:     unix.RT_SCOPE_UNIVERSE,
+		Protocol:  routeProtocol,
+		Table:     table,
+	}
+
+	return errors.Wrap(h.netLink.RouteAddOrReplace(route), "RouteAddOrReplace")
+}
+
+func (h *Handler) delHostRouteLocked(dstCIDR string, table int) error {
+	link, err := h.netLink.LinkByName(vxlanIfaceName)
+	if err != nil {
+		return errors.Wrapf(err, "link %s not found", vxlanIfaceName)
+	}
+
+	_, dst, err := net.ParseCIDR(dstCIDR)
+	if err != nil {
+		return errors.Wrapf(err, "parse dest %s", dstCIDR)
+	}
+
+	route := &netlink.Route{
+		Dst:       dst,
+		LinkIndex: link.Attrs().Index,
+		Protocol:  routeProtocol,
+		Table:     table,
+	}
+
+	err = h.netLink.RouteDel(route)
+	if err == nil {
+		return nil
+	}
+
+	// Fall back: match by dst (+ table) only (gw may differ).
+	routes, listErr := h.netLink.RouteList(link, k8snet.IPv4)
+	if listErr != nil {
+		return errors.Wrap(err, "RouteDel")
+	}
+
+	for i := range routes {
+		if routes[i].Dst == nil || routes[i].Dst.String() != dst.String() {
+			continue
+		}
+
+		if routes[i].Table != table {
+			continue
+		}
+
+		if delErr := h.netLink.RouteDel(&routes[i]); delErr != nil {
+			return errors.Wrap(delErr, "RouteDel")
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func podIPv4(pod *corev1.Pod) string {
+	if k8snet.IPFamilyOfString(pod.Status.PodIP) == k8snet.IPv4 {
+		return pod.Status.PodIP
+	}
+
+	for _, p := range pod.Status.PodIPs {
+		if k8snet.IPFamilyOfString(p.IP) == k8snet.IPv4 {
+			return p.IP
+		}
+	}
+
+	return ""
+}

--- a/pkg/routeagent_driver/handlers/awsvpc/tables.go
+++ b/pkg/routeagent_driver/handlers/awsvpc/tables.go
@@ -1,0 +1,186 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsvpc
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	k8snet "k8s.io/utils/net"
+)
+
+// syncCNITableRoutesLocked copies remote cluster CIDRs and the VTEP overlay into
+// AWS VPC CNI PBR tables (issue #3697). Must be called with h.mutex held.
+func (h *Handler) syncCNITableRoutesLocked() {
+	if h.State().IsOnGateway() {
+		// On the active gateway, inter-cluster traffic uses the cable interface
+		// directly; workers need CNI table replication.
+		return
+	}
+
+	tables, err := h.discoverCNIRoutingTables()
+	if err != nil {
+		logger.Errorf(err, "Failed to list CNI routing tables")
+		return
+	}
+
+	if len(tables) == 0 {
+		return
+	}
+
+	link, err := h.netLink.LinkByName(vxlanIfaceName)
+	if err != nil {
+		logger.V(log.DEBUG).Infof("vx-submariner not ready yet: %v", err)
+		return
+	}
+
+	gwIP := h.localGatewayVTEP()
+	if gwIP == nil {
+		logger.V(log.DEBUG).Info("Local gateway VTEP unknown; skip CNI table sync")
+		return
+	}
+
+	cidrs := append(h.remoteCIDRs.UnsortedList(), vtepPrefixCIDR)
+
+	for _, table := range tables {
+		for _, cidrStr := range cidrs {
+			if err := h.ensureTableRoute(link, gwIP, cidrStr, table); err != nil {
+				logger.Errorf(err, "Failed to program %s in table %d", cidrStr, table)
+			}
+		}
+	}
+}
+
+func (h *Handler) clearCNITableRoutesLocked() {
+	tables, err := h.discoverCNIRoutingTables()
+	if err != nil {
+		logger.Errorf(err, "Failed to list CNI routing tables during cleanup")
+		return
+	}
+
+	link, err := h.netLink.LinkByName(vxlanIfaceName)
+	if err != nil {
+		return
+	}
+
+	cidrs := append(h.remoteCIDRs.UnsortedList(), vtepPrefixCIDR)
+
+	for _, table := range tables {
+		for _, cidrStr := range cidrs {
+			_, dst, err := net.ParseCIDR(cidrStr)
+			if err != nil {
+				continue
+			}
+
+			_ = h.netLink.RouteDel(&netlink.Route{
+				Dst:       dst,
+				LinkIndex: link.Attrs().Index,
+				Table:     table,
+				Protocol:  routeProtocol,
+			})
+		}
+	}
+}
+
+func (h *Handler) ensureTableRoute(link netlink.Link, gwIP net.IP, cidrStr string, table int) error {
+	_, dst, err := net.ParseCIDR(cidrStr)
+	if err != nil {
+		return errors.Wrapf(err, "parse %s", cidrStr)
+	}
+
+	route := &netlink.Route{
+		Dst:       dst,
+		LinkIndex: link.Attrs().Index,
+		Scope:     unix.RT_SCOPE_UNIVERSE,
+		Protocol:  routeProtocol,
+		Table:     table,
+	}
+
+	// VTEP CIDR is on-link; remote CIDRs go via the local gateway VTEP.
+	if cidrStr == vtepPrefixCIDR {
+		route.Scope = unix.RT_SCOPE_LINK
+	} else {
+		route.Gw = gwIP
+	}
+
+	return errors.Wrapf(h.netLink.RouteAddOrReplace(route), "table %d route %s", table, cidrStr)
+}
+
+func (h *Handler) discoverCNIRoutingTables() ([]int, error) {
+	rules, err := h.netLink.RuleList(k8snet.IPv4)
+	if err != nil {
+		return nil, errors.Wrap(err, "RuleList")
+	}
+
+	seen := map[int]struct{}{}
+	var tables []int
+
+	for i := range rules {
+		table := rules[i].Table
+		if table == 0 || table == mainRoutingTableID || table == unix.RT_TABLE_LOCAL {
+			continue
+		}
+
+		// Skip Submariner-managed tables.
+		if table == constants.RouteAgentInterClusterNetworkTableID ||
+			table == constants.RouteAgentHostNetworkTableID ||
+			table == awsVPCNodeIngressTableID {
+			continue
+		}
+
+		// AWS CNI uses "from <podIP> lookup <table>".
+		if rules[i].Src == nil {
+			continue
+		}
+
+		if _, ok := seen[table]; ok {
+			continue
+		}
+
+		seen[table] = struct{}{}
+		tables = append(tables, table)
+	}
+
+	return tables, nil
+}
+
+func (h *Handler) localGatewayVTEP() net.IP {
+	// Prefer the vxlan Group / neigh path: route to remote via vx-submariner uses Gw = local GW VTEP.
+	link, err := h.netLink.LinkByName(vxlanIfaceName)
+	if err != nil {
+		return nil
+	}
+
+	routes, err := h.netLink.RouteList(link, k8snet.IPv4)
+	if err != nil {
+		return nil
+	}
+
+	for i := range routes {
+		if routes[i].Gw != nil && !routes[i].Gw.IsUnspecified() {
+			return routes[i].Gw
+		}
+	}
+
+	return nil
+}

--- a/pkg/routeagent_driver/handlers/handlers_test.go
+++ b/pkg/routeagent_driver/handlers/handlers_test.go
@@ -40,6 +40,7 @@ import (
 	fakenetlink "github.com/submariner-io/submariner/pkg/netlink/fake"
 	fakePF "github.com/submariner-io/submariner/pkg/packetfilter/fake"
 	"github.com/submariner-io/submariner/pkg/pinger"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/awsvpc"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/calico"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
@@ -131,6 +132,9 @@ var _ = Describe("", func() {
 
 		calicoHandler := calico.NewCalicoIPPoolHandler(nil, testing.Namespace, dynClient)
 		Expect(calicoHandler.Init(ctx)).To(Succeed())
+
+		awsVPCHandler := awsvpc.NewHandler(k8sClient, k8snet.IPv4)
+		Expect(awsVPCHandler.Init(ctx)).To(Succeed())
 
 		healthCheckerHandler := healthchecker.New(&healthchecker.Config{
 			ControllerConfig: pinger.ControllerConfig{

--- a/pkg/routeagent_driver/main.go
+++ b/pkg/routeagent_driver/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/cabledriver"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/chains"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/environment"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/awsvpc"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/calico"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/healthchecker"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/kubeproxy"
@@ -158,6 +159,7 @@ func main() {
 			mtu.NewHandler(family, env.ClusterCidr, len(env.GlobalCidr) != 0, getTCPMssValue(localNode)))
 
 		handlers = append(handlers, ovn.GetHandlers(family, &env, smClientset, k8sClientSet, dynamicClientSet, config)...)
+		handlers = append(handlers, awsvpc.NewHandler(k8sClientSet, family))
 	}
 
 	handlers = append(handlers,


### PR DESCRIPTION
## What this PR does / why we need it

Amazon VPC CNI (EKS) is not a kube-proxy / OVN-style overlay. Pods get VPC ENI
addresses, and AWS CNI installs **custom PBR tables** for secondary ENIs. The
existing kubeproxy VXLAN route-agent path assumes a different model: routes in
the main table and a shared host network path that “just works” once VXLAN is up.

On EKS that is not enough:

1. **Workers** — remote cluster CIDRs programmed only in `main` are ignored for
   traffic that AWS CNI sends through its ENI-specific tables, so packets leave
   via the VPC default route instead of Submariner (see #3697).
2. **Active gateway** — return traffic from the cable must reach local pods via
   VTEP. Putting node InternalIP `/32` into `main` via VTEP breaks VXLAN underlay
   (FDB destination is the node IP). Pod `/32` via VTEP belongs in `main`; node
   `/32` must live in a dedicated PBR table selected only for cable/remote ingress.

Security Groups typically drop foreign pod CIDRs on the VPC path, so “just open
the VPC route” is not a reliable substitute for a correct Submariner datapath.

A separate `awsvpc` handler keeps this logic out of the generic kubeproxy path
and activates only when `SUBMARINER_NETWORKPLUGIN=amazon-vpc-cni` (set by the
operator discovery companion PR).

What it does:

- Active gateway: pod `/32` via VTEP in `main`; node `/32` in a dedicated PBR table
- Workers: replicate remote CIDRs (and related ranges) into AWS CNI PBR tables
- Periodic reconcile re-lists pods/nodes to avoid races before `vx-submariner` exists
- No-op for other CNIs (no regression on kube-proxy / OVN handlers)

## Fixes / addresses

- Addresses https://github.com/submariner-io/submariner/issues/3697 (route-agent not populating AWS CNI custom PBR tables)

## Depends on / related

- Prefer after operator discovery PR that sets plugin name to `amazon-vpc-cni`
- Related diagnose support in subctl

## Checklist

- [ ] Unit tests
- [ ] No regression on kube-proxy / OVN handlers

## Cross-links (this series)

- Prefer after operator discovery: https://github.com/submariner-io/submariner-operator/pull/4143
- Companion diagnose (subctl): will link after opening

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Amazon VPC CNI (`amazon-vpc-cni`) to the supported network plugins list.
  * Introduced an AWSVPC route-agent handler with on-gateway ingress route management.
  * Programs `/32` pod ingress routes via VTEPs and manages gateway node ingress routing using dedicated policy-based routing tables.
  * Continuously reconciles ingress and routing policy as pods, nodes, and endpoints change.
* **Tests**
  * Added an AWSVPC route-agent test suite covering gateway behavior and table selection.
  * Updated handler initialization tests to include the AWSVPC route-agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->