### PR TITLE
Fix AmneziaWG gateway startup failure

### DIFF
--- a/pkg/cable/amneziawg/amneziawg_test.go
+++ b/pkg/cable/amneziawg/amneziawg_test.go
@@ -158,10 +158,8 @@ func testNewDriver() {
 		Expect(device.Jmax).To(Equal(200))
 		Expect(device.S1).To(Equal(45))
 		Expect(device.S2).To(Equal(60))
-		Expect(device.S3).To(Equal(35))
-		Expect(device.S4).To(Equal(12))
-		Expect(device.H1).To(Equal("200000000-280000000"))
-		Expect(device.H2).To(Equal("400000000-480000000"))
+		Expect(device.H1).To(Equal("240000000"))
+		Expect(device.H2).To(Equal("440000000"))
 		Expect(device.I1).To(Equal("<r 40>"))
 		Expect(device.Peers).To(BeEmpty(), "ReplacePeers should clear the pre-seeded peer")
 
@@ -171,7 +169,7 @@ func testNewDriver() {
 
 	When("cable driver options are set", func() {
 		BeforeEach(func() {
-			os.Setenv(cable.CableDriverOptionsEnv, `{"jc":"3","h1":"10-20","i1":"<b 0x64>"}`)
+			os.Setenv(cable.CableDriverOptionsEnv, `{"jc":"3","h1":"300000000","i1":"<b 0x64>"}`)
 		})
 
 		AfterEach(func() {
@@ -181,9 +179,9 @@ func testNewDriver() {
 		It("should override the default obfuscation parameters", func() {
 			device := t.client.devices[amneziawg.DefaultDeviceName]
 			Expect(device.Jc).To(Equal(3))
-			Expect(device.H1).To(Equal("10-20"))
+			Expect(device.H1).To(Equal("300000000"))
 			Expect(device.I1).To(Equal("<b 0x64>"))
-			Expect(device.S3).To(Equal(35))
+			Expect(device.S1).To(Equal(45))
 		})
 	})
 

--- a/pkg/cable/amneziawg/obfuscation.go
+++ b/pkg/cable/amneziawg/obfuscation.go
@@ -32,10 +32,18 @@ import (
 // AmneziaWG always applies these defaults (there is no "plain WireGuard" mode via options):
 // the driver is intentionally an obfuscating tunnel, not a WG drop-in with optional junk.
 //
-// H1–H4 and S1–S4 MUST be identical on every Submariner peer (every cluster using this driver).
+// The vendored github.com/amnezia-vpn/amneziawg-go device only implements the subset of the
+// AmneziaWG protocol below: magic headers (H1-H4) are single uint32 values, not "min-max"
+// ranges, and there is no S3 (cookie) / S4 (transport) padding support. Sending either of
+// those over the UAPI configuration protocol fails the whole "set" operation with EINVAL,
+// which previously broke every fresh AmneziaWG gateway (see the issue link below).
+//
+// H1–H4 and S1–S2 MUST be identical on every Submariner peer (every cluster using this driver).
 // Jc / Jmin / Jmax / I1–I5 may differ per side, but the shipped defaults keep both sides symmetric
 // so a single cableDriverOptions map (or no overrides) works out of the box. Mismatched H*/S*
 // typically yields silent connectivity failure — override carefully and keep clusters in sync.
+//
+// Report: https://github.com/submariner-io/submariner/issues/4118
 func obfuscationOptionTable(cfg *wgtypes.Config) []cableDriverOption {
 	return []cableDriverOption{
 		// Junk packets before each handshake (helps break WG size signatures).
@@ -43,18 +51,16 @@ func obfuscationOptionTable(cfg *wgtypes.Config) []cableDriverOption {
 		option("jmin", "80", parsePositiveInt, &cfg.Jmin),
 		option("jmax", "200", parsePositiveInt, &cfg.Jmax),
 
-		// Message padding (AWG 2.0: S3 cookie, S4 transport). Must match on every peer.
+		// Message padding. Must match on every peer.
 		option("s1", "45", parseNonNegativeInt, &cfg.S1),
 		option("s2", "60", parseNonNegativeInt, &cfg.S2),
-		option("s3", "35", parseNonNegativeInt, &cfg.S3),
-		option("s4", "12", parseNonNegativeInt, &cfg.S4),
 
-		// Magic headers as non-overlapping ranges (AWG 2.0) — not the fixed WG types 1–4.
+		// Magic headers (single uint32 per packet type) — not the fixed WG types 1–4.
 		// Must match on every peer.
-		option("h1", "200000000-280000000", parseHeader, &cfg.H1),
-		option("h2", "400000000-480000000", parseHeader, &cfg.H2),
-		option("h3", "600000000-680000000", parseHeader, &cfg.H3),
-		option("h4", "800000000-880000000", parseHeader, &cfg.H4),
+		option("h1", "240000000", parseHeader, &cfg.H1),
+		option("h2", "440000000", parseHeader, &cfg.H2),
+		option("h3", "640000000", parseHeader, &cfg.H3),
+		option("h4", "840000000", parseHeader, &cfg.H4),
 
 		// Custom init packets (AWG 2.0) — random-looking UDP before handshake.
 		option("i1", "<r 40>", parseInitPacket, &cfg.I1),
@@ -76,13 +82,12 @@ func validateObfuscationOptions(table []cableDriverOption) []error {
 			"invalid AmneziaWG options: jmin (%d) must be <= jmax (%d)", *jmin, *jmax))
 	}
 
-	type namedRange struct {
+	type namedHeader struct {
 		name  string
-		value string
-		r     headerRange
+		value uint64
 	}
 
-	headers := make([]namedRange, 0, 4)
+	headers := make([]namedHeader, 0, 4)
 
 	for _, key := range []string{"h1", "h2", "h3", "h4"} {
 		val, ok := optionValue[*string](table, key)
@@ -90,22 +95,21 @@ func validateObfuscationOptions(table []cableDriverOption) []error {
 			continue
 		}
 
-		r, err := parseHeaderRange(*val)
+		// Already validated by parseHeader; the error was reported there.
+		n, err := strconv.ParseUint(*val, 10, 32)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "invalid AmneziaWG option %q", key))
 			continue
 		}
 
-		headers = append(headers, namedRange{name: key, value: *val, r: r})
+		headers = append(headers, namedHeader{name: key, value: n})
 	}
 
 	for i := range headers {
 		for j := i + 1; j < len(headers); j++ {
-			left, right := headers[i], headers[j]
-			if left.r.start <= right.r.end && right.r.start <= left.r.end {
+			if headers[i].value == headers[j].value {
 				errs = append(errs, errors.Errorf(
-					"invalid AmneziaWG options: %s (%s) overlaps %s (%s)",
-					left.name, left.value, right.name, right.value))
+					"invalid AmneziaWG options: %s and %s must not have the same value (%d)",
+					headers[i].name, headers[j].name, headers[i].value))
 			}
 		}
 	}
@@ -113,44 +117,13 @@ func validateObfuscationOptions(table []cableDriverOption) []error {
 	return errs
 }
 
-type headerRange struct {
-	start uint64
-	end   uint64
-}
-
+// parseHeader mirrors amneziawg-go's handleDeviceLine for h1-h4: a single uint32, not a range.
 func parseHeader(key, value string) (*string, error) {
-	if _, err := parseHeaderRange(value); err != nil {
-		return nil, errors.Wrapf(err, "invalid AmneziaWG option %q=%q", key, value)
+	if _, err := strconv.ParseUint(value, 10, 32); err != nil {
+		return nil, errors.Wrapf(err, "invalid AmneziaWG option %q=%q: must be a single uint32", key, value)
 	}
 
 	return new(value), nil
-}
-
-// parseHeaderRange mirrors amneziawg-go newMagicHeader: single uint32 or min-max with min <= max.
-func parseHeaderRange(value string) (headerRange, error) {
-	parts := strings.Split(value, "-")
-	if len(parts) < 1 || len(parts) > 2 {
-		return headerRange{}, errors.New("expected uint32 or min-max range")
-	}
-
-	start, err := strconv.ParseUint(parts[0], 10, 32)
-	if err != nil {
-		return headerRange{}, errors.Wrap(err, "invalid range start")
-	}
-
-	end := start
-	if len(parts) == 2 {
-		end, err = strconv.ParseUint(parts[1], 10, 32)
-		if err != nil {
-			return headerRange{}, errors.Wrap(err, "invalid range end")
-		}
-	}
-
-	if end < start {
-		return headerRange{}, errors.New("range start must be <= end")
-	}
-
-	return headerRange{start: start, end: end}, nil
 }
 
 func parseInitPacket(key, value string) (*string, error) {

--- a/pkg/cable/amneziawg/options_internal_test.go
+++ b/pkg/cable/amneziawg/options_internal_test.go
@@ -30,10 +30,10 @@ func newOptionsDriver() *amneziawgDriver {
 	return &amneziawgDriver{keepAlive: 10 * time.Second}
 }
 
-var _ = Describe("parseHeaderRange", func() {
+var _ = Describe("parseHeader", func() {
 	DescribeTable("validation",
 		func(value string, wantErr bool) {
-			_, err := parseHeaderRange(value)
+			_, err := parseHeader("h1", value)
 			if wantErr {
 				Expect(err).To(HaveOccurred())
 			} else {
@@ -41,14 +41,10 @@ var _ = Describe("parseHeaderRange", func() {
 			}
 		},
 		Entry("single uint32", "123", false),
-		Entry("valid range", "10-20", false),
-		Entry("equal bounds", "5-5", false),
-		Entry("inverted range", "20-10", true),
+		Entry("range (unsupported by amneziawg-go)", "10-20", true),
 		Entry("non-numeric", "foo", true),
-		Entry("too many parts", "1-2-3", true),
 		Entry("empty", "", true),
-		Entry("trailing dash", "10-", true),
-		Entry("leading dash", "-10", true),
+		Entry("negative", "-10", true),
 	)
 })
 
@@ -84,9 +80,9 @@ var _ = Describe("applyCableDriverOptionsMap", func() {
 		Expect(applyCableDriverOptionsMap(a, &cfg, nil)).To(Succeed())
 
 		Expect(*cfg.Jc).To(Equal(7))
-		Expect(*cfg.H1).To(Equal("200000000-280000000"))
+		Expect(*cfg.H1).To(Equal("240000000"))
 		Expect(*cfg.I1).To(Equal("<r 40>"))
-		Expect(*cfg.S3).To(Equal(35))
+		Expect(cfg.S3).To(BeNil(), "S3 is unsupported by the vendored amneziawg-go device")
 		Expect(a.keepAlive).To(Equal(10 * time.Second))
 	})
 
@@ -95,16 +91,16 @@ var _ = Describe("applyCableDriverOptionsMap", func() {
 		var cfg wgtypes.Config
 		Expect(applyCableDriverOptionsMap(a, &cfg, map[string]string{
 			"jc":        "3",
-			"h1":        "10-20",
+			"h1":        "300000000",
 			"i1":        "<b 0x64>",
 			"keepalive": "25",
 		})).To(Succeed())
 
 		Expect(*cfg.Jc).To(Equal(3))
-		Expect(*cfg.H1).To(Equal("10-20"))
+		Expect(*cfg.H1).To(Equal("300000000"))
 		Expect(*cfg.I1).To(Equal("<b 0x64>"))
-		Expect(*cfg.S3).To(Equal(35))
-		Expect(*cfg.H2).To(Equal("400000000-480000000"))
+		Expect(cfg.S3).To(BeNil(), "S3 is unsupported by the vendored amneziawg-go device")
+		Expect(*cfg.H2).To(Equal("440000000"))
 		Expect(a.keepAlive).To(Equal(25 * time.Second))
 	})
 
@@ -143,7 +139,7 @@ var _ = Describe("applyCableDriverOptionsMap", func() {
 		})).To(Succeed())
 
 		Expect(*cfg.Jc).To(Equal(7))
-		Expect(*cfg.H1).To(Equal("200000000-280000000"))
+		Expect(*cfg.H1).To(Equal("240000000"))
 		Expect(*cfg.I1).To(Equal("<r 40>"))
 		Expect(a.keepAlive).To(Equal(10 * time.Second))
 	})
@@ -163,12 +159,12 @@ var _ = Describe("applyCableDriverOptionsMap", func() {
 		Expect(err).To(MatchError(ContainSubstring(`invalid AmneziaWG option "h1"="20-10"`)))
 	})
 
-	It("should fail when header ranges overlap", func() {
+	It("should fail when two magic headers have the same value", func() {
 		err := applyCableDriverOptionsMap(newOptionsDriver(), &wgtypes.Config{}, map[string]string{
-			"h1": "10-30",
-			"h2": "20-40",
+			"h1": "300000000",
+			"h2": "300000000",
 		})
-		Expect(err).To(MatchError(ContainSubstring("overlaps")))
+		Expect(err).To(MatchError(ContainSubstring("must not have the same value")))
 	})
 
 	It("should fail on an invalid init packet option", func() {

--- a/pkg/cable/amneziawg/protocol_test.go
+++ b/pkg/cable/amneziawg/protocol_test.go
@@ -1,0 +1,65 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amneziawg
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/advanced-wg/awgctrl-go/wgtypes"
+	"github.com/amnezia-vpn/amneziawg-go/conn"
+	"github.com/amnezia-vpn/amneziawg-go/device"
+	"github.com/amnezia-vpn/amneziawg-go/tun/tuntest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// newRealAmneziaDevice starts the actual amnezia-vpn/amneziawg-go device (the same package
+// StartUserspaceDevice embeds in daemon.go) over an in-memory TUN. It exercises the real UAPI
+// protocol parser, unlike the fakeClient used elsewhere in this package's tests, which accepts
+// any string and so cannot catch a driver default that the real device rejects.
+func newRealAmneziaDevice() *device.Device {
+	return device.NewDevice(tuntest.NewChannelTUN().TUN(), conn.NewDefaultBind(), device.NewLogger(device.LogLevelSilent, ""))
+}
+
+// uapiSetConfig renders the obfuscation fields applyCableDriverOptionsMap populates in the same
+// wire format awgctrl-go's internal/wguser.writeConfig sends over the UAPI "set" socket.
+func uapiSetConfig(cfg *wgtypes.Config) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "jc=%d\njmin=%d\njmax=%d\n", *cfg.Jc, *cfg.Jmin, *cfg.Jmax)
+	fmt.Fprintf(&b, "s1=%d\ns2=%d\n", *cfg.S1, *cfg.S2)
+	fmt.Fprintf(&b, "h1=%s\nh2=%s\nh3=%s\nh4=%s\n", *cfg.H1, *cfg.H2, *cfg.H3, *cfg.H4)
+	fmt.Fprintf(&b, "i1=%s\ni2=%s\ni3=%s\ni4=%s\ni5=%s\n", *cfg.I1, *cfg.I2, *cfg.I3, *cfg.I4, *cfg.I5)
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+var _ = Describe("default obfuscation config against the real AmneziaWG device", func() {
+	It("should be accepted by the vendored amneziawg-go UAPI parser", func() {
+		var cfg wgtypes.Config
+		Expect(applyCableDriverOptionsMap(newOptionsDriver(), &cfg, nil)).To(Succeed())
+
+		dev := newRealAmneziaDevice()
+		defer dev.Close()
+
+		Expect(dev.IpcSet(uapiSetConfig(&cfg))).To(Succeed())
+	})
+})


### PR DESCRIPTION
Motivation:
The AmneziaWG cable driver's default obfuscation options never
configure successfully against the vendored
amnezia-vpn/amneziawg-go v1.0.4 userspace device: E2E jobs failed
immediately after gateway startup with "failed to configure
AmneziaWG device: read: wguser: errno=-22".

Approach:
The vendored device only implements a subset of the AmneziaWG
protocol: magic headers (h1-h4) are single uint32 values, not
"min-max" ranges, and there is no s3 (cookie) / s4 (transport)
padding support at all. The driver's shipped defaults sent both an
"s3"/"s4" key the device rejects outright and h1-h4 as ranges, so
the very first UAPI "set" operation always failed with EINVAL,
regardless of any cableDriverOptions override.

Remove the s3/s4 options (now rejected as an unknown option instead
of a silent runtime EINVAL if ever set) and change h1-h4 defaults to
single uint32 values, matching what the real device parses.
Simplify header validation to match: drop the range parsing/overlap
checks and replace them with a plain "no two magic headers may
share a value" check, mirroring the device's own uniqueness check.

Validation:
Reproduced the failure and confirmed the fix by driving the actual
vendored github.com/amnezia-vpn/amneziawg-go device (via its
tun/tuntest in-memory TUN, no root or kernel device needed) with
the driver's real UAPI wire output: the original defaults failed
with "IPC error -22: invalid UAPI device key: s3", a range-format
h1 failed with "IPC error -22: ... invalid syntax", and the new
defaults succeeded with no error. Added protocol_test.go so this is
checked against the real device going forward, instead of only the
fakeClient the rest of this package's tests use (which accepts any
string and did not catch this).

Ran, all succeeding:
  GOOS=linux GOARCH=amd64 go build ./...
  GOOS=linux GOARCH=amd64 go vet ./pkg/cable/amneziawg/...
  GOOS=linux GOARCH=amd64 go test -c ./pkg/cable/amneziawg/...
  GOOS=linux GOARCH=arm64 go build ./pkg/cable/amneziawg/...
Could not execute `go test` or `make unit` in this sandbox: this
repo requires Linux, the sandbox is macOS, and
github.com/vishvananda/netlink does not build on darwin at all -
confirmed pre-existing and unrelated by reproducing the identical
failure on an unmodified checkout.

Impact: this only affects AmneziaWG gateway startup. Every fresh
AmneziaWG cable driver instance failed to start, with or without a
cableDriverOptions override; no data-plane traffic or already
established tunnel is affected.

Report: https://github.com/submariner-io/submariner/issues/4118
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AmneziaWG obfuscation settings to match the supported driver format.
  * Replaced header ranges with fixed numeric values and removed unsupported S3/S4 options.
  * Improved validation to reject duplicate header values and invalid configurations.
* **Tests**
  * Added coverage confirming generated default configurations are accepted by the protocol parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->