### PR TITLE
Fetch GlobalIngressIP from API server to avoid stale cache

### DIFF
--- a/pkg/globalnet/controllers/global_ingressip_controller.go
+++ b/pkg/globalnet/controllers/global_ingressip_controller.go
@@ -73,6 +73,7 @@ func NewGlobalIngressIPController(ctx context.Context, config *syncer.ResourceSy
 	federator := federate.NewUpdateStatusFederator(config.SourceClient, config.RestMapper, corev1.NamespaceAll)
 
 	client := config.SourceClient.Resource(*gvr)
+	controller.globalIngressIPs = client
 
 	list, err := client.Namespace(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -141,6 +142,22 @@ func (c *globalIngressIPController) GetSyncer() syncer.Interface {
 	return c.resourceSyncer
 }
 
+func (c *globalIngressIPController) fetchLatestFromAPIServer(ctx context.Context, ingressIP *submarinerv1.GlobalIngressIP) error {
+	key, _ := cache.MetaNamespaceKeyFunc(ingressIP)
+
+	freshObj, err := c.globalIngressIPs.Namespace(ingressIP.Namespace).Get(ctx, ingressIP.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error retrieving latest GlobalIngressIP %q from API server", key)
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(freshObj.Object, ingressIP)
+	if err != nil {
+		return errors.Wrapf(err, "error converting GlobalIngressIP %q", key)
+	}
+
+	return nil
+}
+
 func (c *globalIngressIPController) process(from runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
 	ctx := wait.ContextForChannel(c.stopCh)
 
@@ -151,6 +168,14 @@ func (c *globalIngressIPController) process(from runtime.Object, numRequeues int
 
 	switch op {
 	case syncer.Create:
+		// Always fetch the latest version from the API server to avoid processing stale cached data.
+		// This can happen when the service controller re-queues the GlobalIngressIP immediately after initial allocation,
+		// before the syncer's cache has been updated with the new status.
+		if err := c.fetchLatestFromAPIServer(ctx, ingressIP); err != nil {
+			logger.Error(err, "Failed to fetch latest GlobalIngressIP from API server")
+			return nil, true
+		}
+
 		prevStatus := ingressIP.Status
 
 		trimAllocatedStatusCondition(&ingressIP.Status.Conditions)

--- a/pkg/globalnet/controllers/types.go
+++ b/pkg/globalnet/controllers/types.go
@@ -174,8 +174,9 @@ type clusterGlobalEgressIPController struct {
 
 type globalIngressIPController struct {
 	*baseIPAllocationController
-	services dynamic.NamespaceableResourceInterface
-	scheme   *runtime.Scheme
+	services         dynamic.NamespaceableResourceInterface
+	globalIngressIPs dynamic.NamespaceableResourceInterface
+	scheme           *runtime.Scheme
 }
 
 type serviceExportController struct {


### PR DESCRIPTION
When the service controller re-queues a `GlobalIngressIP` immediately after initial allocation, the syncer's cache may not yet reflect the updated status with the allocated IP. This causes the controller to attempt re-allocation instead of updating the internal service.

Fix by always fetching the latest `GlobalIngressIP` from the API server at the start of the Create operation, before trimming status conditions or processing. This ensures we have fresh data even when the cache is stale.

Fixes: #4122



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GlobalIngressIP processing by retrieving the latest resource state before handling status updates.
  * Added automatic retry handling when the latest resource cannot be retrieved or converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->