### PR TITLE
Automated backport of #4149: Fix VXLAN loopback drops from shared MAC

### DIFF
--- a/pkg/globalnet/controllers/ingress_endpoints_controller.go
+++ b/pkg/globalnet/controllers/ingress_endpoints_controller.go
@@ -79,7 +79,9 @@ func startIngressEndpointsController(svc *corev1.Service, config *syncer.Resourc
 		return nil, errors.Wrap(err, "error starting the endpoint syncer")
 	}
 
-	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(corev1.NamespaceAll)
+	// Scope reconcile to this Service's namespace so a same-named headless Service
+	// in another namespace does not have its GlobalIngressIPs deleted.
+	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(svc.Namespace)
 	controller.reconcile(ingressIPs, "" /* labelSelector */, fieldSelector, func(obj *unstructured.Unstructured) runtime.Object {
 		endpointsName, exists, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
 		if exists {

--- a/pkg/globalnet/controllers/ingress_pod_controller.go
+++ b/pkg/globalnet/controllers/ingress_pod_controller.go
@@ -82,8 +82,11 @@ func startIngressPodController(svc *corev1.Service, config *syncer.ResourceSynce
 		ServiceRefLabel: svc.Name,
 	}
 
+	// Reconcile only GlobalIngressIPs in this Service's namespace. Listing across
+	// NamespaceAll with just the service name label incorrectly deletes GIPs for
+	// other namespaces that export a headless Service with the same name.
 	ingressIPSelector := labels.Set(selector).AsSelector().String()
-	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(corev1.NamespaceAll)
+	ingressIPs := config.SourceClient.Resource(*gvr).Namespace(svc.Namespace)
 	controller.reconcile(ingressIPs, ingressIPSelector, "" /* fieldSelector*/, func(obj *unstructured.Unstructured) runtime.Object {
 		podName, exists, _ := unstructured.NestedString(obj.Object, "spec", "podRef", "name")
 		if exists {

--- a/pkg/globalnet/controllers/service_export_controller_test.go
+++ b/pkg/globalnet/controllers/service_export_controller_test.go
@@ -35,6 +35,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("ServiceExport controller", func() {
@@ -295,6 +297,69 @@ func testHeadlessService() {
 				list, _ := t.globalIngressIPs.List(context.TODO(), metav1.ListOptions{})
 				return list.Items
 			}, time.Second*3).Should(BeEmpty())
+		})
+	})
+
+	When("the same headless Service name is exported from another namespace", func() {
+		const otherNamespace = "other-ns"
+
+		var otherService *corev1.Service
+		var otherPod *corev1.Pod
+
+		BeforeEach(func() {
+			t.createPod(backendPod)
+
+			otherService = newHeadlessService()
+			otherService.Namespace = otherNamespace
+
+			otherPod = newHeadlessServicePod(otherService.Name)
+			otherPod.Namespace = otherNamespace
+			otherPod.Status.PodIP = "172.45.4.4"
+		})
+
+		It("should retain GlobalIngressIPs for both namespaces", func(ctx context.Context) {
+			localIngressIP := t.awaitHeadlessGlobalIngressIP(service.Name, backendPod.Name)
+
+			gvrService := *test.GetGroupVersionResourceFor(t.restMapper, &corev1.Service{})
+			gvrServiceExport := *test.GetGroupVersionResourceFor(t.restMapper, &mcsv1a1.ServiceExport{})
+			gvrGlobalIngressIP := *test.GetGroupVersionResourceFor(t.restMapper, &submarinerv1.GlobalIngressIP{})
+
+			test.CreateResource(t.dynClient.Resource(gvrService).Namespace(otherNamespace), otherService)
+			t.createPod(otherPod)
+			test.CreateResource(t.dynClient.Resource(gvrServiceExport).Namespace(otherNamespace), &mcsv1a1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      otherService.Name,
+					Namespace: otherNamespace,
+				},
+			})
+
+			var otherIngressIP *submarinerv1.GlobalIngressIP
+
+			Eventually(ctx, func(g Gomega, ctx context.Context) {
+				list, err := t.dynClient.Resource(gvrGlobalIngressIP).Namespace(otherNamespace).List(ctx, metav1.ListOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(list.Items).NotTo(BeEmpty())
+
+				gip := &submarinerv1.GlobalIngressIP{}
+				g.Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[0].Object, gip)).To(Succeed())
+				otherIngressIP = gip
+			}).Within(5 * time.Second).Should(Succeed())
+
+			Expect(otherIngressIP.Spec.ServiceRef.Name).To(Equal(otherService.Name))
+			Expect(otherIngressIP.Spec.PodRef.Name).To(Equal(otherPod.Name))
+
+			Consistently(ctx, func(ctx context.Context) error {
+				_, err := t.globalIngressIPs.Get(ctx, localIngressIP.Name, metav1.GetOptions{})
+
+				return err
+			}).Within(2 * time.Second).Should(Succeed())
+
+			Consistently(ctx, func(ctx context.Context) error {
+				_, err := t.dynClient.Resource(gvrGlobalIngressIP).Namespace(otherNamespace).
+					Get(ctx, otherIngressIP.Name, metav1.GetOptions{})
+
+				return err
+			}).Within(2 * time.Second).Should(Succeed())
 		})
 	})
 }

--- a/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
+++ b/pkg/routeagent_driver/handlers/kubeproxy/vxlan.go
@@ -52,17 +52,22 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 		return errors.Wrapf(err, "failed to derive the vxlan vtepIP for %s", ipAddr)
 	}
 
+	hwAddr := vxlan.HardwareAddrFromIP(ipAddr)
+
 	if ifaceType == VxInterfaceGateway {
 		attrs := &vxlan.Attributes{
-			Name:     kp.vxlanIface,
-			VxlanID:  100,
-			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU(),
+			Name:         kp.vxlanIface,
+			VxlanID:      100,
+			VtepPort:     port.IntraClusterVxLAN,
+			Mtu:          kp.defaultHostIface.MTU(),
+			SrcAddr:      ipAddr,
+			HardwareAddr: hwAddr,
 		}
 
-		// For IPv6 VxLAN interface SrcAddr should be set with local IP
-		if kp.ipFamily == k8snet.IPv6 {
+		// For IPv6, prefer the gateway VTEP/local endpoint IP when available.
+		if kp.ipFamily == k8snet.IPv6 && kp.vxlanGwIP != nil {
 			attrs.SrcAddr = *kp.vxlanGwIP
+			attrs.HardwareAddr = vxlan.HardwareAddrFromIP(attrs.SrcAddr)
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)
@@ -86,11 +91,13 @@ func (kp *SyncHandler) createVxLANInterface(ifaceType int, gatewayNodeIP net.IP)
 	} else if ifaceType == VxInterfaceWorker {
 		// non-Gateway/Worker Node
 		attrs := &vxlan.Attributes{
-			Name:     kp.vxlanIface,
-			VxlanID:  100,
-			Group:    gatewayNodeIP,
-			VtepPort: port.IntraClusterVxLAN,
-			Mtu:      kp.defaultHostIface.MTU(),
+			Name:         kp.vxlanIface,
+			VxlanID:      100,
+			Group:        gatewayNodeIP,
+			VtepPort:     port.IntraClusterVxLAN,
+			Mtu:          kp.defaultHostIface.MTU(),
+			SrcAddr:      ipAddr,
+			HardwareAddr: hwAddr,
 		}
 
 		kp.vxlanDevice, err = kp.newVxlanInterface(attrs)

--- a/pkg/vxlan/vxlan.go
+++ b/pkg/vxlan/vxlan.go
@@ -19,6 +19,8 @@ limitations under the License.
 package vxlan
 
 import (
+	"bytes"
+	"hash/fnv"
 	"io/fs"
 	"net"
 	"syscall"
@@ -33,12 +35,13 @@ import (
 )
 
 type Attributes struct {
-	Name     string
-	VxlanID  int
-	Group    net.IP
-	SrcAddr  net.IP
-	VtepPort int
-	Mtu      int
+	Name         string
+	VxlanID      int
+	Group        net.IP
+	SrcAddr      net.IP
+	VtepPort     int
+	Mtu          int
+	HardwareAddr net.HardwareAddr
 }
 
 type Interface struct {
@@ -62,12 +65,35 @@ func NewInterface(attrs *Attributes, netLink netlinkAPI.Interface) (*Interface, 
 	}, nil
 }
 
+// HardwareAddrFromIP returns a locally-administered unicast MAC derived from the
+// given IP. This avoids Linux VXLAN loopback drops when gateway and worker
+// vx-submariner interfaces would otherwise share the same kernel-assigned MAC
+// (see https://github.com/submariner-io/submariner/issues/4024).
+func HardwareAddrFromIP(ip net.IP) net.HardwareAddr {
+	if ip4 := ip.To4(); ip4 != nil {
+		return net.HardwareAddr{0x02, 0x00, ip4[0], ip4[1], ip4[2], ip4[3]}
+	}
+
+	if ip6 := ip.To16(); ip6 != nil {
+		h := fnv.New64a()
+		_, _ = h.Write(ip6)
+		sum := h.Sum64()
+
+		// Truncation to bytes is intentional for a 40-bit MAC payload.
+		//nolint:gosec // G115: truncate hash to MAC bytes
+		return net.HardwareAddr{0x02, byte(sum >> 32), byte(sum >> 24), byte(sum >> 16), byte(sum >> 8), byte(sum)}
+	}
+
+	return nil
+}
+
 func createLinkDevice(attrs *Attributes, netLink netlinkAPI.Interface) (*netlink.Vxlan, error) {
 	link := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:  attrs.Name,
-			MTU:   attrs.Mtu - MTUOverhead,
-			Flags: net.FlagUp,
+			Name:         attrs.Name,
+			MTU:          attrs.Mtu - MTUOverhead,
+			Flags:        net.FlagUp,
+			HardwareAddr: attrs.HardwareAddr,
 		},
 		VxlanId: attrs.VxlanID,
 		SrcAddr: attrs.SrcAddr,
@@ -129,6 +155,13 @@ func isVxlanConfigTheSame(newLink, currentLink netlink.Link) bool {
 
 	if required.Port != existing.Port {
 		logger.Warningf("Vxlan Port (%d) of existing interface does not match with required Port (%d)", existing.Port, required.Port)
+		return false
+	}
+
+	if len(required.HardwareAddr) > 0 && !bytes.Equal(required.HardwareAddr, existing.HardwareAddr) {
+		logger.Warningf("Vxlan HardwareAddr (%v) of existing interface does not match with required HardwareAddr (%v)",
+			existing.HardwareAddr, required.HardwareAddr)
+
 		return false
 	}
 

--- a/pkg/vxlan/vxlan_test.go
+++ b/pkg/vxlan/vxlan_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package vxlan_test
 
 import (
+	"crypto/rand"
 	"net"
 	"testing"
 
@@ -93,8 +94,97 @@ var _ = Describe("NewInterface", func() {
 				t.assertLink(&newAttrs)
 			})
 		})
+
+		Context("and the HardwareAddr differs", func() {
+			It("should re-create it", func() {
+				newAttrs.HardwareAddr = net.HardwareAddr{0x02, 0x00, 0x01, 0x02, 0x03, 0x04}
+				_ = t.newInterface(&newAttrs)
+				t.assertLink(&newAttrs)
+			})
+		})
 	})
 })
+
+var _ = Describe("HardwareAddrFromIP", func() {
+	It("should return nil for an invalid IP", func() {
+		Expect(vxlan.HardwareAddrFromIP(nil)).To(BeNil())
+		Expect(vxlan.HardwareAddrFromIP(net.IP{})).To(BeNil())
+	})
+
+	DescribeTableSubtree("for random addresses",
+		func(randomIP func() net.IP) {
+			It("should be stable, locally-administered, unicast, and unique", func() {
+				const samples = 32
+
+				ips := make([]net.IP, 0, samples)
+				seenIP := map[string]bool{}
+
+				for len(ips) < samples {
+					ip := randomIP()
+					if seenIP[ip.String()] {
+						continue
+					}
+
+					seenIP[ip.String()] = true
+					ips = append(ips, ip)
+				}
+
+				seenMAC := map[string]bool{}
+
+				for _, ip := range ips {
+					mac := vxlan.HardwareAddrFromIP(ip)
+					Expect(mac).ToNot(BeNil())
+					Expect(mac).To(HaveLen(6))
+
+					// Stable for a given input.
+					Expect(vxlan.HardwareAddrFromIP(ip)).To(Equal(mac))
+
+					// Locally administered (U/L bit) and unicast (I/G bit clear).
+					Expect(mac[0] & 0x02).NotTo(BeZero())
+					Expect(mac[0] & 0x01).To(BeZero())
+
+					Expect(seenMAC).NotTo(HaveKey(mac.String()))
+					seenMAC[mac.String()] = true
+				}
+			})
+		},
+		Entry("IPv4", randomIPv4),
+		Entry("IPv6", randomIPv6),
+	)
+
+	It("should derive different MACs when IPv6 addresses share a suffix but differ in prefix", func() {
+		suffix := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+
+		ip1 := make(net.IP, net.IPv6len)
+		ip1[0] = 0x20
+		copy(ip1[11:], suffix)
+
+		ip2 := make(net.IP, net.IPv6len)
+		ip2[0] = 0xfd
+		copy(ip2[11:], suffix)
+
+		mac1 := vxlan.HardwareAddrFromIP(ip1)
+		mac2 := vxlan.HardwareAddrFromIP(ip2)
+
+		Expect(mac1).ToNot(Equal(mac2))
+	})
+})
+
+func randomIPv4() net.IP {
+	b := make([]byte, 4)
+	_, err := rand.Read(b)
+	Expect(err).NotTo(HaveOccurred())
+
+	return net.IP(b)
+}
+
+func randomIPv6() net.IP {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	Expect(err).NotTo(HaveOccurred())
+
+	return net.IP(b)
+}
 
 var _ = Describe("GetVtepIPAddressFrom", func() {
 	It("should return the correct IP", func() {
@@ -235,4 +325,8 @@ func (t *testDriver) assertLink(attrs *vxlan.Attributes) {
 	Expect(link.Group).To(Equal(attrs.Group))
 	Expect(link.Port).To(Equal(attrs.VtepPort))
 	Expect(link.MTU).To(Equal(attrs.Mtu - vxlan.MTUOverhead))
+
+	if len(attrs.HardwareAddr) > 0 {
+		Expect(link.HardwareAddr).To(Equal(attrs.HardwareAddr))
+	}
 }


### PR DESCRIPTION
Backport of #4149 on release-0.23.

#4149: Fix VXLAN loopback drops from shared MAC

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented identically named Services in different namespaces from affecting one another’s GlobalIngressIP resources.
  - Improved IPv6 VXLAN gateway handling to avoid configuration-related failures.
  - Ensured VXLAN interfaces use stable, locally unique hardware addresses.

- **Improvements**
  - Added support for configuring VXLAN interface hardware addresses.
  - VXLAN configuration changes are now detected and applied more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->