### PR TITLE
Automated backport of CVE fixes

### DIFF
--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -73,7 +74,50 @@ var (
 	FatalError            = func(err error, msg string) {
 		logger.FatalOnError(err, msg)
 	}
+
+	// cableNamePattern matches safe characters for connection names (alphanumeric, dash, underscore, dot).
+	cableNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 )
+
+// validateCableName ensures the cable name doesn't contain injection characters.
+func validateCableName(cableName string) error {
+	if cableName == "" {
+		return errors.New("cable name is empty")
+	}
+
+	if !cableNamePattern.MatchString(cableName) {
+		return fmt.Errorf("cable name %q contains invalid characters", cableName)
+	}
+
+	return nil
+}
+
+// validateEndpointInputs validates endpoint configuration to prevent injection attacks.
+func validateEndpointInputs(endpoint *subv1.EndpointSpec, localIP, remoteIP string) error {
+	// Validate cable name
+	if err := validateCableName(endpoint.CableName); err != nil {
+		return err
+	}
+
+	// Validate all subnets
+	for _, subnet := range endpoint.Subnets {
+		if _, _, err := net.ParseCIDR(subnet); err != nil {
+			return errors.Wrapf(err, "invalid CIDR %q", subnet)
+		}
+	}
+
+	// Validate remote IP address
+	if net.ParseIP(remoteIP) == nil {
+		return fmt.Errorf("invalid IP address %q", remoteIP)
+	}
+
+	// Validate local IP address
+	if net.ParseIP(localIP) == nil {
+		return fmt.Errorf("invalid IP address %q", localIP)
+	}
+
+	return nil
+}
 
 func init() {
 	cable.AddDriver(cableDriverName, NewLibreswan)
@@ -370,6 +414,12 @@ func (i *libreswan) ConnectToEndpoint(endpointInfo *natdiscovery.NATEndpointInfo
 
 	// We'll panic if endpointInfo is nil, this is intentional
 	endpoint := &endpointInfo.Endpoint
+
+	// Validate endpoint inputs to prevent config injection
+	localIP := i.localEndpoint.GetPrivateIP(endpointInfo.UseFamily)
+	if err := validateEndpointInputs(&endpoint.Spec, localIP, endpointInfo.UseIP); err != nil {
+		return "", err
+	}
 
 	rightNATTPort, err := endpoint.Spec.GetBackendPort(subv1.UDPPortConfig, i.defaultNATTPort)
 	if err != nil {

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -75,8 +75,9 @@ var (
 		logger.FatalOnError(err, msg)
 	}
 
-	// cableNamePattern matches safe characters for connection names (alphanumeric, dash, underscore, dot).
-	cableNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	// cableNamePattern matches safe characters for connection names (alphanumeric, dash, underscore, dot)
+	// and caps length at 200 to prevent oversized ipsec.conf stanzas.
+	cableNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,200}$`)
 )
 
 // validateCableName ensures the cable name doesn't contain injection characters.

--- a/pkg/cable/libreswan/libreswan.go
+++ b/pkg/cable/libreswan/libreswan.go
@@ -21,7 +21,6 @@ package libreswan
 import (
 	"bufio"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io/fs"
 	"net"
@@ -29,7 +28,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -39,6 +37,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/log"
 	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cable/psk"
 	submendpoint "github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	"github.com/submariner-io/submariner/pkg/netlink"
@@ -177,23 +176,9 @@ func NewLibreswan(localEndpoint *submendpoint.Local, _ *types.SubmarinerCluster)
 		return nil, err
 	}
 
-	encodedPsk := ipSecSpec.PSK
-
-	if ipSecSpec.PSKSecret != "" {
-		pskBytes, err := os.ReadFile(RootDir + fmt.Sprintf("/var/run/secrets/submariner.io/%s/psk", ipSecSpec.PSKSecret))
-		if err != nil {
-			return nil, errors.Wrapf(err, "error reading secret %s", ipSecSpec.PSKSecret)
-		}
-		var psk strings.Builder
-		encoder := base64.NewEncoder(base64.StdEncoding, &psk)
-
-		if _, err := encoder.Write(pskBytes); err != nil {
-			return nil, errors.Wrap(err, "error encoding secret")
-		}
-
-		encoder.Close()
-
-		encodedPsk = psk.String()
+	encodedPsk, err := psk.Resolve(ipSecSpec.PSK, ipSecSpec.PSKSecret, RootDir)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // No need to wrap
 	}
 
 	logger.Infof("Using NATT UDP port %d", nattPort)

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -299,10 +299,6 @@ func testConnectToEndpoint() {
 	When("the remote Endpoint has a CableName exceeding 200 characters", func() {
 		t := newTestDriver()
 
-		JustBeforeEach(func() {
-			Expect(t.driver.Init(context.TODO())).To(Succeed())
-		})
-
 		It("should reject the connection", func() {
 			longName := strings.Repeat("a", 201)
 			_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
@@ -324,10 +320,6 @@ func testConnectToEndpoint() {
 
 	When("the remote Endpoint has a CableName of exactly 200 characters", func() {
 		t := newTestDriver()
-
-		JustBeforeEach(func() {
-			Expect(t.driver.Init(context.TODO())).To(Succeed())
-		})
 
 		It("should not reject it for length", func() {
 			maxName := strings.Repeat("a", 200)

--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -295,6 +295,60 @@ func testConnectToEndpoint() {
 			UseFamily: k8snet.IPv4,
 		})
 	})
+
+	When("the remote Endpoint has a CableName exceeding 200 characters", func() {
+		t := newTestDriver()
+
+		JustBeforeEach(func() {
+			Expect(t.driver.Init(context.TODO())).To(Succeed())
+		})
+
+		It("should reject the connection", func() {
+			longName := strings.Repeat("a", 201)
+			_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
+				Endpoint: subv1.Endpoint{
+					Spec: subv1.EndpointSpec{
+						ClusterID:  "remote",
+						CableName:  longName,
+						PrivateIPs: []string{"192.68.2.1"},
+						Subnets:    []string{"20.0.0.0/16"},
+					},
+				},
+				UseIP:     "172.93.2.1",
+				UseFamily: k8snet.IPv4,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid characters"))
+		})
+	})
+
+	When("the remote Endpoint has a CableName of exactly 200 characters", func() {
+		t := newTestDriver()
+
+		JustBeforeEach(func() {
+			Expect(t.driver.Init(context.TODO())).To(Succeed())
+		})
+
+		It("should not reject it for length", func() {
+			maxName := strings.Repeat("a", 200)
+			_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
+				Endpoint: subv1.Endpoint{
+					Spec: subv1.EndpointSpec{
+						ClusterID:  "remote",
+						CableName:  maxName,
+						PrivateIPs: []string{"192.68.2.1"},
+						Subnets:    []string{"20.0.0.0/16"},
+					},
+				},
+				UseIP:     "172.93.2.1",
+				UseFamily: k8snet.IPv4,
+			})
+			// Any error here is from the connection machinery, not from cable name validation
+			if err != nil {
+				Expect(err.Error()).NotTo(ContainSubstring("invalid characters"))
+			}
+		})
+	})
 }
 
 func testDisconnectFromEndpoint() {

--- a/pkg/cable/psk/psk.go
+++ b/pkg/cable/psk/psk.go
@@ -1,0 +1,54 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package psk
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Resolve returns the PSK to use, prioritizing PSKSecret over PSK.
+// If pskSecret is non-empty, it reads from the secret file and base64 encodes it.
+// Otherwise, it returns the psk value directly.
+// rootDir is the root directory for reading secrets, primarily used for testing.
+func Resolve(psk, pskSecret, rootDir string) (string, error) {
+	if pskSecret == "" {
+		return psk, nil
+	}
+
+	pskBytes, err := os.ReadFile(rootDir + fmt.Sprintf("/var/run/secrets/submariner.io/%s/psk", pskSecret))
+	if err != nil {
+		return "", errors.Wrapf(err, "error reading secret %s", pskSecret)
+	}
+
+	var encodedPsk strings.Builder
+	encoder := base64.NewEncoder(base64.StdEncoding, &encodedPsk)
+
+	if _, err := encoder.Write(pskBytes); err != nil {
+		return "", errors.Wrap(err, "error encoding secret")
+	}
+
+	encoder.Close()
+
+	return encodedPsk.String(), nil
+}

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -100,6 +100,10 @@ func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable
 		return nil, errors.Wrap(err, "error processing environment config for wireguard")
 	}
 
+	if w.spec.PSK == "" || w.spec.PSK == "default psk" {
+		return nil, errors.New("CE_IPSEC_PSK must be set to a strong random value for the WireGuard driver")
+	}
+
 	if err = w.setWGLink(); err != nil {
 		return nil, errors.Wrap(err, "failed to setup WireGuard link")
 	}
@@ -399,7 +403,7 @@ func (w *wireguard) verifyNewPeer(peerCfg *wgtypes.PeerConfig) error {
 	}
 
 	if p.PresharedKey.String() != peerCfg.PresharedKey.String() {
-		return fmt.Errorf("peer PresharedKey does not match configured value")
+		return errors.New("peer PresharedKey does not match configured value")
 	}
 
 	if p.Endpoint.String() != peerCfg.Endpoint.String() {

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cable"
+	"github.com/submariner-io/submariner/pkg/cable/psk"
 	"github.com/submariner-io/submariner/pkg/endpoint"
 	"github.com/submariner-io/submariner/pkg/natdiscovery"
 	netlinkAPI "github.com/submariner-io/submariner/pkg/netlink"
@@ -71,8 +72,9 @@ func init() {
 }
 
 type specification struct {
-	PSK      string `default:"default psk"`
-	NATTPort int32  `default:"4500"`
+	PSK       string `default:"default psk"`
+	PSKSecret string
+	NATTPort  int32 `default:"4500"`
 }
 
 type wireguard struct {
@@ -100,7 +102,12 @@ func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable
 		return nil, errors.Wrap(err, "error processing environment config for wireguard")
 	}
 
-	if w.spec.PSK == "" || w.spec.PSK == "default psk" {
+	resolvedPSK, err := psk.Resolve(w.spec.PSK, w.spec.PSKSecret, "")
+	if err != nil {
+		return nil, err //nolint:wrapcheck // No need to wrap
+	}
+
+	if resolvedPSK == "" || resolvedPSK == "default psk" {
 		return nil, errors.New("CE_IPSEC_PSK must be set to a strong random value for the WireGuard driver")
 	}
 
@@ -124,13 +131,13 @@ func NewDriver(localEndpoint *endpoint.Local, _ *types.SubmarinerCluster) (cable
 	}()
 
 	// Generate local keys and set public key in BackendConfig.
-	var priv, pub, psk wgtypes.Key
+	var priv, pub, psKey wgtypes.Key
 
-	if psk, err = genPsk(w.spec.PSK); err != nil {
+	if psKey, err = genPsk(resolvedPSK); err != nil {
 		return nil, errors.Wrap(err, "error generating pre-shared key")
 	}
 
-	w.psk = &psk
+	w.psk = &psKey
 
 	if priv, err = wgtypes.GeneratePrivateKey(); err != nil {
 		return nil, errors.Wrap(err, "error generating private key")
@@ -438,9 +445,9 @@ func (w *wireguard) keyMismatch(cid string, key *wgtypes.Key) bool {
 	return false
 }
 
-func genPsk(psk string) (wgtypes.Key, error) {
+func genPsk(psKey string) (wgtypes.Key, error) {
 	// Convert spec PSK string to right length byte array, using sha256.Size == wgtypes.KeyLen.
-	pskBytes := sha256.Sum256([]byte(psk))
+	pskBytes := sha256.Sum256([]byte(psKey))
 	return wgtypes.NewKey(pskBytes[:]) //nolint:wrapcheck // Let the caller wrap it
 }
 

--- a/pkg/cable/wireguard/driver.go
+++ b/pkg/cable/wireguard/driver.go
@@ -399,7 +399,7 @@ func (w *wireguard) verifyNewPeer(peerCfg *wgtypes.PeerConfig) error {
 	}
 
 	if p.PresharedKey.String() != peerCfg.PresharedKey.String() {
-		return fmt.Errorf("peer's PresharedKey %q does not match configured %q", p.PresharedKey.String(), peerCfg.PresharedKey.String())
+		return fmt.Errorf("peer PresharedKey does not match configured value")
 	}
 
 	if p.Endpoint.String() != peerCfg.Endpoint.String() {

--- a/pkg/cable/wireguard/wireguard_suite_test.go
+++ b/pkg/cable/wireguard/wireguard_suite_test.go
@@ -76,6 +76,8 @@ func newTestDriver() *testDriver {
 	t := &testDriver{}
 
 	BeforeEach(func() {
+		os.Setenv("CE_IPSEC_PSK", "test-psk-value")
+
 		t.endpointSpec = submarinerv1.EndpointSpec{
 			ClusterID:  "local",
 			CableName:  "submariner-cable-local-192-68-1-1",

--- a/pkg/cidr/cidr_test.go
+++ b/pkg/cidr/cidr_test.go
@@ -63,6 +63,20 @@ var _ = Describe("ExtractSubnets", func() {
 	})
 })
 
+var _ = Describe("IsContained", func() {
+	It("should return the correct results", func() {
+		Expect(cidr.IsContained([]string{"10.0.0.0/14"}, "10.1.0.0/16")).To(BeTrue())
+		Expect(cidr.IsContained([]string{"10.0.0.0/14", ipV6CIDR}, "10.0.0.0/14")).To(BeTrue())
+		Expect(cidr.IsContained([]string{"10.1.0.0/16"}, "10.0.0.0/14")).To(BeFalse())
+		Expect(cidr.IsContained([]string{"10.0.0.0/14"}, "11.0.0.0/16")).To(BeFalse())
+		Expect(cidr.IsContained([]string{}, "10.0.0.0/14")).To(BeFalse())
+		Expect(cidr.IsContained([]string{ipV6CIDR}, "10.0.0.0/14")).To(BeFalse())
+
+		_, err := cidr.IsContained([]string{ipV4CIDR}, "bogus")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
 var _ = Describe("IsOverlapping", func() {
 	It("should return the correct results", func() {
 		Expect(cidr.IsOverlapping([]string{ipV4CIDR, ipV6CIDR}, ipV4CIDR2)).To(BeFalse())

--- a/pkg/cidr/iputil.go
+++ b/pkg/cidr/iputil.go
@@ -68,6 +68,31 @@ func OverlappingSubnets(localServiceCIDRs, localPodCIDRs, remoteSubnets []string
 	return nil
 }
 
+// IsContained returns true iff inner is wholly contained within at least one CIDR in outerList
+// (i.e. every address of inner is also an address of some outer). An empty outerList contains nothing.
+func IsContained(outerList []string, inner string) (bool, error) {
+	_, innerNet, err := net.ParseCIDR(inner)
+	if err != nil {
+		return false, errors.Wrapf(err, "error parsing CIDR %q", inner)
+	}
+
+	innerOnes, innerBits := innerNet.Mask.Size()
+
+	for _, o := range outerList {
+		_, outerNet, err := net.ParseCIDR(o)
+		if err != nil {
+			return false, errors.Wrapf(err, "error parsing CIDR %q", o)
+		}
+
+		outerOnes, outerBits := outerNet.Mask.Size()
+		if outerBits == innerBits && outerOnes <= innerOnes && outerNet.Contains(innerNet.IP) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func IsOverlapping(cidrList []string, cidr string) (bool, error) {
 	_, newNet, err := net.ParseCIDR(cidr)
 	if err != nil {

--- a/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
+++ b/pkg/controllers/datastoresyncer/datastore_endpoint_sync_test.go
@@ -82,8 +82,10 @@ func testEndpointSyncing() {
 	})
 
 	When("a remote Endpoint is created, updated and deleted on the broker", func() {
-		It("should correctly sync the local datastore", func() {
+		It("should correctly sync the local datastore", func(ctx context.Context) {
 			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
+
+			t.createRemoteCluster(otherClusterID, "200.0.0.0/16", "201.0.0.0/16", "20.0.0.0/14")
 
 			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
 				CableName:  fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
@@ -103,6 +105,49 @@ func testEndpointSyncing() {
 
 			Expect(t.brokerEndpoints.Delete(context.TODO(), endpoint.GetName(), metav1.DeleteOptions{})).To(Succeed())
 			test.AwaitNoResource(t.localEndpoints, endpoint.GetName())
+		})
+	})
+
+	When("a remote Endpoint advertises a subnet not declared by its Cluster CR", func() {
+		It("should not sync it to the local datastore", func() {
+			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
+
+			t.createRemoteCluster(otherClusterID, "20.0.0.0/14")
+
+			endpoint := newEndpoint(&submarinerv1.EndpointSpec{
+				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
+				ClusterID: otherClusterID,
+				Subnets:   []string{"20.0.0.0/14", "30.0.0.0/14"},
+			})
+
+			test.CreateResource(t.brokerEndpoints, test.SetClusterIDLabel(endpoint, endpoint.Spec.ClusterID))
+			testutil.EnsureNoResource(resource.ForDynamic(t.localEndpoints), endpoint.GetName())
+		})
+	})
+
+	When("a remote Endpoint advertises a subnet that overlaps another remote cluster's accepted subnets", func() {
+		const thirdClusterID = "south"
+
+		It("should not sync it to the local datastore", func() {
+			awaitEndpoint(t.brokerEndpoints, t.localEndpoint)
+
+			t.createRemoteCluster(otherClusterID, "20.0.0.0/14")
+			victim := newEndpoint(&submarinerv1.EndpointSpec{
+				CableName: fmt.Sprintf("submariner-cable-%s-10-253-1-2", otherClusterID),
+				ClusterID: otherClusterID,
+				Subnets:   []string{"20.0.0.0/14"},
+			})
+			test.CreateResource(t.brokerEndpoints, test.SetClusterIDLabel(victim, victim.Spec.ClusterID))
+			awaitEndpoint(t.localEndpoints, &victim.Spec)
+
+			t.createRemoteCluster(thirdClusterID, "20.0.0.0/14")
+			attacker := newEndpoint(&submarinerv1.EndpointSpec{
+				CableName: fmt.Sprintf("submariner-cable-%s-10-254-1-2", thirdClusterID),
+				ClusterID: thirdClusterID,
+				Subnets:   []string{"20.0.0.0/16"},
+			})
+			test.CreateResource(t.brokerEndpoints, test.SetClusterIDLabel(attacker, attacker.Spec.ClusterID))
+			testutil.EnsureNoResource(resource.ForDynamic(t.localEndpoints), attacker.GetName())
 		})
 	})
 

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -50,8 +50,6 @@ type DatastoreSyncer struct {
 	syncer        *broker.Syncer
 }
 
-const maxRemoteEndpointRequeues = 20
-
 var logger = log.Logger{Logger: logf.Log.WithName("DSSyncer")}
 
 func New(syncerConfig *broker.SyncerConfig, localCluster *types.SubmarinerCluster,
@@ -241,17 +239,10 @@ func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarin
 	}
 
 	if remoteCluster == nil {
-		if numRequeues < maxRemoteEndpointRequeues {
-			logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
-				remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
+		logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
+			remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
 
-			return true, true
-		}
-
-		logger.Errorf(nil, "Rejecting remote Endpoint %q: no Cluster CR found for cluster %q after %d retries",
-			remoteEndpoint.Name, remoteEndpoint.Spec.ClusterID, numRequeues)
-
-		return true, false
+		return true, true
 	}
 
 	allowed := make([]string, 0, len(remoteCluster.Spec.ServiceCIDR)+len(remoteCluster.Spec.ClusterCIDR)+len(remoteCluster.Spec.GlobalCIDR))

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -47,7 +47,10 @@ type DatastoreSyncer struct {
 	localCluster  types.SubmarinerCluster
 	localEndpoint *endpoint.Local
 	syncerConfig  broker.SyncerConfig
+	syncer        *broker.Syncer
 }
+
+const maxRemoteEndpointRequeues = 20
 
 var logger = log.Logger{Logger: logf.Log.WithName("DSSyncer")}
 
@@ -73,6 +76,8 @@ func (d *DatastoreSyncer) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	d.syncer = syncer
 
 	err = syncer.Start(ctx.Done())
 	if err != nil {
@@ -183,10 +188,14 @@ func (d *DatastoreSyncer) createSyncer() (*broker.Syncer, error) {
 	return syncer, errors.Wrap(err, "error creating the syncer")
 }
 
-func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, _ int,
-	_ resourceSyncer.Operation,
+func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, numRequeues int,
+	op resourceSyncer.Operation,
 ) (runtime.Object, bool) {
 	remoteEndpoint := obj.(*submarinerv1.Endpoint)
+
+	if op == resourceSyncer.Delete {
+		return obj, false
+	}
 
 	for _, localSubnet := range d.localEndpoint.Spec().Subnets {
 		overlap, err := cidr.IsOverlapping(remoteEndpoint.Spec.Subnets, localSubnet)
@@ -201,7 +210,97 @@ func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, _ int,
 		}
 	}
 
+	if rejected, requeue := d.validateRemoteEndpointSubnets(remoteEndpoint, numRequeues); rejected {
+		return nil, requeue
+	}
+
 	return obj, false
+}
+
+// validateRemoteEndpointSubnets ensures that subnets in a broker-supplied remote Endpoint are
+// consistent with that cluster's declared CIDRs and do not conflict with subnets already
+// accepted from other clusters. A remote Endpoint is rejected unless every Spec.Subnets entry
+// (i) is wholly contained in the CIDRs declared by that cluster's own Cluster CR
+// (Service/Cluster/Global), and (ii) does not overlap any subnet already accepted from a
+// different remote cluster. Returns (rejected, requeue).
+//
+//nolint:gocyclo // Method is not really that complex.
+func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarinerv1.Endpoint, numRequeues int) (bool, bool) {
+	if len(remoteEndpoint.Spec.Subnets) == 0 || d.syncer == nil {
+		return false, false
+	}
+
+	var remoteCluster *submarinerv1.Cluster
+
+	for _, o := range d.syncer.ListLocalResources(&submarinerv1.Cluster{}) {
+		c := o.(*submarinerv1.Cluster)
+		if c.Spec.ClusterID == remoteEndpoint.Spec.ClusterID {
+			remoteCluster = c
+			break
+		}
+	}
+
+	if remoteCluster == nil {
+		if numRequeues < maxRemoteEndpointRequeues {
+			logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
+				remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
+
+			return true, true
+		}
+
+		logger.Errorf(nil, "Rejecting remote Endpoint %q: no Cluster CR found for cluster %q after %d retries",
+			remoteEndpoint.Name, remoteEndpoint.Spec.ClusterID, numRequeues)
+
+		return true, false
+	}
+
+	allowed := make([]string, 0, len(remoteCluster.Spec.ServiceCIDR)+len(remoteCluster.Spec.ClusterCIDR)+len(remoteCluster.Spec.GlobalCIDR))
+	allowed = append(allowed, remoteCluster.Spec.ServiceCIDR...)
+	allowed = append(allowed, remoteCluster.Spec.ClusterCIDR...)
+	allowed = append(allowed, remoteCluster.Spec.GlobalCIDR...)
+
+	for _, subnet := range remoteEndpoint.Spec.Subnets {
+		contained, err := cidr.IsContained(allowed, subnet)
+		if err != nil {
+			logger.Errorf(err, "Rejecting remote Endpoint %q: invalid subnet %q", remoteEndpoint.Name, subnet)
+			return true, false
+		}
+
+		if !contained {
+			logger.Errorf(nil, "Rejecting remote Endpoint %q: subnet %q is not within Cluster %q declared CIDRs %v",
+				remoteEndpoint.Name, subnet, remoteCluster.Spec.ClusterID, allowed)
+
+			return true, false
+		}
+	}
+
+	for _, o := range d.syncer.ListLocalResources(&submarinerv1.Endpoint{}) {
+		other := o.(*submarinerv1.Endpoint)
+		if other.Spec.ClusterID == remoteEndpoint.Spec.ClusterID || other.Spec.ClusterID == d.localCluster.Spec.ClusterID {
+			continue
+		}
+
+		for _, subnet := range remoteEndpoint.Spec.Subnets {
+			overlap, err := cidr.IsOverlapping(other.Spec.Subnets, subnet)
+			if err != nil {
+				logger.Errorf(err, "Rejecting remote Endpoint %q: unable to validate overlap with cluster %q",
+					remoteEndpoint.Name, other.Spec.ClusterID)
+
+				return true, false
+			}
+
+			if !overlap {
+				continue
+			}
+
+			logger.Errorf(nil, "Rejecting remote Endpoint %q: subnet %q overlaps subnet already accepted from cluster %q (%v)",
+				remoteEndpoint.Name, subnet, other.Spec.ClusterID, other.Spec.Subnets)
+
+			return true, false
+		}
+	}
+
+	return false, false
 }
 
 func (d *DatastoreSyncer) ensureExclusiveEndpoint(ctx context.Context, syncer *broker.Syncer) error {

--- a/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer_suite_test.go
@@ -207,6 +207,15 @@ func newEndpoint(spec *submarinerv1.EndpointSpec) *submarinerv1.Endpoint {
 	}
 }
 
+func (t *testDriver) createRemoteCluster(id string, cidrs ...string) {
+	cluster := newCluster(&submarinerv1.ClusterSpec{
+		ClusterID:   id,
+		ClusterCIDR: cidrs,
+	})
+	test.CreateResource(t.brokerClusters, test.SetClusterIDLabel(cluster, id))
+	awaitCluster(t.localClusters, &cluster.Spec)
+}
+
 func newCluster(spec *submarinerv1.ClusterSpec) *submarinerv1.Cluster {
 	return &submarinerv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/gateway/gateway_test.go
+++ b/pkg/gateway/gateway_test.go
@@ -58,7 +58,10 @@ import (
 	k8snet "k8s.io/utils/net"
 )
 
-const publicIP = "1.2.3.4"
+const (
+	publicIP        = "1.2.3.4"
+	remoteClusterID = "west"
+)
 
 var _ = Describe("Run", func() {
 	t := newTestDriver()
@@ -76,6 +79,7 @@ var _ = Describe("Run", func() {
 			return gw.Status.HAStatus == submarinerv1.HAStatusActive
 		})
 
+		t.createRemoteClusterOnBroker()
 		endpoint := t.awaitRemoteEndpointSyncedLocal(t.createRemoteEndpointOnBroker())
 		t.cableEngine.VerifyInstallCable(&endpoint.Spec)
 	})
@@ -119,6 +123,8 @@ var _ = Describe("Run", func() {
 		})
 
 		It("should re-acquire the leader lease after the failure is cleared", func() {
+			t.createRemoteClusterOnBroker()
+
 			endpoint := t.awaitRemoteEndpointSyncedLocal(t.createRemoteEndpointOnBroker())
 			fakeDriver.AwaitConnectToEndpoint(&natdiscovery.NATEndpointInfo{
 				Endpoint:  *endpoint,
@@ -242,6 +248,7 @@ type testDriver struct {
 	localPodName    string
 	nodeName        string
 	endpoints       dynamic.NamespaceableResourceInterface
+	clusters         dynamic.NamespaceableResourceInterface
 	expectedRunErr  error
 	cableEngine     *enginefake.Engine
 	kubeClient      *k8sfake.Clientset
@@ -300,6 +307,7 @@ func newTestDriver() *testDriver {
 		t.leaderElection = testutil.NewLeaderElectionSupport(t.kubeClient, t.config.Spec.Namespace, gateway.LeaderElectionLockName)
 
 		t.endpoints = t.config.SyncerConfig.LocalClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Endpoint{}))
+		t.clusters = t.config.SyncerConfig.LocalClient.Resource(*test.GetGroupVersionResourceFor(restMapper, &submarinerv1.Cluster{}))
 
 		t.localPodName = "local-pod"
 		t.nodeName = "raiders"
@@ -407,10 +415,10 @@ func (t *testDriver) newRemoteEndpoint() *submarinerv1.Endpoint {
 	ep := &submarinerv1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   string(uuid.NewUUID()),
-			Labels: map[string]string{federate.ClusterIDLabelKey: "west"},
+			Labels: map[string]string{federate.ClusterIDLabelKey: remoteClusterID},
 		},
 		Spec: submarinerv1.EndpointSpec{
-			ClusterID:  "west",
+			ClusterID:  remoteClusterID,
 			CableName:  fmt.Sprintf("submariner-cable-west-192-168-40-%d", t.remoteIPCounter),
 			Hostname:   "redsox",
 			Subnets:    []string{"169.254.3.0/24"},
@@ -431,6 +439,19 @@ func (t *testDriver) createEndpoint(ns string, endpoint *submarinerv1.Endpoint) 
 
 func (t *testDriver) createRemoteEndpointOnBroker() *submarinerv1.Endpoint {
 	return t.createEndpoint(t.config.SyncerConfig.BrokerNamespace, t.newRemoteEndpoint())
+}
+
+func (t *testDriver) createRemoteClusterOnBroker() {
+	test.CreateResource(t.clusters.Namespace(t.config.SyncerConfig.BrokerNamespace), &submarinerv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   remoteClusterID,
+			Labels: map[string]string{federate.ClusterIDLabelKey: remoteClusterID},
+		},
+		Spec: submarinerv1.ClusterSpec{
+			ClusterID:   remoteClusterID,
+			ClusterCIDR: []string{"169.254.0.0/16"},
+		},
+	})
 }
 
 func (t *testDriver) awaitRemoteEndpointSyncedLocal(endpoint *submarinerv1.Endpoint) *submarinerv1.Endpoint {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,7 +42,6 @@ type SubmarinerSpecification struct {
 	ClusterID                     string
 	Namespace                     string
 	PublicIP                      string
-	Token                         string
 	Debug                         bool
 	NATEnabled                    bool
 	HealthCheckEnabled            bool `default:"true"`


### PR DESCRIPTION
Backport of #4157 on release-0.21.

#4157: Prevent WireGuard pre-shared key printed in error logs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - WireGuard and IPsec connections can resolve pre-shared keys from configured secrets.
  - Added CIDR containment validation for network configuration.

- **Bug Fixes**
  - Invalid cable names, subnets, and IP addresses are rejected earlier.
  - Endpoint synchronization now ignores undeclared or malformed subnets and prevents overlaps across remote clusters.
  - Empty or default WireGuard pre-shared keys are rejected.
  - Remote endpoint synchronization waits for the corresponding cluster to be available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->