### PR TITLE
Fix CVE in release-0.24

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -5,3 +5,9 @@ ignore:
     fix-state: not-fixed
     package:
       name: golang.org/x/crypto
+  # No fix available for golang.org/x/crypto.
+  - vulnerability: GO-2026-5932
+    fix-state: not-fixed
+    package:
+      name: golang.org/x/crypto
+      location: /go.mod


### PR DESCRIPTION
See commit message for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a vulnerability scan exception for GO-2026-5932 affecting the Go cryptography package.
  * Scoped the exception to the package declaration and noted that no fix is currently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->