### PR TITLE
Apply code review fixes for CVEs from backports

### DIFF
--- a/pkg/cable/libreswan/libreswan_test.go
+++ b/pkg/cable/libreswan/libreswan_test.go
@@ -366,59 +366,31 @@ func testConnectToEndpoint() {
 			UseIP:     "172.93.2.1",
 			UseFamily: k8snet.IPv4,
 		}, libreswan.AuthModeCert)
-	})
 
-	When("the remote Endpoint has a CableName exceeding 200 characters", func() {
-		t := newTestDriver()
+		When("the remote Endpoint has a CableName exceeding 200 characters", func() {
+			t := newTestDriver()
 
-		JustBeforeEach(func() {
-			Expect(t.driver.Init(context.TODO())).To(Succeed())
-		})
-
-		It("should reject the connection", func() {
-			longName := strings.Repeat("a", 201)
-			_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
-				Endpoint: subv1.Endpoint{
-					Spec: subv1.EndpointSpec{
-						ClusterID:  "remote",
-						CableName:  longName,
-						PrivateIPs: []string{"192.68.2.1"},
-						Subnets:    []string{"20.0.0.0/16"},
-					},
-				},
-				UseIP:     "172.93.2.1",
-				UseFamily: k8snet.IPv4,
+			JustBeforeEach(func() {
+				Expect(t.driver.Init(context.TODO())).To(Succeed())
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid characters"))
-		})
-	})
 
-	When("the remote Endpoint has a CableName of exactly 200 characters", func() {
-		t := newTestDriver()
-
-		JustBeforeEach(func() {
-			Expect(t.driver.Init(context.TODO())).To(Succeed())
-		})
-
-		It("should not reject it for length", func() {
-			maxName := strings.Repeat("a", 200)
-			_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
-				Endpoint: subv1.Endpoint{
-					Spec: subv1.EndpointSpec{
-						ClusterID:  "remote",
-						CableName:  maxName,
-						PrivateIPs: []string{"192.68.2.1"},
-						Subnets:    []string{"20.0.0.0/16"},
+			It("should reject the connection", func() {
+				longName := strings.Repeat("a", 201)
+				_, err := t.driver.ConnectToEndpoint(&natdiscovery.NATEndpointInfo{
+					Endpoint: subv1.Endpoint{
+						Spec: subv1.EndpointSpec{
+							ClusterID:  "remote",
+							CableName:  longName,
+							PrivateIPs: []string{"192.68.2.1"},
+							Subnets:    []string{"20.0.0.0/16"},
+						},
 					},
-				},
-				UseIP:     "172.93.2.1",
-				UseFamily: k8snet.IPv4,
+					UseIP:     "172.93.2.1",
+					UseFamily: k8snet.IPv4,
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid characters"))
 			})
-			// Any error here is from the connection machinery, not from cable name validation
-			if err != nil {
-				Expect(err.Error()).NotTo(ContainSubstring("invalid characters"))
-			}
 		})
 	})
 }

--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -52,8 +52,6 @@ type DatastoreSyncer struct {
 	syncer        *broker.Syncer
 }
 
-const maxRemoteEndpointRequeues = 20
-
 var logger = log.Logger{Logger: logf.Log.WithName("DSSyncer")}
 
 func New(syncerConfig *broker.SyncerConfig, localCluster *types.SubmarinerCluster,
@@ -231,9 +229,7 @@ func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, numRequeu
 // (i) is wholly contained in the CIDRs declared by that cluster's own Cluster CR
 // (Service/Cluster/Global), and (ii) does not overlap any subnet already accepted from a
 // different remote cluster. Returns (rejected, requeue).
-//
-//nolint:gocyclo // Method is not really that complex.
-func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarinerv1.Endpoint, numRequeues int) (bool, bool) {
+func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarinerv1.Endpoint, _ int) (bool, bool) {
 	if len(remoteEndpoint.Spec.Subnets) == 0 || d.syncer == nil {
 		return false, false
 	}
@@ -249,17 +245,10 @@ func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarin
 	}
 
 	if remoteCluster == nil {
-		if numRequeues < maxRemoteEndpointRequeues {
-			logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
-				remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
+		logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
+			remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
 
-			return true, true
-		}
-
-		logger.Errorf(nil, "Rejecting remote Endpoint %q: no Cluster CR found for cluster %q after %d retries",
-			remoteEndpoint.Name, remoteEndpoint.Spec.ClusterID, numRequeues)
-
-		return true, false
+		return true, true
 	}
 
 	allowed := make([]string, 0, len(remoteCluster.Spec.ServiceCIDR)+len(remoteCluster.Spec.ClusterCIDR)+len(remoteCluster.Spec.GlobalCIDR))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remote endpoints referencing temporarily unavailable clusters are now continuously retried instead of being rejected after a fixed number of attempts.
  - Improved handling of remote endpoint cable names exceeding the supported length limit.
- **Tests**
  - Updated validation coverage for remote endpoint cable-name length boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->