### PR TITLE
Remove max requeues on Endpoint validation when Cluster missing

### DIFF
--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -52,8 +52,6 @@ type DatastoreSyncer struct {
 	syncer        *broker.Syncer
 }
 
-const maxRemoteEndpointRequeues = 20
-
 var logger = log.Logger{Logger: logf.Log.WithName("DSSyncer")}
 
 func New(syncerConfig *broker.SyncerConfig, localCluster *types.SubmarinerCluster,
@@ -231,9 +229,7 @@ func (d *DatastoreSyncer) shouldSyncRemoteEndpoint(obj runtime.Object, numRequeu
 // (i) is wholly contained in the CIDRs declared by that cluster's own Cluster CR
 // (Service/Cluster/Global), and (ii) does not overlap any subnet already accepted from a
 // different remote cluster. Returns (rejected, requeue).
-//
-//nolint:gocyclo // Method is not really that complex.
-func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarinerv1.Endpoint, numRequeues int) (bool, bool) {
+func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarinerv1.Endpoint, _ int) (bool, bool) {
 	if len(remoteEndpoint.Spec.Subnets) == 0 || d.syncer == nil {
 		return false, false
 	}
@@ -249,17 +245,10 @@ func (d *DatastoreSyncer) validateRemoteEndpointSubnets(remoteEndpoint *submarin
 	}
 
 	if remoteCluster == nil {
-		if numRequeues < maxRemoteEndpointRequeues {
-			logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
-				remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
+		logger.V(log.DEBUG).Infof("Cluster CR for %q not yet synced; re-queueing remote Endpoint %q",
+			remoteEndpoint.Spec.ClusterID, remoteEndpoint.Name)
 
-			return true, true
-		}
-
-		logger.Errorf(nil, "Rejecting remote Endpoint %q: no Cluster CR found for cluster %q after %d retries",
-			remoteEndpoint.Name, remoteEndpoint.Spec.ClusterID, numRequeues)
-
-		return true, false
+		return true, true
 	}
 
 	allowed := make([]string, 0, len(remoteCluster.Spec.ServiceCIDR)+len(remoteCluster.Spec.ClusterCIDR)+len(remoteCluster.Spec.GlobalCIDR))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote endpoints now continue retrying until their associated cluster is synchronized.
  * Retry-count settings no longer limit synchronization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->