### PR TITLE
Add egress self-SNAT workaround for OVN-K local gateway mode

### DIFF
--- a/pkg/routeagent_driver/handlers/ovn/constants.go
+++ b/pkg/routeagent_driver/handlers/ovn/constants.go
@@ -34,4 +34,5 @@ const (
 	defaultOpenshiftOVNNBDB          = "ssl:ovnkube-db.openshift-ovn-kubernetes.svc.cluster.local:9641"
 	ovnPodLabel                      = "app=ovnkube-node"
 	OVNKSNATExcludeSubnetsAnnotation = "k8s.ovn.org/node-ingress-snat-exclude-subnets"
+	ovnGatewayConfigAnnotation       = "k8s.ovn.org/l3-gateway-config"
 )

--- a/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
+++ b/pkg/routeagent_driver/handlers/ovn/gateway_dataplane.go
@@ -26,15 +26,18 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/global"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/admiral/pkg/util"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"github.com/submariner-io/submariner/pkg/cidr"
 	nodeutil "github.com/submariner-io/submariner/pkg/node"
 	"github.com/submariner-io/submariner/pkg/packetfilter"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/chains"
 	"github.com/submariner-io/submariner/pkg/routeagent_driver/constants"
+	"github.com/submariner-io/submariner/pkg/routeagent_driver/handlers/mtu"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,7 +172,12 @@ func (ovn *Handler) setupForwardingIptables() error {
 		return err
 	}
 
-	return ovn.updateIPtableChains(packetfilter.TableTypeFilter, chains.SmForward, ovn.getForwardingRuleSpecs)
+	if err := ovn.updateIPtableChains(packetfilter.TableTypeFilter, chains.SmForward, ovn.getForwardingRuleSpecs); err != nil {
+		return err
+	}
+
+	// Setup OVN self-SNAT workaround
+	return ovn.setupOVNSelfSNAT()
 }
 
 func (ovn *Handler) updateNoMasqueradeRules(subnet string, add bool) error {
@@ -231,6 +239,10 @@ func (ovn *Handler) initIPtablesChains() error {
 
 	if err := ovn.ensureForwardChains(); err != nil {
 		return errors.Wrap(err, "error ensuring FORWARD sub-chain entries")
+	}
+
+	if err := ovn.pFilter.CreateIPHookChainIfNotExists(chains.NewSelfSnat()); err != nil {
+		return errors.Wrapf(err, "error installing %q IPHook chain", chains.SmSelfSnat)
 	}
 
 	return nil
@@ -318,4 +330,93 @@ func (ovn *Handler) nodeResourceInterface() resource.Interface[*corev1.Node] {
 		GetFunc:    ovn.K8sClient.CoreV1().Nodes().Get,
 		UpdateFunc: ovn.K8sClient.CoreV1().Nodes().Update,
 	}
+}
+
+const disableOVNSelfSNATKey = "disable-ovn-selfsnat"
+
+func (ovn *Handler) shouldApplyOVNSelfSNAT() bool {
+	if global.Get(disableOVNSelfSNATKey, false) {
+		logger.V(log.DEBUG).Info("OVN self-SNAT explicitly disabled via submariner-global ConfigMap")
+		return false
+	}
+
+	if ovn.isLocalGWMode {
+		logger.Infof("OVN self-SNAT auto enabled (OVN-K local gateway mode detected)")
+	} else {
+		logger.V(log.DEBUG).Info("OVN self-SNAT disabled (OVN-K shared gateway mode detected)")
+	}
+
+	return ovn.isLocalGWMode
+}
+
+func (ovn *Handler) detectLocalGWMode(ctx context.Context) bool {
+	node, err := nodeutil.GetLocalNode(ctx, ovn.K8sClient)
+	if err != nil {
+		logger.Errorf(err, "Error getting local node to detect OVN-K gateway mode — assuming shared gateway")
+		return false
+	}
+
+	annotation, ok := node.Annotations[ovnGatewayConfigAnnotation]
+	if !ok {
+		return false
+	}
+
+	var gwConfig map[string]struct {
+		Mode string `json:"mode"`
+	}
+
+	if err := json.Unmarshal([]byte(annotation), &gwConfig); err != nil {
+		logger.Errorf(err, "Error parsing %q annotation — assuming shared gateway", ovnGatewayConfigAnnotation)
+		return false
+	}
+
+	isLocal := gwConfig["default"].Mode == "local"
+	if isLocal {
+		logger.Infof("OVN-K local gateway mode detected via %q annotation", ovnGatewayConfigAnnotation)
+	}
+
+	return isLocal
+}
+
+func (ovn *Handler) getOVNSelfSNATRuleSpecs() []*packetfilter.Rule {
+	if !ovn.State().IsOnGateway() {
+		logger.V(log.DEBUG).Info("Skipping OVN self-SNAT rules - not on gateway node")
+		return nil
+	}
+
+	if !ovn.shouldApplyOVNSelfSNAT() {
+		return nil
+	}
+
+	var rules []*packetfilter.Rule
+
+	var remoteSetName string
+	if ovn.ipFamily == k8snet.IPv4 {
+		remoteSetName = mtu.RemoteCIDRIPSetIPv4
+	} else {
+		remoteSetName = mtu.RemoteCIDRIPSetIPv6
+	}
+
+	// Create SNAT-to-self rules using existing remote CIDR sets
+	for _, localCIDR := range cidr.ExtractSubnets(ovn.ipFamily, ovn.ClusterCIDR) {
+		// SNAT-to-self rule: when traffic from local cluster CIDR goes to any remote CIDR the set
+		rule := &packetfilter.Rule{
+			SrcCIDR:     localCIDR,
+			DestSetName: remoteSetName, // Use existing set instead of individual CIDRs
+			Action:      packetfilter.RuleActionSelfSNAT,
+		}
+		rules = append(rules, rule)
+	}
+
+	if len(rules) > 0 {
+		logger.Infof("Adding %d OVN self-SNAT rules using remote CIDR set %q (workaround enabled via ConfigMap)",
+			len(rules), remoteSetName)
+	}
+
+	return rules
+}
+
+func (ovn *Handler) setupOVNSelfSNAT() error {
+	return errors.Wrap(ovn.pFilter.UpdateChainRules(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+		ovn.getOVNSelfSNATRuleSpecs()), "error updating OVN self-SNAT rules")
 }

--- a/pkg/routeagent_driver/handlers/ovn/handler.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler.go
@@ -70,6 +70,7 @@ type Handler struct {
 	nonGatewayRouteController *NonGatewayRouteController
 	stopCh                    chan struct{}
 	ipFamily                  k8snet.IPFamily
+	isLocalGWMode             bool
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("OVN")}
@@ -152,6 +153,8 @@ func (ovn *Handler) Init(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "error initializing TransitSwitchIP")
 	}
+
+	ovn.isLocalGWMode = ovn.detectLocalGWMode(ctx)
 
 	gatewayRouteController, err := NewGatewayRouteController(ovn.ipFamily, *ovn.WatcherConfig, connectionHandler, ovn.Namespace)
 	if err != nil {

--- a/pkg/routeagent_driver/handlers/ovn/handler_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/handler_test.go
@@ -29,6 +29,7 @@ import (
 	libovsdbclient "github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/nbdb"
+	"github.com/submariner-io/admiral/pkg/global"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	assert "github.com/submariner-io/admiral/pkg/test"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -73,6 +74,7 @@ var _ = Describe("Handler", func() {
 		t.testGatewayTransitions(ipv4Subnets, ipv6Subnets)
 		t.testGatewayRoute(ipv4Subnets, ipv6OVNK8sMgmntIntGw, ipv6Subnets)
 		t.testNonGatewayRoutes(ipv4OVNK8sMgmntIntGw, ipv4Subnets, []string{"172.0.1.0/24"}, ipv6OVNK8sMgmntIntGw, ipv6Subnets)
+		t.testOVNSelfSNAT()
 	})
 
 	Context("IPv6", func() {
@@ -84,6 +86,7 @@ var _ = Describe("Handler", func() {
 		t.testGatewayTransitions(ipv6Subnets, ipv4Subnets)
 		t.testGatewayRoute(ipv6Subnets, ipv4OVNK8sMgmntIntGw, ipv4Subnets)
 		t.testNonGatewayRoutes(ipv6OVNK8sMgmntIntGw, ipv6Subnets, []string{"ab00:100::/64"}, ipv4OVNK8sMgmntIntGw, ipv4Subnets)
+		t.testOVNSelfSNAT()
 	})
 
 	When("the OVN management interface address changes", t.testOVNMgmtInterfaceAddressChange)
@@ -169,6 +172,7 @@ type handlerTestDriver struct {
 	OVNK8sMgmntIntGw     string
 	ovsdbClient          *fakeovn.OVSDBClient
 	intraRoutingDisabled bool
+	localGWMode          bool
 }
 
 func newHandlerTestDriver() *handlerTestDriver {
@@ -177,6 +181,12 @@ func newHandlerTestDriver() *handlerTestDriver {
 	BeforeEach(func() {
 		t.ipFamily = k8snet.IPv4
 		t.intraRoutingDisabled = false
+		t.localGWMode = false
+		t.testDriver.extraNodeAnnotations = nil
+		global.Init()
+		DeferCleanup(func() {
+			global.Init()
+		})
 	})
 
 	JustBeforeEach(func(ctx context.Context) {
@@ -1075,5 +1085,72 @@ func (t *handlerTestDriver) testIntraClusterRoutingDisabled() {
 
 	It("should not try to process NonGatewayRoutes", func() {
 		assert.EnsureNoActionsForResource(&t.dynClient.Fake, "nongatewayroutes", "watch")
+	})
+}
+
+func (t *handlerTestDriver) testOVNSelfSNAT() {
+	Context("OVN Self-SNAT workaround", func() {
+		When("OVN-K local gateway mode is detected", func() {
+			BeforeEach(func() {
+				t.localGWMode = true
+				t.testDriver.extraNodeAnnotations = map[string]string{
+					"k8s.ovn.org/l3-gateway-config": `{"default":{"mode":"local"}}`,
+				}
+			})
+
+			When("on gateway node", func() {
+				JustBeforeEach(func(ctx context.Context) {
+					t.CreateLocalHostEndpoint(ctx)
+				})
+
+				It("should add self-SNAT rules for local cluster CIDRs", func() {
+					t.pFilter.AwaitRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+						ContainSubstring("\"Action\":6"))
+				})
+
+				It("should use remote CIDR sets for efficiency", func() {
+					if t.ipFamily == k8snet.IPv4 {
+						t.pFilter.AwaitRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+							ContainSubstring("SUBMARINER-REMOTECIDRS"))
+					} else {
+						t.pFilter.AwaitRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+							ContainSubstring("SUBMARINER-REMOTECIDRS-V6"))
+					}
+				})
+			})
+
+			When("not on gateway node", func() {
+				It("should not add self-SNAT rules", func() {
+					t.pFilter.EnsureNoRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+						ContainSubstring("\"Action\":6"))
+				})
+			})
+
+			When("disable-ovn-selfsnat is set in ConfigMap", func() {
+				BeforeEach(func() {
+					global.Init(&corev1.ConfigMap{Data: map[string]string{"disable-ovn-selfsnat": "true"}})
+				})
+
+				JustBeforeEach(func(ctx context.Context) {
+					t.CreateLocalHostEndpoint(ctx)
+				})
+
+				It("should not add self-SNAT rules", func() {
+					t.pFilter.EnsureNoRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+						ContainSubstring("\"Action\":6"))
+				})
+			})
+		})
+
+		When("OVN-K shared gateway mode is detected", func() {
+			JustBeforeEach(func(ctx context.Context) {
+				t.CreateLocalHostEndpoint(ctx)
+			})
+
+			It("should not add self-SNAT rules", func() {
+				t.pFilter.EnsureNoRule(packetfilter.TableTypeNAT, chains.SmSelfSnat,
+					ContainSubstring("\"Action\":6"))
+			})
+		})
 	})
 }

--- a/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/ovn_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"maps"
 	"net"
 	"os"
 	"sort"
@@ -75,13 +76,14 @@ func TestOvn(t *testing.T) {
 
 type testDriver struct {
 	*eventtesting.ControllerSupport
-	submClient         *fakesubm.Clientset
-	k8sClient          *fakek8s.Clientset
-	dynClient          *fakedynamic.FakeDynamicClient
-	netLink            *fakenetlink.NetLink
-	transitSwitchIP    map[k8snet.IPFamily]string
-	OVNK8sMgmntIntCIDR map[k8snet.IPFamily]*net.IPNet
-	node               *corev1.Node
+	submClient           *fakesubm.Clientset
+	k8sClient            *fakek8s.Clientset
+	dynClient            *fakedynamic.FakeDynamicClient
+	netLink              *fakenetlink.NetLink
+	transitSwitchIP      map[k8snet.IPFamily]string
+	OVNK8sMgmntIntCIDR   map[k8snet.IPFamily]*net.IPNet
+	node                 *corev1.Node
+	extraNodeAnnotations map[string]string
 }
 
 // SpecCtx is inherited from embedded ControllerSupport for Ginkgo-driven tests.
@@ -97,6 +99,7 @@ func newTestDriver() *testDriver {
 		t.k8sClient = fakek8s.NewClientset()
 		t.dynClient = fakedynamic.NewSimpleDynamicClient(scheme.Scheme)
 		t.OVNK8sMgmntIntCIDR = map[k8snet.IPFamily]*net.IPNet{}
+		t.extraNodeAnnotations = nil
 
 		t.netLink = fakenetlink.New()
 		netlinkAPI.NewFunc = func() netlinkAPI.Interface {
@@ -132,7 +135,7 @@ func newTestDriver() *testDriver {
 }
 
 func (t *testDriver) createNode() {
-	t.node = createNode(t.k8sClient, t.transitSwitchIP[k8snet.IPv4], t.transitSwitchIP[k8snet.IPv6])
+	t.node = createNode(t.k8sClient, t.extraNodeAnnotations, t.transitSwitchIP[k8snet.IPv4], t.transitSwitchIP[k8snet.IPv6])
 }
 
 func (t *testDriver) awaitOVNKNodeAnnotationContaining(ctx context.Context, expected ...string) {
@@ -162,16 +165,19 @@ func (t *testDriver) createEndpoint(ctx context.Context, subnets ...string) *sub
 	return t.CreateEndpoint(ctx, eventtesting.NewEndpoint(remoteClusterID, "host", subnets...))
 }
 
-func createNode(k8sClient kubernetes.Interface, transitSwitchIP ...string) *corev1.Node {
+func createNode(k8sClient kubernetes.Interface, extraAnnotations map[string]string, transitSwitchIP ...string) *corev1.Node {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-node",
+			Name:        "test-node",
+			Annotations: map[string]string{},
 		},
 	}
 
+	maps.Copy(node.Annotations, extraAnnotations)
+
 	tsIPAnnotation := toTransitSwitchIPAnnotation(transitSwitchIP...)
 	if tsIPAnnotation != "" {
-		node.Annotations = map[string]string{constants.OvnTransitSwitchIPAnnotation: tsIPAnnotation}
+		node.Annotations[constants.OvnTransitSwitchIPAnnotation] = tsIPAnnotation
 	}
 
 	_, err := k8sClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})

--- a/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
+++ b/pkg/routeagent_driver/handlers/ovn/transit_switch_ip_test.go
@@ -49,7 +49,7 @@ var _ = Describe("TransitSwitchIP", func() {
 
 		JustBeforeEach(func() {
 			k8sClient = fakek8s.NewClientset()
-			node = createNode(k8sClient, nodeIP)
+			node = createNode(k8sClient, nil, nodeIP)
 		})
 
 		When("the node annotation exists", func() {

--- a/pkg/routeagent_driver/handlers/ovn/uninstall.go
+++ b/pkg/routeagent_driver/handlers/ovn/uninstall.go
@@ -68,6 +68,7 @@ func (ovn *Handler) Uninstall(ctx context.Context) error {
 	ovn.deleteIPHookChain(packetfilter.TableTypeFilter, chains.NewForwarding())
 	ovn.deleteIPHookChain(packetfilter.TableTypeFilter, chains.NewForwardingMSSClamp())
 	ovn.deleteIPHookChain(packetfilter.TableTypeNAT, chains.NewPostRouting())
+	ovn.deleteIPHookChain(packetfilter.TableTypeNAT, chains.NewSelfSnat())
 
 	err = util.Update[*corev1.Node](ctx, ovn.nodeResourceInterface(), &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeutil.GetLocalNodeName()},


### PR DESCRIPTION
Problem:
When OVN-K is configured in local gateway mode, Submariner gateway
health checks fail, causing tunnel connections to remain in an error state.

The failure path is:
1. OVN-K's nftables rule SNATs the health check ICMP packet to an IP outside
   the local CIDR before packet encapsulation in IPsec.
2. The remote gateway receives the health check packet but cannot route the
   reply back through the tunnel due to the unroutable source IP.
3. Health check replies never arrive, leaving the tunnel in an error state.

Fix:
Add a nftables SNAT rule (SUBMARINER-SELF-SNAT chain) in the route-agent's
OVN dataplane handler. Executing before OVN-K's SNAT chains, this rule
creates a conntrack entry that preserves the original source IP of health
check packets. Once established, OVN-K's SNAT rules cannot override the
source IP, allowing health check packets to reach the remote gateway with
a routable source address.

The workaround is automatically enabled when OVN-K local gateway mode is
detected via node annotation. 
It is a no-op in shared gateway mode where the problem does not occur.

If needed, the workaround can be explicitly disabled via the
submariner-global ConfigMap (requires route-agent pod restart):

  kubectl patch configmap submariner-global -n submariner-operator \
    --type merge -p '{"data":{"disable-ovn-selfsnat":"true"}}'

This workaround serves as a temporary mitigation until the underlying
OVN-K issue is resolved upstream (https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6811).

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OVN self-SNAT support for gateway nodes, controlled through the GlobalConfigMap.
  * Supports both IPv4 and IPv6 traffic with the appropriate remote CIDR sets.
  * Uses local cluster CIDRs when generating self-SNAT rules.

* **Bug Fixes**
  * Self-SNAT rules are limited to gateway nodes and omitted when disabled or unconfigured.
  * Uninstallation now removes associated self-SNAT networking rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->