### PR TITLE
Allow LB IP resolution in air-gapped deployments

### DIFF
--- a/pkg/endpoint/public_ip.go
+++ b/pkg/endpoint/public_ip.go
@@ -35,6 +35,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	v1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/types"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -120,14 +121,10 @@ func GetPublicIP(ctx context.Context, family k8snet.IPFamily, submSpec *types.Su
 		}
 
 		if airGapped {
-			ip, resolver, err := invokeResolvers(ctx, family, k8sClient, submSpec.Namespace, config, func(method string) bool {
-				return method == v1.IPv4 || method == v1.IPv6
-			})
+			ip, resolver, err := resolvePublicIPAirGapped(ctx, family, k8sClient, submSpec.Namespace, config)
 			if err != nil {
 				logger.Errorf(err, "Unable to resolve public IPv%s in an air-gapped deployment using %q - using empty value",
 					family, config)
-
-				return "", "", nil
 			}
 
 			return ip, resolver, nil
@@ -140,8 +137,48 @@ func GetPublicIP(ctx context.Context, family k8snet.IPFamily, submSpec *types.Su
 	return "", "", nil
 }
 
+func resolvePublicIPAirGapped(ctx context.Context, family k8snet.IPFamily, k8sClient kubernetes.Interface, namespace, config string,
+) (string, string, error) {
+	var errs []error
+
+	ip, resolver, err := invokeResolvers(ctx, family, k8sClient, namespace, config, func(method string) bool {
+		return method == v1.IPv4 || method == v1.IPv6
+	})
+	if ip != "" {
+		return ip, resolver, nil
+	}
+
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	for r := range strings.SplitSeq(config, ",") {
+		method, param, parseErr := parseResolver(r)
+		if parseErr != nil {
+			errs = append(errs, parseErr)
+			continue
+		}
+
+		if method != v1.LoadBalancer {
+			continue
+		}
+
+		ip, lbErr := publicLoadBalancerDirectIP(ctx, family, k8sClient, namespace, param)
+		if lbErr == nil && ip != "" {
+			return ip, r, nil
+		}
+
+		if lbErr != nil {
+			errs = append(errs, errors.Wrapf(lbErr, "\nResolver[%q]", r))
+		}
+	}
+
+	return "", "", goerrors.Join(errs...)
+}
+
 func invokeResolvers(ctx context.Context,
-	family k8snet.IPFamily, k8sClient kubernetes.Interface, namespace, config string, useResolver func(string) bool,
+	family k8snet.IPFamily, k8sClient kubernetes.Interface, namespace, config string,
+	useResolver func(string) bool,
 ) (string, string, error) {
 	resolvers := strings.Split(config, ",")
 
@@ -234,6 +271,21 @@ var LoadBalancerRetryConfig = wait.Backoff{
 
 func publicLoadBalancerIP(ctx context.Context, family k8snet.IPFamily, clientset kubernetes.Interface, namespace, loadBalancerName string,
 ) (string, error) {
+	return resolveLoadBalancerIP(ctx, family, clientset, namespace, loadBalancerName, publicDNSIP)
+}
+
+// publicLoadBalancerDirectIP resolves the public IP from a LoadBalancer service using only direct
+// IP entries in the ingress status. Hostname entries are skipped, making this safe for air-gapped
+// deployments where DNS may not be available.
+func publicLoadBalancerDirectIP(ctx context.Context, family k8snet.IPFamily, clientset kubernetes.Interface,
+	namespace, loadBalancerName string,
+) (string, error) {
+	return resolveLoadBalancerIP(ctx, family, clientset, namespace, loadBalancerName, nil)
+}
+
+func resolveLoadBalancerIP(ctx context.Context, family k8snet.IPFamily, clientset kubernetes.Interface, namespace, loadBalancerName string,
+	hostnameResolver publicIPResolverFunction,
+) (string, error) {
 	resolvedIP := ""
 	var lastErr error
 
@@ -249,31 +301,15 @@ func publicLoadBalancerIP(ctx context.Context, family k8snet.IPFamily, clientset
 			return false, nil
 		}
 
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			switch {
-			case ingress.IP != "":
-				if k8snet.IPFamilyOfString(ingress.IP) == family {
-					resolvedIP = ingress.IP
-					return true, nil
-				}
-			case ingress.Hostname != "":
-				ip, err := publicDNSIP(ctx, family, clientset, namespace, ingress.Hostname)
-				if err != nil {
-					lastErr = err
-					return false, nil //nolint:nilerr // This retries on error until timeout
-				}
-
-				if ip != "" {
-					resolvedIP = ip
-					return true, nil
-				}
-			}
+		ip, done, resolveErr := resolveIngressIP(ctx, family, clientset, namespace, loadBalancerName,
+			service.Status.LoadBalancer.Ingress, hostnameResolver)
+		if resolveErr != nil {
+			lastErr = resolveErr
 		}
 
-		lastErr = errors.Errorf("no IP or Hostname resolved for service LoadBalancer %q Ingress: %s",
-			loadBalancerName, resource.ToJSON(service.Status.LoadBalancer.Ingress))
+		resolvedIP = ip
 
-		return false, nil
+		return done, nil
 	})
 	if wait.Interrupted(err) {
 		if lastErr != nil {
@@ -282,6 +318,54 @@ func publicLoadBalancerIP(ctx context.Context, family k8snet.IPFamily, clientset
 	}
 
 	return resolvedIP, errors.Wrapf(err, "error resolving service LoadBalancer %q", loadBalancerName)
+}
+
+func resolveIngressIP(ctx context.Context, family k8snet.IPFamily, clientset kubernetes.Interface, namespace, loadBalancerName string,
+	ingresses []corev1.LoadBalancerIngress, hostnameResolver publicIPResolverFunction,
+) (string, bool, error) {
+	hasAnyDirectIP := false
+
+	for _, ingress := range ingresses {
+		if ingress.IP != "" {
+			hasAnyDirectIP = true
+
+			if k8snet.IPFamilyOfString(ingress.IP) == family {
+				return ingress.IP, true, nil
+			}
+		}
+	}
+
+	if hostnameResolver == nil {
+		if !hasAnyDirectIP {
+			for _, ingress := range ingresses {
+				if ingress.Hostname != "" {
+					logger.Warningf("Skipping hostname ingress %q for service %q: DNS resolution is not available "+
+						"in air-gapped mode; only LoadBalancer services with a direct IP in the ingress status are supported",
+						ingress.Hostname, loadBalancerName)
+				}
+			}
+
+			return "", true, nil
+		}
+	} else {
+		for _, ingress := range ingresses {
+			if ingress.Hostname == "" {
+				continue
+			}
+
+			ip, err := hostnameResolver(ctx, family, clientset, namespace, ingress.Hostname)
+			if err != nil {
+				return "", false, err
+			}
+
+			if ip != "" {
+				return ip, true, nil
+			}
+		}
+	}
+
+	return "", false, errors.Errorf("no IP or Hostname resolved for service LoadBalancer %q Ingress: %s",
+		loadBalancerName, resource.ToJSON(ingresses))
 }
 
 var LookupIP = net.DefaultResolver.LookupIP

--- a/pkg/endpoint/public_ip_test.go
+++ b/pkg/endpoint/public_ip_test.go
@@ -182,6 +182,40 @@ func testLoadBalancerResolver() {
 		})
 	}
 
+	When("both a direct IP and a hostname Ingress are configured", func() {
+		It("should return the direct IP without DNS resolution", func(ctx context.Context) {
+			dnsLookupCalled := false
+
+			endpoint.LookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return []net.IP{net.ParseIP(testIPv4DNS)}, nil
+			}
+
+			ip, _, err := invokeGetPublicIP(ctx, k8snet.IPv4, v4IngressWithIP, v4IngressWithHostname)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(Equal(testIPv4))
+			Expect(dnsLookupCalled).To(BeFalse())
+		})
+	})
+
+	When("the hostname Ingress is listed before the direct IP Ingress", func() {
+		It("should still return the direct IP without DNS resolution", func(ctx context.Context) {
+			dnsLookupCalled := false
+
+			endpoint.LookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return []net.IP{net.ParseIP(testIPv4DNS)}, nil
+			}
+
+			ip, _, err := invokeGetPublicIP(ctx, k8snet.IPv4, v4IngressWithHostname, v4IngressWithIP)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(Equal(testIPv4))
+			Expect(dnsLookupCalled).To(BeFalse())
+		})
+	})
+
 	When("no Ingress is configured", func() {
 		It("should return an error", func(ctx context.Context) {
 			_, _, err := invokeGetPublicIP(ctx, k8snet.IPv4)
@@ -219,6 +253,12 @@ func testLoadBalancerResolver() {
 func testResolverInAirGapped() {
 	t := newResolverTestDriver()
 
+	BeforeEach(func() {
+		endpoint.LoadBalancerRetryConfig.Cap = 1 * time.Second
+		endpoint.LoadBalancerRetryConfig.Duration = 50 * time.Millisecond
+		endpoint.LoadBalancerRetryConfig.Steps = 1
+	})
+
 	testGetPublicIP := func(family k8snet.IPFamily, expectedIP string) {
 		Context(fmt.Sprintf("with IPv%s requested", family), func() {
 			It(fmt.Sprintf("should return a valid IPv%s address", family), func(ctx context.Context) {
@@ -253,6 +293,101 @@ func testResolverInAirGapped() {
 			ip, _, err := endpoint.GetPublicIP(ctx, k8snet.IPv4, t.submSpec, fake.NewClientset(), map[string]string{
 				submarinerv1.PublicIP: submarinerv1.API + ":bogus",
 			}, true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(BeEmpty())
+		})
+	})
+
+	newLBClient := func(ingresses ...v1.LoadBalancerIngress) *fake.Clientset {
+		return fake.NewClientset(&v1.Service{
+			ObjectMeta: v1meta.ObjectMeta{Name: testServiceName, Namespace: testNamespace},
+			Status:     v1.ServiceStatus{LoadBalancer: v1.LoadBalancerStatus{Ingress: ingresses}},
+		})
+	}
+
+	lbConfig := map[string]string{submarinerv1.PublicIP: submarinerv1.LoadBalancer + ":" + testServiceName}
+
+	for _, family := range []k8snet.IPFamily{k8snet.IPv4, k8snet.IPv6} {
+		expectedIP := map[k8snet.IPFamily]string{k8snet.IPv4: testIPv4, k8snet.IPv6: testIPv6}[family]
+		ingressWithIP := map[k8snet.IPFamily]v1.LoadBalancerIngress{
+			k8snet.IPv4: {IP: testIPv4},
+			k8snet.IPv6: {IP: testIPv6},
+		}[family]
+
+		When(fmt.Sprintf("a LoadBalancer resolver with a direct IPv%s is configured", family), func() {
+			It("should return the IP address without DNS lookup", func(ctx context.Context) {
+				ip, resolver, err := endpoint.GetPublicIP(ctx, family, t.submSpec,
+					newLBClient(ingressWithIP), lbConfig, true)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ip).To(Equal(expectedIP))
+				Expect(resolver).To(Equal(lbConfig[submarinerv1.PublicIP]))
+			})
+		})
+	}
+
+	When("a LoadBalancer resolver has only a hostname ingress", func() {
+		It("should not attempt DNS resolution and return an empty IP", func(ctx context.Context) {
+			dnsLookupCalled := false
+
+			endpoint.LookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return []net.IP{net.ParseIP(testIPv4DNS)}, nil
+			}
+
+			ip, _, err := endpoint.GetPublicIP(ctx, k8snet.IPv4, t.submSpec,
+				newLBClient(v1.LoadBalancerIngress{Hostname: dnsHostv4}), lbConfig, true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(BeEmpty())
+			Expect(dnsLookupCalled).To(BeFalse(), "DNS should not be called in air-gapped mode")
+		})
+	})
+
+	When("a LoadBalancer resolver has both a direct IP and a hostname ingress", func() {
+		It("should return the direct IP without attempting DNS resolution", func(ctx context.Context) {
+			dnsLookupCalled := false
+
+			endpoint.LookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return []net.IP{net.ParseIP(testIPv4DNS)}, nil
+			}
+
+			ip, resolver, err := endpoint.GetPublicIP(ctx, k8snet.IPv4, t.submSpec,
+				newLBClient(v1.LoadBalancerIngress{IP: testIPv4}, v1.LoadBalancerIngress{Hostname: dnsHostv4}),
+				lbConfig, true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(Equal(testIPv4))
+			Expect(resolver).To(Equal(lbConfig[submarinerv1.PublicIP]))
+			Expect(dnsLookupCalled).To(BeFalse(), "DNS should not be called in air-gapped mode")
+		})
+	})
+
+	When("a LoadBalancer resolver has a direct IP for the wrong family and a hostname ingress", func() {
+		It("should not stop retrying immediately and return an empty IP without calling DNS", func(ctx context.Context) {
+			dnsLookupCalled := false
+
+			endpoint.LookupIP = func(_ context.Context, _, _ string) ([]net.IP, error) {
+				dnsLookupCalled = true
+				return []net.IP{net.ParseIP(testIPv4DNS)}, nil
+			}
+
+			ip, _, err := endpoint.GetPublicIP(ctx, k8snet.IPv4, t.submSpec,
+				newLBClient(v1.LoadBalancerIngress{IP: testIPv6}, v1.LoadBalancerIngress{Hostname: dnsHostv4}),
+				lbConfig, true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).To(BeEmpty())
+			Expect(dnsLookupCalled).To(BeFalse())
+		})
+	})
+
+	When("a LoadBalancer resolver config string is malformed", func() {
+		It("should return an empty IP and include the parse error", func(ctx context.Context) {
+			ip, _, err := endpoint.GetPublicIP(ctx, k8snet.IPv4, t.submSpec, fake.NewClientset(),
+				map[string]string{submarinerv1.PublicIP: "lb:"}, true)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip).To(BeEmpty())


### PR DESCRIPTION
In air-gapped mode, LoadBalancer public IP resolution is currently blocked entirely to prevent DNS lookups, which may not be available in such environments. This is overly restrictive: when the LB provider sets a direct IP address in the service's status.loadBalancer.ingress[].ip field, no DNS lookup is needed.

Providers like MetalLB assign IP addresses directly to LoadBalancer services rather than hostnames, yet their IP addresses cannot be resolved in air-gapped mode due to this restriction.

Add support for LoadBalancer public IP resolution in air-gapped mode when status.loadBalancer.ingress[].ip is populated. Ingress entries that carry only a hostname are still skipped, since resolving a hostname requires DNS. If both ip and hostname are present in the ingress status, the direct IP is used.

Closes: #4108

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved public IP resolution in air-gapped environments by checking available IPv4 and IPv6 sources before LoadBalancer ingress.
  - Direct IP addresses from LoadBalancer ingress are now detected without requiring DNS resolution.
  - Hostname-only LoadBalancer entries no longer trigger unavailable DNS lookups or unnecessary retries in air-gapped environments.
  - Mixed ingress configurations now use available direct IP addresses while avoiding hostname resolution when DNS is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->