### PR TITLE
Pin release-images action to a reviewed commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and release new images
-        uses: submariner-io/shipyard/gh-actions/release-images@release-0.19
+        uses: submariner-io/shipyard/gh-actions/release-images@6156e54b88aad8342859250e1e80856ebd5d069b  # release-0.19
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
#4143 merged before this fix could land — recreating it here.

Granting `id-token: write` lets the `release-images` action mint Sigstore OIDC tokens and access the Quay credentials passed to it. Referencing shipyard's mutable `release-0.19` branch let an unreviewed change to that action obtain the same access (flagged by coderabbitai on #4138, the equivalent fix for release-0.24). Pin to `release-0.19`'s current commit instead.

https://claude.ai/code/session_01RmkKzKd3ZRYRNtUwv45mZN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use a fixed version of the image release action, improving release consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->